### PR TITLE
Release of v2.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 0, revision: 0)
+def versionObj = new Version(major: 2, minor: 1, revision: 0)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 1, revision: 0)
+def versionObj = new Version(major: 2, minor: 1, revision: 1)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/src/examples/java/AudioExample.java
+++ b/src/examples/java/AudioExample.java
@@ -27,11 +27,16 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AudioExample extends ListenerAdapter
 {
 
-    private Player player = null;
+    /**
+     * This map is used as cache and contains all player instances
+     */
+    private Map<String,Player> players = new HashMap<>();
 
     public static void main(String[] args)
     {
@@ -59,6 +64,7 @@ public class AudioExample extends ListenerAdapter
     public void onGuildMessageReceived(GuildMessageReceivedEvent event)
     {
         String message = event.getMessage().getContent();
+        Player player = players.get(event.getGuild().getId());
 
         //Start an audio connection with a VoiceChannel
         if (message.startsWith("join "))
@@ -91,11 +97,14 @@ public class AudioExample extends ListenerAdapter
                 URL audioUrl = null;
                 try
                 {
-                    audioFile = new File("aac-41100.m4a");
+                    audioFile = new File("BABYMETAL Gimme chocolate!!.wav");
 //                    audioUrl = new URL("https://dl.dropboxusercontent.com/u/41124983/anime-48000.mp3?dl=1");
 
                     player = new FilePlayer(audioFile);
 //                    player = new URLPlayer(event.getJDA(), audioUrl);
+
+                    //Add the new player to the cache
+                    players.put(event.getGuild().getId(), player);
 
                     //Provide the handler to send audio.
                     //NOTE: You don't have to set the handler each time you create an audio connection with the
@@ -154,4 +163,5 @@ public class AudioExample extends ListenerAdapter
                 player.restart();
         }
     }
+
 }

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -307,7 +307,7 @@ public interface JDA
     void setAutoReconnect(boolean reconnect);
 
     /**
-     * Returns whether or not autoReconnect is enabled for JDA
+     * Returns whether or not autoReconnect is enabled for JDA.
      *
      * @return
      *      True if JDA attempts to autoReconnect
@@ -318,7 +318,7 @@ public interface JDA
      * Used to determine whether the instance of JDA supports audio and has it enabled.
      *
      * @return
-     *      True if JDA can currently utalize the audio system.
+     *      True if JDA can currently utilize the audio system.
      */
     boolean isAudioEnabled();
 
@@ -344,7 +344,7 @@ public interface JDA
     void shutdown(boolean free);
 
     /**
-     * Installs an auxillary cable into your system.
+     * Installs an auxiliary cable into your system.
      * 
      * @param port the port
      * @throws UnsupportedOperationException

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -157,25 +157,6 @@ public class JDABuilder
     }
 
     /**
-     * <b>This method is deprecated! Please switch to {@link #setEventManager(IEventManager)}.</b>
-     * <p>
-     * Changes the internal EventManager.
-     * The default EventManager is {@link net.dv8tion.jda.hooks.InterfacedEventManager InterfacedEventListener}.
-     * There is also an {@link AnnotatedEventManager AnnotatedEventManager} available.
-     *
-     * @param useAnnotated
-     *      Whether or not to use the {@link net.dv8tion.jda.hooks.AnnotatedEventManager AnnotatedEventManager}
-     * @return
-     *      Returns the {@link net.dv8tion.jda.JDABuilder JDABuilder} instance. Useful for chaining.
-     */
-    @Deprecated
-    public JDABuilder useAnnotatedEventManager(boolean useAnnotated)
-    {
-        this.useAnnotatedManager = useAnnotated;
-        return this;
-    }
-
-    /**
      * Changes the internally used EventManager.
      * There are 2 provided Implementations:
      * <ul>

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -255,7 +255,7 @@ public class JDABuilder
     }
 
     /**
-     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided email and password to start the login process.<br>
+     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided token to start the login process.<br>
      * The login process runs in a different thread, so while this will return immediately, {@link net.dv8tion.jda.JDA} has not
      * finished loading, thus many {@link net.dv8tion.jda.JDA} methods have the chance to return incorrect information.
      * <p>
@@ -266,9 +266,9 @@ public class JDABuilder
      * @return
      *      A {@link net.dv8tion.jda.JDA} instance that has started the login process. It is unknown as to whether or not loading has finished when this returns.
      * @throws LoginException
-     *          If the provided email-password combination fails the Discord security authentication.
+     *          If the provided token is invalid.
      * @throws IllegalArgumentException
-     *          If either the provided email or password is empty or null.
+     *          If the provided token is empty or null.
      */
     public JDA buildAsync() throws LoginException, IllegalArgumentException
     {
@@ -293,16 +293,16 @@ public class JDABuilder
     }
 
     /**
-     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided email and password to start the login process.<br>
+     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided token to start the login process.<br>
      * This method will block until JDA has logged in and finished loading all resources. This is an alternative
      * to using {@link net.dv8tion.jda.events.ReadyEvent ReadyEvent}.
      *
      * @return
      *      A {@link net.dv8tion.jda.JDA} Object that is <b>guaranteed</b> to be logged in and finished loading.
      * @throws LoginException
-     *          If the provided email-password combination fails the Discord security authentication.
+     *          If the provided token is invalid.
      * @throws IllegalArgumentException
-     *          If either the provided email or password is empty or null.
+     *          If the provided token is empty or null.
      * @throws InterruptedException
      *          If an interrupt request is received while waiting for {@link net.dv8tion.jda.JDA} to finish logging in.
      *          This would most likely be caused by a JVM shutdown request.

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -172,8 +172,11 @@ public class AudioConnection
                             }
                             else
                             {
-                                byte[] encodedAudio = encodeToOpus(rawAudio);
-                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), encodedAudio);
+                                if (!sendHandler.isOpus())
+                                {
+                                    rawAudio = encodeToOpus(rawAudio);
+                                }
+                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), rawAudio);
                                 if (!speaking)
                                     setSpeaking(true);
                                 udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));

--- a/src/main/java/net/dv8tion/jda/audio/AudioSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioSendHandler.java
@@ -18,5 +18,11 @@ package net.dv8tion.jda.audio;
 public interface AudioSendHandler
 {
     boolean canProvide();
+    
     byte[] provide20MsAudio();
+    
+    default boolean isOpus()
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/entities/User.java
@@ -41,7 +41,7 @@ public interface User
     String getUsername();
 
     /**
-     * The descriminator of the {@link net.dv8tion.jda.entities.User User}. Used to differentiate between users with the same usernames.<br>
+     * The discriminator of the {@link net.dv8tion.jda.entities.User User}. Used to differentiate between users with the same usernames.<br>
      * This will be important when the friends list is released for human readable searching.<br>
      * Ex: DV8FromTheWorld#9148
      *

--- a/src/main/java/net/dv8tion/jda/managers/AccountManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/AccountManager.java
@@ -49,7 +49,7 @@ public class AccountManager
      * Avatars can get generated through the methods of {@link net.dv8tion.jda.utils.AvatarUtil AvatarUtil}
      *
      * @param avatar
-     *      a Avatar object, null to keep current Avatar or {@link net.dv8tion.jda.utils.AvatarUtil#DELETE_AVATAR AvatarUtil#DELETE_AVATAR} to remove the avatar
+     *      an Avatar object, null to keep current Avatar or {@link net.dv8tion.jda.utils.AvatarUtil#DELETE_AVATAR AvatarUtil#DELETE_AVATAR} to remove the avatar
      * @return
      *      this
      */
@@ -117,7 +117,7 @@ public class AccountManager
      * This change will be applied <b>immediately</b>
      *
      * @param idle
-     *      weather the account should be displayed as idle o not
+     *      whether the account should be displayed as idle or not
      */
     public void setIdle(boolean idle)
     {

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -712,6 +712,36 @@ public class GuildManager
     }
 
     /**
+     * Deafens a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_DEAF_OTHERS VOICE_DEAF_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be deafened.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#undeafen(User)
+     */
+    public void deafen(User user)
+    {
+        this.deafen(user, true);
+    }
+
+    /**
+     * Mutes a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_MUTE_OTHERS VOICE_MUTE_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be muted.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#unmute(User)
+     */
+    public void mute(User user)
+    {
+        this.mute(user, true);
+    }
+
+    /**
      * Gets an unmodifiable list of the currently banned {@link net.dv8tion.jda.entities.User Users}.<br>
      * If you wish to ban or unban a user, please use one of the ban or unban methods of this Manager
      *
@@ -785,6 +815,36 @@ public class GuildManager
     }
 
     /**
+     * Undeafens a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_DEAF_OTHERS VOICE_DEAF_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be undeafened.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#deafen(User)
+     */
+    public void undeafen(User user)
+    {
+        this.deafen(user, false);
+    }
+    
+    /**
+     * Unmutes a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_MUTE_OTHERS VOICE_MUTE_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be unmuted.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#mute(User)
+     */
+    public void unmute(User user)
+    {
+        this.mute(user, false);
+    }
+
+    /**
      * Leaves this {@link net.dv8tion.jda.entities.Guild Guild}.
      * If the logged in {@link net.dv8tion.jda.entities.User User} is the owner of
      * this {@link net.dv8tion.jda.entities.Guild Guild}, this method will throw an {@link net.dv8tion.jda.exceptions.PermissionException PermissionException}.
@@ -808,6 +868,36 @@ public class GuildManager
         ((JDAImpl) guild.getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "users/@me/guilds/" + guild.getId());
     }
 
+    private void deafen(User user, boolean deafen)
+    {
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+
+        checkPermission(Permission.VOICE_DEAF_OTHERS);
+
+        String url = Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/" + user.getId();
+
+        ((JDAImpl) guild.getJDA()).getRequester()
+                .patch(url, new JSONObject().put("deaf", deafen));
+    }
+    
+    private void mute(User user, boolean mute)
+    {
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+
+        checkPermission(Permission.VOICE_MUTE_OTHERS);
+
+        String url = Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/" + user.getId();
+
+        ((JDAImpl) guild.getJDA()).getRequester()
+                .patch(url, new JSONObject().put("mute", mute));
+    }
+
     private JSONObject getFrame()
     {
         return new JSONObject().put("name", guild.getName());
@@ -822,7 +912,6 @@ public class GuildManager
     {
         if (!PermissionUtil.checkPermission(getGuild().getJDA().getSelfInfo(), perm, getGuild()))
             throw new PermissionException(perm);
-
     }
 
     private void checkPosition(User u)

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -250,7 +250,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 AudioManagerImpl mngImpl = (AudioManagerImpl) mng;
                 VoiceChannel channel = null;
                 if (mngImpl.isConnected())
+                {
+                    //This causes the AudioDisconnectEvent to be fired.. maybe we should reevaluate that.
                     channel = mng.getConnectedChannel();
+                    mngImpl.closeAudioConnection();
+                }
                 else if (mngImpl.isAttemptingToConnect())
                     channel = mng.getQueuedAudioConnection();
                 else if (mngImpl.wasUnexpectedlyDisconnected())


### PR DESCRIPTION
**+** Added support for muting and deafening User as an administrator using GuildManager
**+** Added support for providing pre-encoded opus audio using a AudioSendHandler


*Fixed issue where audio connections weren't closed internally when the main websocket lost connection, causing an error in JDA because JDA thought it was trying to open a second connection when it attempt to reconnect audio connections after successfully reconnecting the main websocket.