### PR TITLE
Release of v2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ tokens.json
 *.iml
 *.ipr
 *.iws
+
+# netbeans files
+/.nb-gradle/
+*.nb-gradle-properties

--- a/README.md
+++ b/README.md
@@ -2,28 +2,26 @@
 JDA strives to provide a clean and full wrapping of the Discord REST api and its Websocket-Events for Java.<br>
 Besides audio, this library is full featured, allowing every operation that the Discord Client can provide.
 
+## JDA 2.x
+After the release of the official Discord API, we decided to split JDA into 2 seperate libraries.
+
+JDA will be continued with version 2.x and will only have Bot-features (for bot-accounts).
+Please see the [Discord docs](https://discordapp.com/developers/docs/reference) for more information about bot accounts.
+
+
+We will also create a new library called JDA-Client, which extends the functionality of JDA 2.x
+and add some client-only features like friends-list, acks, creating/owning Guilds,...
+
 ## Creating the JDA Object
 Creating the JDA Object is done via the JDABuilder class.
-After setting email and password either via Constructor, or via setters,
+After setting the bot-token via setter,
 the JDA Object is then created by calling the `.buildBlocking()` or the `.buildAsync()` (non-blocking login) method.
 <p>
-Examples:
-
-```java
-JDA jda = new JDABuilder("email", "password").buildBlocking();
-```
-
-```java
-JDA jda = new JDABuilder().setEmail("email").setPassword("password").buildBlocking();
-```
-
-If the account that you intend on using is registered as a bot account (eg it has a BOT tag), you must provide the bot token instead of the email and password.
+Example:
 
 ```java
 JDA jda = new JDABuilder().setBotToken("token").buildBlocking();
 ```
-
-Please see the [Discord docs](https://discordapp.com/developers/docs/reference) for more information about bot accounts.
 
 ## Events
 There a TON of events in JDA that you can listen to.<br>
@@ -39,7 +37,7 @@ public class ReadyListener implements EventListener
 {
     public static void main(String[] args)
     {
-        JDA jda = new JDABuilder(args[0], args[1]).addListener(new ReadyListener()).buildBlocking();
+        JDA jda = new JDABuilder().setBotToken("token").addListener(new ReadyListener()).buildBlocking();
     }
 
     @Override
@@ -56,7 +54,7 @@ public class MessageListener extends ListenerAdapter
 {
     public static void main(String[] args)
     {
-        JDA jda = new JDABuilder(args[0], args[1]).buildBlocking();
+        JDA jda = new JDABuilder().setBotToken("token").buildBlocking();
         jda.addEventListener(new MessageListener());
     }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # JDA (Java Discord API)
 JDA strives to provide a clean and full wrapping of the Discord REST api and its Websocket-Events for Java.<br>
-Besides audio, this library is full featured, allowing every operation that the Discord Client can provide.
 
 ## JDA 2.x
 After the release of the official Discord API, we decided to split JDA into 2 seperate libraries.
@@ -9,14 +8,15 @@ JDA will be continued with version 2.x and will only have Bot-features (for bot-
 Please see the [Discord docs](https://discordapp.com/developers/docs/reference) for more information about bot accounts.
 
 
-We will also create a new library called JDA-Client, which extends the functionality of JDA 2.x
-and add some client-only features like friends-list, acks, creating/owning Guilds,...
+We are also creating a new library called JDA-Client, which extends the functionality of JDA 2.x
+and add some client-only features like friends-list, acks, creating/owning Guilds,...<br/>
+You can find JDA-Client [Here](https://github.com/DV8FromTheWorld/JDA-Client)
 
 ## Creating the JDA Object
 Creating the JDA Object is done via the JDABuilder class.
 After setting the bot-token via setter,
 the JDA Object is then created by calling the `.buildBlocking()` or the `.buildAsync()` (non-blocking login) method.
-<p>
+
 Example:
 
 ```java
@@ -26,7 +26,7 @@ JDA jda = new JDABuilder().setBotToken("token").buildBlocking();
 ## Events
 There a TON of events in JDA that you can listen to.<br>
 There are 2 ways of writing your Event-Listener:
-  1. Extend ListenerAdapter and use the provided methods that get fire dependent on the Event-Type. [Event Methods](https://github.com/DV8FromTheWorld/JDA/blob/master/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java#L179-L254)
+  1. Extend ListenerAdapter and use the provided methods that get fire dependent on the Event-Type. [Event Methods](https://github.com/DV8FromTheWorld/JDA/blob/master/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java)
   2. Implement EventListener and listen to onEvent and figure out if it is the event you want (Not suggested)<br>
 
 Listeners can be registered either in the JDABuilder (will catch all Events; recommended), or in the JDA instance (initial Events, especially the *READY*-Event could get lost)
@@ -88,8 +88,8 @@ The dev builds are also available for maven/gradle on JCenter through Bintray [J
 ## Docs
 Javadocs are available in both jar format and web format.<br>
 The jar format is available on the [Promoted Downloads](https://github.com/DV8FromTheWorld/JDA/releases) page or on any of the
-build pages of the [Beta Downloads](http://home.dv8tion.net:8080/job/JDA/).<br>
-<br>
+build pages of the [Beta Downloads](http://home.dv8tion.net:8080/job/JDA/).
+
 The web format allows for viewing of the [Latest Promoted Docs](http://home.dv8tion.net:8080/job/JDA/Promoted%20Build/javadoc/)
 and also viewing of each individual build's javadoc. To view the javadoc for a specific build, you will need to go to that build's page
 on [the build server](http://home.dv8tion.net:8080/job/JDA/) and click the javadoc button on the left side of the build page.<br>

--- a/README.md
+++ b/README.md
@@ -147,3 +147,7 @@ All dependencies are managed automatically by Gradle.
    * Version: **1.3**
    * [Sourceforge](https://sourceforge.net/projects/jflac/)
    * [JCenter Repository](https://bintray.com/dv8fromtheworld/maven/jFLAC/view)
+ * JAADec
+   * Version: **0.8.5**
+   * [Github](https://github.com/DV8FromTheWorld/JAADec)
+   * [JCenter Repository](https://bintray.com/dv8fromtheworld/maven/JAADec/view)

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,10 @@ jar {
     manifest {
         attributes 'Implementation-Version': version
     }
+    include "net/dv8tion/jda/**"
+    include "com/iwebpp/crypto/**"
+    include "org/tritonus/**"
+    include "tomp2p/opuswrapper/**"
 }
 
 task javadocJar(type: Jar) {
@@ -96,6 +100,10 @@ task javadocJar(type: Jar) {
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.filtered.java
+    include "net/dv8tion/jda/**"
+    include "com/iwebpp/crypto/**"
+    include "org/tritonus/**"
+    include "tomp2p/opuswrapper/**"
 }
 
 // create a single Jar with all dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 0, revision: 0)
+def versionObj = new Version(major: 2, minor: 1, revision: 0)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+//use: gradlew clean build fatJar signArchives install bintrayUpload
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
@@ -5,6 +6,7 @@ plugins {
 }
 
 apply plugin: 'java'
+apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
@@ -177,7 +179,17 @@ bintray {
         name = 'JDA'
         licenses = ['Apache-2.0']
         vcsUrl = 'https://github.com/DV8FromTheWorld/JDA.git'
-        configurations = ['archives']
+        filesSpec {
+            from ('build/libs') {
+                exclude "**withDependencies**"
+            }
+            from 'build/poms'
+            into "${project.group.replace(".", "/")}/${archivesBaseName}/${project.version}"
+
+            rename { String fileName ->
+                fileName.replace("pom-default.xml", "${archivesBaseName}-${project.version}.pom")
+            }
+        }
         publish = true
         version {
             name = project.version
@@ -206,9 +218,7 @@ String getProjectProperty(String propertyName)
 compileJava.source = sourceSets.filtered.java
 compileJava.dependsOn processVersion
 
-// Creates the w/ dependencies jar.
-signArchives.dependsOn fatJar
-bintrayUpload.dependsOn signArchives
+//use: gradlew clean build fatJar signArchives install bintrayUpload
 
 // If we don't have the username and password for uploading, we probably also
 // can't sign the archives, so skip these tasks.

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ jar {
     include "com/iwebpp/crypto/**"
     include "org/tritonus/**"
     include "tomp2p/opuswrapper/**"
+    include "natives/**"
 }
 
 task javadocJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
 }
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
@@ -170,77 +169,6 @@ class Version {
     }
 }
 
-uploadArchives {
-      onlyIf {
-        System.getenv("BUILD_NUMBER")
-      }
-      repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-        
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-        
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-        
-            pom.project {
-                name 'JDA'
-                packaging 'jar'
-                // optionally artifactId can be defined here 
-                description 'A wrapping of the Discord REST api and its Websocket-Events for Java.'
-                url 'https://github.com/DV8FromTheWorld/JDA'
-        
-                scm {
-                    connection 'scm:git:git@github.com:DV8FromTheWorld/JDA.git'
-                    developerConnection 'scm:git:git@github.com:DV8FromTheWorld/JDA.git'
-                    url 'scm:git:git@github.com:DV8FromTheWorld/JDA.git'
-                }
-        
-                licenses {
-                    license {
-                        name 'The Apache License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-        
-                developers {
-                    developer {
-                        id 'DV8FromTheWorld'
-                        name 'Austin Keener'
-                        email 'keeneraustin@yahoo.com'
-                    }
-                    developer {
-                        id 'Kantekugel'
-                        name 'Michael Ritter'
-                        email 'ritter.michael92@gmail.com'
-                    }
-                }
-            }.withXml {
-                //If we use a repository that isn't just MavenCentral
-                if (project.repositories.size() > 1)
-                {
-                    int i = 0
-                    def reposNode = asNode().appendNode("repositories")
-                    project.repositories.each { repo ->
-                        //Ignore the MavenCentral repository. Don't need to add it.
-                        if (!("https://repo1.maven.org/maven2/" == repo.properties["url"]))
-                        {
-                            def repoNode = reposNode.appendNode("repository")
-                            repoNode.appendNode("id", "JDA-repo-" + i)
-                            repoNode.appendNode("name", "JDA Repo " + i)
-                            repoNode.appendNode("url", repo.properties["url"]);
-                            i++
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
 bintray {
     user = bintrayUsername
     key = bintrayApiKey
@@ -264,16 +192,28 @@ bintrayUpload {
     }
 }
 
-// tell the compileJava task to compile the filtered source 
+String getProjectProperty(String propertyName)
+{
+    String property = ""
+    if (hasProperty(propertyName))
+    {
+        property = this.properties[propertyName]
+    }
+    return property
+}
+
+// tell the compileJava task to compile the filtered source
 compileJava.source = sourceSets.filtered.java
 compileJava.dependsOn processVersion
 
 // Creates the w/ dependencies jar.
-uploadArchives.dependsOn fatJar
-bintrayUpload.dependsOn uploadArchives
+signArchives.dependsOn fatJar
+bintrayUpload.dependsOn signArchives
 
 // If we don't have the username and password for uploading, we probably also
 // can't sign the archives, so skip these tasks.
-signArchives.onlyIf { !ossrhUsername.empty && !ossrhPassword.empty }
-uploadArchives.onlyIf { !ossrhUsername.empty && !ossrhPassword.empty }
-bintrayUpload.onlyIf { !bintrayUsername.empty && !bintrayApiKey.empty }
+signArchives.onlyIf {(!getProjectProperty("signing.keyId").empty
+        && !getProjectProperty("signing.password").empty
+        && !getProjectProperty("signing.secretKeyRingFile").empty) }
+bintrayUpload.onlyIf { (!getProjectProperty("bintrayUsername").empty
+        && !getProjectProperty("bintrayApiKey").empty) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
-signing.keyId=""
-signing.password=""
-signing.secretKeyRingFile=""
-
-ossrhUsername=
-ossrhPassword=
+signing.keyId=
+signing.password=
+signing.secretKeyRingFile=
 
 bintrayUsername=
 bintrayApiKey=

--- a/src/examples/java/AudioExample.java
+++ b/src/examples/java/AudioExample.java
@@ -44,11 +44,11 @@ public class AudioExample extends ListenerAdapter
         }
         catch (IllegalArgumentException e)
         {
-            System.out.println("The config was not populated. Please enter an email and password.");
+            System.out.println("The config was not populated. Please enter a bot token.");
         }
         catch (LoginException e)
         {
-            System.out.println("The provided email / password combination was incorrect. Please provide valid details.");
+            System.out.println("The provided bot token was incorrect. Please provide valid details.");
         }
         catch (InterruptedException e)
         {

--- a/src/examples/java/ChannelListenerExample.java
+++ b/src/examples/java/ChannelListenerExample.java
@@ -34,11 +34,11 @@ public class ChannelListenerExample extends ListenerAdapter
         }
         catch (IllegalArgumentException e)
         {
-            System.out.println("The config was not populated. Please enter an email and password.");
+            System.out.println("The config was not populated. Please enter a bot token.");
         }
         catch (LoginException e)
         {
-            System.out.println("The provided email / password combination was incorrect. Please provide valid details.");
+            System.out.println("The provided bot token was incorrect. Please provide valid details.");
         }
         catch (InterruptedException e)
         {

--- a/src/examples/java/GuildListenerExample.java
+++ b/src/examples/java/GuildListenerExample.java
@@ -46,11 +46,11 @@ public class GuildListenerExample extends ListenerAdapter
         }
         catch (IllegalArgumentException e)
         {
-            System.out.println("The config was not populated. Please enter an email and password.");
+            System.out.println("The config was not populated. Please enter a bot token.");
         }
         catch (LoginException e)
         {
-            System.out.println("The provided email / password combination was incorrect. Please provide valid details.");
+            System.out.println("The provided bot token was incorrect. Please provide valid details.");
         }
         catch (InterruptedException e)
         {

--- a/src/examples/java/GuildListenerExample.java
+++ b/src/examples/java/GuildListenerExample.java
@@ -79,7 +79,7 @@ public class GuildListenerExample extends ListenerAdapter
     @Override
     public void onGuildMemberUnban(GuildMemberUnbanEvent event)
     {
-        System.out.println(event.getUserName() + " was unbanned.  Better keep an eye on them...");
+        System.out.println(event.getUser().getUsername() + " was unbanned.  Better keep an eye on them...");
     }
 
     @Override

--- a/src/examples/java/GuildListenerExample.java
+++ b/src/examples/java/GuildListenerExample.java
@@ -18,12 +18,12 @@ import net.dv8tion.jda.JDABuilder;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.events.guild.GuildLeaveEvent;
-import net.dv8tion.jda.events.guild.GuildRoleCreateEvent;
-import net.dv8tion.jda.events.guild.GuildRoleDeleteEvent;
 import net.dv8tion.jda.events.guild.member.GuildMemberBanEvent;
 import net.dv8tion.jda.events.guild.member.GuildMemberRoleAddEvent;
 import net.dv8tion.jda.events.guild.member.GuildMemberRoleRemoveEvent;
 import net.dv8tion.jda.events.guild.member.GuildMemberUnbanEvent;
+import net.dv8tion.jda.events.guild.role.GuildRoleCreateEvent;
+import net.dv8tion.jda.events.guild.role.GuildRoleDeleteEvent;
 import net.dv8tion.jda.hooks.ListenerAdapter;
 
 import javax.security.auth.login.LoginException;

--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -41,11 +41,11 @@ public class MessageListenerExample extends ListenerAdapter
         }
         catch (IllegalArgumentException e)
         {
-            System.out.println("The config was not populated. Please enter an email and password.");
+            System.out.println("The config was not populated. Please enter a bot token.");
         }
         catch (LoginException e)
         {
-            System.out.println("The provided email / password combination was incorrect. Please provide valid details.");
+            System.out.println("The provided bot token was incorrect. Please provide valid details.");
         }
         catch (InterruptedException e)
         {

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda;
 
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.hooks.AnnotatedEventManager;
+import net.dv8tion.jda.hooks.EventListener;
 import net.dv8tion.jda.hooks.IEventManager;
 import net.dv8tion.jda.managers.AccountManager;
 import net.dv8tion.jda.managers.AudioManager;
@@ -60,6 +61,14 @@ public interface JDA
      *          The listener to be removed.
      */
     void removeEventListener(Object listener);
+
+    /**
+     * Returns an unmodifiable List of Objects that have been registered as EventListeners.
+     *
+     * @return
+     *      List of currently registered Objects acting as EventListeners.
+     */
+    List<Object> getRegisteredListeners();
 
     /**
      * The login token that is currently being used for Discord authentication.

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -44,12 +44,12 @@ public class JDABuilder
     protected static boolean jdaCreated = false;
     protected static String proxyUrl = null;
     protected static int proxyPort = -1;
-    final List<Object> listeners;
-    String token = null;
-    boolean enableVoice = true;
-    boolean useAnnotatedManager = false;
-    IEventManager eventManager = null;
-    boolean reconnect = true;
+    protected final List<Object> listeners;
+    protected String token = null;
+    protected boolean enableVoice = true;
+    protected boolean useAnnotatedManager = false;
+    protected IEventManager eventManager = null;
+    protected boolean reconnect = true;
 
     /**
      * Creates a completely empty JDABuilder.<br>

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -51,6 +51,7 @@ public class JDABuilder
     protected boolean useAnnotatedManager = false;
     protected IEventManager eventManager = null;
     protected boolean reconnect = true;
+    protected int[] sharding = null;
 
     /**
      * Creates a completely empty JDABuilder.<br>
@@ -229,6 +230,31 @@ public class JDABuilder
     }
 
     /**
+     * This will enable sharding mode for JDA.
+     * In sharding mode, guilds are split up and assigned one of multiple shards (clients).
+     * The shardId that receives all stuff related to given bot is calculated as follows: shardId = (guildId &gt;&gt; 22)%numShards .
+     * PMs are only sent to shard 0.
+     *
+     * Please note, that a shard will not even know about guilds not assigned to.
+     *
+     * @param shardId
+     *      The id of this shard (starting at 0).
+     * @param numShards
+     *      The number of overall shards.
+     * @return
+     *      Returns the {@link net.dv8tion.jda.JDABuilder JDABuilder} instance. Useful for chaining.
+     */
+    public JDABuilder useSharding(int shardId, int numShards)
+    {
+        if (shardId < 0 || numShards < 2 || shardId >= numShards)
+        {
+            throw new RuntimeException("This configuration of shardId and numShards is not allowed! 0 <= shardId < numShards with numShards > 1");
+        }
+        sharding = new int[] {shardId, numShards};
+        return this;
+    }
+
+    /**
      * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided email and password to start the login process.<br>
      * The login process runs in a different thread, so while this will return immediately, {@link net.dv8tion.jda.JDA} has not
      * finished loading, thus many {@link net.dv8tion.jda.JDA} methods have the chance to return incorrect information.
@@ -262,7 +288,7 @@ public class JDABuilder
             jda.setEventManager(new AnnotatedEventManager());
         }
         listeners.forEach(jda::addEventListener);
-        jda.login(token);
+        jda.login(token, sharding);
         return jda;
     }
 

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -47,6 +47,7 @@ public class JDABuilder
     protected final List<Object> listeners;
     protected String token = null;
     protected boolean enableVoice = true;
+    protected boolean enableShutdownHook = true;
     protected boolean useAnnotatedManager = false;
     protected IEventManager eventManager = null;
     protected boolean reconnect = true;
@@ -118,6 +119,22 @@ public class JDABuilder
     public JDABuilder setAudioEnabled(boolean enabled)
     {
         this.enableVoice = enabled;
+        return this;
+    }
+
+    /**
+     * Enables/Disables the use of a Shutdown hook to clean up JDA.<br>
+     * When the Java program closes shutdown hooks are run. This is used as a last-second cleanup
+     * attempt by JDA to properly severe connections.
+     *
+     * @param enable
+     *          True (default) - use shutdown hook to clean up JDA if the Java program is closed.
+     * @return
+     *      Return the {@link net.dv8tion.jda.JDABuilder JDABuilder } instance. Useful for chaining.
+     */
+    public JDABuilder setEnableShutdownHook(boolean enable)
+    {
+        this.enableShutdownHook = enable;
         return this;
     }
 
@@ -232,9 +249,9 @@ public class JDABuilder
         jdaCreated = true;
         JDAImpl jda;
         if (proxySet)
-            jda = new JDAImpl(proxyUrl, proxyPort, enableVoice);
+            jda = new JDAImpl(proxyUrl, proxyPort, enableVoice, enableShutdownHook);
         else
-            jda = new JDAImpl(enableVoice);
+            jda = new JDAImpl(enableVoice, enableShutdownHook);
         jda.setAutoReconnect(reconnect);
         if (eventManager != null)
         {

--- a/src/main/java/net/dv8tion/jda/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/MessageBuilder.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda;
 
 import net.dv8tion.jda.entities.Message;
+import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.entities.impl.MessageImpl;
@@ -28,6 +29,7 @@ public class MessageBuilder
     private final StringBuilder builder = new StringBuilder();
     private final List<User> mentioned = new LinkedList<>();
     private final List<TextChannel> mentionedTextChannels = new LinkedList<>();
+    private final List<Role> mentionedRoles = new LinkedList<>();
     private boolean mentionEveryone = false;
     private boolean isTTS = false;
 
@@ -142,6 +144,20 @@ public class MessageBuilder
     }
 
     /**
+     * Appends a Role mention to the Message.
+     * For this to work, the given Role has to be from the Guild the mention is posted to.
+     *
+     * @param role the Role to mention
+     * @return this instance
+     */
+    public MessageBuilder appendMention(Role role)
+    {
+        builder.append("<@&").append(role.getId()).append('>');
+        mentionedRoles.add(role);
+        return this;
+    }
+
+    /**
      * Returns the current length of the content that will be built into a {@link net.dv8tion.jda.entities.Message Message}
      * when {@link #build()} is called.<br>
      * If this value is <code>0</code> or greater than <code>2000</code> when {@link #build()} is called, an exception
@@ -175,7 +191,7 @@ public class MessageBuilder
             throw new UnsupportedOperationException("Cannot build a Message with more than 2000 characters. Please limit your input.");
 
         return new MessageImpl("", null).setContent(message).setTTS(isTTS).setMentionedUsers(mentioned)
-                .setMentionedChannels(mentionedTextChannels).setMentionsEveryone(mentionEveryone);
+                .setMentionedChannels(mentionedTextChannels).setMentionedRoles(mentionedRoles).setMentionsEveryone(mentionEveryone);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/Permission.java
+++ b/src/main/java/net/dv8tion/jda/Permission.java
@@ -44,6 +44,9 @@ public enum Permission
     VOICE_MOVE_OTHERS(24),
     VOICE_USE_VAD(25),
 
+    NICKNAME_CHANGE(26),
+    NICKNAME_MANAGE(27),
+
     UNKNOWN(-1);
 
     private final int offset;

--- a/src/main/java/net/dv8tion/jda/Permission.java
+++ b/src/main/java/net/dv8tion/jda/Permission.java
@@ -52,12 +52,12 @@ public enum Permission
     UNKNOWN(-1, false, false);
 
     private final int offset;
-    private final boolean isServer, isChannel;
+    private final boolean isGuild, isChannel;
 
-    Permission(int offset, boolean isServer, boolean isChannel)
+    Permission(int offset, boolean isGuild, boolean isChannel)
     {
         this.offset = offset;
-        this.isServer = isServer;
+        this.isGuild = isGuild;
         this.isChannel = isChannel;
     }
 
@@ -100,9 +100,9 @@ public enum Permission
      * @return
      *      True if this permission is present Guild-side
      */
-    public boolean isServer()
+    public boolean isGuild()
     {
-        return isServer;
+        return isGuild;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/Permission.java
+++ b/src/main/java/net/dv8tion/jda/Permission.java
@@ -20,40 +20,45 @@ import java.util.List;
 
 public enum Permission
 {
-    CREATE_INSTANT_INVITE(0),
-    KICK_MEMBERS(1),
-    BAN_MEMBERS(2),
-    MANAGE_ROLES(3),
-    MANAGE_PERMISSIONS(3),
-    MANAGE_CHANNEL(4),
-    MANAGE_SERVER(5),
+    CREATE_INSTANT_INVITE(0, true, true),
+    KICK_MEMBERS(1, true, false),
+    BAN_MEMBERS(2, true, false),
+    ADMINISTRATOR(3, true, false),
+    MANAGE_CHANNEL(4, true, true),
+    MANAGE_SERVER(5, true, false),
 
-    MESSAGE_READ(10),
-    MESSAGE_WRITE(11),
-    MESSAGE_TTS(12),
-    MESSAGE_MANAGE(13),
-    MESSAGE_EMBED_LINKS(14),
-    MESSAGE_ATTACH_FILES(15),
-    MESSAGE_HISTORY(16),
-    MESSAGE_MENTION_EVERYONE(17),
+    MESSAGE_READ(10, true, true),
+    MESSAGE_WRITE(11, true, true),
+    MESSAGE_TTS(12, true, true),
+    MESSAGE_MANAGE(13, true, true),
+    MESSAGE_EMBED_LINKS(14, true, true),
+    MESSAGE_ATTACH_FILES(15, true, true),
+    MESSAGE_HISTORY(16, true, true),
+    MESSAGE_MENTION_EVERYONE(17, true, true),
 
-    VOICE_CONNECT(20),
-    VOICE_SPEAK(21),
-    VOICE_MUTE_OTHERS(22),
-    VOICE_DEAF_OTHERS(23),
-    VOICE_MOVE_OTHERS(24),
-    VOICE_USE_VAD(25),
+    VOICE_CONNECT(20, true, true),
+    VOICE_SPEAK(21, true, true),
+    VOICE_MUTE_OTHERS(22, true, true),
+    VOICE_DEAF_OTHERS(23, true, true),
+    VOICE_MOVE_OTHERS(24, true, true),
+    VOICE_USE_VAD(25, true, true),
 
-    NICKNAME_CHANGE(26),
-    NICKNAME_MANAGE(27),
+    NICKNAME_CHANGE(26, true, false),
+    NICKNAME_MANAGE(27, true, false),
 
-    UNKNOWN(-1);
+    MANAGE_ROLES(28, true, false),
+    MANAGE_PERMISSIONS(28, false, true),
+
+    UNKNOWN(-1, false, false);
 
     private final int offset;
+    private final boolean isServer, isChannel;
 
-    Permission(int offset)
+    Permission(int offset, boolean isServer, boolean isChannel)
     {
         this.offset = offset;
+        this.isServer = isServer;
+        this.isChannel = isChannel;
     }
 
     /**
@@ -88,6 +93,29 @@ public enum Permission
         }
         return UNKNOWN;
     }
+
+    /**
+     * Returns whether or not this Permission is present Guild-side (configurable via roles)
+     *
+     * @return
+     *      True if this permission is present Guild-side
+     */
+    public boolean isServer()
+    {
+        return isServer;
+    }
+
+    /**
+     * Returns whether or not this Permission is present Channel-side (configurable via chanel-overrides)
+     *
+     * @return
+     *      True if this permission is present Channel-side
+     */
+    public boolean isChannel()
+    {
+        return isChannel;
+    }
+
     /**
      * A list of all {@link net.dv8tion.jda.Permission Permissions} that are specified by this raw int representation of
      * permissions. The is best used with the getRaw methods in {@link net.dv8tion.jda.entities.Role Role},

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -161,26 +161,20 @@ public class AudioConnection
                             {
                                 if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
                                     setSpeaking(false);
-                                continue;
                             }
-                            byte[] encodedAudio = encodeToOpus(rawAudio);
-                            AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), encodedAudio);
-                            if (!speaking)
-                                setSpeaking(true);
-                            udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
-
-                            if (seq + 1 > Character.MAX_VALUE)
-                                seq = 0;
                             else
-                                seq++;
-
-                            timestamp += OPUS_FRAME_SIZE;
-                            long sleepTime = (OPUS_FRAME_TIME_AMOUNT) - (System.currentTimeMillis() - lastFrameSent);
-                            if (sleepTime > 0)
                             {
-                                Thread.sleep(sleepTime);
-                            }
-                            lastFrameSent = System.currentTimeMillis();
+                                byte[] encodedAudio = encodeToOpus(rawAudio);
+                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), encodedAudio);
+                                if (!speaking)
+                                    setSpeaking(true);
+                                udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
+
+                                if (seq + 1 > Character.MAX_VALUE)
+                                    seq = 0;
+                                else
+                                    seq++;
+							}
                         }
                         else if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
                             setSpeaking(false);
@@ -192,10 +186,6 @@ public class AudioConnection
                                 "Are you sure you have internet connection? It is likely that you've lost connection.");
                         webSocket.close(true, -1);
                     }
-                    catch (InterruptedException e)
-                    {
-                        //We've been asked to stop. The next iteration will kill the loop.
-                    }
                     catch (SocketException e)
                     {
                         //Most likely the socket has been closed due to the audio connection be closed. Next iteration will kill loop.
@@ -203,6 +193,22 @@ public class AudioConnection
                     catch (Exception e)
                     {
                         LOG.log(e);
+                    }
+                    finally
+                    {
+                        timestamp += OPUS_FRAME_SIZE;
+                        long sleepTime = (OPUS_FRAME_TIME_AMOUNT) - (System.currentTimeMillis() - lastFrameSent);
+                        if (sleepTime > 0)
+                        {
+                            try
+                            {
+                                Thread.sleep(sleepTime);
+                            } catch (InterruptedException e)
+                            {
+                                //We've been asked to stop. The next iteration will kill the loop. 
+                            }
+                        }
+                        lastFrameSent += OPUS_FRAME_TIME_AMOUNT;
                     }
                 }
             }

--- a/src/main/java/net/dv8tion/jda/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioWebSocket.java
@@ -95,8 +95,8 @@ public class AudioWebSocket extends WebSocketAdapter
         try
         {
             socket = factory.createSocket(wssEndpoint)
-                    .addListener(this)
-                    .connect();
+                    .addListener(this);
+            socket.connect();
         }
         catch (IOException | WebSocketException e)
         {

--- a/src/main/java/net/dv8tion/jda/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioWebSocket.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.audio.AudioDisconnectEvent;
 import net.dv8tion.jda.events.audio.AudioRegionChangeEvent;
+import net.dv8tion.jda.events.audio.AudioTimeoutEvent;
 import net.dv8tion.jda.events.audio.AudioUnableToConnectEvent;
 import net.dv8tion.jda.managers.impl.AudioManagerImpl;
 import net.dv8tion.jda.utils.SimpleLog;
@@ -46,6 +47,7 @@ public class AudioWebSocket extends WebSocketAdapter
     public static final int USER_SPEAKING_UPDATE = 5;
 
     public static final int WEBSOCKET_READ_TIMEOUT = 1008;
+    public static final int CONNECTION_SETUP_TIMEOUT = -41;
     public static final int UDP_UNABLE_TO_CONNECT = -42;
 
     private final JDAImpl api;
@@ -302,13 +304,19 @@ public class AudioWebSocket extends WebSocketAdapter
         {
             api.getEventManager().handle(new AudioRegionChangeEvent(api, disconnectedChannel));
         }
-        else if (disconnectCode == UDP_UNABLE_TO_CONNECT)
-        {
-            api.getEventManager().handle(new AudioUnableToConnectEvent(api, disconnectedChannel));
-        }
         else
         {
-            api.getEventManager().handle(new AudioDisconnectEvent(api, disconnectedChannel));
+            switch (disconnectCode)
+            {
+                case CONNECTION_SETUP_TIMEOUT:
+                    //Handled in AudioConnection
+                    break;
+                case UDP_UNABLE_TO_CONNECT:
+                    api.getEventManager().handle(new AudioUnableToConnectEvent(api, disconnectedChannel));
+                    break;
+                default:
+                    api.getEventManager().handle(new AudioDisconnectEvent(api, disconnectedChannel));
+            }
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/Channel.java
+++ b/src/main/java/net/dv8tion/jda/entities/Channel.java
@@ -82,6 +82,19 @@ public interface Channel
     int getPosition();
 
     /**
+     * The actual position of the {@link net.dv8tion.jda.entities.Channel Channel} as stored and given by Discord.
+     * Role positions are actually based on a pairing of the creation time (as stored in the snowflake id)
+     * and the position. If 2 or more roles share the same position then they are sorted based on their creation date.
+     * The more recent a role was created, the lower it is in the hierachy. This is handled by {@link #getPosition()}
+     * and it is most likely the method you want. If, for some reason, you want the actual position of the
+     * Role then this method will give you that value.
+     *
+     * @return
+     *      The true, Discord stored, position of the {@link net.dv8tion.jda.entities.Channel Channel}.
+     */
+    int getPositionRaw();
+
+    /**
      * Checks if the given {@link net.dv8tion.jda.entities.User User} has the given {@link net.dv8tion.jda.Permission Permission}
      * in this Channel
      *

--- a/src/main/java/net/dv8tion/jda/entities/Game.java
+++ b/src/main/java/net/dv8tion/jda/entities/Game.java
@@ -1,0 +1,85 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package net.dv8tion.jda.entities;
+
+/**
+ * Represents a Discord {@link net.dv8tion.jda.entities.Game Game}. This should contain all information provided from Discord about a Game.
+ */
+public interface Game
+{
+
+    /**
+     * The displayed name of the {@link net.dv8tion.jda.entities.Game Game}. If no name has been set, this returns null.
+     *
+     * @return
+     *      Possibly-null String containing the Game's name.
+     */
+    String getName();
+
+    /**
+     * The URL of the {@link net.dv8tion.jda.entities.Game Game}. This will return null for regular games.
+     *
+     * @return
+     *      Possibly-null String containing the Game's URL.
+     */
+    String getUrl();
+
+    /**
+     * The type of {@link net.dv8tion.jda.entities.Game Game}. This will return null for regular games.
+     *
+     * @return
+     *      Possibly-null int representing the type of Game
+     */
+    GameType getType();
+
+
+    /**
+     * Checks if a given String is a valid Twitch url (ie, one that will display "Streaming" on the Discord client.
+     */
+    static boolean isValidStreamingUrl(String url)
+    {
+        return url != null && url.matches("^https?:\\/\\/(www\\.)?twitch\\.tv\\/.+");
+    }
+
+    enum GameType
+    {
+        DEFAULT(0),
+        TWITCH(1);
+
+        private final int key;
+
+        GameType(int key)
+        {
+            this.key = key;
+        }
+
+        public int getKey()
+        {
+            return key;
+        }
+
+        public static GameType fromKey(int key)
+        {
+            for (GameType level : GameType.values())
+            {
+                if(level.getKey() == key)
+                    return level;
+            }
+            return DEFAULT;
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -281,6 +281,16 @@ public interface Guild
     List<VoiceStatus> getVoiceStatuses();
 
     /**
+     * Returns the current nickname of a user in this Guild.
+     *
+     * @param user
+     *      The user to check.
+     * @return
+     *      The nickname or null, if no nickname is set.
+     */
+    String getNicknameForUser(User user);
+
+    /**
      * Returns the verification-Level of this Guild. For a short description of the different values, see {@link VerificationLevel}.
      * @return
      *      The Verification-Level of this Guild.

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -201,6 +201,16 @@ public interface Guild
     List<Role> getRolesForUser(User user);
 
     /**
+     * Provides all {@link net.dv8tion.jda.entities.User Users} that have the provided role.
+     *
+     * @param role
+     *          The {@link net.dv8tion.jda.entities.Role Role} that we are checking which users have.
+     * @return
+     *      An Immutable List of {@link net.dv8tion.jda.entities.User Users}.
+     */
+    List<User> getUsersWithRole(Role role);
+
+    /**
      * The @everyone {@link net.dv8tion.jda.entities.Role Role} of this {@link net.dv8tion.jda.entities.Guild Guild}
      *
      * @return The @everyone {@link net.dv8tion.jda.entities.Role Role}

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -288,6 +288,16 @@ public interface Guild
     VerificationLevel getVerificationLevel();
 
     /**
+     * Checks if the current Verification-level of this guild allows JDA to send messages to it.
+     *
+     * @return
+     *      True if Verification-level allows sending of messages, false if not.
+     * @see VerificationLevel
+     *      VerificationLevel Enum with a list of possible verification-levels and their requirements
+     */
+    boolean checkVerification();
+
+    /**
      * Returns whether or not this Guild is available. A Guild can be unavailable, if the Discord server has problems.
      * If a Guild is unavailable, no actions on it can be performed (Messages, Manager,...)
      *

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -167,6 +167,17 @@ public interface Guild
     List<Role> getRoles();
 
     /**
+     * This returns the {@link net.dv8tion.jda.entities.Role Role} which has the same id as the one provided.<br>
+     * If there is no {@link net.dv8tion.jda.entities.Role Role} that matches the requested id, <code>null</code> is returned.
+     *
+     * @param id
+     *      The id of the {@link net.dv8tion.jda.entities.Role Role}.
+     * @return
+     *      Possibly-null Role with matching id.
+     */
+    Role getRoleById(String id);
+
+    /**
      * Creates a new {@link net.dv8tion.jda.entities.Role Role} in this Guild.
      * For this to be successful, the logged in account has to have the {@link net.dv8tion.jda.Permission#MANAGE_ROLES MANAGE_ROLES Permission}
      *

--- a/src/main/java/net/dv8tion/jda/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/entities/Message.java
@@ -54,7 +54,7 @@ public interface Message
     List<User> getMentionedUsers();
 
     /**
-     * A immutable list of all mentioned {@link net.dv8tion.jda.entities.TextChannel TextChannels}. if none was mentioned, this list is empty
+     * A immutable list of all mentioned {@link net.dv8tion.jda.entities.TextChannel TextChannels}. if none were mentioned, this list is empty
      * In {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel's}, this always returns an empty List
      *
      * @return immutable list of mentioned TextChannels
@@ -62,7 +62,15 @@ public interface Message
     List<TextChannel> getMentionedChannels();
 
     /**
-     * Is this Message mentioning everyone using @everyone?
+     * A immutable list of all mentioned {@link net.dv8tion.jda.entities.Role Roles}. if none were mentioned, this list is empty
+     * In {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel's}, this always returns an empty List
+     *
+     * @return immutable list of mentioned Roles
+     */
+    List<Role> getMentionedRoles();
+
+    /**
+     * Is this Message mentioning everyone using @everyone or @here?
      * In {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel's}, this always returns false
      *
      * @return if mentioning everyone

--- a/src/main/java/net/dv8tion/jda/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/entities/Message.java
@@ -54,6 +54,16 @@ public interface Message
     List<User> getMentionedUsers();
 
     /**
+     * Checks if given user was mentioned in this message in any way (@User, @everyone, @here).
+     *
+     * @param user
+     *      The user to check on.
+     * @return
+     *      True if the given user was mentioned in this message.
+     */
+    boolean isMentioned(User user);
+
+    /**
      * A immutable list of all mentioned {@link net.dv8tion.jda.entities.TextChannel TextChannels}. if none were mentioned, this list is empty
      * In {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel's}, this always returns an empty List
      *

--- a/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 public interface MessageChannel
 {
     /**
-     * Sents a plain text {@link net.dv8tion.jda.entities.Message Message} to this channel.
+     * Sends a plain text {@link net.dv8tion.jda.entities.Message Message} to this channel.
      * This will fail if the account of the api does not have the {@link net.dv8tion.jda.Permission#MESSAGE_WRITE Write-Permission}
      * for this channel set
      * After the Message has been sent, the created {@link net.dv8tion.jda.entities.Message Message} object is returned

--- a/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
@@ -178,8 +178,8 @@ public interface MessageChannel
 
     /**
      * Sends the typing status to discord. This is what is used to make the message "X is typing..." appear.<br>
-     * The typing status only lasts for 5 seconds, so if you wish to show continuous typing you will need to
-     * call this method once every 5 seconds.
+     * The typing status only lasts for 10 seconds or until a message is sent.
+     * So if you wish to show continuous typing you will need to call this method once every 10 seconds.
      */
     void sendTyping();
 }

--- a/src/main/java/net/dv8tion/jda/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/entities/Role.java
@@ -21,17 +21,30 @@ import net.dv8tion.jda.managers.RoleManager;
 
 import java.util.List;
 
-public interface Role
+public interface Role extends Comparable<Role>
 {
     /**
-     * The position of this {@link net.dv8tion.jda.entities.Role Role} in the {@link net.dv8tion.jda.entities.Guild Guild} hierarchy.<br>
+     * The hierarchical position of this {@link net.dv8tion.jda.entities.Role Role} in the {@link net.dv8tion.jda.entities.Guild Guild} hierarchy.<br>
      * (higher value means higher role).<br>
-     * The @everyone {@link net.dv8tion.jda.entities.Role Role} always return -1
+     * The @everyone {@link net.dv8tion.jda.entities.Role Role} always return -1.
      *
      * @return
      *      The position of this {@link net.dv8tion.jda.entities.Role Role} as integer.
      */
     int getPosition();
+
+    /**
+     * The actual position of the {@link net.dv8tion.jda.entities.Role Role} as stored and given by Discord.
+     * Role positions are actually based on a pairing of the creation time (as stored in the snowflake id)
+     * and the position. If 2 or more roles share the same position then they are sorted based on their creation date.
+     * The more recent a role was created, the lower it is in the heirarchy. This is handled by {@link #getPosition()}
+     * and it is most likely the method you want. If, for some reason, you want the actual position of the
+     * Role then this method will give you that value.
+     *
+     * @return
+     *      The true, Discord stored, position of the {@link net.dv8tion.jda.entities.Role Role}.
+     */
+    int getPositionRaw();
 
     /**
      * The Name of the {@link net.dv8tion.jda.entities.Role Role}.

--- a/src/main/java/net/dv8tion/jda/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/entities/Role.java
@@ -110,7 +110,7 @@ public interface Role
     int getColor();
 
     /**
-     * Checks if this {@link net.dv8tion.jda.entities.Role Role} a
+     * Checks if this {@link net.dv8tion.jda.entities.Role Role} has a
      * {@link net.dv8tion.jda.entities.Guild Guild} level {@link net.dv8tion.jda.Permission Permission}.<br>
      * This does not check the Channel-specific override {@link net.dv8tion.jda.Permission Permission}.
      *

--- a/src/main/java/net/dv8tion/jda/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/entities/Role.java
@@ -60,6 +60,22 @@ public interface Role
     boolean isGrouped();
 
     /**
+     * Returns wheter or not this Role is mentionable
+     *
+     * @return
+     *      True if Role is mentionable.
+     */
+    boolean isMentionable();
+
+    /**
+     * Returns the String needed to mention this Role in a {@link net.dv8tion.jda.entities.Message Message}.
+     *
+     * @return
+     *      The String needed to mention this Role
+     */
+    String getAsMention();
+
+    /**
      * The ID of this {@link net.dv8tion.jda.entities.Role Role}.
      *
      * @return

--- a/src/main/java/net/dv8tion/jda/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/TextChannel.java
@@ -15,6 +15,8 @@
  */
 package net.dv8tion.jda.entities;
 
+import java.util.Collection;
+
 /**
  * Represents a Discord Text Channel. See {@link net.dv8tion.jda.entities.Channel Channel} and
  * {@link net.dv8tion.jda.entities.MessageChannel MessageChannel} for more information.
@@ -34,4 +36,17 @@ public interface TextChannel extends Channel, MessageChannel
      *      The String needed to mention this Channel
      */
     String getAsMention();
+    
+    /**
+     * Bulk deletes a list of messages. Must not be more than 100 messages at a time.
+     * You must have channel permission to delete messages.
+     * If only a single message is supplied then this function will resort to using {@link net.dv8tion.jda.entities.Message#deleteMessage} instead.
+     * @param messages
+     *      The messages to delete.
+     * @throws IllegalArgumentException
+     *      If the size of the list is more than 100 messages.
+     * @throws IllegalArgumentException
+     *      If this account does not have MANAGE_MESSAGES
+     */
+    void deleteMessages(Collection<Message> messages);
 }

--- a/src/main/java/net/dv8tion/jda/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/TextChannel.java
@@ -21,7 +21,7 @@ import java.util.Collection;
  * Represents a Discord Text Channel. See {@link net.dv8tion.jda.entities.Channel Channel} and
  * {@link net.dv8tion.jda.entities.MessageChannel MessageChannel} for more information.
  */
-public interface TextChannel extends Channel, MessageChannel
+public interface TextChannel extends Channel, MessageChannel, Comparable<TextChannel>
 {
     /**
      * Internal implementation of this class is available at

--- a/src/main/java/net/dv8tion/jda/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/entities/User.java
@@ -77,13 +77,13 @@ public interface User
     String getAvatarUrl();
 
     /**
-     * The name of the game that the user is currently playing.
+     * The game that the user is currently playing.
      * If the user is not currently playing a game, this will return null.
      *
      * @return
-     *      Possibly-null String containing the name of the game that the {@link net.dv8tion.jda.entities.User User} is currently playing.
+     *      Possibly-null {@link net.dv8tion.jda.entities.Game Game} containing the game that the {@link net.dv8tion.jda.entities.User User} is currently playing.
      */
-    String getCurrentGame();
+    Game getCurrentGame();
 
     /**
      * Returns the {@link net.dv8tion.jda.OnlineStatus OnlineStatus} of the User.<br>

--- a/src/main/java/net/dv8tion/jda/entities/VoiceChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/VoiceChannel.java
@@ -24,4 +24,25 @@ package net.dv8tion.jda.entities;
  */
 public interface VoiceChannel extends Channel, Comparable<VoiceChannel>
 {
+    /**
+     * The maximum amount of {@link net.dv8tion.jda.entities.User Users} that can be in this
+     * {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} at one time.
+     * <br>
+     * 0 - No limit <br>
+     *
+     * @return
+     *      The maximum amount of users allowed in this channel at one time.
+     */
+    int getUserLimit();
+
+    /**
+     * The audio bitrate of the voice audio that is played in this channel. While higher bitrates can be sent to
+     * this channel, it will be scaled down by the client.
+     * <br>
+     * Default and recommended value is 64000
+     *
+     * @return
+     *      The audio bitrate of this voice channel.
+     */
+    int getBitrate();
 }

--- a/src/main/java/net/dv8tion/jda/entities/VoiceChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/VoiceChannel.java
@@ -22,6 +22,6 @@ package net.dv8tion.jda.entities;
  * This interface only exists to distinct {@link net.dv8tion.jda.entities.Channel Channels} into
  * VoiceChannels and {@link net.dv8tion.jda.entities.TextChannel TextChannels}.
  */
-public interface VoiceChannel extends Channel
+public interface VoiceChannel extends Channel, Comparable<VoiceChannel>
 {
 }

--- a/src/main/java/net/dv8tion/jda/entities/impl/GameImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GameImpl.java
@@ -1,0 +1,73 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package net.dv8tion.jda.entities.impl;
+
+import net.dv8tion.jda.entities.Game;
+
+public class GameImpl implements Game
+{
+    private String name;
+    private String url;
+    private GameType type;
+
+    public GameImpl(String name, String url, GameType type)
+    {
+        this.name = name;
+        this.url = url;
+        this.type = type;
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public String getUrl()
+    {
+        return url;
+    }
+
+    @Override
+    public GameType getType()
+    {
+        return type;
+    }
+
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if(!( obj instanceof Game ))
+            return false;
+        Game other = (Game) obj;
+        if(other.getType() != type)
+            return false;
+        if(name == null)
+            return other.getName() == null;
+        if(url == null)
+            return other.getUrl() == null;
+        return name.equals(other.getName()) && url.equals(other.getUrl());
+    }
+
+    @Override
+    public String toString()
+    {
+        return getName();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -165,7 +165,7 @@ public class GuildImpl implements Guild
         else
         {
             TextChannel channel = new EntityBuilder(api).createTextChannel(response, getId());
-            return new ChannelManager(channel);
+            return channel.getManager();
         }
     }
 
@@ -201,7 +201,7 @@ public class GuildImpl implements Guild
         else
         {
             VoiceChannel channel = new EntityBuilder(api).createVoiceChannel(response, getId());
-            return new ChannelManager(channel);
+            return channel.getManager();
         }
     }
 
@@ -239,7 +239,7 @@ public class GuildImpl implements Guild
         else
         {
             Role role = new EntityBuilder(api).createRole(response, getId());
-            return new RoleManager(role);
+            return role.getManager();
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -250,6 +250,18 @@ public class GuildImpl implements Guild
     }
 
     @Override
+    public List<User> getUsersWithRole(Role role)
+    {
+        List<User> users = new LinkedList<>();
+        userRoles.entrySet().forEach(entry ->
+        {
+            if (entry.getValue().contains(role))
+                users.add(entry.getKey());
+        });
+        return Collections.unmodifiableList(users);
+    }
+
+    @Override
     public Role getPublicRole()
     {
         return publicRole;

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -52,6 +52,7 @@ public class GuildImpl implements Guild
     private final Map<String, Role> roles = new HashMap<>();
     private final Map<User, VoiceStatus> voiceStatusMap = new HashMap<>();
     private final Map<User, OffsetDateTime> joinedAtMap = new HashMap<>();
+    private final Map<User, String> nickMap = new HashMap<>();
     private Role publicRole;
     private TextChannel publicChannel;
     private final JDAImpl api;
@@ -293,6 +294,12 @@ public class GuildImpl implements Guild
     }
 
     @Override
+    public String getNicknameForUser(User user)
+    {
+        return nickMap.get(user);
+    }
+
+    @Override
     public VerificationLevel getVerificationLevel()
     {
         return verificationLevel;
@@ -403,6 +410,11 @@ public class GuildImpl implements Guild
     public Map<User, OffsetDateTime> getJoinedAtMap()
     {
         return joinedAtMap;
+    }
+
+    public Map<User, String> getNickMap()
+    {
+        return nickMap;
     }
 
     public GuildImpl setVerificationLevel(VerificationLevel level)

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -214,6 +214,12 @@ public class GuildImpl implements Guild
     }
 
     @Override
+    public Role getRoleById(String id)
+    {
+        return roles.get(id);
+    }
+
+    @Override
     public RoleManager createRole()
     {
         if (!PermissionUtil.checkPermission(getJDA().getSelfInfo(), Permission.MANAGE_ROLES, this))

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -21,7 +21,6 @@ import net.dv8tion.jda.Region;
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.exceptions.GuildUnavailableException;
 import net.dv8tion.jda.exceptions.PermissionException;
-import net.dv8tion.jda.exceptions.VerificationLevelException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.managers.AudioManager;
 import net.dv8tion.jda.managers.ChannelManager;
@@ -300,6 +299,29 @@ public class GuildImpl implements Guild
     }
 
     @Override
+    public boolean checkVerification()
+    {
+        if(canSendVerification)
+            return true;
+        switch (verificationLevel)
+        {
+            case HIGH:
+                if(ChronoUnit.MINUTES.between(getJoinDateForUser(api.getSelfInfo()), OffsetDateTime.now()) < 10)
+                    break;
+            case MEDIUM:
+                if(ChronoUnit.MINUTES.between(MiscUtil.getCreationTime(api.getSelfInfo()), OffsetDateTime.now()) < 5)
+                    break;
+            case LOW:
+                if(!api.getSelfInfo().isVerified())
+                    break;
+            case NONE:
+                canSendVerification = true;
+                return true;
+        }
+        return false;
+    }
+
+    @Override
     public boolean isAvailable()
     {
         return available;
@@ -388,28 +410,6 @@ public class GuildImpl implements Guild
         this.verificationLevel = level;
         this.canSendVerification = false;   //recalc on next send
         return this;
-    }
-
-    public void checkVerification()
-    {
-        if(canSendVerification)
-            return;
-        switch (verificationLevel)
-        {
-            case HIGH:
-                if(ChronoUnit.MINUTES.between(getJoinDateForUser(api.getSelfInfo()), OffsetDateTime.now()) < 10)
-                    break;
-            case MEDIUM:
-                if(ChronoUnit.MINUTES.between(MiscUtil.getCreationTime(api.getSelfInfo()), OffsetDateTime.now()) < 5)
-                    break;
-            case LOW:
-                if(!api.getSelfInfo().isVerified())
-                    break;
-            case NONE:
-                canSendVerification = true;
-                return;
-        }
-        throw new VerificationLevelException(verificationLevel);
     }
 
     public GuildImpl setAvailable(boolean available)

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -137,7 +137,7 @@ public class GuildImpl implements Guild
     public List<TextChannel> getTextChannels()
     {
         ArrayList<TextChannel> textChannels = new ArrayList<>(this.textChannels.values());
-        Collections.sort(textChannels, (c1, c2) -> Integer.compare(c1.getPosition(), c2.getPosition()));
+        Collections.sort(textChannels, (c1, c2) -> c2.compareTo(c1));
         return Collections.unmodifiableList(textChannels);
     }
 
@@ -173,7 +173,7 @@ public class GuildImpl implements Guild
     public List<VoiceChannel> getVoiceChannels()
     {
         List<VoiceChannel> list = new ArrayList<>(voiceChannels.values());
-        Collections.sort(list, (v1, v2) -> Integer.compare(v1.getPosition(), v2.getPosition()));
+        Collections.sort(list, (v1, v2) -> v2.compareTo(v1));
         return Collections.unmodifiableList(list);
     }
 
@@ -209,7 +209,7 @@ public class GuildImpl implements Guild
     public List<Role> getRoles()
     {
         List<Role> list = new ArrayList<>(roles.values());
-        Collections.sort(list, (r1, r2) -> Integer.compare(r2.getPosition(), r1.getPosition()));
+        Collections.sort(list, (r1, r2) -> r2.compareTo(r1));
         return Collections.unmodifiableList(list);
     }
 
@@ -246,7 +246,12 @@ public class GuildImpl implements Guild
     @Override
     public List<Role> getRolesForUser(User user)
     {
-        return userRoles.get(user) == null ? new LinkedList<>() : Collections.unmodifiableList(userRoles.get(user));
+        List<Role> roles = userRoles.get(user);
+        if (roles == null)
+            return new LinkedList<>();
+
+        Collections.sort(roles, (r1, r2) -> r2.compareTo(r1));
+        return Collections.unmodifiableList(roles);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -59,7 +59,7 @@ public class JDAImpl implements JDA
     protected final Map<String, TextChannel> textChannelMap = new HashMap<>();
     protected final Map<String, VoiceChannel> voiceChannelMap = new HashMap<>();
     protected final Map<String, PrivateChannel> pmChannelMap = new HashMap<>();
-    protected final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or PrivateChannelId) - Timeout.
+    protected final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or GlobalPrivateChannel) - Timeout.
     protected final Map<String, String> offline_pms = new HashMap<>();    //Userid -> channelid
     protected final Map<Guild, AudioManager> audioManagers = new HashMap<>();
     protected final boolean audioEnabled;

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -208,6 +208,12 @@ public class JDAImpl implements JDA
         getEventManager().unregister(listener);
     }
 
+    @Override
+    public List<Object> getRegisteredListeners()
+    {
+        return Collections.unmodifiableList(getEventManager().getRegisteredListeners());
+    }
+
     public IEventManager getEventManager()
     {
         return eventManager;

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -156,52 +156,6 @@ public class JDAImpl implements JDA
         return false;
     }
 
-    /**
-     * Takes a provided json file, reads all lines and constructs a {@link org.json.JSONObject JSONObject} from it.
-     *
-     * @param file
-     *          The json file to read.
-     * @return
-     *      The {@link org.json.JSONObject JSONObject} representation of the json in the file.
-     */
-    protected static JSONObject readJson(Path file)
-    {
-        try
-        {
-            return new JSONObject(StringUtils.join(Files.readAllLines(file, StandardCharsets.UTF_8), ""));
-        }
-        catch (IOException e)
-        {
-            LOG.fatal("Error reading token-file. Defaulting to standard");
-            LOG.log(e);
-        }
-        catch (JSONException e)
-        {
-            LOG.warn("Token-file misformatted. Creating default one");
-        }
-        return null;
-    }
-
-    /**
-     * Writes the json representation of the provided {@link org.json.JSONObject JSONObject} to the provided file.
-     *
-     * @param file
-     *          The file which will have the json representation of object written into.
-     * @param object
-     *          The {@link org.json.JSONObject JSONObject} to write to file.
-     */
-    protected static void writeJson(Path file, JSONObject object)
-    {
-        try
-        {
-            Files.write(file, Arrays.asList(object.toString(4).split("\n")), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        }
-        catch (IOException e)
-        {
-            LOG.warn("Error creating token-file");
-        }
-    }
-
     @Override
     public String getAuthToken()
     {

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -69,7 +69,7 @@ public class JDAImpl implements JDA
     protected AccountManager accountManager;
     protected String authToken = null;
     protected WebSocketClient client;
-    protected final Requester requester = new Requester(this);
+    protected Requester requester = new Requester(this);
     protected boolean reconnect;
     protected int responseTotal;
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -101,16 +101,23 @@ public class JDAImpl implements JDA
      *
      * @param token
      *          The token of the bot-account attempting to log in.
+     * @param sharding
+     *          A array of length 2 used for sharding or null. Refer to JDABuilder#useSharding for more details
      * @throws IllegalArgumentException
-     *          Thrown if the botToken provided is empty or null.
+     *          Thrown if: <ul>
+     *              <li>the botToken provided is empty or null.</li>
+     *              <li>The sharding parameter is invalid.</li>
+     *          </ul>
      * @throws LoginException
      *          Thrown if the token fails the auth check with the Discord servers.
      */
-    public void login(String token) throws IllegalArgumentException, LoginException
+    public void login(String token, int[] sharding) throws IllegalArgumentException, LoginException
     {
         LOG.info("JDA starting...");
         if (token == null || token.isEmpty())
             throw new IllegalArgumentException("The provided botToken was empty / null.");
+        if (sharding != null && (sharding.length != 2 || sharding[0] < 0 || sharding[0] >= sharding[1] || sharding[1] < 2))
+            throw new IllegalArgumentException("Sharding array is wrong. please refer to JDABuilder#useSharding for help");
 
         accountManager = new AccountManager(this);
 
@@ -119,7 +126,7 @@ public class JDAImpl implements JDA
         }
 
         LOG.info("Login Successful!");
-        client = new WebSocketClient(this, proxy);
+        client = new WebSocketClient(this, proxy, sharding);
         client.setAutoReconnect(reconnect);
 
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -53,25 +53,25 @@ import java.util.stream.Collectors;
 public class JDAImpl implements JDA
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDA");
-    private final HttpHost proxy;
-    private final Map<String, User> userMap = new HashMap<>();
-    private final Map<String, Guild> guildMap = new HashMap<>();
-    private final Map<String, TextChannel> textChannelMap = new HashMap<>();
-    private final Map<String, VoiceChannel> voiceChannelMap = new HashMap<>();
-    private final Map<String, PrivateChannel> pmChannelMap = new HashMap<>();
-    private final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or PrivateChannelId) - Timeout.
-    private final Map<String, String> offline_pms = new HashMap<>();    //Userid -> channelid
-    private final Map<Guild, AudioManager> audioManagers = new HashMap<>();
-    private final boolean audioEnabled;
-    private final boolean useShutdownHook;
-    private IEventManager eventManager = new InterfacedEventManager();
-    private SelfInfo selfInfo = null;
-    private AccountManager accountManager;
-    private String authToken = null;
-    private WebSocketClient client;
-    private final Requester requester = new Requester(this);
-    private boolean reconnect;
-    private int responseTotal;
+    protected final HttpHost proxy;
+    protected final Map<String, User> userMap = new HashMap<>();
+    protected final Map<String, Guild> guildMap = new HashMap<>();
+    protected final Map<String, TextChannel> textChannelMap = new HashMap<>();
+    protected final Map<String, VoiceChannel> voiceChannelMap = new HashMap<>();
+    protected final Map<String, PrivateChannel> pmChannelMap = new HashMap<>();
+    protected final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or PrivateChannelId) - Timeout.
+    protected final Map<String, String> offline_pms = new HashMap<>();    //Userid -> channelid
+    protected final Map<Guild, AudioManager> audioManagers = new HashMap<>();
+    protected final boolean audioEnabled;
+    protected final boolean useShutdownHook;
+    protected IEventManager eventManager = new InterfacedEventManager();
+    protected SelfInfo selfInfo = null;
+    protected AccountManager accountManager;
+    protected String authToken = null;
+    protected WebSocketClient client;
+    protected final Requester requester = new Requester(this);
+    protected boolean reconnect;
+    protected int responseTotal;
 
     public JDAImpl(boolean enableAudio, boolean useShutdownHook)
     {
@@ -143,7 +143,7 @@ public class JDAImpl implements JDA
         }
     }
 
-    private boolean validate(String authToken)
+    protected boolean validate(String authToken)
     {
         this.authToken = authToken;
         try
@@ -164,7 +164,7 @@ public class JDAImpl implements JDA
      * @return
      *      The {@link org.json.JSONObject JSONObject} representation of the json in the file.
      */
-    private static JSONObject readJson(Path file)
+    protected static JSONObject readJson(Path file)
     {
         try
         {
@@ -190,7 +190,7 @@ public class JDAImpl implements JDA
      * @param object
      *          The {@link org.json.JSONObject JSONObject} to write to file.
      */
-    private static void writeJson(Path file, JSONObject object)
+    protected static void writeJson(Path file, JSONObject object)
     {
         try
         {
@@ -494,10 +494,10 @@ public class JDAImpl implements JDA
         return manager;
     }
 
-    private static class AsyncCallback implements EventListener
+    protected static class AsyncCallback implements EventListener
     {
-        private final Consumer<GuildManager> cb;
-        private final String id;
+        protected final Consumer<GuildManager> cb;
+        protected final String id;
 
         public AsyncCallback(Consumer<GuildManager> cb, String guildId)
         {

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -75,6 +75,12 @@ public class MessageImpl implements Message
     }
 
     @Override
+    public boolean isMentioned(User user)
+    {
+        return mentionsEveryone() || mentionedUsers.contains(user);
+    }
+
+    @Override
     public List<TextChannel> getMentionedChannels()
     {
         return Collections.unmodifiableList(mentionedChannels);

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -225,7 +225,9 @@ public class MessageImpl implements Message
         if (api.getSelfInfo() != getAuthor())
             throw new UnsupportedOperationException("Attempted to update message that was not sent by this account. You cannot modify other User's messages!");
         Message newMessage = new MessageImpl(getId(), api).setContent(newContent).setChannelId(getChannelId());
-        String ratelimitIdentifier = isPrivate ? channelId : api.getTextChannelById(channelId).getGuild().getId();
+        String ratelimitIdentifier = isPrivate
+                ? PrivateChannelImpl.RATE_LIMIT_IDENTIFIER
+                : api.getTextChannelById(channelId).getGuild().getId();
         TextChannelImpl.AsyncMessageSender.getInstance(api, ratelimitIdentifier).enqueue(newMessage, true, callback);
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -225,7 +225,8 @@ public class MessageImpl implements Message
         if (api.getSelfInfo() != getAuthor())
             throw new UnsupportedOperationException("Attempted to update message that was not sent by this account. You cannot modify other User's messages!");
         Message newMessage = new MessageImpl(getId(), api).setContent(newContent).setChannelId(getChannelId());
-        TextChannelImpl.AsyncMessageSender.getInstance(api).enqueue(newMessage, true, callback);
+        String ratelimitIdentifier = isPrivate ? channelId : api.getTextChannelById(channelId).getGuild().getId();
+        TextChannelImpl.AsyncMessageSender.getInstance(api, ratelimitIdentifier).enqueue(newMessage, true, callback);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -46,6 +46,7 @@ public class MessageImpl implements Message
     private OffsetDateTime editedTime = null;
     private List<User> mentionedUsers = new LinkedList<>();
     private List<TextChannel> mentionedChannels = new LinkedList<>();
+    private List<Role> mentionedRoles = new LinkedList<>();
     private List<Attachment> attachments = new LinkedList<>();
     private List<MessageEmbed> embeds = new LinkedList<>();
 
@@ -77,6 +78,12 @@ public class MessageImpl implements Message
     public List<TextChannel> getMentionedChannels()
     {
         return Collections.unmodifiableList(mentionedChannels);
+    }
+
+    @Override
+    public List<Role> getMentionedRoles()
+    {
+        return Collections.unmodifiableList(mentionedRoles);
     }
 
     @Override
@@ -114,14 +121,31 @@ public class MessageImpl implements Message
     {
         if (subContent == null)
         {
+            Guild g = isPrivate ? null : api.getTextChannelById(channelId).getGuild();
             String tmp = content;
             for (User user : mentionedUsers)
             {
-                tmp = tmp.replace("<@" + user.getId() + '>', '@' + user.getUsername());
+                if (isPrivate)
+                {
+                    tmp = tmp.replace("<@" + user.getId() + '>', '@' + user.getUsername())
+                            .replace("<@!" + user.getId() + '>', '@' + user.getUsername());
+                }
+                else
+                {
+                    String name = g.getNicknameForUser(user);
+                    if (name == null)
+                        name = user.getUsername();
+                    tmp = tmp.replace("<@" + user.getId() + '>', '@' + name)
+                            .replace("<@!" + user.getId() + '>', '@' + name);
+                }
             }
             for (TextChannel mentionedChannel : mentionedChannels)
             {
                 tmp = tmp.replace("<#" + mentionedChannel.getId() + '>', '#' + mentionedChannel.getName());
+            }
+            for (Role mentionedRole : mentionedRoles)
+            {
+                tmp = tmp.replace("<@&" + mentionedRole.getId() + '>', '@' + mentionedRole.getName());
             }
             subContent = tmp;
         }
@@ -220,6 +244,12 @@ public class MessageImpl implements Message
     public MessageImpl setMentionedChannels(List<TextChannel> mentionedChannels)
     {
         this.mentionedChannels = mentionedChannels;
+        return this;
+    }
+
+    public MessageImpl setMentionedRoles(List<Role> mentionedRoles)
+    {
+        this.mentionedRoles = mentionedRoles;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -73,9 +73,9 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public Message sendMessage(Message msg)
     {
-        if (api.getMessageLimit() != null)
+        if (api.getMessageLimit(id) != null)
         {
-            throw new RateLimitedException(api.getMessageLimit() - System.currentTimeMillis());
+            throw new RateLimitedException(api.getMessageLimit(id) - System.currentTimeMillis());
         }
         try
         {
@@ -84,7 +84,7 @@ public class PrivateChannelImpl implements PrivateChannel
             if (response.isRateLimit())
             {
                 long retry_after = response.getObject().getLong("retry_after");
-                api.setMessageTimeout(retry_after);
+                api.setMessageTimeout(id, retry_after);
                 throw new RateLimitedException(retry_after);
             }
             if (!response.isOk())
@@ -110,8 +110,8 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public void sendMessageAsync(Message msg, Consumer<Message> callback)
     {
-        ((MessageImpl) msg).setChannelId(getId());
-        TextChannelImpl.AsyncMessageSender.getInstance(getJDA()).enqueue(msg, false, callback);
+        ((MessageImpl) msg).setChannelId(id);
+        TextChannelImpl.AsyncMessageSender.getInstance(getJDA(), id).enqueue(msg, false, callback);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 public class PrivateChannelImpl implements PrivateChannel
 {
+    public static final String RATE_LIMIT_IDENTIFIER = "GLOBAL_PRIV_CHANNEL_RATELIMIT";
     private final String id;
     private final User user;
     private final JDAImpl api;
@@ -73,9 +74,9 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public Message sendMessage(Message msg)
     {
-        if (api.getMessageLimit(id) != null)
+        if (api.getMessageLimit(RATE_LIMIT_IDENTIFIER) != null)
         {
-            throw new RateLimitedException(api.getMessageLimit(id) - System.currentTimeMillis());
+            throw new RateLimitedException(api.getMessageLimit(RATE_LIMIT_IDENTIFIER) - System.currentTimeMillis());
         }
         try
         {
@@ -84,7 +85,7 @@ public class PrivateChannelImpl implements PrivateChannel
             if (response.isRateLimit())
             {
                 long retry_after = response.getObject().getLong("retry_after");
-                api.setMessageTimeout(id, retry_after);
+                api.setMessageTimeout(RATE_LIMIT_IDENTIFIER, retry_after);
                 throw new RateLimitedException(retry_after);
             }
             if (!response.isOk())
@@ -111,7 +112,7 @@ public class PrivateChannelImpl implements PrivateChannel
     public void sendMessageAsync(Message msg, Consumer<Message> callback)
     {
         ((MessageImpl) msg).setChannelId(id);
-        TextChannelImpl.AsyncMessageSender.getInstance(getJDA(), id).enqueue(msg, false, callback);
+        TextChannelImpl.AsyncMessageSender.getInstance(getJDA(), RATE_LIMIT_IDENTIFIER).enqueue(msg, false, callback);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/RoleImpl.java
@@ -31,7 +31,7 @@ public class RoleImpl implements net.dv8tion.jda.entities.Role
     private int color;
     private int position;
     private int permissions;
-    private boolean managed, grouped;
+    private boolean managed, grouped, mentionable;
     private RoleManager manager = null;
 
     public RoleImpl(String id, Guild guild)
@@ -107,6 +107,18 @@ public class RoleImpl implements net.dv8tion.jda.entities.Role
     }
 
     @Override
+    public boolean isMentionable()
+    {
+        return mentionable;
+    }
+
+    @Override
+    public String getAsMention()
+    {
+        return "<@&" + getId() + '>';
+    }
+
+    @Override
     public synchronized RoleManager getManager()
     {
         if (manager == null)
@@ -147,6 +159,12 @@ public class RoleImpl implements net.dv8tion.jda.entities.Role
     public RoleImpl setGrouped(boolean grouped)
     {
         this.grouped = grouped;
+        return this;
+    }
+
+    public RoleImpl setMentionable(boolean mentionable)
+    {
+        this.mentionable = mentionable;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/RoleImpl.java
@@ -91,7 +91,7 @@ public class RoleImpl implements net.dv8tion.jda.entities.Role
     @Override
     public boolean hasPermission(Permission perm)
     {
-        return ((1 << perm.getOffset()) & permissions) > 0 || ((1 << Permission.MANAGE_ROLES.getOffset()) & permissions) > 0;
+        return ((1 << perm.getOffset()) & permissions) > 0 || ((1 << Permission.ADMINISTRATOR.getOffset()) & permissions) > 0;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -297,7 +297,7 @@ public class TextChannelImpl implements TextChannel
         PermissionOverrideImpl override = new PermissionOverrideImpl(this, user, null);
         //hacky way of putting entity to server without using requester here
         override.setAllow(1 << Permission.MANAGE_PERMISSIONS.getOffset()).setDeny(0);
-        PermissionOverrideManager manager = new PermissionOverrideManager(override);
+        PermissionOverrideManager manager = override.getManager();
         manager.reset(Permission.MANAGE_PERMISSIONS).update();
         return manager;
     }
@@ -316,7 +316,7 @@ public class TextChannelImpl implements TextChannel
         PermissionOverrideImpl override = new PermissionOverrideImpl(this, null, role);
         //hacky way of putting entity to server without using requester here
         override.setAllow(1 << Permission.MANAGE_PERMISSIONS.getOffset()).setDeny(0);
-        PermissionOverrideManager manager = new PermissionOverrideManager(override);
+        PermissionOverrideManager manager = override.getManager();
         manager.reset(Permission.MANAGE_PERMISSIONS).update();
         return manager;
     }

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -138,13 +138,11 @@ public class TextChannelImpl implements TextChannel
     @Override
     public int getPosition()
     {
-        //Subtract 1 to get into 0-index;
-        int i = guild.getTextChannels().size() - 1;
-        for (TextChannel chan : guild.getTextChannels())
+        List<TextChannel> channels = guild.getTextChannels();
+        for (int i = 0; i < channels.size(); i++)
         {
-            if (chan == this)
+            if (channels.get(i) == this)
                 return i;
-            i--;
         }
         throw new RuntimeException("Somehow when determining position we never found the TextChannel in the Guild's channels? wtf?");
     }

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -463,7 +463,7 @@ public class TextChannelImpl implements TextChannel
     {
         private static final Map<JDA, Map<String, AsyncMessageSender>> instances = new HashMap<>();
         private final JDAImpl api;
-        private final String ratelimitIdentifier; //GuildId or PrivateChannelId
+        private final String ratelimitIdentifier; //GuildId or GlobalPrivateChannel
         private Runner runner = null;
         private boolean runnerRunning = false;
         private boolean alive = true;

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.Permission;
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.exceptions.PermissionException;
 import net.dv8tion.jda.exceptions.RateLimitedException;
+import net.dv8tion.jda.exceptions.VerificationLevelException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.managers.ChannelManager;
 import net.dv8tion.jda.managers.PermissionOverrideManager;
@@ -147,7 +148,7 @@ public class TextChannelImpl implements TextChannel
     @Override
     public Message sendMessage(Message msg)
     {
-        ((GuildImpl) guild).checkVerification();
+        checkVerification();
         SelfInfo self = getJDA().getSelfInfo();
         if (!checkPermission(self, Permission.MESSAGE_WRITE))
             throw new PermissionException(Permission.MESSAGE_WRITE);
@@ -188,7 +189,7 @@ public class TextChannelImpl implements TextChannel
     @Override
     public void sendMessageAsync(Message msg, Consumer<Message> callback)
     {
-        ((GuildImpl) guild).checkVerification();
+        checkVerification();
         SelfInfo self = getJDA().getSelfInfo();
         if (!checkPermission(self, Permission.MESSAGE_WRITE))
             throw new PermissionException(Permission.MESSAGE_WRITE);
@@ -200,7 +201,7 @@ public class TextChannelImpl implements TextChannel
     @Override
     public Message sendFile(File file, Message message)
     {
-        ((GuildImpl) guild).checkVerification();
+        checkVerification();
         if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_WRITE))
             throw new PermissionException(Permission.MESSAGE_WRITE);
         if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_ATTACH_FILES))
@@ -247,7 +248,7 @@ public class TextChannelImpl implements TextChannel
     @Override
     public void sendFileAsync(File file, Message message, Consumer<Message> callback)
     {
-        ((GuildImpl) guild).checkVerification();
+        checkVerification();
         if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_WRITE))
             throw new PermissionException(Permission.MESSAGE_WRITE);
         if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_ATTACH_FILES))
@@ -353,6 +354,14 @@ public class TextChannelImpl implements TextChannel
     public Map<Role, PermissionOverride> getRolePermissionOverridesMap()
     {
         return rolePermissionOverrides;
+    }
+
+    private void checkVerification()
+    {
+        if (!((GuildImpl) guild).checkVerification())
+        {
+            throw new VerificationLevelException(guild.getVerificationLevel());
+        }
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -358,7 +358,7 @@ public class TextChannelImpl implements TextChannel
 
     private void checkVerification()
     {
-        if (!((GuildImpl) guild).checkVerification())
+        if (!guild.checkVerification())
         {
             throw new VerificationLevelException(guild.getVerificationLevel());
         }

--- a/src/main/java/net/dv8tion/jda/entities/impl/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/UserImpl.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.entities.impl;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.OnlineStatus;
+import net.dv8tion.jda.entities.Game;
 import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.handle.EntityBuilder;
@@ -31,7 +32,7 @@ public class UserImpl implements User
     private String username;
     private String discriminator;
     private String avatarId;
-    private String gameName = null;
+    private Game game = null;
     private OnlineStatus onlineStatus = OnlineStatus.OFFLINE;
     private PrivateChannel privateChannel = null;
     private boolean isBot = false;
@@ -85,9 +86,9 @@ public class UserImpl implements User
     }
 
     @Override
-    public String getCurrentGame()
+    public Game getCurrentGame()
     {
-        return gameName;
+        return game;
     }
 
     @Override
@@ -142,9 +143,9 @@ public class UserImpl implements User
         return this;
     }
 
-    public UserImpl setCurrentGame(String name)
+    public UserImpl setCurrentGame(Game game)
     {
-        this.gameName = name;
+        this.game = game;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -34,6 +34,8 @@ public class VoiceChannelImpl implements VoiceChannel
     private final Guild guild;
     private String name;
     private int position;
+    private int userLimit;
+    private int bitrate;
     private List<User> connectedUsers = new ArrayList<>();
     private final Map<User, PermissionOverride> userPermissionOverrides = new HashMap<>();
     private final Map<Role, PermissionOverride> rolePermissionOverrides = new HashMap<>();
@@ -185,6 +187,18 @@ public class VoiceChannelImpl implements VoiceChannel
         return InviteUtil.getInvites(this);
     }
 
+    @Override
+    public int getUserLimit()
+    {
+        return userLimit;
+    }
+
+    @Override
+    public int getBitrate()
+    {
+        return bitrate;
+    }
+
     public VoiceChannelImpl setName(String name)
     {
         this.name = name;
@@ -200,6 +214,18 @@ public class VoiceChannelImpl implements VoiceChannel
     public VoiceChannelImpl setUsers(List<User> connectedUsers)
     {
         this.connectedUsers = connectedUsers;
+        return this;
+    }
+
+    public VoiceChannelImpl setUserLimit(int userLimit)
+    {
+        this.userLimit = userLimit;
+        return this;
+    }
+
+    public VoiceChannelImpl setBitrate(int bitrate)
+    {
+        this.bitrate = bitrate;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -106,13 +106,11 @@ public class VoiceChannelImpl implements VoiceChannel
     @Override
     public int getPosition()
     {
-        //Subtract 1 to get into 0-index;
-        int i = guild.getVoiceChannels().size() - 1;
-        for (VoiceChannel chan : guild.getVoiceChannels())
+        List<VoiceChannel> channels = guild.getVoiceChannels();
+        for (int i = 0; i < channels.size(); i++)
         {
-            if (chan == this)
+            if (channels.get(i) == this)
                 return i;
-            i--;
         }
         throw new RuntimeException("Somehow when determining position we never found the VoiceChannel in the Guild's channels? wtf?");
     }

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -141,7 +141,7 @@ public class VoiceChannelImpl implements VoiceChannel
         PermissionOverrideImpl override = new PermissionOverrideImpl(this, user, null);
         //hacky way of putting entity to server without using requester here
         override.setAllow(1 << Permission.MANAGE_PERMISSIONS.getOffset()).setDeny(0);
-        PermissionOverrideManager manager = new PermissionOverrideManager(override);
+        PermissionOverrideManager manager = override.getManager();
         manager.reset(Permission.MANAGE_PERMISSIONS).update();
         return manager;
     }
@@ -160,7 +160,7 @@ public class VoiceChannelImpl implements VoiceChannel
         PermissionOverrideImpl override = new PermissionOverrideImpl(this, null, role);
         //hacky way of putting entity to server without using requester here
         override.setAllow(1 << Permission.MANAGE_PERMISSIONS.getOffset()).setDeny(0);
-        PermissionOverrideManager manager = new PermissionOverrideManager(override);
+        PermissionOverrideManager manager = override.getManager();
         manager.reset(Permission.MANAGE_PERMISSIONS).update();
         return manager;
     }

--- a/src/main/java/net/dv8tion/jda/events/audio/AudioUnableToConnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/AudioUnableToConnectEvent.java
@@ -1,0 +1,35 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events.audio;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.VoiceChannel;
+
+public class AudioUnableToConnectEvent extends GenericAudioEvent
+{
+    protected final VoiceChannel channel;
+
+    public AudioUnableToConnectEvent(JDA api, VoiceChannel channel)
+    {
+        super(api, -1);
+        this.channel = channel;
+    }
+
+    public VoiceChannel getChannel()
+    {
+        return channel;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
@@ -1,0 +1,35 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events.channel.voice;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.VoiceChannel;
+
+public class VoiceChannelUpdateBitrateEvent extends GenericVoiceChannelUpdateEvent
+{
+    protected final int oldBitrate;
+
+    public VoiceChannelUpdateBitrateEvent(JDA api, int responseNumber, VoiceChannel channel, int oldBitrate)
+    {
+        super(api, responseNumber, channel);
+        this.oldBitrate = oldBitrate;
+    }
+
+    public int getOldBitrate()
+    {
+        return oldBitrate;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
@@ -1,0 +1,35 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events.channel.voice;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.VoiceChannel;
+
+public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateEvent
+{
+    protected final int oldUserLimit;
+
+    public VoiceChannelUpdateUserLimitEvent(JDA api, int responseNumber, VoiceChannel channel, int oldUserLimit)
+    {
+        super(api, responseNumber, channel);
+        this.oldUserLimit = oldUserLimit;
+    }
+
+    public int getOldUserLimit()
+    {
+        return oldUserLimit;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildAvailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildAvailableEvent.java
@@ -1,0 +1,28 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.events.guild;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.Guild;
+
+public class GuildAvailableEvent extends GenericGuildEvent
+{
+    public GuildAvailableEvent(JDA api, int responseNumber, Guild guild)
+    {
+        super(api, responseNumber, guild);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildUnavailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildUnavailableEvent.java
@@ -1,0 +1,28 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.events.guild;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.Guild;
+
+public class GuildUnavailableEvent extends GenericGuildEvent
+{
+    public GuildUnavailableEvent(JDA api, int responseNumber, Guild guild)
+    {
+        super(api, responseNumber, guild);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/guild/UnavailableGuildJoinedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/UnavailableGuildJoinedEvent.java
@@ -1,0 +1,36 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.events.guild;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.events.Event;
+
+public class UnavailableGuildJoinedEvent extends Event
+{
+    private final String guildId;
+
+    public UnavailableGuildJoinedEvent(JDA api, int responseNumber, String guildId)
+    {
+        super(api, responseNumber);
+        this.guildId = guildId;
+    }
+
+    public String getGuildId()
+    {
+        return guildId;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberNickChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberNickChangeEvent.java
@@ -1,0 +1,43 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.events.guild.member;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.Guild;
+import net.dv8tion.jda.entities.User;
+
+public class GuildMemberNickChangeEvent extends GenericGuildMemberEvent
+{
+    private final String prevNick, newNick;
+
+    public GuildMemberNickChangeEvent(JDA api, int responseNumber, Guild guild, User user, String prevNick, String newNick)
+    {
+        super(api, responseNumber, guild, user);
+        this.prevNick = prevNick;
+        this.newNick = newNick;
+    }
+
+    public String getPrevNick()
+    {
+        return prevNick;
+    }
+
+    public String getNewNick()
+    {
+        return newNick;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberUnbanEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberUnbanEvent.java
@@ -17,33 +17,13 @@ package net.dv8tion.jda.events.guild.member;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
+import net.dv8tion.jda.entities.User;
 
 public class GuildMemberUnbanEvent extends GenericGuildMemberEvent
 {
-    private final String userId;
-    private final String userName;
-    private final String userDiscriminator;
 
-    public GuildMemberUnbanEvent(JDA api, int responseNumber, Guild guild, String userId, String userName, String userDiscriminator)
+    public GuildMemberUnbanEvent(JDA api, int responseNumber, Guild guild, User user)
     {
-        super(api, responseNumber, guild, null);
-        this.userId = userId;
-        this.userName = userName;
-        this.userDiscriminator = userDiscriminator;
-    }
-
-    public String getUserId()
-    {
-        return userId;
-    }
-
-    public String getUserName()
-    {
-        return userName;
-    }
-
-    public String getUserDiscriminator()
-    {
-        return userDiscriminator;
+        super(api, responseNumber, guild, user);
     }
 }

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleCreateEvent.java
@@ -13,24 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package net.dv8tion.jda.events.guild;
+
+package net.dv8tion.jda.events.guild.role;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.Role;
+import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
-public class GuildRoleDeleteEvent extends GenericGuildEvent
+public class GuildRoleCreateEvent extends GenericGuildEvent
 {
-    private final Role deletedRole;
+    private final Role createdRole;
 
-    public GuildRoleDeleteEvent(JDA api, int responseNumber, Guild guild, Role deletedRole)
+    public GuildRoleCreateEvent(JDA api, int responseNumber, Guild guild, Role createdRole)
     {
         super(api, responseNumber, guild);
-        this.deletedRole = deletedRole;
+        this.createdRole = createdRole;
     }
 
     public Role getRole()
     {
-        return deletedRole;
+        return createdRole;
     }
 }

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleDeleteEvent.java
@@ -13,24 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package net.dv8tion.jda.events.guild;
+
+package net.dv8tion.jda.events.guild.role;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.Role;
+import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
-public class GuildRoleCreateEvent extends GenericGuildEvent
+public class GuildRoleDeleteEvent extends GenericGuildEvent
 {
-    private final Role createdRole;
+    private final Role deletedRole;
 
-    public GuildRoleCreateEvent(JDA api, int responseNumber, Guild guild, Role createdRole)
+    public GuildRoleDeleteEvent(JDA api, int responseNumber, Guild guild, Role deletedRole)
     {
         super(api, responseNumber, guild);
-        this.createdRole = createdRole;
+        this.deletedRole = deletedRole;
     }
 
     public Role getRole()
     {
-        return createdRole;
+        return deletedRole;
     }
 }

--- a/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
@@ -39,6 +39,31 @@ public class MessageReceivedEvent extends Event
         return message.getAuthor();
     }
 
+    /**
+     * Returns the author's nickname in the guild the message was sent in.
+     * Returns null if no nickname is set.
+     *
+     * @return
+     *      Author's nickname in guild or null if unset.
+     */
+    public String getAuthorNick()
+    {
+        return getGuild().getNicknameForUser(getAuthor());
+    }
+
+    /**
+     * Returns the Author's effective name in the guild the message was sent in.
+     * This returns the nickname if set or the author's username if no nick is set.
+     *
+     * @return
+     *      Author's effective name.
+     */
+    public String getAuthorName()
+    {
+        String nickname = getAuthorNick();
+        return nickname == null ? getAuthor().getUsername() : nickname;
+    }
+
     public boolean isPrivate()
     {
         return message.isPrivate();

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GenericGuildMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GenericGuildMessageEvent.java
@@ -40,4 +40,29 @@ public class GenericGuildMessageEvent extends GenericMessageEvent
     {
         return channel.getGuild();
     }
+
+    /**
+     * Returns the author's nickname in the guild the message was sent in.
+     * Returns null if no nickname is set.
+     *
+     * @return
+     *      Author's nickname in guild or null if unset.
+     */
+    public String getAuthorNick()
+    {
+        return getGuild().getNicknameForUser(getAuthor());
+    }
+
+    /**
+     * Returns the Author's effective name in the guild the message was sent in.
+     * This returns the nickname if set or the author's username if no nick is set.
+     *
+     * @return
+     *      Author's effective name.
+     */
+    public String getAuthorName()
+    {
+        String nickname = getAuthorNick();
+        return nickname == null ? getAuthor().getUsername() : nickname;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/events/user/UserGameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserGameUpdateEvent.java
@@ -16,20 +16,21 @@
 package net.dv8tion.jda.events.user;
 
 import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.Game;
 import net.dv8tion.jda.entities.User;
 
 public class UserGameUpdateEvent extends GenericUserEvent
 {
-    private final String previousGameName;
+    private final Game previousGame;
 
-    public UserGameUpdateEvent(JDA api, int responseNumber, User user, String previousGameName)
+    public UserGameUpdateEvent(JDA api, int responseNumber, User user, Game previousGame)
     {
         super(api, responseNumber, user);
-        this.previousGameName = previousGameName;
+        this.previousGame = previousGame;
     }
 
-    public String getPreviousGameId()
+    public Game getPreviousGame()
     {
-        return previousGameName;
+        return previousGame;
     }
 }

--- a/src/main/java/net/dv8tion/jda/exceptions/GuildUnavailableException.java
+++ b/src/main/java/net/dv8tion/jda/exceptions/GuildUnavailableException.java
@@ -19,6 +19,11 @@ public class GuildUnavailableException extends RuntimeException
 {
     public GuildUnavailableException()
     {
-        super("This operation is not possible due to the Guild being temporarily unavailable");
+        this("This operation is not possible due to the Guild being temporarily unavailable");
+    }
+
+    public GuildUnavailableException(String reason)
+    {
+        super(reason);
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
@@ -70,6 +70,7 @@ public class ChannelCreateHandler extends SocketHandler
         {
             throw new IllegalArgumentException("ChannelCreateEvent provided an unregonized channel type.  JSON: " + content);
         }
+        EventCache.get(api).playbackCache(EventCache.Type.CHANNEL, content.getString("id"));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelDeleteHandler.java
@@ -71,7 +71,14 @@ public class ChannelDeleteHandler extends SocketHandler
             {
                 TextChannel channel = api.getChannelMap().remove(content.getString("id"));
                 if (channel == null)
-                    throw new IllegalArgumentException("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                {
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                    return null;
+                }
 
                 guild.getTextChannelsMap().remove(channel.getId());
                 api.getEventManager().handle(
@@ -84,8 +91,14 @@ public class ChannelDeleteHandler extends SocketHandler
             {
                 VoiceChannel channel = guild.getVoiceChannelsMap().remove(content.getString("id"));
                 if (channel == null)
-                    throw new IllegalArgumentException("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
-
+                {
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
+                    {
+                        handle(allContent);
+                    });
+                    EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a channel that doesn't exist! JSON: " + content);
+                    return null;
+                }
                 //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
                 AudioManager manager = api.getAudioManagersMap().get(guild);
                 if (manager != null && manager.isConnected()

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -21,9 +21,7 @@ import net.dv8tion.jda.events.channel.text.TextChannelUpdateNameEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelUpdatePermissionsEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelUpdatePositionEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelUpdateTopicEvent;
-import net.dv8tion.jda.events.channel.voice.VoiceChannelUpdateNameEvent;
-import net.dv8tion.jda.events.channel.voice.VoiceChannelUpdatePermissionsEvent;
-import net.dv8tion.jda.events.channel.voice.VoiceChannelUpdatePositionEvent;
+import net.dv8tion.jda.events.channel.voice.*;
 import net.dv8tion.jda.requests.GuildLock;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -138,6 +136,8 @@ public class ChannelUpdateHandler extends SocketHandler
             case "voice":
             {
                 VoiceChannelImpl channel = (VoiceChannelImpl) api.getVoiceChannelMap().get(content.getString("id"));
+                int userLimit = content.getInt("user_limit");
+                int bitrate = content.getInt("bitrate");
                 if (channel == null)
                 {
                     EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
@@ -165,6 +165,24 @@ public class ChannelUpdateHandler extends SocketHandler
                             new VoiceChannelUpdatePositionEvent(
                                     api, responseNumber,
                                     channel, oldPosition));
+                }
+                if (channel.getUserLimit() != userLimit)
+                {
+                    int oldLimit = channel.getUserLimit();
+                    channel.setUserLimit(userLimit);
+                    api.getEventManager().handle(
+                            new VoiceChannelUpdateUserLimitEvent(
+                                    api, responseNumber,
+                                    channel, oldLimit));
+                }
+                if (channel.getBitrate() != bitrate)
+                {
+                    int oldBitrate = channel.getBitrate();
+                    channel.setBitrate(bitrate);
+                    api.getEventManager().handle(
+                            new VoiceChannelUpdateBitrateEvent(
+                                    api, responseNumber,
+                                    channel, oldBitrate));
                 }
 
                 //Determines if a new PermissionOverride was created or updated.

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -91,9 +91,9 @@ public class ChannelUpdateHandler extends SocketHandler
                                     api, responseNumber,
                                     channel, oldTopic));
                 }
-                if (channel.getPosition() != position)
+                if (channel.getPositionRaw() != position)
                 {
-                    int oldPosition = channel.getPosition();
+                    int oldPosition = channel.getPositionRaw();
                     channel.setPosition(position);
                     api.getEventManager().handle(
                             new TextChannelUpdatePositionEvent(
@@ -157,9 +157,9 @@ public class ChannelUpdateHandler extends SocketHandler
                                     api, responseNumber,
                                     channel, oldName));
                 }
-                if (channel.getPosition() != position)
+                if (channel.getPositionRaw() != position)
                 {
-                    int oldPosition = channel.getPosition();
+                    int oldPosition = channel.getPositionRaw();
                     channel.setPosition(position);
                     api.getEventManager().handle(
                             new VoiceChannelUpdatePositionEvent(

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -277,7 +277,6 @@ public class EntityBuilder
                             "GuildId: " + guildObj.getId() + " UserId: " + user.getId() + " RoleId: " + roleId);
                 }
             }
-            Collections.sort(userRoles.get(user), (r2, r1) -> Integer.compare(r1.getPosition(), r2.getPosition()));
             VoiceStatusImpl voiceStatus = new VoiceStatusImpl(user, guildObj);
             voiceStatus.setServerDeaf(member.getBoolean("deaf"));
             voiceStatus.setServerMute(member.getBoolean("mute"));

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -308,7 +308,14 @@ public class EntityBuilder
                 JSONArray permissionOverwrites = channel.getJSONArray("permission_overwrites");
                 for (int j = 0; j < permissionOverwrites.length(); j++)
                 {
-                    createPermissionOverride(permissionOverwrites.getJSONObject(j), channelObj);
+                    try
+                    {
+                        createPermissionOverride(permissionOverwrites.getJSONObject(j), channelObj);
+                    }
+                    catch (IllegalArgumentException e)
+                    {
+                        WebSocketClient.LOG.warn(e.getMessage() + ". Ignoring PermissionOverride.");
+                    }
                 }
             }
             else

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -51,6 +51,12 @@ public class EntityBuilder
             cachedJdaGuildJsons.put(api, new HashMap<>());
     }
 
+    public void clearCache()
+    {
+        cachedJdaGuildCallbacks.get(api).clear();
+        cachedJdaGuildJsons.get(api).clear();
+    }
+
     public Guild createGuildFirstPass(JSONObject guild, Consumer<Guild> secondPassCallback)
     {
         String id = guild.getString("id");

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -356,7 +356,9 @@ public class EntityBuilder
 
         return channel
                 .setName(json.getString("name"))
-                .setPosition(json.getInt("position"));
+                .setPosition(json.getInt("position"))
+                .setUserLimit(json.getInt("user_limit"))
+                .setBitrate(json.getInt("bitrate"));
     }
 
     public PrivateChannel createPrivateChannel(JSONObject privatechat)

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -114,9 +114,16 @@ public class EntityBuilder
                     //corresponding user to presence not found... ignoring
                     continue;
                 }
+                Game presenceGame = null;
+                if( !presence.isNull("game") && !presence.getJSONObject("game").isNull("name") )
+                {
+                    presenceGame = new GameImpl(presence.getJSONObject("game").get("name").toString(),
+                            presence.getJSONObject("game").isNull("url") ? null : presence.getJSONObject("game").get("url").toString(),
+                            presence.getJSONObject("game").isNull("type") ? Game.GameType.DEFAULT : Game.GameType.fromKey((int) presence.getJSONObject("game").get("type")) );
+                }
                 user
-                        .setCurrentGame(presence.isNull("game") || presence.getJSONObject("game").isNull("name") ? null : presence.getJSONObject("game").get("name").toString())
-                        .setOnlineStatus(OnlineStatus.fromKey(presence.getString("status")));
+                    .setCurrentGame(presenceGame)
+                    .setOnlineStatus(OnlineStatus.fromKey(presence.getString("status")));
             }
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -171,6 +171,7 @@ public class EntityBuilder
             HashMap<String, Consumer<Guild>> cachedGuildCallbacks = cachedJdaGuildCallbacks.get(api);
             cachedGuildJsons.put(id, guild);
             cachedGuildCallbacks.put(id, secondPassCallback);
+            GuildMembersChunkHandler.setExpectedGuildMembers(api, id, guild.getInt("member_count"));
             if (api.getClient().isReady())
             {
                 JSONObject obj = new JSONObject()

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.entities.MessageEmbed.Thumbnail;
 import net.dv8tion.jda.entities.MessageEmbed.VideoInfo;
 import net.dv8tion.jda.entities.impl.*;
 import net.dv8tion.jda.requests.GuildLock;
+import net.dv8tion.jda.requests.WebSocketClient;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -264,7 +265,17 @@ public class EntityBuilder
             for (int j = 0; j < roleArr.length(); j++)
             {
                 String roleId = roleArr.getString(j);
-                userRoles.get(user).add(rolesMap.get(roleId));
+                Role role = rolesMap.get(roleId);
+                if (role != null)
+                {
+                    userRoles.get(user).add(role);
+                }
+                else
+                {
+                    WebSocketClient.LOG.warn("While building the guild users, encountered a user that is assigned a " +
+                            "non-existent role. This is a Discord error, not a JDA error. Ignoring the role. " +
+                            "GuildId: " + guildObj.getId() + " UserId: " + user.getId() + " RoleId: " + roleId);
+                }
             }
             Collections.sort(userRoles.get(user), (r2, r1) -> Integer.compare(r1.getPosition(), r2.getPosition()));
             VoiceStatusImpl voiceStatus = new VoiceStatusImpl(user, guildObj);

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -1,0 +1,97 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.handle;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.utils.SimpleLog;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class EventCache
+{
+    public static final SimpleLog LOG = SimpleLog.getLog("EventCache");
+    private static HashMap<JDA, EventCache> caches = new HashMap<>();
+    private HashMap<Type, HashMap<String, List<Runnable>>> eventCache = new HashMap<>();
+
+    public static EventCache get(JDA jda)
+    {
+        EventCache cache = caches.get(jda);
+        if (cache == null)
+        {
+            cache = new EventCache();
+            caches.put(jda, cache);
+        }
+        return cache;
+    }
+
+    protected void cache(Type type, String triggerId, Runnable handler)
+    {
+        HashMap<String, List<Runnable>> triggerCache = eventCache.get(type);
+        if (triggerCache == null)
+        {
+            triggerCache = new HashMap<>();
+            eventCache.put(type, triggerCache);
+        }
+
+        List<Runnable> items = triggerCache.get(triggerId);
+        if (items == null)
+        {
+            items = new LinkedList<>();
+            triggerCache.put(triggerId, items);
+        }
+
+        items.add(handler);
+    }
+
+    protected void playbackCache(Type type, String triggerId)
+    {
+        List<Runnable> items;
+        try
+        {
+            items = eventCache.get(type).get(triggerId);
+        }
+        catch (NullPointerException e)
+        {
+            //If we encounter an NPE that means something didn't exist.
+            return;
+        }
+
+        if (items != null && !items.isEmpty())
+        {
+            EventCache.LOG.debug("Replaying " + items.size() + " events from the EventCache for a " + type + " with id: " + triggerId);
+            List<Runnable> itemsCopy = new LinkedList<>(items);
+            items.clear();
+            for (Runnable item : itemsCopy)
+            {
+                item.run();
+            }
+        }
+    }
+
+    public void clear()
+    {
+        eventCache.clear();
+    }
+
+    enum Type
+    {
+        USER, GUILD, CHANNEL, ROLE
+    }
+}

--- a/src/main/java/net/dv8tion/jda/handle/GuildJoinHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildJoinHandler.java
@@ -51,6 +51,7 @@ public class GuildJoinHandler extends SocketHandler
                                 new GuildJoinEvent(
                                         api, responseNumber,
                                         guild));
+                        EventCache.get(api).playbackCache(EventCache.Type.GUILD, guild.getId());
                     }
                     else if (!wasAvail)                     //was previously unavailable
                     {

--- a/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.impl.GuildImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.entities.impl.UserImpl;
 import net.dv8tion.jda.events.guild.GuildLeaveEvent;
+import net.dv8tion.jda.events.guild.GuildUnavailableEvent;
 import net.dv8tion.jda.managers.AudioManager;
 import net.dv8tion.jda.requests.GuildLock;
 import org.json.JSONObject;
@@ -49,7 +50,9 @@ public class GuildLeaveHandler extends SocketHandler
         if (content.has("unavailable") && content.getBoolean("unavailable"))
         {
             ((GuildImpl) guild).setAvailable(false);
-            //TODO: Unavailable-event. Sever audio connection when guild becomes unavailable.
+            api.getEventManager().handle(
+                    new GuildUnavailableEvent(api, responseNumber, guild)
+            );
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
@@ -16,9 +16,11 @@
 package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.entities.Guild;
+import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.entities.impl.GuildImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.entities.impl.TextChannelImpl;
 import net.dv8tion.jda.entities.impl.UserImpl;
 import net.dv8tion.jda.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.events.guild.GuildUnavailableEvent;
@@ -85,6 +87,7 @@ public class GuildLeaveHandler extends SocketHandler
         }
 
         api.getGuildMap().remove(guild.getId());
+        TextChannelImpl.AsyncMessageSender.stop(api, guild.getId());
         api.getEventManager().handle(
                 new GuildLeaveEvent(
                         api, responseNumber,

--- a/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
@@ -47,6 +47,9 @@ public class GuildLeaveHandler extends SocketHandler
         }
 
         Guild guild = api.getGuildMap().get(content.getString("id"));
+        AudioManager manager = api.getAudioManagersMap().get(guild);
+        if (manager != null)
+            manager.closeAudioConnection();
         if (content.has("unavailable") && content.getBoolean("unavailable"))
         {
             ((GuildImpl) guild).setAvailable(false);
@@ -56,13 +59,8 @@ public class GuildLeaveHandler extends SocketHandler
             return null;
         }
 
-        //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
-        AudioManager manager = api.getAudioManagersMap().get(guild);
-        if (manager != null && manager.isConnected()
-                && manager.getConnectedChannel().getGuild().getId().equals(guild.getId()))
-        {
-            manager.closeAudioConnection();
-        }
+        if (manager != null)
+            api.getAudioManagersMap().remove(guild);
 
         //cleaning up all users that we do not share a guild with anymore
         List<User> users = guild.getUsers();

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberAddHandler.java
@@ -57,6 +57,7 @@ public class GuildMemberAddHandler extends SocketHandler
                 new GuildMemberJoinEvent(
                         api, responseNumber,
                         guild, user));
+        EventCache.get(api).playbackCache(EventCache.Type.USER, user.getId());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
@@ -52,8 +52,11 @@ public class GuildMemberUpdateHandler extends SocketHandler
 
         if(rolesOld == null)
         {
-            //something is fishy...
-            JDAImpl.LOG.warn("Got role-update for user which is not in guild? " + content.toString());
+            EventCache.get(api).cache(EventCache.Type.USER, userJson.getString("id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.debug("Got role-update for user which is not in guild? " + content.toString());
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
@@ -103,15 +103,18 @@ public class GuildMemberUpdateHandler extends SocketHandler
         {
             Map<User, String> nickMap = guild.getNickMap();
             String prevNick = nickMap.get(user);
-            if (content.isNull("nick") && prevNick != null)
+            if (content.isNull("nick"))
             {
-                nickMap.remove(user);
-                api.getEventManager().handle(
-                        new GuildMemberNickChangeEvent(
-                                api, responseNumber,
-                                guild, user, prevNick, null
-                        )
-                );
+                if (prevNick != null)
+                {
+                    nickMap.remove(user);
+                    api.getEventManager().handle(
+                            new GuildMemberNickChangeEvent(
+                                    api, responseNumber,
+                                    guild, user, prevNick, null
+                            )
+                    );
+                }
             }
             else if (!content.getString("nick").equals(prevNick))
             {

--- a/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMemberUpdateHandler.java
@@ -87,7 +87,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
         {
             rolesOld.addAll(rolesNew);
         }
-        Collections.sort(rolesOld, (r2, r1) -> Integer.compare(r1.getPosition(), r2.getPosition()));
+        Collections.sort(rolesOld, (r1, r2) -> r2.compareTo(r1));
         if (removedRoles.size() > 0)
         {
             api.getEventManager().handle(

--- a/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.utils.DebugUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -50,7 +51,18 @@ public class GuildMembersChunkHandler extends SocketHandler
         }
         if (!lastGuildId.equals(guildId))
         {
-            new EntityBuilder(api).createGuildSecondPass(lastGuildId, memberChunks);
+            try
+            {
+                new EntityBuilder(api).createGuildSecondPass(lastGuildId, memberChunks);
+            }
+            catch (Exception e)
+            {
+                JDAImpl.LOG.warn("Error occured when preforming guild second pass. Current JDA state: ");
+                JDAImpl.LOG.warn("\n" + DebugUtil.fromJDA(api, false, true, false, false, false).toString(4));
+                JDAImpl.LOG.warn("GUILD_MEMEBERS_CHUNK json: \n" + content.toString(4));
+                JDAImpl.LOG.warn("The error: ");
+                throw e;
+            }
 
             lastGuildId = guildId;
             lastGuildIdCache.put(api, guildId);

--- a/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
@@ -23,12 +23,13 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 
 public class GuildMembersChunkHandler extends SocketHandler
 {
-    private static HashMap<JDA, String> lastGuildIdCache = new HashMap<>();
-    private static HashMap<JDA, List<JSONArray>> memberChunksCache = new HashMap<>();
+    private static HashMap<JDA, HashMap<String, Integer>> expectedGuildMembers = new HashMap<>();
+    private static HashMap<JDA, HashMap<String, List<JSONArray>>> memberChunksCache = new HashMap<>();
 
     public GuildMembersChunkHandler(JDAImpl api, int responseNumber)
     {
@@ -38,48 +39,65 @@ public class GuildMembersChunkHandler extends SocketHandler
     @Override
     protected String handleInternally(JSONObject content)
     {
-        String lastGuildId = lastGuildIdCache.get(api);
-        List<JSONArray> memberChunks = memberChunksCache.get(api);
         String guildId = content.getString("guild_id");
-        if (lastGuildId == null)
-        {
-            lastGuildId = guildId;
-            lastGuildIdCache.put(api, guildId);
-
-            memberChunks = new ArrayList<>();
-            memberChunksCache.put(api, memberChunks);
-        }
-        if (!lastGuildId.equals(guildId))
-        {
-            try
-            {
-                new EntityBuilder(api).createGuildSecondPass(lastGuildId, memberChunks);
-            }
-            catch (Exception e)
-            {
-                JDAImpl.LOG.warn("Error occured when preforming guild second pass. Current JDA state: ");
-                JDAImpl.LOG.warn("\n" + DebugUtil.fromJDA(api, false, true, false, false, false).toString(4));
-                JDAImpl.LOG.warn("GUILD_MEMEBERS_CHUNK json: \n" + content.toString(4));
-                JDAImpl.LOG.warn("The error: ");
-                throw e;
-            }
-
-            lastGuildId = guildId;
-            lastGuildIdCache.put(api, guildId);
-
-            memberChunks = new ArrayList<>();
-            memberChunksCache.put(api, memberChunks);
-        }
+        List<JSONArray> memberChunks = memberChunksCache.get(api).get(guildId);
+        Integer expectMemberCount = (Integer) expectedGuildMembers.get(api).get(guildId);
 
         JSONArray members = content.getJSONArray("members");
         JDAImpl.LOG.debug("GUILD_MEMBER_CHUNK for: " + guildId + "\tMembers: " + members.length());
         memberChunks.add(members);
-        if (members.length() != 1000)
+
+        int currentTotal = 0;
+        for (JSONArray arr : memberChunks)
         {
-            new EntityBuilder(api).createGuildSecondPass(lastGuildId, memberChunks);
-            lastGuildIdCache.remove(api);
-            memberChunksCache.remove(api);
+            currentTotal += arr.length();
+        }
+
+        if (currentTotal >= expectMemberCount)
+        {
+            new EntityBuilder(api).createGuildSecondPass(guildId, memberChunks);
+            memberChunksCache.get(api).remove(guildId);
+            expectedGuildMembers.get(api).remove(guildId);
         }
         return null;
+    }
+
+    public static void setExpectedGuildMembers(JDA jda, String guildId, int count)
+    {
+        HashMap<String, Integer> guildMembers = expectedGuildMembers.get(jda);
+        if (guildMembers == null)
+        {
+            guildMembers = new HashMap<>();
+            expectedGuildMembers.put(jda, guildMembers);
+        }
+
+        if (guildMembers.get(guildId) != null)
+            JDAImpl.LOG.warn("Set the count of expected users from GuildMembersChunk even though a value already exists! GuildId: " + guildId);
+
+        guildMembers.put(guildId, count);
+
+        HashMap<String, List<JSONArray>> memberChunks = memberChunksCache.get(jda);
+        if (memberChunks == null)
+        {
+            memberChunks = new HashMap<>();
+            memberChunksCache.put(jda, memberChunks);
+        }
+
+        if (memberChunks.get(guildId) != null)
+            JDAImpl.LOG.warn("Set the memberChunks for MemberChunking for a guild that was already setup for chunking! GuildId: " + guildId);
+
+        memberChunks.put(guildId, new LinkedList<>());
+    }
+
+    public static void modifyExpectedGuildMember(JDA jda, String guildId, int changeAmount)
+    {
+        try
+        {
+            Integer i = (Integer) expectedGuildMembers.get(jda).get(guildId);
+            i += changeAmount;
+            expectedGuildMembers.get(jda).put(guildId, i);
+        }
+        //Ignore. If one of the above things doesn't exist, causing an NPE, then we don't need to worry.
+        catch (NullPointerException e) {}
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildMembersChunkHandler.java
@@ -44,7 +44,7 @@ public class GuildMembersChunkHandler extends SocketHandler
         Integer expectMemberCount = (Integer) expectedGuildMembers.get(api).get(guildId);
 
         JSONArray members = content.getJSONArray("members");
-        JDAImpl.LOG.debug("GUILD_MEMBER_CHUNK for: " + guildId + "\tMembers: " + members.length());
+        JDAImpl.LOG.debug("GUILD_MEMBER_CHUNK for: " + guildId + " \tMembers: " + members.length());
         memberChunks.add(members);
 
         int currentTotal = 0;
@@ -55,6 +55,7 @@ public class GuildMembersChunkHandler extends SocketHandler
 
         if (currentTotal >= expectMemberCount)
         {
+            JDAImpl.LOG.debug("Finished chunking for: " + guildId);
             new EntityBuilder(api).createGuildSecondPass(guildId, memberChunks);
             memberChunksCache.get(api).remove(guildId);
             expectedGuildMembers.get(api).remove(guildId);

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
@@ -44,6 +44,7 @@ public class GuildRoleCreateHandler extends SocketHandler
                 new GuildRoleCreateEvent(
                         api, responseNumber,
                         guild, newRole));
+        EventCache.get(api).playbackCache(EventCache.Type.ROLE, newRole.getId());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleCreateHandler.java
@@ -18,7 +18,7 @@ package net.dv8tion.jda.handle;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.impl.GuildImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
-import net.dv8tion.jda.events.guild.GuildRoleCreateEvent;
+import net.dv8tion.jda.events.guild.role.GuildRoleCreateEvent;
 import net.dv8tion.jda.requests.GuildLock;
 import org.json.JSONObject;
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
@@ -43,8 +43,14 @@ public class GuildRoleDeleteHandler extends SocketHandler
         GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
         Role removedRole = guild.getRolesMap().remove(content.getString("role_id"));
         if (removedRole == null)
-            throw new IllegalArgumentException("GUILD_ROLE_DELETE attempted to delete a role that didn't exist! JSON: " + content);
-
+        {
+            EventCache.get(api).cache(EventCache.Type.ROLE, content.getString("role_id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.debug("GUILD_ROLE_DELETE attempted to delete a role that didn't exist! JSON: " + content);
+            return null;
+        }
         //Now that the role is removed from the Guild, remove it from all users.
         for (List<Role> userRoles : guild.getUserRoles().values())
         {

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleDeleteHandler.java
@@ -18,7 +18,7 @@ package net.dv8tion.jda.handle;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.impl.GuildImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
-import net.dv8tion.jda.events.guild.GuildRoleDeleteEvent;
+import net.dv8tion.jda.events.guild.role.GuildRoleDeleteEvent;
 import net.dv8tion.jda.requests.GuildLock;
 import org.json.JSONObject;
 

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
@@ -39,6 +39,17 @@ public class GuildRoleUpdateHandler extends SocketHandler
 
         JSONObject rolejson = content.getJSONObject("role");
         RoleImpl role = (RoleImpl) ((GuildImpl) api.getGuildMap().get(content.getString("guild_id"))).getRolesMap().get(rolejson.getString("id"));
+
+        if (role == null)
+        {
+            EventCache.get(api).cache(EventCache.Type.ROLE, rolejson.getString("id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.debug("Received a Role Update for a non-existent role! JSON: " + content);
+            return null;
+        }
+
         if (!role.getName().equals(rolejson.getString("name")))
         {
             role.setName(rolejson.getString("name"));

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
@@ -55,7 +55,7 @@ public class GuildRoleUpdateHandler extends SocketHandler
             role.setName(rolejson.getString("name"));
             api.getEventManager().handle(new GuildRoleUpdateNameEvent(api, responseNumber, role));
         }
-        if (role.getPosition() != rolejson.getInt("position"))
+        if (role.getPositionRaw() != rolejson.getInt("position"))
         {
             role.setPosition(rolejson.getInt("position"));
             api.getEventManager().handle(new GuildRoleUpdatePositionEvent(api, responseNumber, role));

--- a/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildRoleUpdateHandler.java
@@ -64,6 +64,9 @@ public class GuildRoleUpdateHandler extends SocketHandler
             role.setGrouped(rolejson.getBoolean("hoist"));
             api.getEventManager().handle(new GuildRoleUpdateGroupedEvent(api, responseNumber, role));
         }
+        if (role.isMentionable() != rolejson.getBoolean("mentionable"))
+            role.setMentionable(rolejson.getBoolean("mentionable"));
+        //TODO: Add event?
         api.getEventManager().handle(new GuildRoleUpdateEvent(api, responseNumber, role));
         return null;
     }

--- a/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
@@ -65,7 +65,14 @@ public class MessageEmbedHandler extends SocketHandler
         {
             PrivateChannel privChannel = api.getPmChannelMap().get(channelId);
             if (privChannel == null)
-                throw new IllegalArgumentException("Unrecognized Channel Id! JSON: " + content);
+            {
+                EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () ->
+                {
+                    handle(allContent);
+                });
+                EventCache.LOG.debug("Got unrecognized Channel Id for MessageEmbed! JSON: " + content);
+                return null;
+            }
             api.getEventManager().handle(
                     new PrivateMessageEmbedEvent(
                             api, responseNumber,

--- a/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
@@ -41,7 +41,21 @@ public class MessageReceivedHandler extends SocketHandler
     @Override
     protected String handleInternally(JSONObject content)
     {
-        Message message = new EntityBuilder(api).createMessage(content);
+        Message message;
+        try
+        {
+            message = new EntityBuilder(api).createMessage(content);
+        }
+        catch (IllegalArgumentException e)
+        {
+            EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
+            {
+                handle(allContent);
+            });
+            EventCache.LOG.debug(e.getMessage());
+            return null;
+        }
+
         if (!message.isPrivate())
         {
             TextChannel channel = api.getChannelMap().get(message.getChannelId());

--- a/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
@@ -49,7 +49,11 @@ public class PresenceUpdateHandler extends SocketHandler
 
         if (user == null)
         {
-            //User for update doesn't exist, ignoring
+            //This is basically only received when a user has left a guild. Discord doesn't always send events
+            // in order, so sometimes we get the presence updated after the GuildMemberLeave event has been received
+            // thus there is no user which to apply a presence update to.
+            //We don't cache this event because it is completely unneeded, furthermore it can (and probably will)
+            // cause problems if the user rejoins the guild.
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/PresenceUpdateHandler.java
@@ -16,6 +16,8 @@
 package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.OnlineStatus;
+import net.dv8tion.jda.entities.Game;
+import net.dv8tion.jda.entities.impl.GameImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.entities.impl.UserImpl;
 import net.dv8tion.jda.events.user.*;
@@ -85,8 +87,16 @@ public class PresenceUpdateHandler extends SocketHandler
             }
         }
 
-        String gameName = (content.isNull("game") || content.getJSONObject("game").isNull("name"))
-                ? null : content.getJSONObject("game").get("name").toString();
+        String gameName = null;
+        String gameUrl = null;
+        Game.GameType type = null;
+        if ( !content.isNull("game") && !content.getJSONObject("game").isNull("name") )
+        {
+            gameName = content.getJSONObject("game").get("name").toString();
+            gameUrl = ( content.getJSONObject("game").isNull("url") ? null : content.getJSONObject("game").get("url").toString() );
+            type = (content.getJSONObject("game").isNull("type") ? Game.GameType.DEFAULT : Game.GameType.fromKey((int)content.getJSONObject("game").get("type")));
+        }
+        Game nextGame = ( gameName == null ? null : new GameImpl(gameName, gameUrl, type));
         OnlineStatus status = OnlineStatus.fromKey(content.getString("status"));
 
         if (!user.getOnlineStatus().equals(status))
@@ -98,14 +108,14 @@ public class PresenceUpdateHandler extends SocketHandler
                             api, responseNumber,
                             user, oldStatus));
         }
-        if (!StringUtils.equals(user.getCurrentGame(), gameName))
+        if(user.getCurrentGame() == null ? nextGame != null : !user.getCurrentGame().equals(nextGame))
         {
-            String oldGameName = user.getCurrentGame();
-            user.setCurrentGame(gameName);
+            Game oldGame = user.getCurrentGame();
+            user.setCurrentGame(nextGame);
             api.getEventManager().handle(
                     new UserGameUpdateEvent(
                             api, responseNumber,
-                            user, oldGameName));
+                            user, oldGame));
         }
         api.getEventManager().handle(
                 new GenericUserEvent(

--- a/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
@@ -175,6 +175,6 @@ public class ReadyHandler extends SocketHandler
                     );
             api.getClient().send(obj.toString());
         }
-        chunkIds.clear();
+        chunkIds.get(api).clear();
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.OnlineStatus;
+import net.dv8tion.jda.entities.Game;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import org.json.JSONArray;
@@ -45,7 +46,7 @@ public class ReadyHandler extends SocketHandler
     @Override
     protected String handleInternally(final JSONObject content)
     {
-        String oldGame = null;
+        Game oldGame = null;
         OnlineStatus oldStatus = null;
 
         if (api.getSelfInfo() != null)
@@ -57,9 +58,19 @@ public class ReadyHandler extends SocketHandler
         builder.createSelfInfo(content.getJSONObject("user"));
 
         if (oldGame != null)
-            api.getAccountManager().setGame(oldGame);
+        {
+            if (oldGame.getType() == Game.GameType.DEFAULT)
+            {
+                api.getAccountManager().setGame(oldGame.getName());
+            } else
+            {
+                api.getAccountManager().setStreaming(oldGame.getName(), oldGame.getUrl());
+            }
+        }
         if (oldStatus != null && oldStatus.equals(OnlineStatus.AWAY))
+        {
             api.getAccountManager().setIdle(true);
+        }
 
         JSONArray guilds = content.getJSONArray("guilds");
         if (guilds.length() == 0)

--- a/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
@@ -116,6 +116,23 @@ public class ReadyHandler extends SocketHandler
         }
     }
 
+    public void finishReady(JSONObject content)
+    {
+        JSONArray priv_chats = content.getJSONArray("private_channels");
+        for (int i = 0; i < priv_chats.length(); i++)
+        {
+            builder.createPrivateChannel(priv_chats.getJSONObject(i));
+        }
+        api.getClient().ready();
+    }
+
+    public void clearCache()
+    {
+        guildIds.get(api).clear();
+        chunkIds.get(api).clear();
+        cachedJson.remove(api);
+    }
+
     private void sendChunks()
     {
         Iterator<String> iterator = chunkIds.get(api).iterator();
@@ -147,15 +164,6 @@ public class ReadyHandler extends SocketHandler
                     );
             api.getClient().send(obj.toString());
         }
-    }
-
-    public void finishReady(JSONObject content)
-    {
-        JSONArray priv_chats = content.getJSONArray("private_channels");
-        for (int i = 0; i < priv_chats.length(); i++)
-        {
-            builder.createPrivateChannel(priv_chats.getJSONObject(i));
-        }
-        api.getClient().ready();
+        chunkIds.clear();
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/SocketHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/SocketHandler.java
@@ -23,6 +23,7 @@ public abstract class SocketHandler
 {
     protected final JDAImpl api;
     protected final int responseNumber;
+    protected JSONObject allContent;
 
     public SocketHandler(JDAImpl api, int responseNumber)
     {
@@ -33,6 +34,7 @@ public abstract class SocketHandler
 
     public final void handle(JSONObject o)
     {
+        this.allContent = o;
         String guildId = handleInternally(o.getJSONObject("d"));
         if (guildId != null)
         {

--- a/src/main/java/net/dv8tion/jda/hooks/AnnotatedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/AnnotatedEventManager.java
@@ -20,10 +20,7 @@ import net.dv8tion.jda.events.Event;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class AnnotatedEventManager implements IEventManager
 {
@@ -46,6 +43,12 @@ public class AnnotatedEventManager implements IEventManager
         {
             updateMethods();
         }
+    }
+
+    @Override
+    public List<Object> getRegisteredListeners()
+    {
+        return Collections.unmodifiableList(new LinkedList<>(listeners));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/hooks/IEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/IEventManager.java
@@ -17,6 +17,8 @@ package net.dv8tion.jda.hooks;
 
 import net.dv8tion.jda.events.Event;
 
+import java.util.List;
+
 public interface IEventManager
 {
     void register(Object listener);
@@ -24,4 +26,6 @@ public interface IEventManager
     void unregister(Object listener);
 
     void handle(Event event);
+
+    List<Object> getRegisteredListeners();
 }

--- a/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.hooks;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.Event;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -44,6 +45,12 @@ public class InterfacedEventManager implements IEventManager
     public void unregister(Object listener)
     {
         listeners.remove(listener);
+    }
+
+    @Override
+    public List<Object> getRegisteredListeners()
+    {
+        return Collections.unmodifiableList(listeners);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -95,6 +95,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildMemberUnban(GuildMemberUnbanEvent event) {}
     public void onGuildMemberRoleAdd(GuildMemberRoleAddEvent event) {}
     public void onGuildMemberRoleRemove(GuildMemberRoleRemoveEvent event) {}
+    public void onGuildMemberNickChange(GuildMemberNickChangeEvent event) {}
     public void onGuildRoleCreate(GuildRoleCreateEvent event) {}
     public void onGuildRoleDelete(GuildRoleDeleteEvent event) {}
 
@@ -253,6 +254,8 @@ public abstract class ListenerAdapter implements EventListener
             onGuildMemberRoleAdd((GuildMemberRoleAddEvent) event);
         else if (event instanceof GuildMemberRoleRemoveEvent)
             onGuildMemberRoleRemove((GuildMemberRoleRemoveEvent) event);
+        else if (event instanceof GuildMemberNickChangeEvent)
+            onGuildMemberNickChange((GuildMemberNickChangeEvent) event);
         else if (event instanceof GuildRoleCreateEvent)
             onGuildRoleCreate((GuildRoleCreateEvent) event);
         else if (event instanceof GuildRoleDeleteEvent)

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -120,6 +120,7 @@ public abstract class ListenerAdapter implements EventListener
     //Audio System Events
     public void onAudioConnect(AudioConnectEvent event) {}
     public void onAudioDisconnect(AudioDisconnectEvent event) {}
+    public void onAudioUnableToConnect(AudioUnableToConnectEvent event) {}
     public void onAudioTimeout(AudioTimeoutEvent event) {}
     public void onAudioRegionChange(AudioRegionChangeEvent event) {}
 
@@ -292,6 +293,8 @@ public abstract class ListenerAdapter implements EventListener
             onAudioConnect((AudioConnectEvent) event);
         else if (event instanceof AudioDisconnectEvent)
             onAudioDisconnect((AudioDisconnectEvent) event);
+        else if (event instanceof AudioUnableToConnectEvent)
+            onAudioUnableToConnect((AudioUnableToConnectEvent) event);
         else if (event instanceof AudioTimeoutEvent)
             onAudioTimeout((AudioTimeoutEvent) event);
         else if (event instanceof AudioRegionChangeEvent)

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -76,6 +76,8 @@ public abstract class ListenerAdapter implements EventListener
     public void onVoiceChannelDelete(VoiceChannelDeleteEvent event) {}
     public void onVoiceChannelUpdateName(VoiceChannelUpdateNameEvent event) {}
     public void onVoiceChannelUpdatePosition(VoiceChannelUpdatePositionEvent event) {}
+    public void onVoiceChannelUpdateUserLimit(VoiceChannelUpdateUserLimitEvent event) {}
+    public void onVoiceChannelUpdateBitrate(VoiceChannelUpdateBitrateEvent event) {}
     public void onVoiceChannelUpdatePermissions(VoiceChannelUpdatePermissionsEvent event) {}
     public void onVoiceChannelCreate(VoiceChannelCreateEvent event) {}
 
@@ -221,6 +223,10 @@ public abstract class ListenerAdapter implements EventListener
             onVoiceChannelUpdateName((VoiceChannelUpdateNameEvent) event);
         else if (event instanceof VoiceChannelUpdatePositionEvent)
             onVoiceChannelUpdatePosition((VoiceChannelUpdatePositionEvent) event);
+        else if (event instanceof VoiceChannelUpdateUserLimitEvent)
+            onVoiceChannelUpdateUserLimit((VoiceChannelUpdateUserLimitEvent) event);
+        else if (event instanceof VoiceChannelUpdateBitrateEvent)
+            onVoiceChannelUpdateBitrate((VoiceChannelUpdateBitrateEvent) event);
         else if (event instanceof VoiceChannelUpdatePermissionsEvent)
             onVoiceChannelUpdatePermissions((VoiceChannelUpdatePermissionsEvent) event);
         else if (event instanceof VoiceChannelDeleteEvent)

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -84,8 +84,11 @@ public abstract class ListenerAdapter implements EventListener
 
     //Guild Events
     public void onGuildJoin(GuildJoinEvent event) {}
+    public void onUnavailGuildJoined(UnavailableGuildJoinedEvent event) {}
     public void onGuildUpdate(GuildUpdateEvent event) {}
     public void onGuildLeave(GuildLeaveEvent event) {}
+    public void onGuildAvailable(GuildAvailableEvent event) {}
+    public void onGuildUnavailable(GuildUnavailableEvent event) {}
     public void onGuildMemberJoin(GuildMemberJoinEvent event) {}
     public void onGuildMemberLeave(GuildMemberLeaveEvent event) {}
     public void onGuildMemberBan(GuildMemberBanEvent event) {}
@@ -228,10 +231,16 @@ public abstract class ListenerAdapter implements EventListener
         //Guild Events
         else if (event instanceof GuildJoinEvent)
             onGuildJoin((GuildJoinEvent) event);
+        else if (event instanceof UnavailableGuildJoinedEvent)
+            onUnavailGuildJoined((UnavailableGuildJoinedEvent) event);
         else if (event instanceof GuildUpdateEvent)
             onGuildUpdate((GuildUpdateEvent) event);
         else if (event instanceof GuildLeaveEvent)
             onGuildLeave((GuildLeaveEvent) event);
+        else if (event instanceof GuildAvailableEvent)
+            onGuildAvailable((GuildAvailableEvent) event);
+        else if (event instanceof GuildUnavailableEvent)
+            onGuildUnavailable((GuildUnavailableEvent) event);
         else if (event instanceof GuildMemberJoinEvent)
             onGuildMemberJoin((GuildMemberJoinEvent) event);
         else if (event instanceof GuildMemberBanEvent)

--- a/src/main/java/net/dv8tion/jda/managers/AccountManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/AccountManager.java
@@ -33,10 +33,10 @@ import org.json.JSONObject;
 public class AccountManager
 {
 
-    private AvatarUtil.Avatar avatar = null;
-    private String username = null;
+    protected AvatarUtil.Avatar avatar = null;
+    protected String username = null;
 
-    private final JDAImpl api;
+    protected final JDAImpl api;
 
     public AccountManager(JDAImpl api)
     {
@@ -179,7 +179,7 @@ public class AccountManager
             this.username = null;
     }
 
-    private void updateStatusAndGame()
+    protected void updateStatusAndGame()
     {
         SelfInfo selfInfo = api.getSelfInfo();
         JSONObject game = null;

--- a/src/main/java/net/dv8tion/jda/managers/AccountManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/AccountManager.java
@@ -16,7 +16,9 @@
 package net.dv8tion.jda.managers;
 
 import net.dv8tion.jda.OnlineStatus;
+import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.SelfInfo;
+import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.entities.impl.SelfInfoImpl;
 import net.dv8tion.jda.requests.Requester;
@@ -97,6 +99,29 @@ public class AccountManager
     {
         ((SelfInfoImpl) api.getSelfInfo()).setOnlineStatus(idle ? OnlineStatus.AWAY : OnlineStatus.ONLINE);
         updateStatusAndGame();
+    }
+
+    /**
+     * Changes this user's nickname in given guild.
+     * The nickname is visible to all users of the guild.
+     * This requires the correct Permissions to perform
+     * (either {@link net.dv8tion.jda.Permission#NICKNAME_MANAGE NICKNAME_MANAGE} or
+     * {@link net.dv8tion.jda.Permission#NICKNAME_CHANGE NICKNAME_CHANGE}).
+     *
+     * This change will be applied <b>immediately</b>
+     *
+     * @param guild
+     *      The guild where the nickname should be changed.
+     * @param nickname
+     *      The new nickname of this user, or null/"" to reset
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see net.dv8tion.jda.managers.GuildManager#setNickname(User, String)
+     *      for more details
+     */
+    public void setNickname(Guild guild, String nickname)
+    {
+        guild.getManager().setNickname(api.getSelfInfo(), nickname);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/managers/ChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/ChannelManager.java
@@ -173,7 +173,7 @@ public class ChannelManager
             index++;
         }
         //If the channel was moved to the very bottom, this will make sure it is properly handled.
-        if (!newPositions.containsKey(newPosition))
+        if (!newPositions.containsValue(channel))
             newPositions.put(newPosition, channel);
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -570,7 +570,16 @@ public class GuildManager
      */
     public void kick(User user)
     {
-        kick(user.getId());
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+        checkPermission(Permission.KICK_MEMBERS);
+        if(!PermissionUtil.canKick(guild.getJDA().getSelfInfo(), user, guild))
+            throw new PermissionException("You can't kick requested user due to him having equal/higher perms");
+
+        ((JDAImpl) guild.getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "guilds/"
+                + guild.getId() + "/members/" + user.getId());
     }
 
     /**
@@ -587,14 +596,9 @@ public class GuildManager
      */
     public void kick(String userId)
     {
-        if (!guild.isAvailable())
-        {
-            throw new GuildUnavailableException();
-        }
-        checkPermission(Permission.KICK_MEMBERS);
-
-        ((JDAImpl) guild.getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "guilds/"
-                + guild.getId() + "/members/" + userId);
+        User user = guild.getJDA().getUserById(userId);
+        if(user != null)
+            kick(user);
     }
 
     /**
@@ -615,7 +619,16 @@ public class GuildManager
      */
     public void ban(User user, int delDays)
     {
-        ban(user.getId(), delDays);
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+        checkPermission(Permission.BAN_MEMBERS);
+        if(!PermissionUtil.canBan(guild.getJDA().getSelfInfo(), user, guild))
+            throw new PermissionException("You can't ban requested user due to him having equal/higher perms");
+
+        ((JDAImpl) guild.getJDA()).getRequester().put(Requester.DISCORD_API_PREFIX + "guilds/"
+                + guild.getId() + "/bans/" + user.getId() + (delDays > 0 ? "?delete-message-days=" + delDays : ""), new JSONObject());
     }
 
     /**
@@ -636,14 +649,9 @@ public class GuildManager
      */
     public void ban(String userId, int delDays)
     {
-        if (!guild.isAvailable())
-        {
-            throw new GuildUnavailableException();
-        }
-        checkPermission(Permission.BAN_MEMBERS);
-
-        ((JDAImpl) guild.getJDA()).getRequester().put(Requester.DISCORD_API_PREFIX + "guilds/"
-                + guild.getId() + "/bans/" + userId + (delDays > 0 ? "?delete-message-days=" + delDays : ""), new JSONObject());
+        User user = guild.getJDA().getUserById(userId);
+        if(user != null)
+            ban(user, delDays);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -506,9 +506,11 @@ public class GuildManager
         if (nickname == null)
             nickname = "";
 
+        String url = Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/"
+                + (user == guild.getJDA().getSelfInfo() ? "@me/nick" : user.getId());
+
         ((JDAImpl) guild.getJDA()).getRequester()
-                .patch(Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/" + user.getId(),
-                        new JSONObject().put("nick", nickname));
+                .patch(url, new JSONObject().put("nick", nickname));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -619,7 +619,7 @@ public class GuildManager
     }
 
     /**
-     * Bans the {@link net.dv8tion.jda.entities.User User} specified by the userId nd deletes messages sent by the user
+     * Bans the {@link net.dv8tion.jda.entities.User User} specified by the userId and deletes messages sent by the user
      * based on the amount of delDays.<br>
      * If you wish to ban a user without deleting any messages, provide delDays with a value of 0.
      * This change will be applied immediately.

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -297,7 +297,6 @@ public class GuildManager
             throw new GuildUnavailableException();
         }
         checkPermission(Permission.MANAGE_ROLES);
-        checkPosition(user);
         for (Role role : roles)
         {
             checkPosition(role);
@@ -359,8 +358,10 @@ public class GuildManager
             throw new GuildUnavailableException();
         }
         checkPermission(Permission.MANAGE_ROLES);
-        checkPosition(user);
-        //we automatically are above all roles that are being removed (due to users highest role being lower than ours)
+        for (Role role : roles)
+        {
+            checkPosition(role);
+        }
 
         Set<Role> addRoles = addedRoles.get(user);
         if (addRoles == null)

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -473,6 +473,45 @@ public class GuildManager
     }
 
     /**
+     * Changes a user's nickname in this guild.
+     * The nickname is visible to all users of this guild.
+     * This requires the correct Permissions to perform
+     * ({@link net.dv8tion.jda.Permission#NICKNAME_MANAGE NICKNAME_MANAGE} for others+self and
+     * {@link net.dv8tion.jda.Permission#NICKNAME_CHANGE NICKNAME_CHANGE} for only self).
+     *
+     * @param user
+     *      The user for which the nickname should be changed.
+     * @param nickname
+     *      The new nickname of the user, or null/"" to reset
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     */
+    public void setNickname(User user, String nickname)
+    {
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+
+        if(user == guild.getJDA().getSelfInfo())
+        {
+            if(!PermissionUtil.checkPermission(user, Permission.NICKNAME_CHANGE, guild) && !PermissionUtil.checkPermission(user, Permission.NICKNAME_MANAGE, guild))
+                throw new PermissionException(Permission.NICKNAME_CHANGE, "You neither have NICKNAME_CHANGE nor NICKNAME_MANAGE permission!");
+        }
+        else
+        {
+            checkPermission(Permission.NICKNAME_MANAGE);
+        }
+
+        if (nickname == null)
+            nickname = "";
+
+        ((JDAImpl) guild.getJDA()).getRequester()
+                .patch(Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/" + user.getId(),
+                        new JSONObject().put("nick", nickname));
+    }
+
+    /**
      * Used to move a {@link net.dv8tion.jda.entities.User User} from one {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel}
      * to another {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel}.<br>
      * As a note, you cannot move a User that isn't already in a VoiceChannel. Also they must be in a VoiceChannel

--- a/src/main/java/net/dv8tion/jda/managers/PermissionOverrideManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/PermissionOverrideManager.java
@@ -36,10 +36,10 @@ public class PermissionOverrideManager
      */
     public PermissionOverrideManager(PermissionOverride override)
     {
-        checkPermission(Permission.MANAGE_PERMISSIONS);
         this.override = override;
         this.allow = override.getAllowedRaw();
         this.deny = override.getDeniedRaw();
+        checkPermission(Permission.MANAGE_PERMISSIONS);
     }
 
     //TODO: find a good system for this

--- a/src/main/java/net/dv8tion/jda/managers/PermissionOverrideManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/PermissionOverrideManager.java
@@ -36,15 +36,13 @@ public class PermissionOverrideManager
      */
     public PermissionOverrideManager(PermissionOverride override)
     {
-        if (!override.getChannel().checkPermission(override.getJDA().getSelfInfo(), Permission.MANAGE_PERMISSIONS))
-        {
-            throw new PermissionException(Permission.MANAGE_PERMISSIONS);
-        }
+        checkPermission(Permission.MANAGE_PERMISSIONS);
         this.override = override;
         this.allow = override.getAllowedRaw();
         this.deny = override.getDeniedRaw();
     }
 
+    //TODO: find a good system for this
     /**
      * Sets this Overrides allow/deny flags according to given PermissionOverride (copy behaviour)
      *
@@ -58,9 +56,10 @@ public class PermissionOverrideManager
      */
     public PermissionOverrideManager overwrite(PermissionOverride overwrite)
     {
-        this.allow = overwrite.getAllowedRaw();
-        this.deny = overwrite.getDeniedRaw();
-        return this;
+        throw new UnsupportedOperationException("Method temporarily disabled");
+//        this.allow = overwrite.getAllowedRaw();
+//        this.deny = overwrite.getDeniedRaw();
+//        return this;
     }
 
     /**
@@ -76,6 +75,10 @@ public class PermissionOverrideManager
      */
     public PermissionOverrideManager grant(Permission... perms)
     {
+        for (Permission perm : perms)
+        {
+            checkPermission(perm);
+        }
         for (Permission perm : perms)
         {
             allow = allow | (1<<perm.getOffset());
@@ -99,6 +102,10 @@ public class PermissionOverrideManager
     {
         for (Permission perm : perms)
         {
+            checkPermission(perm);
+        }
+        for (Permission perm : perms)
+        {
             deny = deny | (1<<perm.getOffset());
         }
         allow = allow & (~deny);
@@ -119,6 +126,10 @@ public class PermissionOverrideManager
      */
     public PermissionOverrideManager reset(Permission... perms)
     {
+        for (Permission perm : perms)
+        {
+            checkPermission(perm);
+        }
         for (Permission perm : perms)
         {
             allow = allow & (~(1 << perm.getOffset()));
@@ -163,5 +174,11 @@ public class PermissionOverrideManager
                                 .put("deny", deny)
                                 .put("id", targetId)
                                 .put("type", override.isRoleOverride() ? "role" : "member"));
+    }
+
+    private void checkPermission(Permission permission)
+    {
+        if(!override.getChannel().checkPermission(override.getJDA().getSelfInfo(), permission))
+            throw new PermissionException(permission);
     }
 }

--- a/src/main/java/net/dv8tion/jda/managers/RoleManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/RoleManager.java
@@ -22,12 +22,9 @@ import net.dv8tion.jda.exceptions.PermissionException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.requests.Requester;
 import net.dv8tion.jda.utils.PermissionUtil;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.List;
 
 public class RoleManager
 {
@@ -67,6 +64,7 @@ public class RoleManager
     public RoleManager setName(String name)
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
 
         if (role.getName().equals(name))
         {
@@ -92,6 +90,7 @@ public class RoleManager
     public RoleManager setColor(int color)
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
 
         if (color == role.getColor() || color < 0)
         {
@@ -116,6 +115,8 @@ public class RoleManager
      */
     public RoleManager setColor(Color color)
     {
+        checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
         return setColor(color == null ? -1 : color.getRGB() & 0xFFFFFF);
     }
 
@@ -132,6 +133,7 @@ public class RoleManager
     public RoleManager setGrouped(Boolean group)
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
 
         if (group == null || group == role.isGrouped())
         {
@@ -155,20 +157,22 @@ public class RoleManager
      */
     public RoleManager move(int offset)
     {
-        checkPermission(Permission.MANAGE_ROLES);
-
-        List<Role> newOrder = new ArrayList<>();
-        role.getGuild().getRoles().stream().filter(r -> r != role && r != role.getGuild().getPublicRole())
-                .sorted((c1, c2) -> Integer.compare(c1.getPosition(), c2.getPosition())).forEachOrdered(newOrder::add);
-        int pos = Math.min(0, Math.max(newOrder.size(), role.getPosition() + offset));
-        newOrder.add(pos, role);
-        JSONArray arr = new JSONArray();
-        for (int i = 0; i < newOrder.size(); i++)
-        {
-            arr.put(new JSONObject().put("position", i + 1).put("id", newOrder.get(i).getId()));
-        }
-        ((JDAImpl) role.getJDA()).getRequester().patch(Requester.DISCORD_API_PREFIX + "guilds/" + role.getGuild().getId() + "/roles", arr);
-        return this;
+        throw new UnsupportedOperationException("This is temporarily disabled!");
+//        checkPermission(Permission.MANAGE_ROLES);
+//
+//        //TODO: FIX THIS (roles are now no longer 1 apart from each other position-wise)
+//        List<Role> newOrder = new ArrayList<>();
+//        role.getGuild().getRoles().stream().filter(r -> r != role && r != role.getGuild().getPublicRole())
+//                .sorted((c1, c2) -> Integer.compare(c1.getPosition(), c2.getPosition())).forEachOrdered(newOrder::add);
+//        int pos = Math.min(0, Math.max(newOrder.size(), role.getPosition() + offset));
+//        newOrder.add(pos, role);
+//        JSONArray arr = new JSONArray();
+//        for (int i = 0; i < newOrder.size(); i++)
+//        {
+//            arr.put(new JSONObject().put("position", i + 1).put("id", newOrder.get(i).getId()));
+//        }
+//        ((JDAImpl) role.getJDA()).getRequester().patch(Requester.DISCORD_API_PREFIX + "guilds/" + role.getGuild().getId() + "/roles", arr);
+//        return this;
     }
 
     /**
@@ -184,6 +188,12 @@ public class RoleManager
     public RoleManager give(Permission... perms)
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
+        //we need to have all perms ourself
+        for (Permission perm : perms)
+        {
+            checkPermission(perm);
+        }
 
         for (Permission perm : perms)
         {
@@ -205,6 +215,11 @@ public class RoleManager
     public RoleManager revoke(Permission... perms)
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
+        for (Permission perm : perms)
+        {
+            checkPermission(perm);
+        }
 
         for (Permission perm : perms)
         {
@@ -229,6 +244,7 @@ public class RoleManager
     public void update()
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
 
         JSONObject frame = getFrame();
         if(name != null)
@@ -247,6 +263,7 @@ public class RoleManager
     public void delete()
     {
         checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
 
         ((JDAImpl) role.getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "guilds/" + role.getGuild().getId() + "/roles/" + role.getId());
     }
@@ -275,5 +292,11 @@ public class RoleManager
     {
         if (!PermissionUtil.checkPermission(role.getJDA().getSelfInfo(), perm, role.getGuild()))
             throw new PermissionException(perm);
+    }
+
+    private void checkPosition()
+    {
+        if(!PermissionUtil.canInteract(role.getJDA().getSelfInfo(), role))
+            throw new PermissionException("Can't modify role >= highest self-role");
     }
 }

--- a/src/main/java/net/dv8tion/jda/managers/RoleManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/RoleManager.java
@@ -22,9 +22,13 @@ import net.dv8tion.jda.exceptions.PermissionException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.requests.Requester;
 import net.dv8tion.jda.utils.PermissionUtil;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.awt.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class RoleManager
 {
@@ -150,29 +154,63 @@ public class RoleManager
      * Moves this Role up or down in the list of Roles (changing position attribute)
      * This change takes effect immediately!
      *
-     * @param offset
+     * @param newPosition
      *      the amount of positions to move up (offset &lt; 0) or down (offset &gt; 0)
      * @return
      *      this
      */
-    public RoleManager move(int offset)
+    public RoleManager move(int newPosition)
     {
-        throw new UnsupportedOperationException("This is temporarily disabled!");
-//        checkPermission(Permission.MANAGE_ROLES);
-//
-//        //TODO: FIX THIS (roles are now no longer 1 apart from each other position-wise)
-//        List<Role> newOrder = new ArrayList<>();
-//        role.getGuild().getRoles().stream().filter(r -> r != role && r != role.getGuild().getPublicRole())
-//                .sorted((c1, c2) -> Integer.compare(c1.getPosition(), c2.getPosition())).forEachOrdered(newOrder::add);
-//        int pos = Math.min(0, Math.max(newOrder.size(), role.getPosition() + offset));
-//        newOrder.add(pos, role);
-//        JSONArray arr = new JSONArray();
-//        for (int i = 0; i < newOrder.size(); i++)
-//        {
-//            arr.put(new JSONObject().put("position", i + 1).put("id", newOrder.get(i).getId()));
-//        }
-//        ((JDAImpl) role.getJDA()).getRequester().patch(Requester.DISCORD_API_PREFIX + "guilds/" + role.getGuild().getId() + "/roles", arr);
-//        return this;
+        checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
+        int maxRolePosition = role.getGuild().getRolesForUser(role.getJDA().getSelfInfo()).get(0).getPosition();
+        if (newPosition >= maxRolePosition)
+            throw new PermissionException("Cannot move to a position equal to or higher than the highest role that you have access to.");
+
+        if (newPosition < 0 || newPosition == role.getPosition())
+            return this;
+
+        Map<Integer, Role> newPositions = new HashMap<>();
+        Map<Integer, Role> currentPositions = role.getGuild().getRoles().stream()
+                .collect(Collectors.toMap(
+                    role -> role.getPosition(),
+                    role -> role));
+
+        //Remove the @everyone role from our working set.
+        currentPositions.remove(-1);
+        int searchIndex = newPosition > role.getPosition() ? newPosition : newPosition;
+        int index = 0;
+        for (Role r : currentPositions.values())
+        {
+            if (r == role)
+                continue;
+            if (index == searchIndex)
+            {
+                newPositions.put(index, role);
+                index++;
+            }
+            newPositions.put(index, r);
+            index++;
+        }
+        //If the role was moved to the very top, this will make sure it is properly handled.
+        if (!newPositions.containsValue(role))
+            newPositions.put(newPosition, role);
+
+        for (int i = 0; i < newPositions.size(); i++)
+        {
+            if (currentPositions.get(i) == newPositions.get(i))
+                newPositions.remove(i);
+        }
+
+        JSONArray rolePositions = new JSONArray();
+        newPositions.forEach((pos, r) ->
+        {
+            rolePositions.put(new JSONObject()
+                    .put("id", r.getId())
+                    .put("position", pos + 1));
+        });
+        ((JDAImpl) role.getJDA()).getRequester().patch(Requester.DISCORD_API_PREFIX + "guilds/" + role.getGuild().getId() + "/roles", rolePositions);
+        return this;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/managers/impl/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/managers/impl/AudioManagerImpl.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.audio.AudioSendHandler;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.exceptions.GuildUnavailableException;
 import net.dv8tion.jda.managers.AudioManager;
 import net.dv8tion.jda.utils.NativeUtils;
 import net.dv8tion.jda.utils.ServiceUtil;
@@ -67,6 +68,9 @@ public class AudioManagerImpl implements AudioManager
         if (queuedAudioConnection != null)
             throw new IllegalStateException("Already attempting to start an AudioConnection with a VoiceChannel!\n" +
                     "Currently Attempting Channel ID: " + queuedAudioConnection.getId() + "  |  New Attempt Channel ID: " + channel.getId());
+        if (!guild.isAvailable())
+            throw new GuildUnavailableException("Cannot open an Audio Connection with an unavailable guild. " +
+                    "Please wait until this Guild is available to open a connection.");
         queuedAudioConnection = channel;
         JSONObject obj = new JSONObject()
                 .put("op", 4)

--- a/src/main/java/net/dv8tion/jda/managers/impl/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/managers/impl/AudioManagerImpl.java
@@ -37,18 +37,18 @@ public class AudioManagerImpl implements AudioManager
     public static boolean AUDIO_SUPPORTED;
     public static String OPUS_LIB_NAME;
 
-    private static boolean initialized = false;
+    protected static boolean initialized = false;
 
-    private final JDAImpl api;
-    private final Guild guild;
-    private AudioConnection audioConnection = null;
-    private VoiceChannel queuedAudioConnection = null;
-    private VoiceChannel unexpectedDisconnectedChannel = null;
+    protected final JDAImpl api;
+    protected final Guild guild;
+    protected AudioConnection audioConnection = null;
+    protected VoiceChannel queuedAudioConnection = null;
+    protected VoiceChannel unexpectedDisconnectedChannel = null;
 
-    private AudioSendHandler sendHandler;
-    private AudioReceiveHandler receiveHandler;
+    protected AudioSendHandler sendHandler;
+    protected AudioReceiveHandler receiveHandler;
 
-    private long timeout = DEFAULT_CONNECTION_TIMEOUT;
+    protected long timeout = DEFAULT_CONNECTION_TIMEOUT;
 
     public AudioManagerImpl(Guild guild)
     {

--- a/src/main/java/net/dv8tion/jda/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/requests/Requester.java
@@ -35,7 +35,7 @@ public class Requester
     public static String USER_AGENT = "JDA DiscordBot (" + JDAInfo.GITHUB + ", " + JDAInfo.VERSION + ")";
     public static final String DISCORD_API_PREFIX = "https://discordapp.com/api/";
 
-    private final JDAImpl api;
+    protected final JDAImpl api;
 
     public Requester(JDAImpl api)
     {
@@ -82,7 +82,7 @@ public class Requester
         return exec(addHeaders(Unirest.put(url)).body(body.toString()));
     }
 
-    private Response exec(BaseRequest request)
+    protected Response exec(BaseRequest request)
     {
         HttpResponse<String> ret = null;
         try
@@ -114,7 +114,7 @@ public class Requester
         }
     }
 
-    private <T extends HttpRequest> T addHeaders(T request)
+    protected <T extends HttpRequest> T addHeaders(T request)
     {
         //adding token to all requests to the discord api or cdn pages
         //can't check for startsWith(DISCORD_API_PREFIX) due to cdn endpoints
@@ -137,14 +137,14 @@ public class Requester
         public final int code;
         public final String responseText;
 
-        private Response(int code, String response)
+        protected Response(int code, String response)
         {
             this.code = code;
             this.responseText = response;
             this.exception = null;
         }
 
-        private Response(Exception exception)
+        protected Response(Exception exception)
         {
             this.code = connectionErrCode;
             this.responseText = null;

--- a/src/main/java/net/dv8tion/jda/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/requests/Requester.java
@@ -32,7 +32,7 @@ import org.json.JSONObject;
 public class Requester
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDARequester");
-    public static final String USER_AGENT = "JDA DiscordBot (" + JDAInfo.GITHUB + ", " + JDAInfo.VERSION + ")";
+    public static String USER_AGENT = "JDA DiscordBot (" + JDAInfo.GITHUB + ", " + JDAInfo.VERSION + ")";
     public static final String DISCORD_API_PREFIX = "https://discordapp.com/api/";
 
     private final JDAImpl api;

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -399,6 +399,9 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         api.getUserMap().clear();
         api.getPmChannelMap().clear();
         api.getOffline_pms().clear();
+        new EntityBuilder(api).clearCache();
+        new ReadyHandler(api, 0).clearCache();
+        EventCache.get(api).clear();
         GuildLock.get(api).clear();
     }
 

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -590,7 +590,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                     new GuildMemberAddHandler(api, responseTotal).handle(raw);
                     break;
                 case "GUILD_MEMBER_UPDATE":
-                    new GuildMemberRoleHandler(api, responseTotal).handle(raw);
+                    new GuildMemberUpdateHandler(api, responseTotal).handle(raw);
                     break;
                 case "GUILD_MEMBER_REMOVE":
                     new GuildMemberRemoveHandler(api, responseTotal).handle(raw);

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -46,31 +46,31 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDASocket");
 
-    private final JDAImpl api;
+    protected final JDAImpl api;
 
-    private final int[] sharding;
-    private final HttpHost proxy;
-    private WebSocket socket;
-    private String gatewayUrl = null;
+    protected final int[] sharding;
+    protected final HttpHost proxy;
+    protected WebSocket socket;
+    protected String gatewayUrl = null;
 
-    private String sessionId = null;
+    protected String sessionId = null;
 
-    private Thread keepAliveThread;
-    private boolean connected;
+    protected Thread keepAliveThread;
+    protected boolean connected;
 
-    private boolean initiating;             //cache all events?
-    private final List<JSONObject> cachedEvents = new LinkedList<>();
+    protected boolean initiating;             //cache all events?
+    protected final List<JSONObject> cachedEvents = new LinkedList<>();
 
-    private boolean shouldReconnect = true;
-    private int reconnectTimeoutS = 2;
+    protected boolean shouldReconnect = true;
+    protected int reconnectTimeoutS = 2;
 
-    private final List<VoiceChannel> dcAudioConnections = new LinkedList<>();
-    private final Map<String, AudioSendHandler> audioSendHandlers = new HashMap<>();
-    private final Map<String, AudioReceiveHandler> audioReceivedHandlers = new HashMap<>();
+    protected final List<VoiceChannel> dcAudioConnections = new LinkedList<>();
+    protected final Map<String, AudioSendHandler> audioSendHandlers = new HashMap<>();
+    protected final Map<String, AudioReceiveHandler> audioReceivedHandlers = new HashMap<>();
 
-    private boolean firstInit = true;
+    protected boolean firstInit = true;
 
-    private WebSocketCustomHandler customHandler;
+    protected WebSocketCustomHandler customHandler;
 
     public WebSocketClient(JDAImpl api, HttpHost proxy, int[] sharding)
     {
@@ -164,7 +164,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         ### Start Internal methods ###
      */
 
-    private void connect()
+    protected void connect()
     {
         initiating = true;
         WebSocketFactory factory = new WebSocketFactory();
@@ -196,7 +196,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
     }
 
-    private String getGateway()
+    protected String getGateway()
     {
         try
         {
@@ -266,7 +266,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
     }
 
-    private void reconnect()
+    protected void reconnect()
     {
         LOG.warn("Got disconnected from WebSocket (Internet?!)... Attempting to reconnect in " + reconnectTimeoutS + "s");
         while(shouldReconnect)
@@ -328,7 +328,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
     }
 
-    private void setupKeepAlive(long timeout)
+    protected void setupKeepAlive(long timeout)
     {
         keepAliveThread = new Thread(() -> {
             while (connected) {
@@ -347,12 +347,12 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         keepAliveThread.start();
     }
 
-    private void sendKeepAlive()
+    protected void sendKeepAlive()
     {
         send(new JSONObject().put("op", 1).put("d", api.getResponseTotal()).toString());
     }
 
-    private void sendIdentify()
+    protected void sendIdentify()
     {
         LOG.debug("Sending Identify-packet...");
         JSONObject identify = new JSONObject()
@@ -376,7 +376,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         send(identify.toString()); //Used to make the READY event be given as compressed binary data when over a certain size. TY @ShadowLordAlpha
     }
 
-    private void sendResume()
+    protected void sendResume()
     {
         LOG.debug("Sending Resume-packet...");
         send(new JSONObject()
@@ -388,7 +388,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 .toString());
     }
 
-    private void invalidate()
+    protected void invalidate()
     {
         sessionId = null;
 
@@ -419,7 +419,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         TextChannelImpl.AsyncMessageSender.stopAll(api);
     }
 
-    private void restoreAudioHandlers()
+    protected void restoreAudioHandlers()
     {
         LOG.trace("Restoring cached AudioHandlers.");
 
@@ -457,7 +457,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         LOG.trace("Finished restoring cached AudioHandlers");
     }
 
-    private void reconnectAudioConnections()
+    protected void reconnectAudioConnections()
     {
         if (dcAudioConnections.size() == 0)
             return;
@@ -509,7 +509,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         dcAudioConnections.clear();
     }
 
-    private void handleEvent(JSONObject raw)
+    protected void handleEvent(JSONObject raw)
     {
         String type = raw.getString("t");
         int responseTotal = api.getResponseTotal();

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.audio.AudioSendHandler;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.entities.impl.TextChannelImpl;
 import net.dv8tion.jda.events.*;
 import net.dv8tion.jda.handle.*;
 import net.dv8tion.jda.managers.AudioManager;
@@ -415,6 +416,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         new ReadyHandler(api, 0).clearCache();
         EventCache.get(api).clear();
         GuildLock.get(api).clear();
+        TextChannelImpl.AsyncMessageSender.stopAll(api);
     }
 
     private void restoreAudioHandlers()

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -503,6 +503,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             setupKeepAlive(raw.getJSONObject("d").getLong("heartbeat_interval"));
         }
 
+        if (type.equals("GUILD_MEMBER_ADD"))
+            GuildMembersChunkHandler.modifyExpectedGuildMember(api, raw.getJSONObject("d").getString("guild_id"), 1);
+        if (type.equals("GUILD_MEMBER_REMOVE"))
+            GuildMembersChunkHandler.modifyExpectedGuildMember(api, raw.getJSONObject("d").getString("guild_id"), -1);
+
         if (initiating && !(type.equals("READY") || type.equals("GUILD_MEMBERS_CHUNK") || type.equals("GUILD_CREATE") || type.equals("RESUMED")))
         {
             LOG.debug("Caching " + type + " event during init!");

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketCustomHandler.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketCustomHandler.java
@@ -21,7 +21,7 @@ public interface WebSocketCustomHandler
 {
     /**
      * Handles discord events passed to it. If this handler does not handle the event provided
-     * this should return true.
+     * this should return false.
      *
      * @param obj
      *          The Discord event which needs to be handled

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.utils;
 
+import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.Permission;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.requests.Requester;
@@ -27,6 +28,29 @@ import java.util.Set;
 
 public class ApplicationUtil
 {
+
+    /**
+     * Tries to retrieve the application-id of the Application that owns the logged in Bot-account.
+     * This requires a JDA instance of a bot account for which it retrieves the parent application.
+     *
+     * @param jda
+     *      The jda-instance of a bot account.
+     * @return
+     *      The application-id of the parent Application of the bot account or null on failure.
+     */
+    public static String getApplicationId(JDA jda) {
+        Requester.Response response = ((JDAImpl) jda).getRequester().get(Requester.DISCORD_API_PREFIX + "oauth2/applications/@me");
+        if (response.isOk())
+        {
+            return response.getObject().getString("id");
+        }
+        else
+        {
+            JDAImpl.LOG.debug("Fetching Application-id failed. Response: " + response.toString());
+            return null;
+        }
+    }
+
     /**
      * Creates a OAuth invite-link used to invite bot-accounts.
      * This method does not check if the given application actually has a bot-account assigned.
@@ -302,6 +326,7 @@ public class ApplicationUtil
             throw new RuntimeException("Error creating a new Bot: " + response.toString());
         }
 
+        //TODO: Remove May 1st
         /**
          * Tries to migrate a normal-account to a bot-account and assign it to this Application.
          * For this to succeed, following must be true:<br>

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -344,50 +344,6 @@ public class ApplicationUtil
             throw new RuntimeException("Error creating a new Bot: " + response.toString());
         }
 
-        //TODO: Remove May 1st
-        /**
-         * Tries to migrate a normal-account to a bot-account and assign it to this Application.
-         * For this to succeed, following must be true:<br>
-         * <ul>
-         *     <li>This Application must not have a bot-account already assigned</li>
-         *     <li>The account to migrate must be a normal account</li>
-         *     <li>The account to migrate must not own Applications itself!</li>
-         * </ul><br>
-         * <b>Note: This is irreversible and will remove the possibility to login with email/password!
-         * Do not migrate an account you want to use in the client! Don't pull a Bastian!</b>
-         *
-         * @param email
-         *      The email of the account to migrate
-         * @param password
-         *      The password of the account to migrate
-         * @return
-         *      The new Bot-account
-         * @throws LoginException
-         *      If the login-credentials were incorrect
-         */
-        public Bot migrateBot(String email, String password) throws LoginException
-        {
-            if (hasBot())
-            {
-                throw new RuntimeException("Can't create a 2nd Bot for this Application!");
-            }
-            String tokenSave = api.getAuthToken();
-            api.setAuthToken(null);
-            String botToken = login(email, password);
-            api.setAuthToken(tokenSave);
-
-            Requester.Response response = api.getRequester().post(Requester.DISCORD_API_PREFIX + "oauth2/applications/" + id + "/bot",
-                    new JSONObject().put("token", botToken));
-            if (response.isOk())
-            {
-                JSONObject botO = response.getObject();
-                bot = new Bot(botO.getString("username"), botO.getString("discriminator"), botO.getString("token"),
-                        botO.getString("id"), botO.isNull("avatar") ? null : botO.getString("avatar"));
-                return bot;
-            }
-            throw new RuntimeException("Error creating a new Bot: " + response.toString());
-        }
-
         /**
          * Deletes this Application <b>and its assigned Bot (if present)</b>.
          */

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -72,6 +72,24 @@ public class ApplicationUtil
         return "https://discordapp.com/oauth2/authorize?client_id=" + appId + "&scope=bot&permissions=" + perm;
     }
 
+    /**
+     * Creates a OAuth invite-link used to invite bot-accounts.
+     * This requires a JDA instance of a bot account for which it retrieves the parent application.
+     *
+     * @param jda
+     *      The JDA instance of a bot-account
+     * @param perms
+     *      Possibly empty list of Permissions that should be requested via invite
+     * @return
+     *      The link used to invite the bot or null on failure
+     */
+    public static String getAuthInvite(JDA jda, Permission... perms)
+    {
+        String applicationId = getApplicationId(jda);
+        return applicationId == null ? null : getAuthInvite(applicationId, perms);
+    }
+
+
     private final JDAImpl api;
 
     /**

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -45,7 +45,7 @@ public class ApplicationUtil
         {
             perm = perm | (1 << permission.getOffset());
         }
-        return "https://discordapp.com/oauth2/authorize?&client_id=" + appId + "&scope=bot&permissions=" + perm;
+        return "https://discordapp.com/oauth2/authorize?client_id=" + appId + "&scope=bot&permissions=" + perm;
     }
 
     private final JDAImpl api;
@@ -496,7 +496,7 @@ public class ApplicationUtil
              */
             public String getAuthInvite(Permission... perms)
             {
-                return ApplicationUtil.getAuthInvite(id, perms);
+                return ApplicationUtil.getAuthInvite(Application.this.id, perms);
             }
 
             @Override

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -64,7 +64,7 @@ public class ApplicationUtil
      */
     public ApplicationUtil(String email, String password) throws LoginException
     {
-        api = new JDAImpl(false);
+        api = new JDAImpl(false, true);
         api.setAuthToken(login(email, password));
     }
 

--- a/src/main/java/net/dv8tion/jda/utils/DebugUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/DebugUtil.java
@@ -199,6 +199,8 @@ public class DebugUtil
         JSONObject obj = new JSONObject();
         obj.put("id", chan.getId())
                 .put("name", chan.getName())
+                .put("position", chan.getPosition())
+                .put("position_raw", chan.getPositionRaw())
                 .put("guild_id", chan.getGuild().getId());
         if (chan instanceof TextChannel)
             obj.put("topic", chan.getTopic());
@@ -259,6 +261,7 @@ public class DebugUtil
         obj.put("id", role.getId())
                 .put("name", role.getName())
                 .put("position", role.getPosition())
+                .put("position_raw", role.getPositionRaw())
                 .put("color", role.getColor())
                 .put("hoisted", role.isGrouped())
                 .put("managed", role.isManaged())

--- a/src/main/java/net/dv8tion/jda/utils/DebugUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/DebugUtil.java
@@ -1,0 +1,344 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.utils;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.Permission;
+import net.dv8tion.jda.entities.*;
+import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.handle.EntityBuilder;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class DebugUtil
+{
+    public static JSONObject fromJDA(JDA jda)
+    {
+        return fromJDA(jda, true, true, true, true, true);
+    }
+
+    public static JSONObject fromJDA(JDA iJDA, boolean includeUsers, boolean includeGuilds, boolean includeGuildUsers,
+                                     boolean includeChannels, boolean includePrivateChannels)
+    {
+        JDAImpl jda = (JDAImpl) iJDA;
+        JSONObject obj = new JSONObject();
+        obj.put("self_info", fromUser(jda.getSelfInfo()))
+                .put("proxy", jda.getGlobalProxy() == null ? JSONObject.NULL : new JSONObject()
+                    .put("host", jda.getGlobalProxy().getHostName())
+                    .put("port", jda.getGlobalProxy().getPort()))
+                .put("response_total", jda.getResponseTotal())
+                .put("audio_enabled", jda.isAudioEnabled())
+                .put("auto_reconnect", jda.isAutoReconnect());
+
+        JSONArray array = new JSONArray();
+        for (Object listener : jda.getRegisteredListeners())
+            array.put(listener.getClass().getCanonicalName());
+        obj.put("event_listeners", array);
+
+
+        try
+        {
+            Field f = EntityBuilder.class.getDeclaredField("cachedJdaGuildJsons");
+            f.setAccessible(true);
+            HashMap<String, JSONObject> cachedJsons = ((HashMap<JDA, HashMap<String, JSONObject>>) f.get(null)).get(jda);
+
+            array = new JSONArray();
+            for (String guildId : cachedJsons.keySet())
+                array.put(guildId);
+            obj.put("second_pass_json_guild_ids", array);
+
+            f = EntityBuilder.class.getDeclaredField("cachedJdaGuildCallbacks");
+            f.setAccessible(true);
+            HashMap<String, Consumer<Guild>> cachedCallbacks = ((HashMap<JDA, HashMap<String, Consumer<Guild>>>) f.get(null)).get(jda);
+
+            array = new JSONArray();
+            for (String guildId : cachedCallbacks.keySet())
+                array.put(guildId);
+            obj.put("second_pass_callback_guild_ids", array);
+        }
+        catch (NoSuchFieldException e)
+        {
+            e.printStackTrace();
+        }
+        catch (IllegalAccessException e)
+        {
+            e.printStackTrace();
+        }
+
+        if (includeGuilds)
+        {
+            array = new JSONArray();
+            for (Guild guild : jda.getGuilds())
+                array.put(fromGuild(guild, includeGuildUsers, includeChannels, true, true));
+            obj.put("guilds", array);
+        }
+
+        if (includePrivateChannels)
+        {
+            array = new JSONArray();
+            for (PrivateChannel chan : jda.getPrivateChannels())
+                array.put(fromPrivateChannel(chan, false));
+            obj.put("private_channels", array);
+
+            array = new JSONArray();
+            for (Map.Entry<String, String> entry : jda.getOffline_pms().entrySet())
+            {
+                array.put(new JSONObject()
+                        .put("id", entry.getValue())
+                        .put("user_id", entry.getKey()));
+            }
+            obj.put("offline_private_channels", array);
+        }
+
+        if (includeUsers)
+        {
+            array = new JSONArray();
+            for (User user : jda.getUsers())
+                array.put(fromUser(user));
+            obj.put("users", array);
+        }
+
+        return obj;
+    }
+
+    public static JSONObject fromGuild(Guild guild)
+    {
+        return fromGuild(guild, true, true, true, true);
+    }
+
+    public static JSONObject fromGuild(Guild guild, boolean includeUsers, boolean includeChannels, boolean includeRoles, boolean includeVoiceStatuses)
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("id", guild.getId())
+                .put("name", guild.getName())
+                .put("owner_id", guild.getOwner().getId())
+                .put("region", guild.getRegion())
+                .put("icon_url", guild.getIconUrl())
+                .put("available", guild.isAvailable())
+                .put("verification_level", guild.getVerificationLevel())
+                .put("verification_passed", guild.checkVerification())
+                .put("afk_timeout", guild.getAfkTimeout())
+                .put("afk_channel_id", guild.getAfkChannelId());
+
+        JSONArray array = new JSONArray();
+        for (Channel chan : guild.getTextChannels())
+            array.put(chan.getId());
+        obj.put("text_channel_ids", array);
+
+        array = new JSONArray();
+        for (Channel chan : guild.getVoiceChannels())
+            array.put(chan.getId());
+        obj.put("text_channel_ids", array);
+
+        array = new JSONArray();
+        for (Role role : guild.getRoles())
+            array.put(role.getId());
+        obj.put("role_ids", array);
+
+        if (includeChannels)
+        {
+            array = new JSONArray();
+            for (Channel chan : guild.getTextChannels())
+                array.put(fromGuildChannel(chan, false, false, true));
+            obj.put("text_channels", array);
+
+            array = new JSONArray();
+            for (Channel chan : guild.getVoiceChannels())
+                array.put(fromGuildChannel(chan, false, false, true));
+            obj.put("voice_channels", array);
+        }
+
+        if (includeRoles)
+        {
+            array = new JSONArray();
+            for (Role role : guild.getRoles())
+                array.put(fromRole(role, false, true, true));
+            obj.put("roles", array);
+        }
+
+        return obj;
+    }
+
+    public static JSONObject fromGuildChannel(Channel chan)
+    {
+        return fromGuildChannel(chan, true, true, true);
+    }
+
+    public static JSONObject fromPrivateChannel(PrivateChannel chan, boolean includeUser)
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("id", chan.getId())
+                .put("user_id", chan.getUser().getId());
+
+        if (includeUser)
+            obj.put("user", fromUser(chan.getUser()));
+
+        return obj;
+    }
+
+    public static JSONObject fromGuildChannel(Channel chan, boolean includeUsers, boolean includeGuild, boolean includePermOverrides)
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("id", chan.getId())
+                .put("name", chan.getName())
+                .put("guild_id", chan.getGuild().getId());
+        if (chan instanceof TextChannel)
+            obj.put("topic", chan.getTopic());
+
+        if (includePermOverrides)
+        {
+            JSONArray permsArray = new JSONArray();
+            for (PermissionOverride permOver : chan.getUserPermissionOverrides())
+            {
+                permsArray.put(fromPermOverride(permOver, false, false, false, true));
+            }
+            obj.put("user_permission_overrides", permsArray);
+
+            permsArray = new JSONArray();
+            for (PermissionOverride permOver : chan.getRolePermissionOverrides())
+            {
+                permsArray.put(fromPermOverride(permOver, false, false, false, true));
+            }
+            obj.put("role_permission_overrides", permsArray);
+        }
+
+        if (includeGuild)
+            obj.put("guild", fromGuild(chan.getGuild(), false, false, false, false));
+
+        if (includeUsers)
+        {
+            JSONArray userArray = new JSONArray();
+            for (User user : chan.getUsers())
+            {
+                userArray.put(fromUser(user));
+            }
+            obj.put("users", userArray);
+        }
+        return obj;
+    }
+
+    public static JSONObject fromUser(User user)
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("id", user.getId())
+                .put("username", user.getUsername())
+                .put("disc", user.getDiscriminator())
+                .put("avatar_url", user.getAvatarUrl())
+                .put("online_status", user.getOnlineStatus())
+                .put("current_game", user.getCurrentGame())
+                .put("is_bot", user.isBot());
+        return obj;
+    }
+
+    public static JSONObject fromRole(Role role)
+    {
+        return fromRole(role, true, true, true);
+    }
+
+    public static JSONObject fromRole(Role role, boolean includeGuild, boolean includeUsers, boolean includePermissions)
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("id", role.getId())
+                .put("name", role.getName())
+                .put("position", role.getPosition())
+                .put("color", role.getColor())
+                .put("hoisted", role.isGrouped())
+                .put("managed", role.isManaged())
+                .put("mentionable", role.isMentionable())
+                .put("guild_id", role.getGuild().getId())
+                .put("permissions_raw", role.getPermissionsRaw());
+
+        if (includeGuild)
+            obj.put("guild", fromGuild(role.getGuild(), false, false, false, false));
+
+        if (includeUsers)
+        {
+            JSONArray userArray = new JSONArray();
+            for (User user : role.getGuild().getUsersWithRole(role))
+                userArray.put(user.getId());
+            obj.put("users", userArray);
+        }
+
+        if (includePermissions)
+        {
+            JSONArray permArray = new JSONArray();
+            for (Permission perm : role.getPermissions())
+                permArray.put(perm.toString());
+            obj.put("permissions", permArray);
+        }
+        return obj;
+    }
+
+    public static JSONObject fromPermOverride(PermissionOverride permOver)
+    {
+        return fromPermOverride(permOver, true, true, true, true);
+    }
+
+    public static JSONObject fromPermOverride(PermissionOverride permOver, boolean includeGuild, boolean includeChannel,
+                                              boolean includeRoleOrUserInfo, boolean includePermissions)
+    {
+        JSONObject obj = new JSONObject();
+        obj.put("type", permOver.isRoleOverride() ? "role" : "user")
+                .put("allowed_raw", permOver.getAllowedRaw())
+                .put("inherited_raw", permOver.getInheritRaw())
+                .put("denied_raw", permOver.getDeniedRaw())
+                .put("channel_id", permOver.getChannel().getId())
+                .put("guild_id", permOver.getGuild().getId());
+
+        if (permOver.isRoleOverride())
+            obj.put("role_id", permOver.getRole().getId());
+        else
+            obj.put("user_id", permOver.getUser().getId());
+
+        if (includePermissions)
+        {
+            JSONArray permArray = new JSONArray();
+            for (Permission perm : permOver.getAllowed())
+                permArray.put(perm.toString());
+            obj.put("allowed_perms", permArray);
+
+            permArray = new JSONArray();
+            for (Permission perm : permOver.getInherit())
+                permArray.put(perm.toString());
+            obj.put("inherited_perms", permArray);
+
+            permArray = new JSONArray();
+            for (Permission perm : permOver.getDenied())
+                permArray.put(perm.toString());
+            obj.put("denied_perms", permArray);
+        }
+
+        if (includeChannel)
+            obj.put("channel", fromGuildChannel(permOver.getChannel()));
+
+        if (includeGuild)
+            obj.put("guild", fromGuild(permOver.getGuild()));
+
+        if (includeRoleOrUserInfo)
+        {
+            if (permOver.isRoleOverride())
+                obj.put("role", fromRole(permOver.getRole(), false, false, includePermissions));
+            else
+                obj.put("user", permOver.getUser());
+        }
+        return obj;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
@@ -54,7 +54,7 @@ public class InviteUtil
             String[] split = code.split("/");
             code = split[split.length - 1];
         }
-        JSONObject object = new JDAImpl(false).getRequester().get(Requester.DISCORD_API_PREFIX + "invite/" + code).getObject();
+        JSONObject object = new JDAImpl(false, false).getRequester().get(Requester.DISCORD_API_PREFIX + "invite/" + code).getObject();
         if (object != null && object.has("code"))
         {
             JSONObject guild = object.getJSONObject("guild");

--- a/src/main/java/net/dv8tion/jda/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/PermissionUtil.java
@@ -43,6 +43,10 @@ public class PermissionUtil
      */
     public static boolean canInteract(User issuer, User target, Guild guild)
     {
+        if(guild.getOwner() == issuer)
+            return true;
+        if(guild.getOwner() == target)
+            return false;
         List<Role> issuerRoles = guild.getRolesForUser(issuer);
         List<Role> targetRoles = guild.getRolesForUser(target);
         return !issuerRoles.isEmpty() && (targetRoles.isEmpty() || canInteract(issuerRoles.get(0), targetRoles.get(0)));
@@ -61,6 +65,8 @@ public class PermissionUtil
      */
     public static boolean canInteract(User issuer, Role target)
     {
+        if(target.getGuild().getOwner() == issuer)
+            return true;
         List<Role> issuerRoles = target.getGuild().getRolesForUser(issuer);
         return !issuerRoles.isEmpty() && canInteract(issuerRoles.get(0), target);
     }

--- a/src/main/java/net/dv8tion/jda/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/PermissionUtil.java
@@ -28,6 +28,46 @@ import java.util.Map;
 public class PermissionUtil
 {
 
+    /**
+     * Checks if one given User can kick a 2nd given User from given Guild.
+     *
+     * @param issuer
+     *      The user that tries to kick 2nd user
+     * @param target
+     *      The user that is the target of the kick
+     * @param guild
+     *      The guild where permissions should be checked in
+     * @return
+     *      True, if issuer can kick target in guild
+     */
+    public static boolean canKick(User issuer, User target, Guild guild)
+    {
+        return !checkPermission(target, Permission.MANAGE_ROLES, guild) &&
+                (checkPermission(issuer, Permission.MANAGE_ROLES, guild) ||
+                    (checkPermission(issuer, Permission.KICK_MEMBERS, guild) &&
+                            !checkPermission(target, Permission.KICK_MEMBERS, guild)));
+    }
+
+    /**
+     * Checks if one given User can ban a 2nd given User from given Guild.
+     *
+     * @param issuer
+     *      The user that tries to ban 2nd user
+     * @param target
+     *      The user that is the target of the ban
+     * @param guild
+     *      The guild where permissions should be checked in
+     * @return
+     *      True, if issuer can ban target in guild
+     */
+    public static boolean canBan(User issuer, User target, Guild guild)
+    {
+        return !checkPermission(target, Permission.MANAGE_ROLES, guild) &&
+                (checkPermission(issuer, Permission.MANAGE_ROLES, guild) ||
+                        (checkPermission(issuer, Permission.BAN_MEMBERS, guild) &&
+                                !checkPermission(target, Permission.BAN_MEMBERS, guild)));
+    }
+
     public static PermissionOverride getFullPermOverride()
     {
         PermissionOverrideImpl override = new PermissionOverrideImpl(null, null, null);


### PR DESCRIPTION
**++** Added EventCache. Used to make sure that the internals of JDA stay happy and accurate. Less "IllegalArgumentException: JDA don't know about X" because Discord gave us out of order events.
**++** Rewrote the async message system to work with per-guild ratelimits. Send all the messages!
**++** Added support for Discord's new positioning system (effected TextChannel, VoiceChannel and Roles)
**+** Added sharding support!
**+** Added nickname support!
**+** Added @here support!
**+** Added multi-connection attempts to the audio system to combat UDP packet loss
**+** Added new events for AudioConnection failure to connect
**+** Added mentioning support for Roles and Nicknames
**+** Added support for Streaming statuses.
**+** Added Manager control for VoiceChannel bitrate and user limit fields, + events when they are changed..
**+** Added more permission related support in PermissionUtil and Guild#checkVerification()
**+** Added support for bulk message deletion! TextChannel#deleteMessages(List<Message>)
**+** Added shutdown hook to cleanly close JDA if the JVM shuts down.


*Fixed CPU spike with finished/paused audio playback.
*Fixed incorrect id being used in the ApplicationUtil's getAuthInvite() method.
*Rewrote the GuildChunking system to be less prone to explosions.
*GuildChunking rewrite also fixed possible edge-case bug where logging in would never finish if the last guild chunked during initial login had 1000 * n users (1000, 2000, 3000, etc)
*Made the order of Users returned from Message#getMentionedUsers() be in the order they were mentioned in the message.


-Removed converting UserAccounts to BotAccounts as it is no longer possible!
