### PR TITLE
Added copies to fix ConcurrentModificationExceptions

### DIFF
--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -257,7 +257,7 @@ public class GuildImpl implements Guild
         for (Permission perm : role.getPermissions())
         {
             if (!PermissionUtil.checkPermission(role.getJDA().getSelfInfo(), perm, role.getGuild()))
-                throw new PermissionException(perm);  
+                throw new PermissionException(perm);
         }
 
         RoleManager manager = createRole();
@@ -277,11 +277,12 @@ public class GuildImpl implements Guild
         List<Role> roles = userRoles.get(user);
         if (roles == null)
             return null;
+        roles = new ArrayList<>(roles);
 
         Collections.sort(roles, (r1, r2) -> r2.compareTo(r1));
         return Collections.unmodifiableList(roles);
     }
-    
+
     @Override
     public Role getColorDeterminantRoleForUser(User user)
     {

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -126,7 +126,7 @@ public class VoiceChannelImpl implements VoiceChannel
     @Override
     public List<User> getUsers()
     {
-        return Collections.unmodifiableList(connectedUsers);
+        return Collections.unmodifiableList(new LinkedList<>(connectedUsers));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/DisconnectEvent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.VoiceChannel;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class DisconnectEvent extends Event
@@ -39,7 +40,7 @@ public class DisconnectEvent extends Event
         this.clientCloseFrame = clientCloseFrame;
         this.closedByServer = closedByServer;
         this.disconnectTime = disconnectTime;
-        this.dcAudioConnections = Collections.unmodifiableList(dcAudioConnections);
+        this.dcAudioConnections = Collections.unmodifiableList(new LinkedList<>(dcAudioConnections));
     }
 
     public WebSocketFrame getServiceCloseFrame()

--- a/src/main/java/net/dv8tion/jda/events/ShutdownEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ShutdownEvent.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.entities.VoiceChannel;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class ShutdownEvent extends Event
@@ -27,11 +28,11 @@ public class ShutdownEvent extends Event
     protected final OffsetDateTime shutdownTime;
     protected final List<VoiceChannel> dcAudioConnections;
 
-    public ShutdownEvent(JDA api, OffsetDateTime shutdownTime, List<VoiceChannel> dcAudioConnectons)
+    public ShutdownEvent(JDA api, OffsetDateTime shutdownTime, List<VoiceChannel> dcAudioConnections)
     {
         super(api, -1);
         this.shutdownTime = shutdownTime;
-        this.dcAudioConnections = Collections.unmodifiableList(dcAudioConnectons);
+        this.dcAudioConnections = Collections.unmodifiableList(new LinkedList<>(dcAudioConnections));
     }
 
     public OffsetDateTime getShutdownTime()

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.User;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
@@ -30,7 +31,7 @@ public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
     public GuildMemberRoleAddEvent(JDA api, int responseNumber, Guild guild, User user, List<Role> addedRoles)
     {
         super(api, responseNumber, guild, user);
-        this.addedRoles = addedRoles;
+        this.addedRoles = new LinkedList<>(addedRoles);
     }
 
     public List<Role> getRoles()

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.User;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent
@@ -30,7 +31,7 @@ public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent
     public GuildMemberRoleRemoveEvent(JDA api, int responseNumber, Guild guild, User user, List<Role> removedRoles)
     {
         super(api, responseNumber, guild, user);
-        this.removedRoles = removedRoles;
+        this.removedRoles = new LinkedList<>(removedRoles);
     }
 
     public List<Role> getRoles()

--- a/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
@@ -51,7 +51,7 @@ public class InterfacedEventManager implements IEventManager
     @Override
     public List<Object> getRegisteredListeners()
     {
-        return Collections.unmodifiableList(listeners);
+        return Collections.unmodifiableList(new LinkedList<>(listeners));
     }
 
     @Override


### PR DESCRIPTION
Added list copies where necessary to prevent ConcurrentModificationExceptions and unexpected behavior due to the underlying list being modified. This should fix #75.