### PR TITLE
Implemented EventCache.

### DIFF
--- a/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
@@ -70,7 +70,7 @@ public class ChannelCreateHandler extends SocketHandler
         {
             throw new IllegalArgumentException("ChannelCreateEvent provided an unregonized channel type.  JSON: " + content);
         }
-        EventCache.playbackCache(api, EventCache.Type.CHANNEL, content.getString("id"));
+        EventCache.get(api).playbackCache(EventCache.Type.CHANNEL, content.getString("id"));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
@@ -70,6 +70,7 @@ public class ChannelCreateHandler extends SocketHandler
         {
             throw new IllegalArgumentException("ChannelCreateEvent provided an unregonized channel type.  JSON: " + content);
         }
+        EventCache.playbackCache(api, EventCache.Type.CHANNEL, content.getString("id"));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
@@ -71,7 +71,14 @@ public class ChannelDeleteHandler extends SocketHandler
             {
                 TextChannel channel = api.getChannelMap().remove(content.getString("id"));
                 if (channel == null)
-                    throw new IllegalArgumentException("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                {
+                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.warn("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                    return null;
+                }
 
                 guild.getTextChannelsMap().remove(channel.getId());
                 api.getEventManager().handle(
@@ -84,8 +91,14 @@ public class ChannelDeleteHandler extends SocketHandler
             {
                 VoiceChannel channel = guild.getVoiceChannelsMap().remove(content.getString("id"));
                 if (channel == null)
-                    throw new IllegalArgumentException("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
-
+                {
+                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.warn("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                    return null;
+                }
                 //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
                 AudioManager manager = api.getAudioManagersMap().get(guild);
                 if (manager != null && manager.isConnected()

--- a/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
@@ -76,7 +76,7 @@ public class ChannelDeleteHandler extends SocketHandler
                     {
                         handle(allContent);
                     });
-                    EventCache.LOG.warn("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                    EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
                     return null;
                 }
 
@@ -96,7 +96,7 @@ public class ChannelDeleteHandler extends SocketHandler
                     {
                         handle(allContent);
                     });
-                    EventCache.LOG.warn("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                    EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
                     return null;
                 }
                 //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!

--- a/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
@@ -72,7 +72,7 @@ public class ChannelDeleteHandler extends SocketHandler
                 TextChannel channel = api.getChannelMap().remove(content.getString("id"));
                 if (channel == null)
                 {
-                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
                     {
                         handle(allContent);
                     });
@@ -92,7 +92,7 @@ public class ChannelDeleteHandler extends SocketHandler
                 VoiceChannel channel = guild.getVoiceChannelsMap().remove(content.getString("id"));
                 if (channel == null)
                 {
-                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
                     {
                         handle(allContent);
                     });

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -68,7 +68,7 @@ public class ChannelUpdateHandler extends SocketHandler
                     {
                         handle(allContent);
                     });
-                    EventCache.LOG.warn("CHANNEL_UPDATE attemped to update a TextChannel that does not exist. JSON: " + content);
+                    EventCache.LOG.debug("CHANNEL_UPDATE attemped to update a TextChannel that does not exist. JSON: " + content);
                     return null;
                 }
 
@@ -144,7 +144,7 @@ public class ChannelUpdateHandler extends SocketHandler
                     {
                         handle(allContent);
                     });
-                    EventCache.LOG.warn("CHANNEL_UPDATE attemped to update a VoiceChannel that does not exist. JSON: " + content);
+                    EventCache.LOG.debug("CHANNEL_UPDATE attemped to update a VoiceChannel that does not exist. JSON: " + content);
                     return null;
                 }
                 //If any properties changed, update the values and fire the proper events.
@@ -224,7 +224,7 @@ public class ChannelUpdateHandler extends SocketHandler
                     {
                         handlePermissionOverride(override, channel, content);
                     });
-                    EventCache.LOG.warn("CHANNEL_UPDATE attempted to create or update a PermissionOverride for a Role that doesn't exist! JSON: " + content);
+                    EventCache.LOG.debug("CHANNEL_UPDATE attempted to create or update a PermissionOverride for a Role that doesn't exist! JSON: " + content);
                     return;
                 }
 
@@ -257,7 +257,7 @@ public class ChannelUpdateHandler extends SocketHandler
                     {
                         handlePermissionOverride(override, channel, content);
                     });
-                    EventCache.LOG.warn("CHANNEL_UPDATE attempted to create or update a PermissionOverride for User that doesn't exist in this Guild! JSON: " + content);
+                    EventCache.LOG.debug("CHANNEL_UPDATE attempted to create or update a PermissionOverride for User that doesn't exist in this Guild! JSON: " + content);
                     return;
                 }
 

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -64,7 +64,7 @@ public class ChannelUpdateHandler extends SocketHandler
                 TextChannelImpl channel = (TextChannelImpl) api.getChannelMap().get(content.getString("id"));
                 if (channel == null)
                 {
-                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
                     {
                         handle(allContent);
                     });
@@ -140,7 +140,7 @@ public class ChannelUpdateHandler extends SocketHandler
                 VoiceChannelImpl channel = (VoiceChannelImpl) api.getVoiceChannelMap().get(content.getString("id"));
                 if (channel == null)
                 {
-                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
                     {
                         handle(allContent);
                     });
@@ -220,7 +220,7 @@ public class ChannelUpdateHandler extends SocketHandler
                 Role role = ((GuildImpl) channel.getGuild()).getRolesMap().get(id);
                 if (role == null)
                 {
-                    EventCache.cache(api, EventCache.Type.ROLE, id, () ->
+                    EventCache.get(api).cache(EventCache.Type.ROLE, id, () ->
                     {
                         handlePermissionOverride(override, channel, content);
                     });
@@ -253,7 +253,7 @@ public class ChannelUpdateHandler extends SocketHandler
                 User user = api.getUserMap().get(override.getString("id"));
                 if (user == null || !channel.getGuild().getUsers().contains(user))
                 {
-                    EventCache.cache(api, EventCache.Type.USER, id, () ->
+                    EventCache.get(api).cache(EventCache.Type.USER, id, () ->
                     {
                         handlePermissionOverride(override, channel, content);
                     });

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -63,7 +63,14 @@ public class ChannelUpdateHandler extends SocketHandler
                 String topic = content.isNull("topic") ? null : content.getString("topic");
                 TextChannelImpl channel = (TextChannelImpl) api.getChannelMap().get(content.getString("id"));
                 if (channel == null)
-                    throw new IllegalArgumentException("CHANNEL_UPDATE attemped to update a TextChannel that does not exist. JSON: " + content);
+                {
+                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.warn("CHANNEL_UPDATE attemped to update a TextChannel that does not exist. JSON: " + content);
+                    return null;
+                }
 
                 //If any properties changed, update the values and fire the proper events.
                 if (!StringUtils.equals(channel.getName(), name))
@@ -132,8 +139,14 @@ public class ChannelUpdateHandler extends SocketHandler
             {
                 VoiceChannelImpl channel = (VoiceChannelImpl) api.getVoiceChannelMap().get(content.getString("id"));
                 if (channel == null)
-                    throw new IllegalArgumentException("CHANNEL_UPDATE attemped to update a VoiceChannel that does not exist. JSON: " + content);
-
+                {
+                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.warn("CHANNEL_UPDATE attemped to update a VoiceChannel that does not exist. JSON: " + content);
+                    return null;
+                }
                 //If any properties changed, update the values and fire the proper events.
                 if (!StringUtils.equals(channel.getName(), name))
                 {
@@ -206,7 +219,15 @@ public class ChannelUpdateHandler extends SocketHandler
             {
                 Role role = ((GuildImpl) channel.getGuild()).getRolesMap().get(id);
                 if (role == null)
-                    throw new IllegalArgumentException("CHANNEL_UPDATE attempted to create or update a PermissionOverride for a Role that doesn't exist! JSON: " + content);
+                {
+                    EventCache.cache(api, EventCache.Type.ROLE, id, () ->
+                    {
+                        handlePermissionOverride(override, channel, content);
+                    });
+                    EventCache.LOG.warn("CHANNEL_UPDATE attempted to create or update a PermissionOverride for a Role that doesn't exist! JSON: " + content);
+                    return;
+                }
+
                 PermissionOverride permOverride;
                 if (channel instanceof TextChannel)
                     permOverride = ((TextChannelImpl) channel).getRolePermissionOverridesMap().get(role);
@@ -230,8 +251,16 @@ public class ChannelUpdateHandler extends SocketHandler
             case "member":
             {
                 User user = api.getUserMap().get(override.getString("id"));
-                if (user == null)
-                    throw new IllegalArgumentException("CHANNEL_UPDATE attempted to create or update a PermissionOverride for User that doesn't exist! JSON: " + content);
+                if (user == null || !channel.getGuild().getUsers().contains(user))
+                {
+                    EventCache.cache(api, EventCache.Type.USER, id, () ->
+                    {
+                        handlePermissionOverride(override, channel, content);
+                    });
+                    EventCache.LOG.warn("CHANNEL_UPDATE attempted to create or update a PermissionOverride for User that doesn't exist in this Guild! JSON: " + content);
+                    return;
+                }
+
                 PermissionOverride permOverride;
                 if (channel instanceof TextChannel)
                     permOverride = ((TextChannelImpl) channel).getUserPermissionOverridesMap().get(user);

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -51,6 +51,12 @@ public class EntityBuilder
             cachedJdaGuildJsons.put(api, new HashMap<>());
     }
 
+    public void clearCache()
+    {
+        cachedJdaGuildCallbacks.get(api).clear();
+        cachedJdaGuildJsons.get(api).clear();
+    }
+
     public Guild createGuildFirstPass(JSONObject guild, Consumer<Guild> secondPassCallback)
     {
         String id = guild.getString("id");

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -82,7 +82,9 @@ public class EventCache
 
     public static void clear(JDA jda)
     {
-        eventCache.get(jda).clear();
+        HashMap cache = eventCache.get(jda);
+        if (cache != null)
+            cache.clear();
     }
 
     enum Type

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -68,7 +68,7 @@ public class EventCache
             return;
         }
 
-        if (!items.isEmpty())
+        if (items != null && !items.isEmpty())
         {
             EventCache.LOG.warn("Replaying " + items.size() + " events from the EventCache for a " + type + " with id: " + triggerId);
             List<Runnable> itemsCopy = new LinkedList<>(items);

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -70,7 +70,7 @@ public class EventCache
 
         if (items != null && !items.isEmpty())
         {
-            EventCache.LOG.warn("Replaying " + items.size() + " events from the EventCache for a " + type + " with id: " + triggerId);
+            EventCache.LOG.debug("Replaying " + items.size() + " events from the EventCache for a " + type + " with id: " + triggerId);
             List<Runnable> itemsCopy = new LinkedList<>(items);
             items.clear();
             for (Runnable item : itemsCopy)

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -29,7 +29,7 @@ public class EventCache
     public static final SimpleLog LOG = SimpleLog.getLog("EventCache");
     private static HashMap<JDA, HashMap<Type, HashMap<String, List<Runnable>>>> eventCache = new HashMap<>();
 
-    public static void cache(JDA jda, Type type, String triggerId, Runnable handler)
+    protected static void cache(JDA jda, Type type, String triggerId, Runnable handler)
     {
         HashMap<Type, HashMap<String, List<Runnable>>> typeCache = eventCache.get(jda);
         if (typeCache == null)
@@ -55,7 +55,7 @@ public class EventCache
         items.add(handler);
     }
 
-    public static void playbackCache(JDA jda, Type type, String triggerId)
+    protected static void playbackCache(JDA jda, Type type, String triggerId)
     {
         List<Runnable> items;
         try
@@ -68,16 +68,25 @@ public class EventCache
             return;
         }
 
-        List<Runnable> itemsCopy = new LinkedList<>(items);
-        items.clear();
-        for (Runnable item : itemsCopy)
+        if (!items.isEmpty())
         {
-            item.run();
+            EventCache.LOG.warn("Replaying " + items.size() + " events from the EventCache for a " + type + " with id: " + triggerId);
+            List<Runnable> itemsCopy = new LinkedList<>(items);
+            items.clear();
+            for (Runnable item : itemsCopy)
+            {
+                item.run();
+            }
         }
+    }
+
+    public static void clear(JDA jda)
+    {
+        eventCache.get(jda).clear();
     }
 
     enum Type
     {
-        USER, MESSAGE, GUILD, CHANNEL, ROLE
+        USER, GUILD, CHANNEL, ROLE
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -1,0 +1,83 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.handle;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.utils.SimpleLog;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class EventCache
+{
+    public static final SimpleLog LOG = SimpleLog.getLog("EventCache");
+    private static HashMap<JDA, HashMap<Type, HashMap<String, List<Runnable>>>> eventCache = new HashMap<>();
+
+    public static void cache(JDA jda, Type type, String triggerId, Runnable handler)
+    {
+        HashMap<Type, HashMap<String, List<Runnable>>> typeCache = eventCache.get(jda);
+        if (typeCache == null)
+        {
+            typeCache = new HashMap<>();
+            eventCache.put(jda, typeCache);
+        }
+
+        HashMap<String, List<Runnable>> triggerCache = typeCache.get(type);
+        if (triggerCache == null)
+        {
+            triggerCache = new HashMap<>();
+            typeCache.put(type, triggerCache);
+        }
+
+        List<Runnable> items = triggerCache.get(triggerId);
+        if (items == null)
+        {
+            items = new LinkedList<>();
+            triggerCache.put(triggerId, items);
+        }
+
+        items.add(handler);
+    }
+
+    public static void playbackCache(JDA jda, Type type, String triggerId)
+    {
+        List<Runnable> items;
+        try
+        {
+            items = eventCache.get(jda).get(type).get(triggerId);
+        }
+        catch (NullPointerException e)
+        {
+            //If we encounter an NPE that means something didn't exist.
+            return;
+        }
+
+        List<Runnable> itemsCopy = new LinkedList<>(items);
+        items.clear();
+        for (Runnable item : itemsCopy)
+        {
+            item.run();
+        }
+    }
+
+    enum Type
+    {
+        USER, MESSAGE, GUILD, CHANNEL, ROLE
+    }
+}

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -27,22 +27,27 @@ import java.util.function.Consumer;
 public class EventCache
 {
     public static final SimpleLog LOG = SimpleLog.getLog("EventCache");
-    private static HashMap<JDA, HashMap<Type, HashMap<String, List<Runnable>>>> eventCache = new HashMap<>();
+    private static HashMap<JDA, EventCache> caches = new HashMap<>();
+    private HashMap<Type, HashMap<String, List<Runnable>>> eventCache = new HashMap<>();
 
-    protected static void cache(JDA jda, Type type, String triggerId, Runnable handler)
+    public static EventCache get(JDA jda)
     {
-        HashMap<Type, HashMap<String, List<Runnable>>> typeCache = eventCache.get(jda);
-        if (typeCache == null)
+        EventCache cache = caches.get(jda);
+        if (cache == null)
         {
-            typeCache = new HashMap<>();
-            eventCache.put(jda, typeCache);
+            cache = new EventCache();
+            caches.put(jda, cache);
         }
+        return cache;
+    }
 
-        HashMap<String, List<Runnable>> triggerCache = typeCache.get(type);
+    protected void cache(Type type, String triggerId, Runnable handler)
+    {
+        HashMap<String, List<Runnable>> triggerCache = eventCache.get(type);
         if (triggerCache == null)
         {
             triggerCache = new HashMap<>();
-            typeCache.put(type, triggerCache);
+            eventCache.put(type, triggerCache);
         }
 
         List<Runnable> items = triggerCache.get(triggerId);
@@ -55,12 +60,12 @@ public class EventCache
         items.add(handler);
     }
 
-    protected static void playbackCache(JDA jda, Type type, String triggerId)
+    protected void playbackCache(Type type, String triggerId)
     {
         List<Runnable> items;
         try
         {
-            items = eventCache.get(jda).get(type).get(triggerId);
+            items = eventCache.get(type).get(triggerId);
         }
         catch (NullPointerException e)
         {
@@ -80,11 +85,9 @@ public class EventCache
         }
     }
 
-    public static void clear(JDA jda)
+    public void clear()
     {
-        HashMap cache = eventCache.get(jda);
-        if (cache != null)
-            cache.clear();
+        eventCache.clear();
     }
 
     enum Type

--- a/src/main/java/net/dv8tion/jda/handle/GuildJoinHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildJoinHandler.java
@@ -51,7 +51,7 @@ public class GuildJoinHandler extends SocketHandler
                                 new GuildJoinEvent(
                                         api, responseNumber,
                                         guild));
-                        EventCache.playbackCache(api, EventCache.Type.GUILD, guild.getId());
+                        EventCache.get(api).playbackCache(EventCache.Type.GUILD, guild.getId());
                     }
                     else if (!wasAvail)                     //was previously unavailable
                     {

--- a/src/main/java/net/dv8tion/jda/handle/GuildJoinHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildJoinHandler.java
@@ -51,6 +51,7 @@ public class GuildJoinHandler extends SocketHandler
                                 new GuildJoinEvent(
                                         api, responseNumber,
                                         guild));
+                        EventCache.playbackCache(api, EventCache.Type.GUILD, guild.getId());
                     }
                     else if (!wasAvail)                     //was previously unavailable
                     {

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberAddHandler.java
@@ -57,7 +57,7 @@ public class GuildMemberAddHandler extends SocketHandler
                 new GuildMemberJoinEvent(
                         api, responseNumber,
                         guild, user));
-        EventCache.playbackCache(api, EventCache.Type.USER, user.getId());
+        EventCache.get(api).playbackCache(EventCache.Type.USER, user.getId());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberAddHandler.java
@@ -57,6 +57,7 @@ public class GuildMemberAddHandler extends SocketHandler
                 new GuildMemberJoinEvent(
                         api, responseNumber,
                         guild, user));
+        EventCache.playbackCache(api, EventCache.Type.USER, user.getId());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
@@ -52,8 +52,11 @@ public class GuildMemberUpdateHandler extends SocketHandler
 
         if(rolesOld == null)
         {
-            //something is fishy...
-            JDAImpl.LOG.warn("Got role-update for user which is not in guild? " + content.toString());
+            EventCache.cache(api, EventCache.Type.USER, userJson.getString("id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.warn("Got role-update for user which is not in guild? " + content.toString());
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
@@ -52,7 +52,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
 
         if(rolesOld == null)
         {
-            EventCache.cache(api, EventCache.Type.USER, userJson.getString("id"), () ->
+            EventCache.get(api).cache(EventCache.Type.USER, userJson.getString("id"), () ->
             {
                 handle(allContent);
             });

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
@@ -56,7 +56,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
             {
                 handle(allContent);
             });
-            EventCache.LOG.warn("Got role-update for user which is not in guild? " + content.toString());
+            EventCache.LOG.debug("Got role-update for user which is not in guild? " + content.toString());
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
@@ -44,7 +44,7 @@ public class GuildMembersChunkHandler extends SocketHandler
         Integer expectMemberCount = (Integer) expectedGuildMembers.get(api).get(guildId);
 
         JSONArray members = content.getJSONArray("members");
-        JDAImpl.LOG.debug("GUILD_MEMBER_CHUNK for: " + guildId + "\tMembers: " + members.length());
+        JDAImpl.LOG.debug("GUILD_MEMBER_CHUNK for: " + guildId + " \tMembers: " + members.length());
         memberChunks.add(members);
 
         int currentTotal = 0;
@@ -55,6 +55,7 @@ public class GuildMembersChunkHandler extends SocketHandler
 
         if (currentTotal >= expectMemberCount)
         {
+            JDAImpl.LOG.debug("Finished chunking for: " + guildId);
             new EntityBuilder(api).createGuildSecondPass(guildId, memberChunks);
             memberChunksCache.get(api).remove(guildId);
             expectedGuildMembers.get(api).remove(guildId);

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
@@ -44,7 +44,7 @@ public class GuildRoleCreateHandler extends SocketHandler
                 new GuildRoleCreateEvent(
                         api, responseNumber,
                         guild, newRole));
-        EventCache.playbackCache(api, EventCache.Type.ROLE, newRole.getId());
+        EventCache.get(api).playbackCache(EventCache.Type.ROLE, newRole.getId());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
@@ -44,6 +44,7 @@ public class GuildRoleCreateHandler extends SocketHandler
                 new GuildRoleCreateEvent(
                         api, responseNumber,
                         guild, newRole));
+        EventCache.playbackCache(api, EventCache.Type.ROLE, newRole.getId());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
@@ -48,7 +48,7 @@ public class GuildRoleDeleteHandler extends SocketHandler
             {
                 handle(allContent);
             });
-            EventCache.LOG.warn("GUILD_ROLE_DELETE attempted to delete a role that didn't exist! JSON: " + content);
+            EventCache.LOG.debug("GUILD_ROLE_DELETE attempted to delete a role that didn't exist! JSON: " + content);
             return null;
         }
         //Now that the role is removed from the Guild, remove it from all users.

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
@@ -44,7 +44,7 @@ public class GuildRoleDeleteHandler extends SocketHandler
         Role removedRole = guild.getRolesMap().remove(content.getString("role_id"));
         if (removedRole == null)
         {
-            EventCache.cache(api, EventCache.Type.ROLE, content.getString("role_id"), () ->
+            EventCache.get(api).cache(EventCache.Type.ROLE, content.getString("role_id"), () ->
             {
                 handle(allContent);
             });

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
@@ -43,8 +43,14 @@ public class GuildRoleDeleteHandler extends SocketHandler
         GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
         Role removedRole = guild.getRolesMap().remove(content.getString("role_id"));
         if (removedRole == null)
-            throw new IllegalArgumentException("GUILD_ROLE_DELETE attempted to delete a role that didn't exist! JSON: " + content);
-
+        {
+            EventCache.cache(api, EventCache.Type.ROLE, content.getString("role_id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.warn("GUILD_ROLE_DELETE attempted to delete a role that didn't exist! JSON: " + content);
+            return null;
+        }
         //Now that the role is removed from the Guild, remove it from all users.
         for (List<Role> userRoles : guild.getUserRoles().values())
         {

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
@@ -46,7 +46,7 @@ public class GuildRoleUpdateHandler extends SocketHandler
             {
                 handle(allContent);
             });
-            EventCache.LOG.warn("Received a Role Update for a non-existent role! JSON: " + content);
+            EventCache.LOG.debug("Received a Role Update for a non-existent role! JSON: " + content);
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
@@ -39,6 +39,17 @@ public class GuildRoleUpdateHandler extends SocketHandler
 
         JSONObject rolejson = content.getJSONObject("role");
         RoleImpl role = (RoleImpl) ((GuildImpl) api.getGuildMap().get(content.getString("guild_id"))).getRolesMap().get(rolejson.getString("id"));
+
+        if (role == null)
+        {
+            EventCache.cache(api, EventCache.Type.ROLE, rolejson.getString("id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.warn("Received a Role Update for a non-existent role! JSON: " + content);
+            return null;
+        }
+
         if (!role.getName().equals(rolejson.getString("name")))
         {
             role.setName(rolejson.getString("name"));

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
@@ -42,7 +42,7 @@ public class GuildRoleUpdateHandler extends SocketHandler
 
         if (role == null)
         {
-            EventCache.cache(api, EventCache.Type.ROLE, rolejson.getString("id"), () ->
+            EventCache.get(api).cache(EventCache.Type.ROLE, rolejson.getString("id"), () ->
             {
                 handle(allContent);
             });

--- a/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
@@ -70,7 +70,7 @@ public class MessageEmbedHandler extends SocketHandler
                 {
                     handle(allContent);
                 });
-                EventCache.LOG.warn("Got unrecognized Channel Id for MessageEmbed! JSON: " + content);
+                EventCache.LOG.debug("Got unrecognized Channel Id for MessageEmbed! JSON: " + content);
                 return null;
             }
             api.getEventManager().handle(

--- a/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
@@ -66,7 +66,7 @@ public class MessageEmbedHandler extends SocketHandler
             PrivateChannel privChannel = api.getPmChannelMap().get(channelId);
             if (privChannel == null)
             {
-                EventCache.cache(api, EventCache.Type.CHANNEL, channelId, () ->
+                EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () ->
                 {
                     handle(allContent);
                 });

--- a/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
@@ -65,7 +65,14 @@ public class MessageEmbedHandler extends SocketHandler
         {
             PrivateChannel privChannel = api.getPmChannelMap().get(channelId);
             if (privChannel == null)
-                throw new IllegalArgumentException("Unrecognized Channel Id! JSON: " + content);
+            {
+                EventCache.cache(api, EventCache.Type.CHANNEL, channelId, () ->
+                {
+                    handle(allContent);
+                });
+                EventCache.LOG.warn("Got unrecognized Channel Id for MessageEmbed! JSON: " + content);
+                return null;
+            }
             api.getEventManager().handle(
                     new PrivateMessageEmbedEvent(
                             api, responseNumber,

--- a/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
@@ -41,7 +41,21 @@ public class MessageReceivedHandler extends SocketHandler
     @Override
     protected String handleInternally(JSONObject content)
     {
-        Message message = new EntityBuilder(api).createMessage(content);
+        Message message;
+        try
+        {
+            message = new EntityBuilder(api).createMessage(content);
+        }
+        catch (IllegalArgumentException e)
+        {
+            EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.warn(e.getMessage());
+            return null;
+        }
+
         if (!message.isPrivate())
         {
             TextChannel channel = api.getChannelMap().get(message.getChannelId());

--- a/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
@@ -52,7 +52,7 @@ public class MessageReceivedHandler extends SocketHandler
             {
                 handle(allContent);
             });
-            EventCache.LOG.warn(e.getMessage());
+            EventCache.LOG.debug(e.getMessage());
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
@@ -48,7 +48,7 @@ public class MessageReceivedHandler extends SocketHandler
         }
         catch (IllegalArgumentException e)
         {
-            EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
+            EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
             {
                 handle(allContent);
             });

--- a/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
@@ -49,11 +49,11 @@ public class PresenceUpdateHandler extends SocketHandler
 
         if (user == null)
         {
-            EventCache.cache(api, EventCache.Type.USER, id, () ->
-            {
-                handle(allContent);
-            });
-            EventCache.LOG.warn("Received a Presence Update for an unknown user. UserId: " + id);
+            //This is basically only received when a user has left a guild. Discord doesn't always send events
+            // in order, so sometimes we get the presence updated after the GuildMemberLeave event has been received
+            // thus there is no user which to apply a presence update to.
+            //We don't cache this event because it is completely unneeded, furthermore it can (and probably will)
+            // cause problems if the user rejoins the guild.
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
@@ -49,7 +49,11 @@ public class PresenceUpdateHandler extends SocketHandler
 
         if (user == null)
         {
-            //User for update doesn't exist, ignoring
+            EventCache.cache(api, EventCache.Type.USER, id, () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.warn("Received a Presence Update for an unknown user. UserId: " + id);
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
@@ -116,6 +116,23 @@ public class ReadyHandler extends SocketHandler
         }
     }
 
+    public void finishReady(JSONObject content)
+    {
+        JSONArray priv_chats = content.getJSONArray("private_channels");
+        for (int i = 0; i < priv_chats.length(); i++)
+        {
+            builder.createPrivateChannel(priv_chats.getJSONObject(i));
+        }
+        api.getClient().ready();
+    }
+
+    public void clearCache()
+    {
+        guildIds.get(api).clear();
+        chunkIds.get(api).clear();
+        cachedJson.remove(api);
+    }
+
     private void sendChunks()
     {
         Iterator<String> iterator = chunkIds.get(api).iterator();
@@ -147,15 +164,6 @@ public class ReadyHandler extends SocketHandler
                     );
             api.getClient().send(obj.toString());
         }
-    }
-
-    public void finishReady(JSONObject content)
-    {
-        JSONArray priv_chats = content.getJSONArray("private_channels");
-        for (int i = 0; i < priv_chats.length(); i++)
-        {
-            builder.createPrivateChannel(priv_chats.getJSONObject(i));
-        }
-        api.getClient().ready();
+        chunkIds.clear();
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/SocketHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/SocketHandler.java
@@ -23,6 +23,7 @@ public abstract class SocketHandler
 {
     protected final JDAImpl api;
     protected final int responseNumber;
+    protected JSONObject allContent;
 
     public SocketHandler(JDAImpl api, int responseNumber)
     {
@@ -33,6 +34,7 @@ public abstract class SocketHandler
 
     public final void handle(JSONObject o)
     {
+        this.allContent = o;
         String guildId = handleInternally(o.getJSONObject("d"));
         if (guildId != null)
         {

--- a/src/main/java/net/dv8tion/jda/handle/VoiceChangeHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/VoiceChangeHandler.java
@@ -49,7 +49,7 @@ public class VoiceChangeHandler extends SocketHandler
                 {
                     handle(allContent);
                 });
-                EventCache.LOG.warn("Received a VOICE_STATE_UPDATE for an unknown User! JSON: " + content);
+                EventCache.LOG.debug("Received a VOICE_STATE_UPDATE for an unknown User! JSON: " + content);
                 return null;
             }
             else
@@ -65,7 +65,7 @@ public class VoiceChangeHandler extends SocketHandler
             {
                 handle(allContent);
             });
-            EventCache.LOG.warn("Received a VOICE_STATE_UPDATE for an unknown Guild! JSON: " + content);
+            EventCache.LOG.debug("Received a VOICE_STATE_UPDATE for an unknown Guild! JSON: " + content);
             return null;
         }
 
@@ -104,7 +104,7 @@ public class VoiceChangeHandler extends SocketHandler
                     {
                         handle(allContent);
                     });
-                    EventCache.LOG.warn("Received a VOICE_STATE_CHANGE for an unknown Channel! JSON: " + content);
+                    EventCache.LOG.debug("Received a VOICE_STATE_CHANGE for an unknown Channel! JSON: " + content);
                     return null;
                 }
                 status.setChannel(newChannel);

--- a/src/main/java/net/dv8tion/jda/handle/VoiceChangeHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/VoiceChangeHandler.java
@@ -45,7 +45,7 @@ public class VoiceChangeHandler extends SocketHandler
         {
             if (!content.isNull("channel_id"))
             {
-                EventCache.cache(api, EventCache.Type.USER, content.getString("user_id"), () ->
+                EventCache.get(api).cache(EventCache.Type.USER, content.getString("user_id"), () ->
                 {
                     handle(allContent);
                 });
@@ -61,7 +61,7 @@ public class VoiceChangeHandler extends SocketHandler
         Guild guild = api.getGuildMap().get(content.getString("guild_id"));
         if (guild == null)
         {
-            EventCache.cache(api, EventCache.Type.GUILD, content.getString("guild_id"), () ->
+            EventCache.get(api).cache(EventCache.Type.GUILD, content.getString("guild_id"), () ->
             {
                 handle(allContent);
             });
@@ -100,7 +100,7 @@ public class VoiceChangeHandler extends SocketHandler
                 VoiceChannel newChannel = api.getVoiceChannelMap().get(content.getString("channel_id"));
                 if (newChannel == null)
                 {
-                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
                     {
                         handle(allContent);
                     });

--- a/src/main/java/net/dv8tion/jda/handle/VoiceChangeHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/VoiceChangeHandler.java
@@ -44,7 +44,14 @@ public class VoiceChangeHandler extends SocketHandler
         if (user == null)
         {
             if (!content.isNull("channel_id"))
-                throw new IllegalArgumentException("Received a VOICE_STATE_UPDATE for an unknown User! JSON: " + content);
+            {
+                EventCache.cache(api, EventCache.Type.USER, content.getString("user_id"), () ->
+                {
+                    handle(allContent);
+                });
+                EventCache.LOG.warn("Received a VOICE_STATE_UPDATE for an unknown User! JSON: " + content);
+                return null;
+            }
             else
                 return null; //This is most likely a VOICE_STATE_UPDATE telling us that a user that left/was kicked/was banned
                              // has been disconnected from the VoiceChannel they were in.
@@ -53,7 +60,14 @@ public class VoiceChangeHandler extends SocketHandler
 
         Guild guild = api.getGuildMap().get(content.getString("guild_id"));
         if (guild == null)
-            throw new IllegalArgumentException("Received a VOICE_STATE_UPDATE for an unknown Guild! JSON: " + content);
+        {
+            EventCache.cache(api, EventCache.Type.GUILD, content.getString("guild_id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.warn("Received a VOICE_STATE_UPDATE for an unknown Guild! JSON: " + content);
+            return null;
+        }
 
         VoiceStatusImpl status = (VoiceStatusImpl) guild.getVoiceStatusOfUser(user);
 
@@ -84,6 +98,15 @@ public class VoiceChangeHandler extends SocketHandler
             {
                 VoiceChannel oldChannel = status.getChannel();
                 VoiceChannel newChannel = api.getVoiceChannelMap().get(content.getString("channel_id"));
+                if (newChannel == null)
+                {
+                    EventCache.cache(api, EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.warn("Received a VOICE_STATE_CHANGE for an unknown Channel! JSON: " + content);
+                    return null;
+                }
                 status.setChannel(newChannel);
                 if (oldChannel != null)
                 {

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -401,7 +401,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         api.getOffline_pms().clear();
         new EntityBuilder(api).clearCache();
         new ReadyHandler(api, 0).clearCache();
-        EventCache.clear(api);
+        EventCache.get(api).clear();
         GuildLock.get(api).clear();
     }
 

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -400,6 +400,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         api.getPmChannelMap().clear();
         api.getOffline_pms().clear();
         GuildLock.get(api).clear();
+        EventCache.clear(api);
     }
 
     private void restoreAudioHandlers()

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -399,8 +399,10 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         api.getUserMap().clear();
         api.getPmChannelMap().clear();
         api.getOffline_pms().clear();
-        GuildLock.get(api).clear();
+        new EntityBuilder(api).clearCache();
+        new ReadyHandler(api, 0).clearCache();
         EventCache.clear(api);
+        GuildLock.get(api).clear();
     }
 
     private void restoreAudioHandlers()


### PR DESCRIPTION
EventCache works as a way to reorder events given to JDA from Discord. Discord will often send events out of order due to their distributed systems and "eventually consistent" mentality. JDA expects things to be in order. 

An example of this would be JDA receiving a PrivateMessage before receiving the  CreateChannel event that the private message was sent in. The Discord client doesn't create a new private channel until a message is sent, thus the message will often be received before the private channel create event is sent.

This re-orders all out of order events and handles them when JDA believes it has enough information to properly deal with the event.
