### PR TITLE
Changed the LinkedList to CopyOnWriteArrayList in InterfacedEventManager

### DIFF
--- a/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
@@ -21,10 +21,11 @@ import net.dv8tion.jda.events.Event;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class InterfacedEventManager implements IEventManager
 {
-    private final List<EventListener> listeners = new LinkedList<>();
+    private final CopyOnWriteArrayList<EventListener> listeners = new CopyOnWriteArrayList<>();
 
     public InterfacedEventManager()
     {
@@ -56,8 +57,7 @@ public class InterfacedEventManager implements IEventManager
     @Override
     public void handle(Event event)
     {
-        List<EventListener> listenerCopy = new LinkedList<>(listeners);
-        for (EventListener listener : listenerCopy)
+        for (EventListener listener : listeners)
         {
             try
             {


### PR DESCRIPTION
Eliminates the need to copy the list on every event, which is an unneeded performance hit.