### PR TITLE
InviteUtil Failing when trying to get Guild

### DIFF
--- a/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
@@ -55,7 +55,7 @@ public class InviteUtil
             code = split[split.length - 1];
         }
         JSONObject object = new JDAImpl(false, false).getRequester().get(Requester.DISCORD_API_PREFIX + "invite/" + code).getObject();
-        if (object != null && object.has("code"))
+        if (object != null && object.has("code") && object.has("guild"))
         {
             JSONObject guild = object.getJSONObject("guild");
             JSONObject channel = object.getJSONObject("channel");


### PR DESCRIPTION
When receiving an invite (with old InviteUtil) expecting a "code" value back only if the invite is valid, and we expect the code to be the same one we sent. However, Discord replies with {"code": 10006, "message": "Unknown Invite"} on unknown invites. The old InviteUtil just looks for a "code" field as verification of an invite, whereas it should actually check that the code is not an error-code (or in the case here, that it has an associated guild).

I did some testing, and the api never returns a guild on invalid invites, including: expired invites, invites where the channel no longer exists, invites where the guild no longer exists, and invites that are not valid. Note that we _shouldn't_ check that the code we receive is the same one we send, because we get a different one in return when sending a "human-readable" code.