### PR TITLE
Cleanup imports, propper lambda support

### DIFF
--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -19,7 +19,6 @@ import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.hooks.EventListener;
 import org.apache.http.HttpHost;
 
-import javax.security.auth.login.LoginException;
 import java.util.List;
 
 

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GenericGuildMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GenericGuildMessageEvent.java
@@ -18,7 +18,6 @@ package net.dv8tion.jda.events.message.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.Message;
-import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.events.message.GenericMessageEvent;
 

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageDeleteEvent.java
@@ -16,7 +16,6 @@
 package net.dv8tion.jda.events.message.guild;
 
 import net.dv8tion.jda.JDA;
-import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.TextChannel;
 
 public class GuildMessageDeleteEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageEmbedEvent.java
@@ -15,12 +15,11 @@
  */
 package net.dv8tion.jda.events.message.guild;
 
+import java.util.List;
+
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.MessageEmbed;
-import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.TextChannel;
-
-import java.util.List;
 
 public class GuildMessageEmbedEvent extends GenericGuildMessageEvent
 {

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageReceivedEvent.java
@@ -17,7 +17,6 @@ package net.dv8tion.jda.events.message.guild;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
-import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.TextChannel;
 
 public class GuildMessageReceivedEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageUpdateEvent.java
@@ -17,7 +17,6 @@ package net.dv8tion.jda.events.message.guild;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
-import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.TextChannel;
 
 public class GuildMessageUpdateEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageReceivedEvent.java
@@ -18,7 +18,6 @@ package net.dv8tion.jda.events.message.priv;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
-import net.dv8tion.jda.entities.User;
 
 public class PrivateMessageReceivedEvent extends GenericPrivateMessageEvent
 {

--- a/src/main/java/net/dv8tion/jda/handle/MessageUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageUpdateHandler.java
@@ -15,14 +15,13 @@
  */
 package net.dv8tion.jda.handle;
 
+import org.json.JSONObject;
+
 import net.dv8tion.jda.entities.Message;
-import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
-import net.dv8tion.jda.events.message.MessageEmbedEvent;
 import net.dv8tion.jda.events.message.MessageUpdateEvent;
 import net.dv8tion.jda.events.message.guild.GuildMessageUpdateEvent;
 import net.dv8tion.jda.events.message.priv.PrivateMessageUpdateEvent;
-import org.json.JSONObject;
 
 public class MessageUpdateHandler extends SocketHandler
 {

--- a/src/main/java/net/dv8tion/jda/hooks/EventListener.java
+++ b/src/main/java/net/dv8tion/jda/hooks/EventListener.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.hooks;
 
 import net.dv8tion.jda.events.Event;
 
+@FunctionalInterface
 public interface EventListener
 {
 


### PR DESCRIPTION
Some basic import cleanup of imports that were not being used (some of them may have also been moved around as I simply mass deleted the ones that were not in use in my IDE).

Allows Lambda functions to be used for the EventListener instead of needing to make a class that implements it.

This is pull #10 but going to the proper branch now -_-