### PR TITLE
Release of v2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ public class MessageListener extends ListenerAdapter
     @Override
     public void onMessageReceived(MessageReceivedEvent event)
     {
-        System.out.printf("[%s][%s] %s: %s\n", event.getGuild().getName(),
-            event.getChannel().getName(), event.getAuthor().getUsername(),
-            event.getMessage().getContent());
+        if (event.isPrivate())
+        {
+            System.out.printf("[PM] %s: %s\n", event.getAuthor().getUsername(),
+                                    event.getMessage().getContent());
+        }
+        else
+        {
+            System.out.printf("[%s][%s] %s: %s\n", event.getGuild().getName(),
+                        event.getTextChannel().getName(), event.getAuthor().getUsername(),
+                        event.getMessage().getContent());
+        }
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 1, revision: 1)
+def versionObj = new Version(major: 2, minor: 1, revision: 2)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 0, revision: 0)
+def versionObj = new Version(major: 2, minor: 1, revision: 0)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 1, revision: 0)
+def versionObj = new Version(major: 2, minor: 1, revision: 1)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/src/examples/java/AudioExample.java
+++ b/src/examples/java/AudioExample.java
@@ -27,11 +27,16 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AudioExample extends ListenerAdapter
 {
 
-    private Player player = null;
+    /**
+     * This map is used as cache and contains all player instances
+     */
+    private Map<String,Player> players = new HashMap<>();
 
     public static void main(String[] args)
     {
@@ -59,6 +64,7 @@ public class AudioExample extends ListenerAdapter
     public void onGuildMessageReceived(GuildMessageReceivedEvent event)
     {
         String message = event.getMessage().getContent();
+        Player player = players.get(event.getGuild().getId());
 
         //Start an audio connection with a VoiceChannel
         if (message.startsWith("join "))
@@ -91,11 +97,14 @@ public class AudioExample extends ListenerAdapter
                 URL audioUrl = null;
                 try
                 {
-                    audioFile = new File("aac-41100.m4a");
+                    audioFile = new File("BABYMETAL Gimme chocolate!!.wav");
 //                    audioUrl = new URL("https://dl.dropboxusercontent.com/u/41124983/anime-48000.mp3?dl=1");
 
                     player = new FilePlayer(audioFile);
 //                    player = new URLPlayer(event.getJDA(), audioUrl);
+
+                    //Add the new player to the cache
+                    players.put(event.getGuild().getId(), player);
 
                     //Provide the handler to send audio.
                     //NOTE: You don't have to set the handler each time you create an audio connection with the
@@ -154,4 +163,5 @@ public class AudioExample extends ListenerAdapter
                 player.restart();
         }
     }
+
 }

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -307,7 +307,7 @@ public interface JDA
     void setAutoReconnect(boolean reconnect);
 
     /**
-     * Returns whether or not autoReconnect is enabled for JDA
+     * Returns whether or not autoReconnect is enabled for JDA.
      *
      * @return
      *      True if JDA attempts to autoReconnect
@@ -318,7 +318,7 @@ public interface JDA
      * Used to determine whether the instance of JDA supports audio and has it enabled.
      *
      * @return
-     *      True if JDA can currently utalize the audio system.
+     *      True if JDA can currently utilize the audio system.
      */
     boolean isAudioEnabled();
 
@@ -344,7 +344,7 @@ public interface JDA
     void shutdown(boolean free);
 
     /**
-     * Installs an auxillary cable into your system.
+     * Installs an auxiliary cable into your system.
      * 
      * @param port the port
      * @throws UnsupportedOperationException

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -17,7 +17,6 @@ package net.dv8tion.jda;
 
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.hooks.AnnotatedEventManager;
-import net.dv8tion.jda.hooks.EventListener;
 import net.dv8tion.jda.hooks.IEventManager;
 import net.dv8tion.jda.managers.AccountManager;
 import net.dv8tion.jda.managers.AudioManager;
@@ -42,20 +41,20 @@ public interface JDA
         INITIALIZED,
         /**JDA is currently attempting to log in.*/
         LOGGING_IN,
-        /**JDA is currently attempting to connect its websocket to Discord.*/
+        /**JDA is currently attempting to connect it's websocket to Discord.*/
         CONNECTING_TO_WEBSOCKET,
-        /**JDA has successfully connected its websocket to Discord and is populating internal objects.
+        /**JDA has successfully connected it's websocket to Discord and is populating internal objects.
          * This process often takes the longest of all Statuses (besides CONNECTED)*/
         LOADING_SUBSYSTEMS,
         /**JDA has finished loading everything, is receiving information from Discord and is firing events.*/
         CONNECTED,
-        /**JDA's main websocket has been disconnected. This <b>DOES NOT</b> mean JDA has shutdown permenantly.
+        /**JDA's main websocket has been disconnected. This <b>DOES NOT</b> mean JDA has shutdown permanently.
          * This is an in-between status. Most likely ATTEMPTING_TO_RECONNECT or SHUTTING_DOWN/SHUTDOWN will soon follow.*/
         DISCONNECTED,
-        /**When trying to reconnect to Discord JDA encounter an issue, most likely related to a lack of internet connection,
+        /**When trying to reconnect to Discord JDA encountered an issue, most likely related to a lack of internet connection,
          * and is waiting to try reconnecting again.*/
         WAITING_TO_RECONNECT,
-        /**JDA has been disconnected from Discord and is currently try to reestablish connection.*/
+        /**JDA has been disconnected from Discord and is currently trying to reestablish the connection.*/
         ATTEMPTING_TO_RECONNECT,
         /**JDA has received a shutdown request or has been disconnected from Discord and reconnect is disabled, thus,
          * JDA is in the process of shutting down*/

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -32,6 +32,49 @@ import java.util.List;
 public interface JDA
 {
     /**
+     * The current status of the JDA instance.
+     */
+    enum Status
+    {
+        /**JDA is currently setting up supporting systems like the AudioSystem.*/
+        INITIALIZING,
+        /**JDA has finished setting up supporting systems and is ready to log in.*/
+        INITIALIZED,
+        /**JDA is currently attempting to log in.*/
+        LOGGING_IN,
+        /**JDA is currently attempting to connect its websocket to Discord.*/
+        CONNECTING_TO_WEBSOCKET,
+        /**JDA has successfully connected its websocket to Discord and is populating internal objects.
+         * This process often takes the longest of all Statuses (besides CONNECTED)*/
+        LOADING_SUBSYSTEMS,
+        /**JDA has finished loading everything, is receiving information from Discord and is firing events.*/
+        CONNECTED,
+        /**JDA's main websocket has been disconnected. This <b>DOES NOT</b> mean JDA has shutdown permenantly.
+         * This is an in-between status. Most likely ATTEMPTING_TO_RECONNECT or SHUTTING_DOWN/SHUTDOWN will soon follow.*/
+        DISCONNECTED,
+        /**When trying to reconnect to Discord JDA encounter an issue, most likely related to a lack of internet connection,
+         * and is waiting to try reconnecting again.*/
+        WAITING_TO_RECONNECT,
+        /**JDA has been disconnected from Discord and is currently try to reestablish connection.*/
+        ATTEMPTING_TO_RECONNECT,
+        /**JDA has received a shutdown request or has been disconnected from Discord and reconnect is disabled, thus,
+         * JDA is in the process of shutting down*/
+        SHUTTING_DOWN,
+        /**JDA has finished shutting down and this instance can no longer be used to communicate with the Discord servers.*/
+        SHUTDOWN,
+        /**While attempting to authenticate, Discord reported that the provided authentication information was invalid.*/
+        FAILED_TO_LOGIN,
+    }
+
+    /**
+     * Gets the current status of the JDA instance.
+     *
+     * @return
+     *      Current JDA status.
+     */
+    Status getStatus();
+
+    /**
      * Changes the internal EventManager.
      * The default EventManager is {@link net.dv8tion.jda.hooks.InterfacedEventManager InterfacedEventListener}.
      * There is also an {@link AnnotatedEventManager AnnotatedEventManager} available.

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -323,6 +323,21 @@ public interface JDA
     boolean isAudioEnabled();
 
     /**
+     * Used to determine if JDA will process MESSAGE_DELETE_BULK messages received from Discord as a single
+     * {@link net.dv8tion.jda.events.message.MessageBulkDeleteEvent MessageBulkDeleteEvent} or split
+     * the deleted messages up and fire multiple {@link net.dv8tion.jda.events.message.MessageDeleteEvent MessageDeleteEvents},
+     * one for each deleted message.
+     * <p>
+     * By default, JDA will separate the bulk delete event into individual delete events, but this isn't as efficient as
+     * handling a single event would be. It is recommended that BulkDelete Splitting be disabled and that the developer
+     * should instead handle the {@link net.dv8tion.jda.events.message.MessageBulkDeleteEvent MessageBulkDeleteEvent}
+     *
+     * @return
+     *      Whether or not JDA currently handles the BULK_MESSAGE_DELETE event by splitting it into individual MessageDeleteEvents or not.
+     */
+    boolean isBulkDeleteSplittingEnabled();
+
+    /**
      * Shuts down JDA, closing all its connections.
      * After this command is issued the JDA Instance can not be used anymore.
      * This will also close the background-thread used for requests (which is required for further api calls of other JDA instances).

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda;
 
+import net.dv8tion.jda.JDA.Status;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.ReadyEvent;
 import net.dv8tion.jda.hooks.AnnotatedEventManager;
@@ -308,29 +309,11 @@ public class JDABuilder
      */
     public JDA buildBlocking() throws LoginException, IllegalArgumentException, InterruptedException
     {
-        //Create our ReadyListener and a thread safe Boolean.
-        AtomicBoolean ready = new AtomicBoolean(false);
-        ListenerAdapter readyListener = new ListenerAdapter()
-        {
-            @SubscribeEvent
-            @Override
-            public void onReady(ReadyEvent event)
-            {
-                ready.set(true);
-            }
-        };
-
-        //Add it to our list of listeners, start the login process, wait for the ReadyEvent.
-        listeners.add(readyListener);
         JDA jda = buildAsync();
-        while(!ready.get())
+        while(jda.getStatus() != Status.CONNECTED)
         {
             Thread.sleep(50);
         }
-
-        //We have logged in. Remove the temp ready listener from our local list and the jda listener list.
-        listeners.remove(readyListener);
-        jda.removeEventListener(readyListener);
         return jda;
     }
 }

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -157,25 +157,6 @@ public class JDABuilder
     }
 
     /**
-     * <b>This method is deprecated! Please switch to {@link #setEventManager(IEventManager)}.</b>
-     * <p>
-     * Changes the internal EventManager.
-     * The default EventManager is {@link net.dv8tion.jda.hooks.InterfacedEventManager InterfacedEventListener}.
-     * There is also an {@link AnnotatedEventManager AnnotatedEventManager} available.
-     *
-     * @param useAnnotated
-     *      Whether or not to use the {@link net.dv8tion.jda.hooks.AnnotatedEventManager AnnotatedEventManager}
-     * @return
-     *      Returns the {@link net.dv8tion.jda.JDABuilder JDABuilder} instance. Useful for chaining.
-     */
-    @Deprecated
-    public JDABuilder useAnnotatedEventManager(boolean useAnnotated)
-    {
-        this.useAnnotatedManager = useAnnotated;
-        return this;
-    }
-
-    /**
      * Changes the internally used EventManager.
      * There are 2 provided Implementations:
      * <ul>

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -255,7 +255,7 @@ public class JDABuilder
     }
 
     /**
-     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided email and password to start the login process.<br>
+     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided token to start the login process.<br>
      * The login process runs in a different thread, so while this will return immediately, {@link net.dv8tion.jda.JDA} has not
      * finished loading, thus many {@link net.dv8tion.jda.JDA} methods have the chance to return incorrect information.
      * <p>
@@ -266,9 +266,9 @@ public class JDABuilder
      * @return
      *      A {@link net.dv8tion.jda.JDA} instance that has started the login process. It is unknown as to whether or not loading has finished when this returns.
      * @throws LoginException
-     *          If the provided email-password combination fails the Discord security authentication.
+     *          If the provided token is invalid.
      * @throws IllegalArgumentException
-     *          If either the provided email or password is empty or null.
+     *          If the provided token is empty or null.
      */
     public JDA buildAsync() throws LoginException, IllegalArgumentException
     {
@@ -293,16 +293,16 @@ public class JDABuilder
     }
 
     /**
-     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided email and password to start the login process.<br>
+     * Builds a new {@link net.dv8tion.jda.JDA} instance and uses the provided token to start the login process.<br>
      * This method will block until JDA has logged in and finished loading all resources. This is an alternative
      * to using {@link net.dv8tion.jda.events.ReadyEvent ReadyEvent}.
      *
      * @return
      *      A {@link net.dv8tion.jda.JDA} Object that is <b>guaranteed</b> to be logged in and finished loading.
      * @throws LoginException
-     *          If the provided email-password combination fails the Discord security authentication.
+     *          If the provided token is invalid.
      * @throws IllegalArgumentException
-     *          If either the provided email or password is empty or null.
+     *          If the provided token is empty or null.
      * @throws InterruptedException
      *          If an interrupt request is received while waiting for {@link net.dv8tion.jda.JDA} to finish logging in.
      *          This would most likely be caused by a JVM shutdown request.

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -286,6 +286,7 @@ public class JDABuilder
             jda.setEventManager(eventManager);
         }
         listeners.forEach(jda::addEventListener);
+        jda.setStatus(JDA.Status.INITIALIZED);  //This is already set by JDA internally, but this is to make sure the listeners catch it.
         jda.login(token, sharding);
         return jda;
     }

--- a/src/main/java/net/dv8tion/jda/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/JDABuilder.java
@@ -48,7 +48,7 @@ public class JDABuilder
     protected String token = null;
     protected boolean enableVoice = true;
     protected boolean enableShutdownHook = true;
-    protected boolean useAnnotatedManager = false;
+    protected boolean enableBulkDeleteSplitting = true;
     protected IEventManager eventManager = null;
     protected boolean reconnect = true;
     protected int[] sharding = null;
@@ -110,7 +110,7 @@ public class JDABuilder
      * Enables/Disables Voice functionality.<br>
      * This is useful, if your current system doesn't support Voice and you do not need it.
      * <p>
-     * Default: true
+     * Default: <b>true (enabled)</b>
      *
      * @param enabled
      *          True - enables voice support.
@@ -124,9 +124,29 @@ public class JDABuilder
     }
 
     /**
+     * If enabled, JDA will separate the bulk delete event into individual delete events, but this isn't as efficient as
+     * handling a single event would be. It is recommended that BulkDelete Splitting be disabled and that the developer
+     * should instead handle the {@link net.dv8tion.jda.events.message.MessageBulkDeleteEvent MessageBulkDeleteEvent}
+     * <p>
+     * Default: <b>true (enabled)</b>
+     *
+     * @param enabled
+     *          True - The MESSAGE_DELTE_BULK will be split into multiple individual MessageDeleteEvents.
+     * @return
+     *       Returns the {@link net.dv8tion.jda.JDABuilder JDABuilder} instance. Useful for chaining.
+     */
+    public JDABuilder setBulkDeleteSplittingEnabled(boolean enabled)
+    {
+        this.enableBulkDeleteSplitting = enabled;
+        return this;
+    }
+
+    /**
      * Enables/Disables the use of a Shutdown hook to clean up JDA.<br>
      * When the Java program closes shutdown hooks are run. This is used as a last-second cleanup
      * attempt by JDA to properly severe connections.
+     * <p>
+     * Default: <b>true (enabled)</b>
      *
      * @param enable
      *          True (default) - use shutdown hook to clean up JDA if the Java program is closed.
@@ -180,7 +200,8 @@ public class JDABuilder
     /**
      * Adds a listener to the list of listeners that will be used to populate the {@link net.dv8tion.jda.JDA} object.
      * This uses the {@link net.dv8tion.jda.hooks.InterfacedEventManager InterfacedEventListener} by default.
-     * To switch to the {@link net.dv8tion.jda.hooks.AnnotatedEventManager AnnotatedEventManager}, use {@link #useAnnotatedEventManager(boolean)}.
+     * To switch to the {@link net.dv8tion.jda.hooks.AnnotatedEventManager AnnotatedEventManager},
+     * use {@link #setEventManager(net.dv8tion.jda.hooks.IEventManager) setEventManager(new AnnotatedEventManager())}.
      *
      * Note: when using the {@link net.dv8tion.jda.hooks.InterfacedEventManager InterfacedEventListener} (default),
      * given listener <b>must</b> be instance of {@link net.dv8tion.jda.hooks.EventListener EventListener}!
@@ -256,17 +277,13 @@ public class JDABuilder
         jdaCreated = true;
         JDAImpl jda;
         if (proxySet)
-            jda = new JDAImpl(proxyUrl, proxyPort, enableVoice, enableShutdownHook);
+            jda = new JDAImpl(proxyUrl, proxyPort, enableVoice, enableShutdownHook, enableBulkDeleteSplitting);
         else
-            jda = new JDAImpl(enableVoice, enableShutdownHook);
+            jda = new JDAImpl(enableVoice, enableShutdownHook, enableBulkDeleteSplitting);
         jda.setAutoReconnect(reconnect);
         if (eventManager != null)
         {
             jda.setEventManager(eventManager);
-        }
-        else if (useAnnotatedManager)
-        {
-            jda.setEventManager(new AnnotatedEventManager());
         }
         listeners.forEach(jda::addEventListener);
         jda.login(token, sharding);

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -172,8 +172,11 @@ public class AudioConnection
                             }
                             else
                             {
-                                byte[] encodedAudio = encodeToOpus(rawAudio);
-                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), encodedAudio);
+                                if (!sendHandler.isOpus())
+                                {
+                                    rawAudio = encodeToOpus(rawAudio);
+                                }
+                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), rawAudio);
                                 if (!speaking)
                                     setSpeaking(true);
                                 udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -148,7 +148,7 @@ public class AudioConnection
 
     private void setupSendThread()
     {
-        sendThread = new Thread()
+        sendThread = new Thread("AudioConnection SendThread Guild: " + channel.getGuild().getId())
         {
             @Override
             public void run()
@@ -231,7 +231,7 @@ public class AudioConnection
 
     private void setupReceiveThread()
     {
-        receiveThread = new Thread()
+        receiveThread = new Thread("AudioConnection ReceiveThread Guild: " + channel.getGuild().getId())
         {
             @Override
             public void run()

--- a/src/main/java/net/dv8tion/jda/audio/AudioSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioSendHandler.java
@@ -18,5 +18,11 @@ package net.dv8tion.jda.audio;
 public interface AudioSendHandler
 {
     boolean canProvide();
+    
     byte[] provide20MsAudio();
+    
+    default boolean isOpus()
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioWebSocket.java
@@ -416,7 +416,7 @@ public class AudioWebSocket extends WebSocketAdapter
 
     private void setupUdpKeepAliveThread()
     {
-        udpKeepAliveThread = new Thread()
+        udpKeepAliveThread = new Thread("AudioWebSocket UDP-KeepAlive Guild: " + guild.getId())
         {
             @Override
             public void run()
@@ -461,7 +461,7 @@ public class AudioWebSocket extends WebSocketAdapter
 
     private void setupKeepAliveThread(int keepAliveInterval)
     {
-        keepAliveThread = new Thread()
+        keepAliveThread = new Thread("AudioWebSocket WS-KeepAlive Guild: " + guild.getId())
         {
             @Override
             public void run()

--- a/src/main/java/net/dv8tion/jda/audio/player/FilePlayer.java
+++ b/src/main/java/net/dv8tion/jda/audio/player/FilePlayer.java
@@ -22,6 +22,12 @@ import javax.sound.sampled.UnsupportedAudioFileException;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * <p>This implementation of an {@link net.dv8tion.jda.audio.AudioSendHandler AudioSendHandler} is able to send audio to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} from a local file.
+ * <br/>For that the user has to provide a valid {@link java.io.File File} in a supported audio format.<br/>
+ * <p><b>To use external files that are uploaded to a service use: {@link URLPlayer URLPlayer}</b></p>
+ * </p>
+ */
 public class FilePlayer extends Player
 {
     private File audioFile = null;
@@ -30,12 +36,36 @@ public class FilePlayer extends Player
     private boolean paused = false;
     private boolean stopped = true;
 
+	/**
+     * Creates a new instance of a {@link FilePlayer}.
+     * <p>To directly set a source file: </br>
+     * <pre><code>   new {@link #FilePlayer(File)}</code></pre></p>
+     */
     public FilePlayer() {}
+
+	/**
+	 * Creates a new instance of a {@link FilePlayer} and sets the given File as audio source.
+     * @param file
+     *          An audio file to use as audio source.
+     * @throws IOException
+     *          If the file is not available.
+     * @throws UnsupportedAudioFileException
+     *          If the file is not supported by the player.
+     */
     public FilePlayer(File file) throws IOException, UnsupportedAudioFileException
     {
         setAudioFile(file);
     }
 
+	/**
+     * Sets the given file as the player's audio source if and only if it exists.
+     * @param file
+     *          An audio file to use as audio source.
+     * @throws IOException
+     *          If the file is not available.
+     * @throws UnsupportedAudioFileException
+     *          If the file is not supported by the player.
+     */
     public void setAudioFile(File file) throws IOException, UnsupportedAudioFileException
     {
         if (file == null)

--- a/src/main/java/net/dv8tion/jda/audio/player/URLPlayer.java
+++ b/src/main/java/net/dv8tion/jda/audio/player/URLPlayer.java
@@ -31,7 +31,10 @@ import java.net.URL;
 import java.net.URLConnection;
 
 /**
- * Created by Austin on 1/24/2016.
+ * <p>This implementation of an {@link net.dv8tion.jda.audio.AudioSendHandler AudioSendHandler} is able to send audio to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} from an external source.
+ * <br/> For that the user has to provide a valid {@link java.net.URL URL} to an audio file (like an mp3 file on a cloud).<br/>
+ * <p><b>However, it is unable to process audio sources that come from websites like Youtube/Soundcloud.</b></p>
+ * </p>
  */
 public class URLPlayer extends Player
 {
@@ -51,8 +54,8 @@ public class URLPlayer extends Player
     protected boolean stopped = true;
 
     /**
-     * Creates a new {@link URLPlayer}.
-     * 
+     * Creates a new instance of {@link URLPlayer}.<br/>
+     * To directly set a source URL use <br/><pre><code>    new {@link #URLPlayer(JDA, URL)}</code></pre>
      * @param api
      *        The JDA instance
      */
@@ -64,11 +67,15 @@ public class URLPlayer extends Player
     /**
      * Creates a new {@link net.dv8tion.jda.audio.player.URLPlayer URLPlayer} with the given {@link java.net.URL URL} as resource. <br>
      * Same as {@link URLPlayer#URLPlayer(JDA, URL, int)} using the {@link #DEFAULT_BUFFER_SIZE} of {@value #DEFAULT_BUFFER_SIZE}.
-     * 
+     *
      * @param api
      *        The JDA instance
      * @param urlOfResource
      *        The URL of the resource
+     * @throws IOException
+     *          If the file is not available.
+     * @throws UnsupportedAudioFileException
+     *          If the file is not supported by the player.
      */
     public URLPlayer(JDA api, URL urlOfResource) throws IOException, UnsupportedAudioFileException
     {
@@ -78,13 +85,17 @@ public class URLPlayer extends Player
 
     /**
      * Creates a new {@link net.dv8tion.jda.audio.player.URLPlayer URLPlayer} with the given {@link java.net.URL URL} as resource and a buffer with the given size.
-     * 
+     *
      * @param api
      *        The JDA instance
      * @param urlOfResource
      *        The URL of the resource
      * @param bufferSize
      *        The buffer size in bytes
+     * @throws IOException
+     *          If the file is not available.
+     * @throws UnsupportedAudioFileException
+     *          If the file is not supported by the player.
      */
     public URLPlayer(JDA api, URL urlOfResource, int bufferSize) throws IOException, UnsupportedAudioFileException
     {
@@ -92,11 +103,31 @@ public class URLPlayer extends Player
         setAudioUrl(urlOfResource, bufferSize);
     }
 
+	/**
+     * Sets the audio source to the resource provided by the given {@link URL URL}.
+     * @param urlOfResource
+     *          A URL that links to a supported audio file.
+     * @throws IOException
+     *          If the file is not available.
+     * @throws UnsupportedAudioFileException
+     *          If the file is not supported by the player.
+     */
     public void setAudioUrl(URL urlOfResource) throws IOException, UnsupportedAudioFileException
     {
         setAudioUrl(urlOfResource, DEFAULT_BUFFER_SIZE);
     }
 
+    /**
+     * Sets the audio source to the resource provided by the given {@link URL URL}.
+     * @param urlOfResource
+     *          A URL that links to a supported audio file.
+     * @param bufferSize
+     *          Specifies the buffer size to use for the {@link java.io.BufferedInputStream BufferedInputStream}.
+     * @throws IOException
+     *          If the file is not available.
+     * @throws UnsupportedAudioFileException
+     *          If the file is not supported by the player.
+     */
     public void setAudioUrl(URL urlOfResource, int bufferSize) throws IOException, UnsupportedAudioFileException
     {
         if (urlOfResource == null)

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -189,6 +189,23 @@ public interface Guild
     RoleManager createRole();
 
     /**
+     * Creates a new {@link net.dv8tion.jda.entities.Role Role} in this {@link net.dv8tion.jda.entities.Guild Guild} with the same settings as the given {@link net.dv8tion.jda.entities.Role Role}.
+     * It will be placed at the bottom (just over the @everyone role) to avoid permission hierarchy conflicts.
+     * For this to be successful, the logged in account has to have the {@link net.dv8tion.jda.Permission#MANAGE_ROLES MANAGE_ROLES Permission}
+     * and all {@link net.dv8tion.jda.Permission Permissions} the given {@link net.dv8tion.jda.entities.Role Role} has.
+     *
+     * @param role 
+     *      The {@link net.dv8tion.jda.entities.Role Role} that should be copied 
+     * @return
+     *      the RoleManager for the created Role
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *      if the bot doesn't has {@link net.dv8tion.jda.Permission#MANAGE_ROLES MANAGE_ROLES Permission} and every Permission the given Role has
+     */
+    RoleManager createCopyOfRole(Role role);
+
+    /**
      * Provides all of the {@link net.dv8tion.jda.entities.Role Roles} that the provided {@link net.dv8tion.jda.entities.User User}
      *  has been assigned.
      * The roles returned will be sorted according to their position.

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -229,6 +229,13 @@ public interface Guild
     List<Role> getRolesForUser(User user);
 
     /**
+     * Provides the {@link net.dv8tion.jda.entities.Role Role} that determines the color for the provided {@link net.dv8tion.jda.entities.User User}
+     * 
+     * If the {@link net.dv8tion.jda.entities.User User} has the default color, this returns the same as getPublicRole();
+     */
+    Role getColorDeterminantRoleForUser(User user);
+
+    /**
      * Provides all {@link net.dv8tion.jda.entities.User Users} that have the provided role.
      *
      * @param role

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -114,6 +114,16 @@ public interface Guild
     List<User> getUsers();
 
     /**
+     * Used to determine the provided {@link net.dv8tion.jda.entities.User User} is a member of this Guild.
+     *
+     * @param user
+     *          The user to determine whether or not they are a member of this guild.
+     * @return
+     *      True - if this user is present in this guild.
+     */
+    boolean isMember(User user);
+
+    /**
      * The {@link net.dv8tion.jda.entities.TextChannel TextChannels} available on the {@link net.dv8tion.jda.entities.Guild Guild}.
      * The channels returned will be sorted according to their position.
      *
@@ -207,13 +217,14 @@ public interface Guild
 
     /**
      * Provides all of the {@link net.dv8tion.jda.entities.Role Roles} that the provided {@link net.dv8tion.jda.entities.User User}
-     *  has been assigned.
-     * The roles returned will be sorted according to their position.
+     *  has been assigned.<br>
+     * The roles returned will be sorted according to their position.<br>
+     * If this the provided user is not in this guild, the list returned will be null.
      *
      * @param user
      *          The {@link net.dv8tion.jda.entities.User User} that we wish to get the {@link net.dv8tion.jda.entities.Role Roles} related to.
      * @return
-     *      An Immutable List of {@link net.dv8tion.jda.entities.Role Roles}.
+     *      An Immutable List of {@link net.dv8tion.jda.entities.Role Roles} or null if the provided user isn't in this Guild.
      */
     List<Role> getRolesForUser(User user);
 

--- a/src/main/java/net/dv8tion/jda/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/entities/Message.java
@@ -235,6 +235,34 @@ public interface Message
     JDA getJDA();
 
     /**
+     * Whether or not this Message has been pinned in its parent channel.
+     *
+     * @return
+     *      True - if this message has been pinned.
+     */
+    boolean isPinned();
+
+    /**
+     * This is a shortcut method to {@link MessageChannel#pinMessageById(String)}.<br>
+     * If this method returns true, then the action was successful and this Message's
+     * {@link #isPinned()} will now return true.
+     *
+     * @return
+     *      True - if the action completed successfully and this message became pinned.
+     */
+    boolean pin();
+
+    /**
+     * This is a shortcut method to {@link MessageChannel#unpinMessageById(String)}.<br>
+     * If this method returns true, then the action was successful and this Message's
+     * {@link #isPinned()} will now return false.
+     *
+     * @return
+     *      True - if the action completed successfully and this message was unpinned.
+     */
+    boolean unpin();
+
+    /**
      * Represents a {@link net.dv8tion.jda.entities.Message Message} file attachment.
      */
     class Attachment

--- a/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.entities;
 
+import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.MessageHistory;
 import net.dv8tion.jda.exceptions.VerificationLevelException;
 
@@ -26,6 +27,22 @@ import java.util.function.Consumer;
  */
 public interface MessageChannel
 {
+    /**
+     * Returns the {@link net.dv8tion.jda.JDA JDA} instance of this MessageChannel
+     *
+     * @return
+     *      the corresponding JDA instance
+     */
+    JDA getJDA();
+
+    /**
+     * The Id of the Channel. This is typically 18 characters long.
+     *
+     * @return
+     *      The Id of this Channel
+     */
+    String getId();
+
     /**
      * Sends a plain text {@link net.dv8tion.jda.entities.Message Message} to this channel.
      * This will fail if the account of the api does not have the {@link net.dv8tion.jda.Permission#MESSAGE_WRITE Write-Permission}

--- a/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.MessageHistory;
 import net.dv8tion.jda.exceptions.VerificationLevelException;
 
 import java.io.File;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -250,4 +251,52 @@ public interface MessageChannel
      * The official discord client sends this every 5 seconds even though the typing status lasts 10.
      */
     void sendTyping();
+
+    /**
+     * Used to pin a message.<br>
+     * If the provided messageId is invalid or not in this channel, this does nothing.
+     *
+     * @param messageId
+     *          The message to pin.
+     * @return
+     *      True - if the message was successfully unpinned. If false, the message id probably didn't exist or wasn't a message from this channel.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *          If this is a TextChannel and this account does not have both
+     *          {@link net.dv8tion.jda.Permission#MESSAGE_READ Permission.MESSAGE_READ} and
+     *          {@link net.dv8tion.jda.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
+     * @throws net.dv8tion.jda.exceptions.RateLimitedException
+     *          If Discord informs us that this account has accessed this endpoint too often, thus needs to be ratelimited.
+     */
+    boolean pinMessageById(String messageId);
+
+    /**
+     * Used to unpin a message.<br>
+     * If the provided messageId is invalid or not in this channel, this does nothing.
+     *
+     * @param messageId
+     *          The message to pin.
+     * @return
+     *      True - if the message was successfully unpinned. If false, the message id probably didn't exist or wasn't a message from this channel.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *          If this is a TextChannel and this account does not have both
+     *          {@link net.dv8tion.jda.Permission#MESSAGE_READ Permission.MESSAGE_READ} and
+     *          {@link net.dv8tion.jda.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
+     * @throws net.dv8tion.jda.exceptions.RateLimitedException
+     *          If Discord informs us that this account has accessed this endpoint too often, thus needs to be ratelimited.
+     */
+    boolean unpinMessageById(String messageId);
+
+    /**
+     * Gets a List of {@link net.dv8tion.jda.entities.Message Messages} that have been pinned in this channel.<br>
+     * If no messages have been pinned, this returns an empty List.
+     *
+     * @return
+     *      An unmodifiable List containing all pinned messages.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *          If this is a TextChannel and this account does not have
+     *          {@link net.dv8tion.jda.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     * @throws net.dv8tion.jda.exceptions.RateLimitedException
+     *          If Discord informs us that this account has accessed this endpoint too often, thus needs to be ratelimited.
+     */
+    List<Message> getPinnedMessages();
 }

--- a/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/MessageChannel.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.entities;
 
+import net.dv8tion.jda.MessageHistory;
 import net.dv8tion.jda.exceptions.VerificationLevelException;
 
 import java.io.File;
@@ -177,9 +178,59 @@ public interface MessageChannel
     void sendFileAsync(File file, Message message, Consumer<Message> callback);
 
     /**
+     * Attempts to get a {@link net.dv8tion.jda.entities.Message Message} from the Discord servers that has
+     * the same id as the id provided.<br>
+     *
+     * @param messageId
+     *          The id of the sought after Message
+     * @return
+     *      The Message defined by the provided id. `Null` if the message doesn't exist.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *      Thrown if:
+     *      <ul>
+     *          <li>Attempt to get a message from a channel which this account doesn't have access to.
+     *              ({@link net.dv8tion.jda.Permission#MESSAGE_READ Permission.MESSAGE_READ})</li>
+     *          <li>Attempt to get a message from a channel that this account cannot read the history of.
+     *              ({@link net.dv8tion.jda.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY})</li>
+     *      </ul>
+     */
+    Message getMessageById(String messageId);
+
+    /**
+     * Attempts to delete a {@link net.dv8tion.jda.entities.Message Message} from the Discord servers
+     * that has the same id as the id provided.<br>
+     *
+     * @param messageId
+     *          The id of the Message which should be deleted
+     * @return
+     *      True if the message was successfully deleted. False if the message didn't exist.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *      Thrown if:
+     *      <ul>
+     *          <li>Attempt to get a message from a channel which this account doesn't have access to.
+     *              ({@link net.dv8tion.jda.Permission#MESSAGE_READ Permission.MESSAGE_READ})</li>
+     *          <li>Attempt to delete another user's message in a channel that this account doesn't have permission to manage.
+     *              ({@link net.dv8tion.jda.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE})</li>
+     *          <li>Attempt to delete another user's message in a PrivateChannel.</li>
+     *      </ul>
+     */
+    boolean deleteMessageById(String messageId);
+
+    /**
+     * Creates a new {@link net.dv8tion.jda.MessageHistory MessageHistory} object for each call of this method.<br>
+     * This is <b>NOT</b> and internal message cache, but rather it queries the Discord servers for old messages.
+     *
+     * @return
+     *      The MessageHistory for this channel.
+     */
+    MessageHistory getHistory();
+
+    /**
      * Sends the typing status to discord. This is what is used to make the message "X is typing..." appear.<br>
-     * The typing status only lasts for 10 seconds or until a message is sent.
+     * The typing status only lasts for 10 seconds or until a message is sent.<br>
      * So if you wish to show continuous typing you will need to call this method once every 10 seconds.
+     * <p>
+     * The official discord client sends this every 5 seconds even though the typing status lasts 10.
      */
     void sendTyping();
 }

--- a/src/main/java/net/dv8tion/jda/entities/SelfInfo.java
+++ b/src/main/java/net/dv8tion/jda/entities/SelfInfo.java
@@ -15,6 +15,8 @@
  */
 package net.dv8tion.jda.entities;
 
+import net.dv8tion.jda.Permission;
+
 /**
  * Represents the currently logged in account.
  */
@@ -29,4 +31,16 @@ public interface SelfInfo extends User
      *      boolean specifying whether or not this account is verified.
      */
     boolean isVerified();
+
+    /**
+     * Creates a OAuth invite-link used to invite bot-accounts.<br>
+     * This is literally just a shortcut to
+     * {@link net.dv8tion.jda.utils.ApplicationUtil#getAuthInvite(net.dv8tion.jda.JDA, net.dv8tion.jda.Permission...) ApplicationUtil.getAuthInvite(JDA, Permission...)}
+     *
+     * @param perms
+     *      Possibly empty list of Permissions that should be requested via invite
+     * @return
+     *      The link used to invite the bot
+     */
+    String getAuthUrl(Permission... perms);
 }

--- a/src/main/java/net/dv8tion/jda/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/TextChannel.java
@@ -38,15 +38,48 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
     String getAsMention();
     
     /**
-     * Bulk deletes a list of messages. Must not be more than 100 messages at a time.
-     * You must have channel permission to delete messages.
-     * If only a single message is supplied then this function will resort to using {@link net.dv8tion.jda.entities.Message#deleteMessage} instead.
+     * Bulk deletes a list of messages. <b>This is not the same as calling {@link net.dv8tion.jda.entities.Message#deleteMessage()} in a loop.</b><br>
+     * This is much more efficient, but it has a different ratelimit. You may call this once per second per Guild.
+     * <p>
+     * Must be at least 2 messages and not be more than 100 messages at a time.<br>
+     * If you only have 1 message, use the {@link Message#deleteMessage()} method.<br>
+     * <p>
+     * You must have {@link net.dv8tion.jda.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel to use
+     * this function.
+     * <p>
+     * This method is best used when using {@link net.dv8tion.jda.MessageHistory MessageHistory} to delete a large amount
+     * of messages. If you have a large amount of messages but only their message Ids, please use
+     * {@link #deleteMessagesByIds(java.util.Collection)}
+     *
      * @param messages
      *      The messages to delete.
-     * @throws IllegalArgumentException
-     *      If the size of the list is more than 100 messages.
-     * @throws IllegalArgumentException
+     * @throws java.lang.IllegalArgumentException
+     *      If the size of the list less than 2 or more than 100 messages.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
      *      If this account does not have MANAGE_MESSAGES
      */
     void deleteMessages(Collection<Message> messages);
+
+    /**
+     * Bulk deletes a list of messages. <b>This is not the same as calling {@link net.dv8tion.jda.entities.MessageChannel#deleteMessageById(String) in a loop.</b> <br>
+     * This is much more efficient, but it has a different ratelimit. You may call this once per second per Guild.
+     * <p>
+     * Must be at least 2 messages and not be more than 100 messages at a time.<br>
+     * If you only have 1 message, use the {@link Message#deleteMessage()} method.<br>
+     * <p>
+     * You must have {@link net.dv8tion.jda.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel to use
+     * this function.
+     * <p>
+     * This method is best used when you have a large amount of messages but only their message Ids. If you are using
+     * {@link net.dv8tion.jda.MessageHistory MessageHistory} or have {@link net.dv8tion.jda.entities.Message Message}
+     * objects, it would be easier to use {@link #deleteMessages(java.util.Collection)}.
+     *
+     * @param messageIds
+     *      The messages to delete.
+     * @throws java.lang.IllegalArgumentException
+     *      If the size of the list less than 2 or more than 100 messages.
+     * @throws net.dv8tion.jda.exceptions.PermissionException
+     *      If this account does not have MANAGE_MESSAGES
+     */
+    void deleteMessagesByIds(Collection<String> messageIds);
 }

--- a/src/main/java/net/dv8tion/jda/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/TextChannel.java
@@ -57,6 +57,8 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *      If the size of the list less than 2 or more than 100 messages.
      * @throws net.dv8tion.jda.exceptions.PermissionException
      *      If this account does not have MANAGE_MESSAGES
+     * @throws net.dv8tion.jda.exceptions.RateLimitedException
+     *      If the a ratelimit is encountered. Ratelimit for bulk_delete is 1 call / second / guild.
      */
     void deleteMessages(Collection<Message> messages);
 
@@ -80,6 +82,8 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *      If the size of the list less than 2 or more than 100 messages.
      * @throws net.dv8tion.jda.exceptions.PermissionException
      *      If this account does not have MANAGE_MESSAGES
+     * @throws net.dv8tion.jda.exceptions.RateLimitedException
+     *      If the a ratelimit is encountered. Ratelimit for bulk_delete is 1 call / second / guild.
      */
     void deleteMessagesByIds(Collection<String> messageIds);
 }

--- a/src/main/java/net/dv8tion/jda/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/entities/User.java
@@ -41,7 +41,7 @@ public interface User
     String getUsername();
 
     /**
-     * The descriminator of the {@link net.dv8tion.jda.entities.User User}. Used to differentiate between users with the same usernames.<br>
+     * The discriminator of the {@link net.dv8tion.jda.entities.User User}. Used to differentiate between users with the same usernames.<br>
      * This will be important when the friends list is released for human readable searching.<br>
      * Ex: DV8FromTheWorld#9148
      *

--- a/src/main/java/net/dv8tion/jda/entities/VoiceChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/VoiceChannel.java
@@ -24,4 +24,25 @@ package net.dv8tion.jda.entities;
  */
 public interface VoiceChannel extends Channel, Comparable<VoiceChannel>
 {
+    /**
+     * The maximum amount of {@link net.dv8tion.jda.entities.User Users} that can be in this
+     * {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} at one time.
+     * <br>
+     * 0 - No limit <br>
+     *
+     * @return
+     *      The maximum amount of users allowed in this channel at one time.
+     */
+    int getUserLimit();
+
+    /**
+     * The audio bitrate of the voice audio that is played in this channel. While higher bitrates can be sent to
+     * this channel, it will be scaled down by the client.
+     * <br>
+     * Default and recommended value is 64000
+     *
+     * @return
+     *      The audio bitrate of this voice channel.
+     */
+    int getBitrate();
 }

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -257,7 +257,7 @@ public class GuildImpl implements Guild
         for (Permission perm : role.getPermissions())
         {
             if (!PermissionUtil.checkPermission(role.getJDA().getSelfInfo(), perm, role.getGuild()))
-                throw new PermissionException(perm);  
+                throw new PermissionException(perm);
         }
 
         RoleManager manager = createRole();
@@ -277,11 +277,12 @@ public class GuildImpl implements Guild
         List<Role> roles = userRoles.get(user);
         if (roles == null)
             return null;
+        roles = new ArrayList<>(roles);
 
         Collections.sort(roles, (r1, r2) -> r2.compareTo(r1));
         return Collections.unmodifiableList(roles);
     }
-    
+
     @Override
     public Role getColorDeterminantRoleForUser(User user)
     {

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -281,6 +281,15 @@ public class GuildImpl implements Guild
         Collections.sort(roles, (r1, r2) -> r2.compareTo(r1));
         return Collections.unmodifiableList(roles);
     }
+    
+    @Override
+    public Role getColorDeterminantRoleForUser(User user)
+    {
+        for(Role role : getRolesForUser(user))
+            if(role.getColor() != 0)
+                return role;
+        return publicRole;
+    }
 
     @Override
     public List<User> getUsersWithRole(Role role)

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -134,6 +134,12 @@ public class GuildImpl implements Guild
     }
 
     @Override
+    public boolean isMember(User user)
+    {
+        return getRolesForUser(user) != null;
+    }
+
+    @Override
     public List<TextChannel> getTextChannels()
     {
         ArrayList<TextChannel> textChannels = new ArrayList<>(this.textChannels.values());
@@ -270,7 +276,7 @@ public class GuildImpl implements Guild
     {
         List<Role> roles = userRoles.get(user);
         if (roles == null)
-            return new LinkedList<>();
+            return null;
 
         Collections.sort(roles, (r1, r2) -> r2.compareTo(r1));
         return Collections.unmodifiableList(roles);

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -244,6 +244,28 @@ public class GuildImpl implements Guild
     }
 
     @Override
+    public RoleManager createCopyOfRole(Role role)
+    {
+        if (!PermissionUtil.checkPermission(role.getJDA().getSelfInfo(), Permission.MANAGE_ROLES, role.getGuild()))
+            throw new PermissionException(Permission.MANAGE_ROLES);
+        for (Permission perm : role.getPermissions())
+        {
+            if (!PermissionUtil.checkPermission(role.getJDA().getSelfInfo(), perm, role.getGuild()))
+                throw new PermissionException(perm);  
+        }
+
+        RoleManager manager = createRole();
+        manager.setPermissionsRaw(role.getPermissionsRaw());
+        manager.setName(role.getName());
+        manager.setColor(role.getColor());
+        manager.setGrouped(role.isGrouped());
+        manager.setMentionable(role.isMentionable());
+        manager.update();
+
+        return manager;
+    }
+
+    @Override
     public List<Role> getRolesForUser(User user)
     {
         List<Role> roles = userRoles.get(user);

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -363,6 +363,8 @@ public class GuildImpl implements Guild
     @Override
     public boolean checkVerification()
     {
+        if (api.getSelfInfo().isBot())
+            return true;
         if(canSendVerification)
             return true;
         switch (verificationLevel)

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -59,7 +59,7 @@ public class JDAImpl implements JDA
     protected final Map<String, TextChannel> textChannelMap = new HashMap<>();
     protected final Map<String, VoiceChannel> voiceChannelMap = new HashMap<>();
     protected final Map<String, PrivateChannel> pmChannelMap = new HashMap<>();
-    protected final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or PrivateChannelId) - Timeout.
+    protected final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or GlobalPrivateChannel) - Timeout.
     protected final Map<String, String> offline_pms = new HashMap<>();    //Userid -> channelid
     protected final Map<Guild, AudioManager> audioManagers = new HashMap<>();
     protected final boolean audioEnabled;

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -64,6 +64,7 @@ public class JDAImpl implements JDA
     protected final Map<Guild, AudioManager> audioManagers = new HashMap<>();
     protected final boolean audioEnabled;
     protected final boolean useShutdownHook;
+    protected final boolean bulkDeleteSplittingEnabled;
     protected IEventManager eventManager = new InterfacedEventManager();
     protected SelfInfo selfInfo = null;
     protected AccountManager accountManager;
@@ -73,7 +74,7 @@ public class JDAImpl implements JDA
     protected boolean reconnect;
     protected int responseTotal;
 
-    public JDAImpl(boolean enableAudio, boolean useShutdownHook)
+    public JDAImpl(boolean enableAudio, boolean useShutdownHook, boolean enableBulkDeleteSplitting)
     {
         proxy = null;
         if (enableAudio)
@@ -81,9 +82,11 @@ public class JDAImpl implements JDA
         else
             this.audioEnabled = false;
         this.useShutdownHook = useShutdownHook;
+        this.bulkDeleteSplittingEnabled = enableBulkDeleteSplitting;
     }
 
-    public JDAImpl(String proxyUrl, int proxyPort, boolean enableAudio, boolean useShutdownHook)
+    public JDAImpl(String proxyUrl, int proxyPort, boolean enableAudio, boolean useShutdownHook,
+                   boolean enableBulkDeleteSplitting)
     {
         if (proxyUrl == null || proxyUrl.isEmpty() || proxyPort == -1)
             throw new IllegalArgumentException("The provided proxy settings cannot be used to make a proxy. Settings: URL: '" + proxyUrl + "'  Port: " + proxyPort);
@@ -94,6 +97,7 @@ public class JDAImpl implements JDA
         else
             this.audioEnabled = false;
         this.useShutdownHook = useShutdownHook;
+        this.bulkDeleteSplittingEnabled = enableBulkDeleteSplitting;
     }
 
     /**
@@ -391,6 +395,12 @@ public class JDAImpl implements JDA
     public boolean isAudioEnabled()
     {
         return audioEnabled;
+    }
+
+    @Override
+    public boolean isBulkDeleteSplittingEnabled()
+    {
+        return bulkDeleteSplittingEnabled;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -176,7 +176,7 @@ public class JDAImpl implements JDA
     @Override
     public Status getStatus()
     {
-        return null;
+        return status;
     }
 
     public void setStatus(Status status)

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -156,52 +156,6 @@ public class JDAImpl implements JDA
         return false;
     }
 
-    /**
-     * Takes a provided json file, reads all lines and constructs a {@link org.json.JSONObject JSONObject} from it.
-     *
-     * @param file
-     *          The json file to read.
-     * @return
-     *      The {@link org.json.JSONObject JSONObject} representation of the json in the file.
-     */
-    protected static JSONObject readJson(Path file)
-    {
-        try
-        {
-            return new JSONObject(StringUtils.join(Files.readAllLines(file, StandardCharsets.UTF_8), ""));
-        }
-        catch (IOException e)
-        {
-            LOG.fatal("Error reading token-file. Defaulting to standard");
-            LOG.log(e);
-        }
-        catch (JSONException e)
-        {
-            LOG.warn("Token-file misformatted. Creating default one");
-        }
-        return null;
-    }
-
-    /**
-     * Writes the json representation of the provided {@link org.json.JSONObject JSONObject} to the provided file.
-     *
-     * @param file
-     *          The file which will have the json representation of object written into.
-     * @param object
-     *          The {@link org.json.JSONObject JSONObject} to write to file.
-     */
-    protected static void writeJson(Path file, JSONObject object)
-    {
-        try
-        {
-            Files.write(file, Arrays.asList(object.toString(4).split("\n")), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        }
-        catch (IOException e)
-        {
-            LOG.warn("Error creating token-file");
-        }
-    }
-
     @Override
     public String getAuthToken()
     {

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -69,7 +69,7 @@ public class JDAImpl implements JDA
     protected AccountManager accountManager;
     protected String authToken = null;
     protected WebSocketClient client;
-    protected final Requester requester = new Requester(this);
+    protected Requester requester = new Requester(this);
     protected boolean reconnect;
     protected int responseTotal;
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -83,6 +83,8 @@ public class JDAImpl implements JDA
             this.audioEnabled = false;
         this.useShutdownHook = useShutdownHook;
         this.bulkDeleteSplittingEnabled = enableBulkDeleteSplitting;
+        if (bulkDeleteSplittingEnabled)
+            LOG.warn("BulkDeleteSplitting is enabled. For best performance, please look at the javadoc for JDABuilder#setBulkDeleteEnabled(boolean).");
     }
 
     public JDAImpl(String proxyUrl, int proxyPort, boolean enableAudio, boolean useShutdownHook,
@@ -98,6 +100,8 @@ public class JDAImpl implements JDA
             this.audioEnabled = false;
         this.useShutdownHook = useShutdownHook;
         this.bulkDeleteSplittingEnabled = enableBulkDeleteSplitting;
+        if (bulkDeleteSplittingEnabled)
+            LOG.warn("BulkDeleteSplitting is enabled. For best performance, please look at the javadoc for JDABuilder#setBulkDeleteEnabled(boolean).");
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -132,7 +132,7 @@ public class JDAImpl implements JDA
 
         if (useShutdownHook)
         {
-            Runtime.getRuntime().addShutdownHook(new Thread()
+            Runtime.getRuntime().addShutdownHook(new Thread("JDA Shutdown Hook")
             {
                 @Override
                 public void run()

--- a/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/JDAImpl.java
@@ -53,25 +53,25 @@ import java.util.stream.Collectors;
 public class JDAImpl implements JDA
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDA");
-    private final HttpHost proxy;
-    private final Map<String, User> userMap = new HashMap<>();
-    private final Map<String, Guild> guildMap = new HashMap<>();
-    private final Map<String, TextChannel> textChannelMap = new HashMap<>();
-    private final Map<String, VoiceChannel> voiceChannelMap = new HashMap<>();
-    private final Map<String, PrivateChannel> pmChannelMap = new HashMap<>();
-    private final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or PrivateChannelId) - Timeout.
-    private final Map<String, String> offline_pms = new HashMap<>();    //Userid -> channelid
-    private final Map<Guild, AudioManager> audioManagers = new HashMap<>();
-    private final boolean audioEnabled;
-    private final boolean useShutdownHook;
-    private IEventManager eventManager = new InterfacedEventManager();
-    private SelfInfo selfInfo = null;
-    private AccountManager accountManager;
-    private String authToken = null;
-    private WebSocketClient client;
-    private final Requester requester = new Requester(this);
-    private boolean reconnect;
-    private int responseTotal;
+    protected final HttpHost proxy;
+    protected final Map<String, User> userMap = new HashMap<>();
+    protected final Map<String, Guild> guildMap = new HashMap<>();
+    protected final Map<String, TextChannel> textChannelMap = new HashMap<>();
+    protected final Map<String, VoiceChannel> voiceChannelMap = new HashMap<>();
+    protected final Map<String, PrivateChannel> pmChannelMap = new HashMap<>();
+    protected final Map<String, Long> messageRatelimitTimeouts = new HashMap<>(); //(GuildId or PrivateChannelId) - Timeout.
+    protected final Map<String, String> offline_pms = new HashMap<>();    //Userid -> channelid
+    protected final Map<Guild, AudioManager> audioManagers = new HashMap<>();
+    protected final boolean audioEnabled;
+    protected final boolean useShutdownHook;
+    protected IEventManager eventManager = new InterfacedEventManager();
+    protected SelfInfo selfInfo = null;
+    protected AccountManager accountManager;
+    protected String authToken = null;
+    protected WebSocketClient client;
+    protected final Requester requester = new Requester(this);
+    protected boolean reconnect;
+    protected int responseTotal;
 
     public JDAImpl(boolean enableAudio, boolean useShutdownHook)
     {
@@ -143,7 +143,7 @@ public class JDAImpl implements JDA
         }
     }
 
-    private boolean validate(String authToken)
+    protected boolean validate(String authToken)
     {
         this.authToken = authToken;
         try
@@ -164,7 +164,7 @@ public class JDAImpl implements JDA
      * @return
      *      The {@link org.json.JSONObject JSONObject} representation of the json in the file.
      */
-    private static JSONObject readJson(Path file)
+    protected static JSONObject readJson(Path file)
     {
         try
         {
@@ -190,7 +190,7 @@ public class JDAImpl implements JDA
      * @param object
      *          The {@link org.json.JSONObject JSONObject} to write to file.
      */
-    private static void writeJson(Path file, JSONObject object)
+    protected static void writeJson(Path file, JSONObject object)
     {
         try
         {
@@ -494,10 +494,10 @@ public class JDAImpl implements JDA
         return manager;
     }
 
-    private static class AsyncCallback implements EventListener
+    protected static class AsyncCallback implements EventListener
     {
-        private final Consumer<GuildManager> cb;
-        private final String id;
+        protected final Consumer<GuildManager> cb;
+        protected final String id;
 
         public AsyncCallback(Consumer<GuildManager> cb, String guildId)
         {

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.Permission;
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.exceptions.PermissionException;
+import net.dv8tion.jda.exceptions.RateLimitedException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.requests.Requester;
 import org.json.JSONException;
@@ -241,7 +242,9 @@ public class MessageImpl implements Message
             else if (!api.getTextChannelById(getChannelId()).checkPermission(api.getSelfInfo(), Permission.MESSAGE_MANAGE))
                 throw new PermissionException(Permission.MESSAGE_MANAGE);
         }
-        api.getRequester().delete(Requester.DISCORD_API_PREFIX + "channels/" + channelId + "/messages/" + getId());
+        Requester.Response response = api.getRequester().delete(Requester.DISCORD_API_PREFIX + "channels/" + channelId + "/messages/" + getId());
+        if (response.isRateLimit())
+            throw new RateLimitedException(response.getObject().getInt("retry_after"));
     }
 
     public MessageImpl setMentionedUsers(List<User> mentionedUsers)

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -225,7 +225,9 @@ public class MessageImpl implements Message
         if (api.getSelfInfo() != getAuthor())
             throw new UnsupportedOperationException("Attempted to update message that was not sent by this account. You cannot modify other User's messages!");
         Message newMessage = new MessageImpl(getId(), api).setContent(newContent).setChannelId(getChannelId());
-        String ratelimitIdentifier = isPrivate ? channelId : api.getTextChannelById(channelId).getGuild().getId();
+        String ratelimitIdentifier = isPrivate
+                ? PrivateChannelImpl.RATE_LIMIT_IDENTIFIER
+                : api.getTextChannelById(channelId).getGuild().getId();
         TextChannelImpl.AsyncMessageSender.getInstance(api, ratelimitIdentifier).enqueue(newMessage, true, callback);
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -38,6 +38,7 @@ public class MessageImpl implements Message
     private boolean mentionsEveryone = false;
     private boolean isTTS = false;
     private boolean isPrivate;
+    private boolean pinned;
     private String channelId;
     private String content;
     private String subContent = null;
@@ -61,6 +62,36 @@ public class MessageImpl implements Message
     public JDA getJDA()
     {
         return api;
+    }
+
+    @Override
+    public boolean isPinned()
+    {
+        return pinned;
+    }
+
+    public MessageImpl setPinned(boolean pinned)
+    {
+        this.pinned = pinned;
+        return this;
+    }
+
+    @Override
+    public boolean pin()
+    {
+        boolean result = getChannel().pinMessageById(id);
+        if (result)
+            this.pinned = true;
+        return result;
+    }
+
+    @Override
+    public boolean unpin()
+    {
+        boolean result = getChannel().unpinMessageById(id);
+        if (result)
+            this.pinned = false;
+        return result;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -225,7 +225,8 @@ public class MessageImpl implements Message
         if (api.getSelfInfo() != getAuthor())
             throw new UnsupportedOperationException("Attempted to update message that was not sent by this account. You cannot modify other User's messages!");
         Message newMessage = new MessageImpl(getId(), api).setContent(newContent).setChannelId(getChannelId());
-        TextChannelImpl.AsyncMessageSender.getInstance(api).enqueue(newMessage, true, callback);
+        String ratelimitIdentifier = isPrivate ? channelId : api.getTextChannelById(channelId).getGuild().getId();
+        TextChannelImpl.AsyncMessageSender.getInstance(api, ratelimitIdentifier).enqueue(newMessage, true, callback);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -30,10 +30,14 @@ import net.dv8tion.jda.exceptions.PermissionException;
 import net.dv8tion.jda.exceptions.RateLimitedException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.requests.Requester;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class PrivateChannelImpl implements PrivateChannel
@@ -210,6 +214,47 @@ public class PrivateChannelImpl implements PrivateChannel
     public void sendTyping()
     {
         api.getRequester().post(Requester.DISCORD_API_PREFIX + "channels/" + getId() + "/typing", new JSONObject());
+    }
+
+    @Override
+    public boolean pinMessageById(String messageId)
+    {
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().put(
+                Requester.DISCORD_API_PREFIX + "/channels/" + id + "/pins/" + messageId, new JSONObject());
+        if (response.isRateLimit())
+            throw new RateLimitedException(response.getObject().getInt("retry_after"));
+        return response.isOk();
+    }
+
+    @Override
+    public boolean unpinMessageById(String messageId)
+    {
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().delete(
+                Requester.DISCORD_API_PREFIX + "/channels/" + id + "/pins/" + messageId);
+        if (response.isRateLimit())
+            throw new RateLimitedException(response.getObject().getInt("retry_after"));
+        return response.isOk();
+    }
+
+    @Override
+    public List<Message> getPinnedMessages()
+    {
+        List<Message> pinnedMessages = new LinkedList<>();
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().get(
+                Requester.DISCORD_API_PREFIX + "/channels/" + id + "/pins");
+        if (response.isOk())
+        {
+            JSONArray pins = response.getArray();
+            for (int i = 0; i < pins.length(); i++)
+            {
+                pinnedMessages.add(new EntityBuilder((JDAImpl) getJDA()).createMessage(pins.getJSONObject(i)));
+            }
+            return Collections.unmodifiableList(pinnedMessages);
+        }
+        else if (response.isRateLimit())
+            throw new RateLimitedException(response.getObject().getInt("retry_after"));
+        else
+            throw new RuntimeException("An unknown error occured attempting to get pinned messages. Ask devs for help.\n" + response);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -20,10 +20,13 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.body.MultipartBody;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.MessageBuilder;
+import net.dv8tion.jda.MessageHistory;
+import net.dv8tion.jda.Permission;
 import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.exceptions.BlockedException;
+import net.dv8tion.jda.exceptions.PermissionException;
 import net.dv8tion.jda.exceptions.RateLimitedException;
 import net.dv8tion.jda.handle.EntityBuilder;
 import net.dv8tion.jda.requests.Requester;
@@ -169,6 +172,38 @@ public class PrivateChannelImpl implements PrivateChannel
         thread.setName("PrivateChannelImpl SendFileAsync Channel: " + id);
         thread.setDaemon(true);
         thread.start();
+    }
+
+    @Override
+    public Message getMessageById(String messageId)
+    {
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().get(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/" + messageId);
+
+        if (response.isOk())
+            return new EntityBuilder((JDAImpl) getJDA()).createMessage(response.getObject());
+
+        //Doesn't exist.
+        return null;
+    }
+
+    @Override
+    public boolean deleteMessageById(String messageId)
+    {
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/" + messageId);
+
+        if (response.isOk())
+            return true;
+        else if (response.code == 403)
+            throw new PermissionException("Cannot delete another User's messages in a PrivateChannel.");
+
+        //Doesn't exist. Either never existed, bad id, was deleted already, or not in this channel.
+        return false;
+    }
+
+    @Override
+    public MessageHistory getHistory()
+    {
+        return new MessageHistory(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -73,9 +73,9 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public Message sendMessage(Message msg)
     {
-        if (api.getMessageLimit() != null)
+        if (api.getMessageLimit(id) != null)
         {
-            throw new RateLimitedException(api.getMessageLimit() - System.currentTimeMillis());
+            throw new RateLimitedException(api.getMessageLimit(id) - System.currentTimeMillis());
         }
         try
         {
@@ -84,7 +84,7 @@ public class PrivateChannelImpl implements PrivateChannel
             if (response.isRateLimit())
             {
                 long retry_after = response.getObject().getLong("retry_after");
-                api.setMessageTimeout(retry_after);
+                api.setMessageTimeout(id, retry_after);
                 throw new RateLimitedException(retry_after);
             }
             if (!response.isOk())
@@ -110,8 +110,8 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public void sendMessageAsync(Message msg, Consumer<Message> callback)
     {
-        ((MessageImpl) msg).setChannelId(getId());
-        TextChannelImpl.AsyncMessageSender.getInstance(getJDA()).enqueue(msg, false, callback);
+        ((MessageImpl) msg).setChannelId(id);
+        TextChannelImpl.AsyncMessageSender.getInstance(getJDA(), id).enqueue(msg, false, callback);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -167,7 +167,7 @@ public class PrivateChannelImpl implements PrivateChannel
         {
             Message messageReturn = sendFile(file, message);
             if (callback != null)
-                callback.accept(message);
+                callback.accept(messageReturn);
         });
         thread.setName("PrivateChannelImpl SendFileAsync Channel: " + id);
         thread.setDaemon(true);

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -166,6 +166,7 @@ public class PrivateChannelImpl implements PrivateChannel
             if (callback != null)
                 callback.accept(message);
         });
+        thread.setName("PrivateChannelImpl SendFileAsync Channel: " + id);
         thread.setDaemon(true);
         thread.start();
     }

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -35,6 +35,7 @@ import java.util.function.Consumer;
 
 public class PrivateChannelImpl implements PrivateChannel
 {
+    public static final String RATE_LIMIT_IDENTIFIER = "GLOBAL_PRIV_CHANNEL_RATELIMIT";
     private final String id;
     private final User user;
     private final JDAImpl api;
@@ -73,9 +74,9 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public Message sendMessage(Message msg)
     {
-        if (api.getMessageLimit(id) != null)
+        if (api.getMessageLimit(RATE_LIMIT_IDENTIFIER) != null)
         {
-            throw new RateLimitedException(api.getMessageLimit(id) - System.currentTimeMillis());
+            throw new RateLimitedException(api.getMessageLimit(RATE_LIMIT_IDENTIFIER) - System.currentTimeMillis());
         }
         try
         {
@@ -84,7 +85,7 @@ public class PrivateChannelImpl implements PrivateChannel
             if (response.isRateLimit())
             {
                 long retry_after = response.getObject().getLong("retry_after");
-                api.setMessageTimeout(id, retry_after);
+                api.setMessageTimeout(RATE_LIMIT_IDENTIFIER, retry_after);
                 throw new RateLimitedException(retry_after);
             }
             if (!response.isOk())
@@ -111,7 +112,7 @@ public class PrivateChannelImpl implements PrivateChannel
     public void sendMessageAsync(Message msg, Consumer<Message> callback)
     {
         ((MessageImpl) msg).setChannelId(id);
-        TextChannelImpl.AsyncMessageSender.getInstance(getJDA(), id).enqueue(msg, false, callback);
+        TextChannelImpl.AsyncMessageSender.getInstance(getJDA(), RATE_LIMIT_IDENTIFIER).enqueue(msg, false, callback);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/SelfInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/SelfInfoImpl.java
@@ -15,7 +15,9 @@
  */
 package net.dv8tion.jda.entities.impl;
 
+import net.dv8tion.jda.Permission;
 import net.dv8tion.jda.entities.SelfInfo;
+import net.dv8tion.jda.utils.ApplicationUtil;
 
 public class SelfInfoImpl extends UserImpl implements SelfInfo
 {
@@ -30,6 +32,12 @@ public class SelfInfoImpl extends UserImpl implements SelfInfo
     public boolean isVerified()
     {
         return verified;
+    }
+
+    @Override
+    public String getAuthUrl(Permission... perms)
+    {
+        return ApplicationUtil.getAuthInvite(getJDA(), perms);
     }
 
     public SelfInfoImpl setVerified(boolean verified)

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -274,6 +274,7 @@ public class TextChannelImpl implements TextChannel
             if (callback != null)
                 callback.accept(message);
         });
+        thread.setName("TextChannelImpl sendFileAsync Channel: " + id);
         thread.setDaemon(true);
         thread.start();
     }
@@ -588,6 +589,7 @@ public class TextChannelImpl implements TextChannel
             public Runner(AsyncMessageSender sender)
             {
                 this.sender = sender;
+                this.setName("AsyncMessageSender Runner. Identifier: " + sender.ratelimitIdentifier);
             }
 
             @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -463,7 +463,7 @@ public class TextChannelImpl implements TextChannel
     {
         private static final Map<JDA, Map<String, AsyncMessageSender>> instances = new HashMap<>();
         private final JDAImpl api;
-        private final String ratelimitIdentifier; //GuildId or PrivateChannelId
+        private final String ratelimitIdentifier; //GuildId or GlobalPrivateChannel
         private Runner runner = null;
         private boolean runnerRunning = false;
         private boolean alive = true;

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -273,7 +273,7 @@ public class TextChannelImpl implements TextChannel
         {
             Message messageReturn = sendFile(file, message);
             if (callback != null)
-                callback.accept(message);
+                callback.accept(messageReturn);
         });
         thread.setName("TextChannelImpl sendFileAsync Channel: " + id);
         thread.setDaemon(true);

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -439,7 +439,9 @@ public class TextChannelImpl implements TextChannel
         }
 
         JSONObject body = new JSONObject().put("messages", messageIds);
-        ((JDAImpl) getJDA()).getRequester().post(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/bulk_delete", body);
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().post(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/bulk_delete", body);
+        if (response.isRateLimit())
+            throw new RateLimitedException(response.getObject().getInt("retry_after"));
     }
 
     private void checkVerification()

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -20,6 +20,7 @@ import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.body.MultipartBody;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.MessageBuilder;
+import net.dv8tion.jda.MessageHistory;
 import net.dv8tion.jda.Permission;
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.exceptions.PermissionException;
@@ -279,6 +280,52 @@ public class TextChannelImpl implements TextChannel
         thread.start();
     }
 
+    @Override
+    public Message getMessageById(String messageId)
+    {
+        if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_READ))
+            throw new PermissionException(Permission.MESSAGE_READ);
+        if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_HISTORY))
+            throw new PermissionException(Permission.MESSAGE_HISTORY);
+
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().get(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/" + messageId);
+
+        if (response.isOk())
+            return new EntityBuilder((JDAImpl) getJDA()).createMessage(response.getObject());
+
+        //Doesn't exist.
+        return null;
+    }
+
+    @Override
+    public boolean deleteMessageById(String messageId)
+    {
+        if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_READ))
+            throw new PermissionException(Permission.MESSAGE_READ);
+
+        Requester.Response response = ((JDAImpl) getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/" + messageId);
+
+        if (response.isOk())
+            return true;
+        else if (response.code == 403)  //This block is needed because we cant check who owns the message before attempting to delete.
+        {
+            //We double check to make sure the permission didn't change.
+            if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_READ))
+                throw new PermissionException(Permission.MESSAGE_READ);
+            else
+                throw new PermissionException(Permission.MESSAGE_MANAGE, "You need MESSAGE_MANAGE permission to delete another users Messages");
+        }
+
+        //Doesn't exist. Either never existed, bad id, was deleted already, or not in this channel.
+        return false;
+    }
+
+    @Override
+    public MessageHistory getHistory()
+    {
+        return new MessageHistory(this);
+    }
+
     public void sendTyping()
     {
         ((JDAImpl) getJDA()).getRequester().post(Requester.DISCORD_API_PREFIX + "channels/" + getId() + "/typing", new JSONObject());
@@ -374,39 +421,24 @@ public class TextChannelImpl implements TextChannel
     @Override
     public void deleteMessages(Collection<Message> messages)
     {
-        if(messages.size() > 100)
+        deleteMessagesByIds(messages.stream()
+                .map(msg -> msg.getId())
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public void deleteMessagesByIds(Collection<String> messageIds)
+    {
+        if (messageIds.size() < 2 || messageIds.size() > 100)
         {
-            throw new IllegalArgumentException("Can't delete more than 100 messages at a time, got " + messages.size());
+            throw new IllegalArgumentException("Must provide at least 2 or at most 100 messages to be deleted.");
         }
-        
-        JSONObject body = new JSONObject();
-        ArrayList<String> ids = new ArrayList<>();
-        Message lastProcessedMessage = null;//In case we only have one message to delete
-        for(Message msg : messages)
-        {
-            //Check if the message has been sent, if not then ignore
-            if(msg.getId() != null && !"".equals(msg.getId()))
-            {
-                ids.add(msg.getId());
-                lastProcessedMessage = msg;
-            }
-        }
-        
-        if(ids.size() == 1)
-        {
-            lastProcessedMessage.deleteMessage();
-            return;
-        }
-        else if(ids.isEmpty())
-        {
-            return;
-        }
-        else if(!PermissionUtil.checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_MANAGE, this))
+        else if (!PermissionUtil.checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_MANAGE, this))
         {
             throw new PermissionException(Permission.MESSAGE_MANAGE, "Must have MESSAGE_MANAGE in order to bulk delete messages in this channel regardless of author.");
         }
-        
-        body.put("messages", ids);
+
+        JSONObject body = new JSONObject().put("messages", messageIds);
         ((JDAImpl) getJDA()).getRequester().post(Requester.DISCORD_API_PREFIX + "channels/" + id + "/messages/bulk_delete", body);
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -34,6 +34,8 @@ public class VoiceChannelImpl implements VoiceChannel
     private final Guild guild;
     private String name;
     private int position;
+    private int userLimit;
+    private int bitrate;
     private List<User> connectedUsers = new ArrayList<>();
     private final Map<User, PermissionOverride> userPermissionOverrides = new HashMap<>();
     private final Map<Role, PermissionOverride> rolePermissionOverrides = new HashMap<>();
@@ -185,6 +187,18 @@ public class VoiceChannelImpl implements VoiceChannel
         return InviteUtil.getInvites(this);
     }
 
+    @Override
+    public int getUserLimit()
+    {
+        return userLimit;
+    }
+
+    @Override
+    public int getBitrate()
+    {
+        return bitrate;
+    }
+
     public VoiceChannelImpl setName(String name)
     {
         this.name = name;
@@ -200,6 +214,18 @@ public class VoiceChannelImpl implements VoiceChannel
     public VoiceChannelImpl setUsers(List<User> connectedUsers)
     {
         this.connectedUsers = connectedUsers;
+        return this;
+    }
+
+    public VoiceChannelImpl setUserLimit(int userLimit)
+    {
+        this.userLimit = userLimit;
+        return this;
+    }
+
+    public VoiceChannelImpl setBitrate(int bitrate)
+    {
+        this.bitrate = bitrate;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -126,7 +126,7 @@ public class VoiceChannelImpl implements VoiceChannel
     @Override
     public List<User> getUsers()
     {
-        return Collections.unmodifiableList(connectedUsers);
+        return Collections.unmodifiableList(new LinkedList<>(connectedUsers));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/DisconnectEvent.java
@@ -24,6 +24,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * <b><u>DisconnectEvent</u></b><br>
+ * Fired if our connection to the WebSocket was disrupted.<br>
+ * <br>
+ * Use: Reconnect manually or stop background threads that need fired events to function properly.
+ */
 public class DisconnectEvent extends Event
 {
     protected final WebSocketFrame serverCloseFrame;

--- a/src/main/java/net/dv8tion/jda/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/DisconnectEvent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.VoiceChannel;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class DisconnectEvent extends Event
@@ -39,7 +40,7 @@ public class DisconnectEvent extends Event
         this.clientCloseFrame = clientCloseFrame;
         this.closedByServer = closedByServer;
         this.disconnectTime = disconnectTime;
-        this.dcAudioConnections = Collections.unmodifiableList(dcAudioConnections);
+        this.dcAudioConnections = Collections.unmodifiableList(new LinkedList<>(dcAudioConnections));
     }
 
     public WebSocketFrame getServiceCloseFrame()

--- a/src/main/java/net/dv8tion/jda/events/Event.java
+++ b/src/main/java/net/dv8tion/jda/events/Event.java
@@ -17,6 +17,14 @@ package net.dv8tion.jda.events;
 
 import net.dv8tion.jda.JDA;
 
+/**
+ * <b><u>Event</u></b><br>
+ * Fired for every event.<br>
+ * All events JDA fires are based on an instance of this class.<br>
+ * <br>
+ * Use: Used in {@link net.dv8tion.jda.hooks.EventListener EventListener} implementations to distinguish what event is being fired.<br><br>
+ * Example implementation: {@link net.dv8tion.jda.hooks.ListenerAdapter ListenerAdapter}
+ */
 public abstract class Event
 {
     private final JDA api;

--- a/src/main/java/net/dv8tion/jda/events/InviteReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/InviteReceivedEvent.java
@@ -20,6 +20,12 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.events.message.GenericMessageEvent;
 import net.dv8tion.jda.utils.InviteUtil;
 
+/**
+ * <b><u>InviteReceivedEvent</u></b><br>
+ * Fired if we received a message that contains an invite url. (Example: https://discord.gg/0hMr4ce0tIl3SLv5)<br>
+ * <br>
+ * Use: Detect messages containing an invite and providing an {@link net.dv8tion.jda.utils.InviteUtil.Invite Invite} instance.
+ */
 public class InviteReceivedEvent extends GenericMessageEvent
 {
     private final InviteUtil.Invite invite;

--- a/src/main/java/net/dv8tion/jda/events/ReadyEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ReadyEvent.java
@@ -17,6 +17,13 @@ package net.dv8tion.jda.events;
 
 import net.dv8tion.jda.JDA;
 
+/**
+ * <b><u>ReadyEvent</u></b><br>
+ * Fired if our connection finished loading the ready event.<br>
+ * Before this event was fired all entity related functions (like JDA#getUserById(String)) were not guaranteed to work as expected.<br>
+ * <br>
+ * Use: JDA finished populating internal objects and is now ready to be used. When this is fired all entities are cached and accessible.
+ */
 public class ReadyEvent extends Event
 {
     public ReadyEvent(JDA api, int responseNumber)

--- a/src/main/java/net/dv8tion/jda/events/ReconnectedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ReconnectedEvent.java
@@ -17,6 +17,13 @@ package net.dv8tion.jda.events;
 
 import net.dv8tion.jda.JDA;
 
+/**
+ * <b><u>ReconnectedEvent</u></b><br>
+ * Fired if JDA successfully re-established it's connection to the WebSocket.<br/>
+ * All Objects have been replaced when this is fired and events were likely missed in the downtime.<br/>
+ * <br/>
+ * Use: This marks the continuation of event flow stopped by the {@link net.dv8tion.jda.events.DisconnectEvent DisconnectEvent}. User should replace any cached Objects (like User/Guild objects).
+ */
 public class ReconnectedEvent extends Event
 {
     public ReconnectedEvent(JDA api, int responseNumber)

--- a/src/main/java/net/dv8tion/jda/events/ResumedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ResumedEvent.java
@@ -17,6 +17,13 @@ package net.dv8tion.jda.events;
 
 import net.dv8tion.jda.JDA;
 
+/**
+ * <b><u>ResumedEvent</u></b><br>
+ * Fired if JDA successfully re-established it's connection to the WebSocket.<br/>
+ * All Objects are still in place and events are replayed.<br/>
+ * <br/>
+ * Use: This marks the continuation of event flow stopped by the {@link net.dv8tion.jda.events.DisconnectEvent DisconnectEvent}.
+ */
 public class ResumedEvent extends Event
 {
     public ResumedEvent(JDA api, int responseNumber)

--- a/src/main/java/net/dv8tion/jda/events/ShutdownEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ShutdownEvent.java
@@ -23,6 +23,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * <b><u>ShutdownEvent</u></b><br>
+ * Fired if JDA successfully finished shutting down.<br>
+ *<br>
+ * Use: Confirmation of JDA#shutdown(boolean).
+ */
 public class ShutdownEvent extends Event
 {
     protected final OffsetDateTime shutdownTime;

--- a/src/main/java/net/dv8tion/jda/events/ShutdownEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ShutdownEvent.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.entities.VoiceChannel;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class ShutdownEvent extends Event
@@ -27,11 +28,11 @@ public class ShutdownEvent extends Event
     protected final OffsetDateTime shutdownTime;
     protected final List<VoiceChannel> dcAudioConnections;
 
-    public ShutdownEvent(JDA api, OffsetDateTime shutdownTime, List<VoiceChannel> dcAudioConnectons)
+    public ShutdownEvent(JDA api, OffsetDateTime shutdownTime, List<VoiceChannel> dcAudioConnections)
     {
         super(api, -1);
         this.shutdownTime = shutdownTime;
-        this.dcAudioConnections = Collections.unmodifiableList(dcAudioConnectons);
+        this.dcAudioConnections = Collections.unmodifiableList(new LinkedList<>(dcAudioConnections));
     }
 
     public OffsetDateTime getShutdownTime()

--- a/src/main/java/net/dv8tion/jda/events/StatusChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/StatusChangeEvent.java
@@ -17,6 +17,12 @@ package net.dv8tion.jda.events;
 
 import net.dv8tion.jda.JDA;
 
+/**
+ * <b><u>StatusChangedEvent</u></b><br>
+ * Fired if our {@link net.dv8tion.jda.JDA.Status Status} changed. (Example: SHUTTING_DOWN -> SHUTDOWN)<br>
+ * <br>
+ * Use: Detect internal status changes. Possibly to log or forward on user's end.
+ */
 public class StatusChangeEvent extends Event
 {
     protected final JDA.Status newStatus;

--- a/src/main/java/net/dv8tion/jda/events/StatusChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/StatusChangeEvent.java
@@ -1,0 +1,41 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events;
+
+import net.dv8tion.jda.JDA;
+
+public class StatusChangeEvent extends Event
+{
+    protected final JDA.Status newStatus;
+    protected final JDA.Status oldStatus;
+
+    public StatusChangeEvent(JDA api, JDA.Status newStatus, JDA.Status oldStatus)
+    {
+        super(api, -1);
+        this.newStatus = newStatus;
+        this.oldStatus = oldStatus;
+    }
+
+    public JDA.Status getStatus()
+    {
+        return newStatus;
+    }
+
+    public JDA.Status getOldStatus()
+    {
+        return oldStatus;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/audio/AudioConnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/AudioConnectEvent.java
@@ -19,6 +19,12 @@ package net.dv8tion.jda.events.audio;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>AudioConnectedEvent</u></b><br>
+ * Fired if we established an {@link net.dv8tion.jda.audio.AudioConnection AudioConnection} to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} successfully.<br>
+ * <br>
+ * Use: Retrieve newly connected {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel}.
+ */
 public class AudioConnectEvent extends GenericAudioEvent
 {
     protected final VoiceChannel connectedChannel;

--- a/src/main/java/net/dv8tion/jda/events/audio/AudioDisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/AudioDisconnectEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.audio;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>AudioDisconnectedEvent</u></b><br>
+ * Fired if we disconnected from a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel}.<br>
+ * <br>
+ * Use: Retrieve the {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} we disconnected from.
+ */
 public class AudioDisconnectEvent extends GenericAudioEvent
 {
     protected final VoiceChannel disconnectedChannel;

--- a/src/main/java/net/dv8tion/jda/events/audio/AudioRegionChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/AudioRegionChangeEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>AudioRegionChangeEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Guild Guild}'s voice region has been changed.<br>
+ * <br>
+ * Use: Know which {@link net.dv8tion.jda.entities.Guild Guild} changed it's region and what {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} we were connected to.
+ */
 public class AudioRegionChangeEvent extends GenericAudioEvent
 {
     protected final VoiceChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/audio/AudioTimeoutEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/AudioTimeoutEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.audio;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>AudioTimeoutEvent</u></b><br>
+ * Fired if an attempt to connect to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} failed due to a timeout.<br>
+ * <br>
+ * Use: Retrieve {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} which caused this event to fire.
+ */
 public class AudioTimeoutEvent extends GenericAudioEvent
 {
     protected final VoiceChannel attemptedConnectChannel;

--- a/src/main/java/net/dv8tion/jda/events/audio/AudioUnableToConnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/AudioUnableToConnectEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.audio;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>AudioUnableToConnectEvent</u></b><br>
+ * Fired if an attempt to connect to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} failed.<br>
+ * <br>
+ * Use: Retrieve {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} which caused this event to fire.
+ */
 public class AudioUnableToConnectEvent extends GenericAudioEvent
 {
     protected final VoiceChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/audio/GenericAudioEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/audio/GenericAudioEvent.java
@@ -18,6 +18,13 @@ package net.dv8tion.jda.events.audio;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericAudioEvent</u></b><br>
+ * Fired whenever an audio event is fired.<br>
+ * Any audio event is an instance of this event and can be casted.<br>
+ * <br>
+ * Use: Detect any AudioEvent.
+ */
 public class GenericAudioEvent extends Event
 {
     protected GenericAudioEvent(JDA api, int responseNumber)

--- a/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelCreateEvent.java
@@ -20,6 +20,12 @@ import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>PrivateChannelCreateEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.PrivateChannel Private Channel} was created.<br/>
+ * <br/>
+ * Use: Retrieve the freshly created private channel and it's {@link net.dv8tion.jda.entities.User User}.
+ */
 public class PrivateChannelCreateEvent extends Event
 {
     private User user;

--- a/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelDeleteEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>PrivateChannelDeleteEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.PrivateChannel Private Channel} was deleted.<br/>
+ * <br/>
+ * Use: Retrieve the issuing {@link net.dv8tion.jda.entities.User User}.
+ */
 public class PrivateChannelDeleteEvent extends Event
 {
     protected final User user;

--- a/src/main/java/net/dv8tion/jda/events/channel/text/GenericTextChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/GenericTextChannelEvent.java
@@ -20,6 +20,13 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericTextChannelEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.TextChannel TextChannel} event is fired.<br>
+ * Every TextChannelEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any TextChannelEvent. <i>(No real use for JDA user)</i>
+ */
 public abstract class GenericTextChannelEvent extends Event
 {
     private final TextChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/channel/text/GenericTextChannelUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/GenericTextChannelUpdateEvent.java
@@ -18,6 +18,13 @@ package net.dv8tion.jda.events.channel.text;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>GenericTextChannelUpdateEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.TextChannel TextChannel} is updated.<br>
+ * Every TextChannelUpdateEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any TextChannelUpdateEvent. <i>(No real use for JDA user)</i>
+ */
 public class GenericTextChannelUpdateEvent extends GenericTextChannelEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelCreateEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.text;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>TextChannelCreateEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.TextChannel TextChannel} has been created.<br>
+ * <br>
+ * Use: Detect new TextChannel creation.
+ */
 public class TextChannelCreateEvent extends GenericTextChannelEvent
 {
     public TextChannelCreateEvent(JDA api, int responseNumber, TextChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelDeleteEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.text;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>TextChannelDeleteEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.TextChannel TextChannel} has been deleted.<br>
+ * <br>
+ * Use: Detect when a TextChannel has been deleted.
+ */
 public class TextChannelDeleteEvent extends GenericTextChannelEvent
 {
     public TextChannelDeleteEvent(JDA api, int responseNumber, TextChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdateNameEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.text;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>TextChannelUpdateNameEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.TextChannel TextChannel}'s name changes.<br>
+ * <br>
+ * Use: Detect when a TextChannel name changes and get it's previous name.
+ */
 public class TextChannelUpdateNameEvent extends GenericTextChannelUpdateEvent
 {
     private final String oldName;

--- a/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdatePermissionsEvent.java
@@ -22,6 +22,12 @@ import net.dv8tion.jda.entities.User;
 
 import java.util.List;
 
+/**
+ * <b><u>TextChannelUpdatePermissionsEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.TextChannel TextChannel}'s permission overrides change.<br>
+ * <br>
+ * Use: Detect when a TextChannel's permission overrides change and get affected {@link net.dv8tion.jda.entities.Role Roles}/{@link net.dv8tion.jda.entities.User Users}.
+ */
 public class TextChannelUpdatePermissionsEvent extends GenericTextChannelUpdateEvent
 {
     private final List<Role> changedRoles;

--- a/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdatePositionEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.text;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>TextChannelUpdatePositionEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.TextChannel TextChannel}'s position changes.<br>
+ * <br>
+ * Use: Detect when a TextChannel position changes and get it's previous position.
+ */
 public class TextChannelUpdatePositionEvent extends GenericTextChannelUpdateEvent
 {
     private final int oldPosition;

--- a/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdateTopicEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/text/TextChannelUpdateTopicEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.text;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>TextChannelUpdateTopicEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.TextChannel TextChannel}'s topic changes.<br>
+ * <br>
+ * Use: Detect when a TextChannel topic changes and get it's previous topic.
+ */
 public class TextChannelUpdateTopicEvent extends GenericTextChannelUpdateEvent
 {
     private final String oldTopic;

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/GenericVoiceChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/GenericVoiceChannelEvent.java
@@ -20,6 +20,13 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericVoiceChannelEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} event is fired.<br>
+ * Every VoiceChannelEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any VoiceChannelEvent.
+ */
 public abstract class GenericVoiceChannelEvent extends Event
 {
     private final VoiceChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/GenericVoiceChannelUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/GenericVoiceChannelUpdateEvent.java
@@ -19,6 +19,13 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>GenericVoiceChannelUpdateEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} updates.<br>
+ * Every VoiceChannelUpdateEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any VoiceChannelUpdateEvent.
+ */
 public class GenericVoiceChannelUpdateEvent extends GenericVoiceChannelEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelCreateEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>VoiceChannelCreateEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel} is created.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel.
+ */
 public class VoiceChannelCreateEvent extends GenericVoiceChannelEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelDeleteEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>VoiceChannelDeleteEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel} is deleted.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel(likely to be null) or affected Guild.
+ */
 public class VoiceChannelDeleteEvent extends GenericVoiceChannelEvent
 {
     public VoiceChannelDeleteEvent(JDA api, int responseNumber, VoiceChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
@@ -1,0 +1,35 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events.channel.voice;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.VoiceChannel;
+
+public class VoiceChannelUpdateBitrateEvent extends GenericVoiceChannelUpdateEvent
+{
+    protected final int oldBitrate;
+
+    public VoiceChannelUpdateBitrateEvent(JDA api, int responseNumber, VoiceChannel channel, int oldBitrate)
+    {
+        super(api, responseNumber, channel);
+        this.oldBitrate = oldBitrate;
+    }
+
+    public int getOldBitrate()
+    {
+        return oldBitrate;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>VoiceChannelUpdateBitrateEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s bitrate changes.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel, affected Guild and previous bitrate.
+ */
 public class VoiceChannelUpdateBitrateEvent extends GenericVoiceChannelUpdateEvent
 {
     protected final int oldBitrate;

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateNameEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>VoiceChannelUpdateNameEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s name changes.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel, affected Guild and previous name.
+ */
 public class VoiceChannelUpdateNameEvent extends GenericVoiceChannelUpdateEvent
 {
     private final String oldName;

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePermissionsEvent.java
@@ -22,6 +22,12 @@ import net.dv8tion.jda.entities.VoiceChannel;
 
 import java.util.List;
 
+/**
+ * <b><u>VoiceChannelUpdatePermissionsEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s permission overrides change.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel, affected Guild and affected {@link net.dv8tion.jda.entities.Role Roles}/{@link net.dv8tion.jda.entities.User Users}.
+ */
 public class VoiceChannelUpdatePermissionsEvent extends GenericVoiceChannelUpdateEvent
 {
     private final List<Role> changedRoles;

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePositionEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>VoiceChannelUpdatePositionEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s position changes.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel, affected Guild and previous position.
+ */
 public class VoiceChannelUpdatePositionEvent extends GenericVoiceChannelUpdateEvent
 {
     private final int oldPosition;

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
@@ -1,0 +1,35 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events.channel.voice;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.VoiceChannel;
+
+public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateEvent
+{
+    protected final int oldUserLimit;
+
+    public VoiceChannelUpdateUserLimitEvent(JDA api, int responseNumber, VoiceChannel channel, int oldUserLimit)
+    {
+        super(api, responseNumber, channel);
+        this.oldUserLimit = oldUserLimit;
+    }
+
+    public int getOldUserLimit()
+    {
+        return oldUserLimit;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.channel.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
+/**
+ * <b><u>VoiceChannelUpdateUserLimitEvent</u></b><br/>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s user limit changes.<br/>
+ * <br/>
+ * Use: Get affected VoiceChannel, affected Guild and previous user limit.
+ */
 public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateEvent
 {
     protected final int oldUserLimit;

--- a/src/main/java/net/dv8tion/jda/events/guild/GenericGuildEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GenericGuildEvent.java
@@ -19,6 +19,13 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericGuildEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Guild Guild} event is fired.<br>
+ * Every GuildEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any GuildEvent. <i>(No real use for the JDA user)</i>
+ */
 public abstract class GenericGuildEvent extends Event
 {
     private final Guild guild;

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildAvailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildAvailableEvent.java
@@ -19,6 +19,12 @@ package net.dv8tion.jda.events.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
+/**
+ * <b><u>GuildAvailableEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Guild Guild} becomes available.<br/>
+ * <br/>
+ * Use: This indicates that a Guild will now start sending events and can be interacted with.
+ */
 public class GuildAvailableEvent extends GenericGuildEvent
 {
     public GuildAvailableEvent(JDA api, int responseNumber, Guild guild)

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildJoinEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
+/**
+ * <b><u>GuildJoinEvent</u></b><br/>
+ * Fired if a you join a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
+ * <br/>
+ * Warning: Discord already triggered a mass amount of these events due to a downtime. Be careful!
+ */
 public class GuildJoinEvent extends GenericGuildEvent
 {
     public GuildJoinEvent(JDA api, int responseNumber, Guild guild)

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildLeaveEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
+/**
+ * <b><u>GuildLeaveEvent</u></b><br/>
+ * Fired if a you leave a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
+ * <br/>
+ * Use: Detect when you leave a Guild.
+ */
 public class GuildLeaveEvent extends GenericGuildEvent
 {
     public GuildLeaveEvent(JDA api, int responseNumber, Guild guild)

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildUnavailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildUnavailableEvent.java
@@ -19,6 +19,13 @@ package net.dv8tion.jda.events.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
+/**
+ * <b><u>GuildUnavailableEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Guild Guild} becomes unavailable.<br/>
+ * Possibly due to a downtime.<br/>
+ * <br/>
+ * Use: This indicates that a Guild stopped responding.
+ */
 public class GuildUnavailableEvent extends GenericGuildEvent
 {
     public GuildUnavailableEvent(JDA api, int responseNumber, Guild guild)

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildUpdateEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
+/**
+ * <b><u>GuildUpdateEvent</u></b><br/>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Guild Guild} updates.<br/>
+ * <br/>
+ * Use: Detect what Guild updated.
+ */
 public class GuildUpdateEvent extends GenericGuildEvent
 {
     public GuildUpdateEvent(JDA api, int responseNumber, Guild guild)

--- a/src/main/java/net/dv8tion/jda/events/guild/UnavailableGuildJoinedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/UnavailableGuildJoinedEvent.java
@@ -19,6 +19,12 @@ package net.dv8tion.jda.events.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>UnavailableGuildJoinedEvent</u></b><br/>
+ * Fired if you joined a {@link net.dv8tion.jda.entities.Guild Guild} that is not yet available.<br/>
+ * <br/>
+ * Use: Retrieve id of unavailable Guild.
+ */
 public class UnavailableGuildJoinedEvent extends Event
 {
     private final String guildId;

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GenericGuildMemberEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GenericGuildMemberEvent.java
@@ -20,6 +20,13 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
+/**
+ * <b><u>GenericGuildMemberEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Guild Guild} member causes an event.<br>
+ * Every GuildMemberEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any GuildMemberEvent.
+ */
 public class GenericGuildMemberEvent extends GenericGuildEvent
 {
     private final User user;

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberBanEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberBanEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>GuildMemberBanEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} is banned from a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
+ * <br/>
+ * Use: Retrieve user who was banned (if available) and triggering guild.
+ */
 public class GuildMemberBanEvent extends GuildMemberLeaveEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberJoinEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>GuildMemberJoinEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} joins a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
+ * <br/>
+ * Use: Retrieve user who joined (if available) and affected guild.
+ */
 public class GuildMemberJoinEvent extends GenericGuildMemberEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberLeaveEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>GuildMemberLeaveEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} leaves a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
+ * <br/>
+ * Use: Retrieve user who left (if available) and triggering guild.
+ */
 public class GuildMemberLeaveEvent extends GenericGuildMemberEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberNickChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberNickChangeEvent.java
@@ -20,6 +20,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>GuildMemberNickChangeEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} updates their {@link net.dv8tion.jda.entities.Guild Guild} nickname.<br/>
+ * <br/>
+ * Use: Retrieve user who changed their nickname, triggering guild, the old nick and the new nick.
+ */
 public class GuildMemberNickChangeEvent extends GenericGuildMemberEvent
 {
     private final String prevNick, newNick;

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.User;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
@@ -30,7 +31,7 @@ public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
     public GuildMemberRoleAddEvent(JDA api, int responseNumber, Guild guild, User user, List<Role> addedRoles)
     {
         super(api, responseNumber, guild, user);
-        this.addedRoles = addedRoles;
+        this.addedRoles = new LinkedList<>(addedRoles);
     }
 
     public List<Role> getRoles()

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
@@ -24,6 +24,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * <b><u>GuildMemberRoleAddEvent</u></b><br/>
+ * Fired if one or more {@link net.dv8tion.jda.entities.Role Roles} are assigned to a {@link net.dv8tion.jda.entities.User User}.<br/>
+ * <br/>
+ * Use: Retrieve affected user and guild. Provides a list of added roles.
+ */
 public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
 {
     private final List<Role> addedRoles;

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.entities.User;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent
@@ -30,7 +31,7 @@ public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent
     public GuildMemberRoleRemoveEvent(JDA api, int responseNumber, Guild guild, User user, List<Role> removedRoles)
     {
         super(api, responseNumber, guild, user);
-        this.removedRoles = removedRoles;
+        this.removedRoles = new LinkedList<>(removedRoles);
     }
 
     public List<Role> getRoles()

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
@@ -24,6 +24,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * <b><u>GuildMemberRoleRemoveEvent</u></b><br/>
+ * Fired if one or more {@link net.dv8tion.jda.entities.Role Roles} are removed from a {@link net.dv8tion.jda.entities.User User}.<br/>
+ * <br/>
+ * Use: Retrieve affected user and guild. Provides a list of removed roles.
+ */
 public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent
 {
     private final List<Role> removedRoles;

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberUnbanEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberUnbanEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>GuildMemberBanEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} is unbanned from a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
+ * <br/>
+ * Use: Retrieve user who was unbanned (if available) and the guild which they were unbanned from.
+ */
 public class GuildMemberUnbanEvent extends GenericGuildMemberEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GenericGuildRoleUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GenericGuildRoleUpdateEvent.java
@@ -19,6 +19,13 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericGuildRoleUpdateEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Guild Guild} role is updated/created/deleted.<br>
+ * Every GuildRoleEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any GuildRoleEvent. <i>(No real use for the JDA user)</i>
+ */
 public class GenericGuildRoleUpdateEvent extends Event
 {
     protected final Role role;

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleCreateEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
+/**
+ * <b><u>GuildRoleCreateEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role} is created.<br/>
+ * <br/>
+ * Use: Retrieve created Role and it's Guild.
+ */
 public class GuildRoleCreateEvent extends GenericGuildEvent
 {
     private final Role createdRole;

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleDeleteEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
+/**
+ * <b><u>GuildRoleDeleteEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role} is deleted.<br/>
+ * <br/>
+ * Use: Retrieve deleted Role and it's Guild.
+ */
 public class GuildRoleDeleteEvent extends GenericGuildEvent
 {
     private final Role deletedRole;

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateColorEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateColorEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild.role;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
+/**
+ * <b><u>GuildRoleUpdateColorEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s color changes.<br/>
+ * <br/>
+ * Use: Retrieve affected Role and Guild.
+ */
 public class GuildRoleUpdateColorEvent extends GenericGuildRoleUpdateEvent
 {
     public GuildRoleUpdateColorEvent(JDA api, int responseNumber, Role role)

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GuildRoleUpdateEvent</u></b><br/>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Role Role} is updated.<br/>
+ * <br/>
+ * Use: Retrieve affected Role. <i>(No real use for JDA user)</i>
+ */
 public class GuildRoleUpdateEvent extends Event
 {
     protected final Role role;

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateGroupedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateGroupedEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild.role;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
+/**
+ * <b><u>GuildRoleUpdateGroupedEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s grouped property changes.<br/>
+ * <br/>
+ * Use: Retrieve affected Role.
+ */
 public class GuildRoleUpdateGroupedEvent extends GenericGuildRoleUpdateEvent
 {
     public GuildRoleUpdateGroupedEvent(JDA api, int responseNumber, Role role)

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateNameEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild.role;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
+/**
+ * <b><u>GuildRoleUpdateNameEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s name changes.<br/>
+ * <br/>
+ * Use: Retrieve affected Role.
+ */
 public class GuildRoleUpdateNameEvent extends GenericGuildRoleUpdateEvent
 {
     public GuildRoleUpdateNameEvent(JDA api, int responseNumber, Role role)

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePermissionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePermissionEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild.role;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
+/**
+ * <b><u>GuildRoleUpdatePermissionEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s permissions change.<br/>
+ * <br/>
+ * Use: Retrieve affected Role.
+ */
 public class GuildRoleUpdatePermissionEvent extends GenericGuildRoleUpdateEvent
 {
     public GuildRoleUpdatePermissionEvent(JDA api, int responseNumber, Role role)

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePositionEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.guild.role;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
+/**
+ * <b><u>GuildRoleUpdatePositionEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s position changes.<br/>
+ * <br/>
+ * Use: Retrieve affected Role.
+ */
 public class GuildRoleUpdatePositionEvent extends GenericGuildRoleUpdateEvent
 {
     public GuildRoleUpdatePositionEvent(JDA api, int responseNumber, Role role)

--- a/src/main/java/net/dv8tion/jda/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/GenericMessageEvent.java
@@ -20,6 +20,13 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericMessageEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Message Message} event is fired.<br>
+ * Every MessageEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any MessageEvent. <i>(No real use for the JDA user)</i>
+ */
 public abstract class GenericMessageEvent extends Event
 {
     protected final Message message;

--- a/src/main/java/net/dv8tion/jda/events/message/MessageBulkDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageBulkDeleteEvent.java
@@ -22,6 +22,12 @@ import net.dv8tion.jda.events.Event;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * <b><u>MessageBulkDeleteEvent</u></b><br/>
+ * Fired if a bulk deletion is executed in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br/>
+ * <br/>
+ * Use: This event indicates that a large chunk of Messages is deleted in a TextChannel. Providing a list of Message IDs and the specific TextChannel.
+ */
 public class MessageBulkDeleteEvent extends Event
 {
     protected final TextChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/message/MessageBulkDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageBulkDeleteEvent.java
@@ -1,0 +1,46 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.events.message;
+
+import net.dv8tion.jda.JDA;
+import net.dv8tion.jda.entities.TextChannel;
+import net.dv8tion.jda.events.Event;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MessageBulkDeleteEvent extends Event
+{
+    protected final TextChannel channel;
+    protected final List<String> messageIds;
+
+    public MessageBulkDeleteEvent(JDA api, int responseNumber, TextChannel channel, List<String> messageIds)
+    {
+        super(api, responseNumber);
+        this.channel = channel;
+        this.messageIds = Collections.unmodifiableList(messageIds);
+    }
+
+    public TextChannel getChannel()
+    {
+        return channel;
+    }
+
+    public List<String> getMessageIds()
+    {
+        return messageIds;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/events/message/MessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageDeleteEvent.java
@@ -22,6 +22,12 @@ import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>MessageDeleteEvent</u></b><br/>
+ * Fired if a Message was deleted in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
+ * <br/>
+ * Use: Detect when a Message is deleted. No matter if private or guild.
+ */
 public class MessageDeleteEvent extends Event
 {
     private final boolean isPrivate;

--- a/src/main/java/net/dv8tion/jda/events/message/MessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageEmbedEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.events.Event;
 
 import java.util.List;
 
+/**
+ * <b><u>MessageEmbedEvent</u></b><br/>
+ * Fired if a Message contains an {@link net.dv8tion.jda.entities.MessageEmbed Embed} in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
+ * <br/>
+ * Use: Grab MessageEmbeds from any message. No matter if private or guild.
+ */
 public class MessageEmbedEvent extends Event
 {
     private final boolean isPrivate;

--- a/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>MessageReceivedEvent</u></b><br/>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
+ * <br/>
+ * Use: This event indicates that a Message is sent in either a private or guild channel. Providing a MessageChannel and Message.
+ */
 public class MessageReceivedEvent extends Event
 {
     private final Message message;

--- a/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
@@ -60,7 +60,7 @@ public class MessageReceivedEvent extends Event
      */
     public String getAuthorName()
     {
-        String nickname = getAuthorNick();
+        String nickname = isPrivate() ? getAuthor().getUsername() : getAuthorNick();
         return nickname == null ? getAuthor().getUsername() : nickname;
     }
 

--- a/src/main/java/net/dv8tion/jda/events/message/MessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageUpdateEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>MessageUpdateEvent</u></b><br/>
+ * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
+ * <br/>
+ * Use: This event indicates that a Message is edited in either a private or guild channel. Providing a MessageChannel and Message.
+ */
 public class MessageUpdateEvent extends Event
 {
     private final Message message;

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GenericGuildMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GenericGuildMessageEvent.java
@@ -21,6 +21,13 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.events.message.GenericMessageEvent;
 
+/**
+ * <b><u>GenericGuildMessageEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Message Message} event is fired from a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br>
+ * Every GuildMessageEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any GuildMessageEvent. <i>(No real use for the JDA user)</i>
+ */
 public class GenericGuildMessageEvent extends GenericMessageEvent
 {
     protected TextChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageDeleteEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.message.guild;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>GuildMessageDeleteEvent</u></b><br/>
+ * Fired if a Guild Message was deleted.<br/>
+ * <br/>
+ * Use: Retrieve affected TextChannel and the id of the deleted Message.
+ */
 public class GuildMessageDeleteEvent extends GenericGuildMessageEvent
 {
     private final String messageId;

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageEmbedEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.entities.TextChannel;
 
 import java.util.List;
 
+/**
+ * <b><u>GuildMessageEmbedEvent</u></b><br/>
+ * Fired if a Guild Message contains one or more {@link net.dv8tion.jda.entities.MessageEmbed Embeds}.<br/>
+ * <br/>
+ * Use: Retrieve affected TextChannel, the id of the affected Message and a list of MessageEmbeds.
+ */
 public class GuildMessageEmbedEvent extends GenericGuildMessageEvent
 {
     private final String messageId;

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageReceivedEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>GuildMessageReceivedEvent</u></b><br/>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br/>
+ * <br/>
+ * Use: Retrieve affected TextChannel and Message.
+ */
 public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
 {
     public GuildMessageReceivedEvent(JDA api, int responseNumber, Message message, TextChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageUpdateEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.TextChannel;
 
+/**
+ * <b><u>GuildMessageReceivedEvent</u></b><br/>
+ * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br/>
+ * <br/>
+ * Use: Retrieve affected TextChannel and Message.
+ */
 public class GuildMessageUpdateEvent extends GenericGuildMessageEvent
 {
     public GuildMessageUpdateEvent(JDA api, int responseNumber, Message message, TextChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/message/priv/GenericPrivateMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/GenericPrivateMessageEvent.java
@@ -20,6 +20,13 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.events.message.GenericMessageEvent;
 
+/**
+ * <b><u>GenericPrivateMessageEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Message Message} event is fired from a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br>
+ * Every PrivateMessageEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any PrivateMessageEvent. <i>(No real use for the JDA user)</i>
+ */
 public class GenericPrivateMessageEvent extends GenericMessageEvent
 {
     protected PrivateChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageDeleteEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.message.priv;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.PrivateChannel;
 
+/**
+ * <b><u>PrivateMessageDeleteEvent</u></b><br/>
+ * Fired if a Message is deleted in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
+ * <br/>
+ * Use: Retrieve affected PrivateChannel and the ID of the deleted Message.
+ */
 public class PrivateMessageDeleteEvent extends GenericPrivateMessageEvent
 {
     private final String messageId;

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageEmbedEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.entities.PrivateChannel;
 
 import java.util.List;
 
+/**
+ * <b><u>PrivateMessageEmbedEvent</u></b><br/>
+ * Fired if a Message contains {@link net.dv8tion.jda.entities.MessageEmbed Embeds} in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
+ * <br/>
+ * Use: Retrieve affected PrivateChannel, the ID of the deleted Message and a list of MessageEmbeds.
+ */
 public class PrivateMessageEmbedEvent extends GenericPrivateMessageEvent
 {
     private final String messageId;

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageReceivedEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
 
+/**
+ * <b><u>PrivateMessageReceivedEvent</u></b><br/>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
+ * <br/>
+ * Use: Retrieve affected PrivateChannel and Message.
+ */
 public class PrivateMessageReceivedEvent extends GenericPrivateMessageEvent
 {
     public PrivateMessageReceivedEvent(JDA api, int responseNumber, Message message, PrivateChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageUpdateEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
 
+/**
+ * <b><u>PrivateMessageUpdateEvent</u></b><br/>
+ * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
+ * <br/>
+ * Use: Retrieve affected PrivateChannel and edited Message.
+ */
 public class PrivateMessageUpdateEvent extends GenericPrivateMessageEvent
 {
     public PrivateMessageUpdateEvent(JDA api, int responseNumber, Message message, PrivateChannel channel)

--- a/src/main/java/net/dv8tion/jda/events/user/GenericUserEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/GenericUserEvent.java
@@ -19,6 +19,13 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericUserEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.User User} changes their presence. (like avatar/game)<br>
+ * Every UserEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any UserEvent. <i>(No real use for the JDA user)</i>
+ */
 public class GenericUserEvent extends Event
 {
     private final User user;

--- a/src/main/java/net/dv8tion/jda/events/user/UserAvatarUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserAvatarUpdateEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.user;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>UserAvatarUpdateEvent</u></b><br/>
+ * Fired if the Avatar of a {@link net.dv8tion.jda.entities.User User} changes.<br/>
+ * <br/>
+ * Use: Retrieve the User who's Avatar changed and their previous Avatar ID/URL.
+ */
 public class UserAvatarUpdateEvent extends GenericUserEvent
 {
     private final String previousAvatarId;

--- a/src/main/java/net/dv8tion/jda/events/user/UserGameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserGameUpdateEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Game;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>UserGameUpdateEvent</u></b><br/>
+ * Fired if the {@link net.dv8tion.jda.entities.Game Game} of a {@link net.dv8tion.jda.entities.User User} changes.<br/>
+ * <br/>
+ * Use: Retrieve the User who's Game changed and their previous Game.
+ */
 public class UserGameUpdateEvent extends GenericUserEvent
 {
     private final Game previousGame;

--- a/src/main/java/net/dv8tion/jda/events/user/UserNameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserNameUpdateEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.user;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>UserNameUpdateEvent</u></b><br/>
+ * Fired if the username of a {@link net.dv8tion.jda.entities.User User} changes. (Not Nickname)<br/>
+ * <br/>
+ * Use: Retrieve the User who's username changed and their previous username.
+ */
 public class UserNameUpdateEvent extends GenericUserEvent
 {
     private final String previousUsername;

--- a/src/main/java/net/dv8tion/jda/events/user/UserOnlineStatusUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserOnlineStatusUpdateEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.OnlineStatus;
 import net.dv8tion.jda.entities.User;
 
+/**
+ * <b><u>UserOnlineStatusUpdateEvent</u></b><br/>
+ * Fired if the {@link OnlineStatus OnlineStatus} of a {@link net.dv8tion.jda.entities.User User} changes.<br/>
+ * <br/>
+ * Use: Retrieve the User who's status changed and their previous status.
+ */
 public class UserOnlineStatusUpdateEvent extends GenericUserEvent
 {
     private final OnlineStatus previousOnlineStatus;

--- a/src/main/java/net/dv8tion/jda/events/user/UserTypingEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserTypingEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.entities.User;
 
 import java.time.OffsetDateTime;
 
+/**
+ * <b><u>UserTypingUpdateEvent</u></b><br/>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} starts typing. (Similar to the typing indicator in the Discord client)<br/>
+ * <br/>
+ * Use: Retrieve the User who started typing and when and in which MessageChannel they started typing.
+ */
 public class UserTypingEvent extends GenericUserEvent
 {
     private final MessageChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/voice/GenericVoiceEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/GenericVoiceEvent.java
@@ -21,6 +21,13 @@ import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.entities.VoiceStatus;
 import net.dv8tion.jda.events.Event;
 
+/**
+ * <b><u>GenericVoiceEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.VoiceStatus VoiceStatus} of a {@link net.dv8tion.jda.entities.User User} changes. (like mute/deaf/leave)<br>
+ * Every VoiceEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any VoiceEvent. <i>(No real use for the JDA user)</i>
+ */
 public abstract class GenericVoiceEvent extends Event
 {
     protected final VoiceStatus voiceStatus;

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceDeafEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceDeafEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceDeafEvent</u></b><br/>
+ * Fired if we are (un-)deafened. <br/>
+ * This can indicate both deafen and un-deafen and can be caused by both us or the server.<br/>
+ * {@link net.dv8tion.jda.events.voice.VoiceSelfDeafEvent} and {@link net.dv8tion.jda.events.voice.VoiceServerDeafEvent} are specifications of this event.
+ */
 public class VoiceDeafEvent extends GenericVoiceEvent
 {
     public VoiceDeafEvent(JDA api, int responseNumber, VoiceStatus voiceStatus)

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceJoinEvent.java
@@ -19,6 +19,11 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceJoinEvent</u></b><br/>
+ * Fired if we successfully joined a VoiceChannel.<br/><br/>
+ * Use: Retrieve VoiceChannel we connected to.
+ */
 public class VoiceJoinEvent extends GenericVoiceEvent
 {
 

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceLeaveEvent.java
@@ -19,6 +19,12 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceLeaveEvent</u></b><br/>
+ * Fired if we successfully left a VoiceChannel.<br/>
+ * <br/>
+ * Use: Retrieve previous VoiceChannel.
+ */
 public class VoiceLeaveEvent extends GenericVoiceEvent
 {
     protected final VoiceChannel channel;

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceMuteEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.events.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceMuteEvent</u></b><br/>
+ * Fired if we are (un-)muted. <br/>
+ * This can indicate both mute and un-mute and can be caused by both us or the server.<br/>
+ * {@link net.dv8tion.jda.events.voice.VoiceSelfMuteEvent} and {@link net.dv8tion.jda.events.voice.VoiceServerMuteEvent} are specifications of this event.
+ */
 public class VoiceMuteEvent extends GenericVoiceEvent
 {
     public VoiceMuteEvent(JDA api, int responseNumber, VoiceStatus voiceStatus)

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfDeafEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfDeafEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.events.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceSelfDeafEvent</u></b><br/>
+ * Fired if we (un-)deafen us. <br/>
+ * This can indicate both deafen and un-deafen and can <u>only</u> be caused by us.
+ */
 public class VoiceSelfDeafEvent extends VoiceDeafEvent
 {
     public VoiceSelfDeafEvent(JDA api, int responseNumber, VoiceStatus voiceStatus)

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfMuteEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.events.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceSelfMuteEvent</u></b><br/>
+ * Fired if we (un-)mute us. <br/>
+ * This can indicate both mute and un-mute and can <u>only</u> be caused by us.
+ */
 public class VoiceSelfMuteEvent extends VoiceMuteEvent
 {
     public VoiceSelfMuteEvent(JDA api, int responseNumber, VoiceStatus voiceStatus)

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceServerDeafEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceServerDeafEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.events.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceServerDeafEvent</u></b><br/>
+ * Fired if we are (un-)deafened by the server. <br/>
+ * This can indicate both deafen and un-deafen and can <u>only</u> be caused by the server.
+ */
 public class VoiceServerDeafEvent extends VoiceDeafEvent
 {
     public VoiceServerDeafEvent(JDA api, int responseNumber, VoiceStatus voiceStatus)

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceServerMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceServerMuteEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.events.voice;
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
+/**
+ * <b><u>VoiceServerMuteEvent</u></b><br/>
+ * Fired if we are (un-)muted by the server. <br/>
+ * This can indicate both muted and un-muted and can <u>only</u> be caused by the server.
+ */
 public class VoiceServerMuteEvent extends VoiceMuteEvent
 {
     public VoiceServerMuteEvent(JDA api, int responseNumber, VoiceStatus voiceStatus)

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -21,9 +21,7 @@ import net.dv8tion.jda.events.channel.text.TextChannelUpdateNameEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelUpdatePermissionsEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelUpdatePositionEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelUpdateTopicEvent;
-import net.dv8tion.jda.events.channel.voice.VoiceChannelUpdateNameEvent;
-import net.dv8tion.jda.events.channel.voice.VoiceChannelUpdatePermissionsEvent;
-import net.dv8tion.jda.events.channel.voice.VoiceChannelUpdatePositionEvent;
+import net.dv8tion.jda.events.channel.voice.*;
 import net.dv8tion.jda.requests.GuildLock;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
@@ -138,6 +136,8 @@ public class ChannelUpdateHandler extends SocketHandler
             case "voice":
             {
                 VoiceChannelImpl channel = (VoiceChannelImpl) api.getVoiceChannelMap().get(content.getString("id"));
+                int userLimit = content.getInt("user_limit");
+                int bitrate = content.getInt("bitrate");
                 if (channel == null)
                 {
                     EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
@@ -165,6 +165,24 @@ public class ChannelUpdateHandler extends SocketHandler
                             new VoiceChannelUpdatePositionEvent(
                                     api, responseNumber,
                                     channel, oldPosition));
+                }
+                if (channel.getUserLimit() != userLimit)
+                {
+                    int oldLimit = channel.getUserLimit();
+                    channel.setUserLimit(userLimit);
+                    api.getEventManager().handle(
+                            new VoiceChannelUpdateUserLimitEvent(
+                                    api, responseNumber,
+                                    channel, oldLimit));
+                }
+                if (channel.getBitrate() != bitrate)
+                {
+                    int oldBitrate = channel.getBitrate();
+                    channel.setBitrate(bitrate);
+                    api.getEventManager().handle(
+                            new VoiceChannelUpdateBitrateEvent(
+                                    api, responseNumber,
+                                    channel, oldBitrate));
                 }
 
                 //Determines if a new PermissionOverride was created or updated.

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -447,7 +447,8 @@ public class EntityBuilder
                 .setContent(content)
                 .setTime(OffsetDateTime.parse(jsonObject.getString("timestamp")))
                 .setMentionsEveryone(jsonObject.getBoolean("mention_everyone"))
-                .setTTS(jsonObject.getBoolean("tts"));
+                .setTTS(jsonObject.getBoolean("tts"))
+                .setPinned(jsonObject.getBoolean("pinned"));
 
         List<Message.Attachment> attachments = new LinkedList<>();
         JSONArray jsonAttachments = jsonObject.getJSONArray("attachments");

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -356,7 +356,9 @@ public class EntityBuilder
 
         return channel
                 .setName(json.getString("name"))
-                .setPosition(json.getInt("position"));
+                .setPosition(json.getInt("position"))
+                .setUserLimit(json.getInt("user_limit"))
+                .setBitrate(json.getInt("bitrate"));
     }
 
     public PrivateChannel createPrivateChannel(JSONObject privatechat)

--- a/src/main/java/net/dv8tion/jda/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/handle/EventCache.java
@@ -17,12 +17,11 @@ package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.utils.SimpleLog;
-import org.json.JSONObject;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Consumer;
 
 public class EventCache
 {
@@ -83,6 +82,19 @@ public class EventCache
                 item.run();
             }
         }
+    }
+
+    public int size()
+    {
+        int count = 0;
+        for (HashMap<String, List<Runnable>> typeMap : eventCache.values())
+        {
+            for (List<Runnable> eventList : typeMap.values())
+            {
+                count += eventList.size();
+            }
+        }
+        return count;
     }
 
     public void clear()

--- a/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
@@ -16,9 +16,11 @@
 package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.entities.Guild;
+import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.entities.impl.GuildImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.entities.impl.TextChannelImpl;
 import net.dv8tion.jda.entities.impl.UserImpl;
 import net.dv8tion.jda.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.events.guild.GuildUnavailableEvent;
@@ -85,6 +87,7 @@ public class GuildLeaveHandler extends SocketHandler
         }
 
         api.getGuildMap().remove(guild.getId());
+        TextChannelImpl.AsyncMessageSender.stop(api, guild.getId());
         api.getEventManager().handle(
                 new GuildLeaveEvent(
                         api, responseNumber,

--- a/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildLeaveHandler.java
@@ -87,6 +87,8 @@ public class GuildLeaveHandler extends SocketHandler
         }
 
         api.getGuildMap().remove(guild.getId());
+        guild.getTextChannels().forEach(chan -> api.getChannelMap().remove(chan.getId()));
+        guild.getVoiceChannels().forEach(chan -> api.getVoiceChannelMap().remove(chan.getId()));
         TextChannelImpl.AsyncMessageSender.stop(api, guild.getId());
         api.getEventManager().handle(
                 new GuildLeaveEvent(

--- a/src/main/java/net/dv8tion/jda/handle/MessageBulkDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageBulkDeleteHandler.java
@@ -1,0 +1,68 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.handle;
+
+import net.dv8tion.jda.entities.TextChannel;
+import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.events.message.MessageBulkDeleteEvent;
+import net.dv8tion.jda.requests.GuildLock;
+import org.json.JSONObject;
+
+import java.util.LinkedList;
+
+public class MessageBulkDeleteHandler extends SocketHandler
+{
+    public MessageBulkDeleteHandler(JDAImpl api, int responseNumber)
+    {
+        super(api, responseNumber);
+    }
+
+    @Override
+    protected String handleInternally(JSONObject content)
+    {
+        String channelId = content.getString("channel_id");
+
+        if (api.isBulkDeleteSplittingEnabled())
+        {
+            content.getJSONArray("ids").forEach(id ->
+            {
+                new MessageDeleteHandler(api, responseNumber).handle(new JSONObject()
+                    .put("d", new JSONObject()
+                        .put("channel_id", channelId)
+                        .put("id", id)
+                    ));
+            });
+        }
+        else
+        {
+            TextChannel channel = api.getChannelMap().get(channelId);
+            if (channel != null)
+            {
+                if (GuildLock.get(api).isLocked(channel.getGuild().getId()))
+                {
+                    return channel.getGuild().getId();
+                }
+                LinkedList<String> msgIds = new LinkedList<>();
+                content.getJSONArray("ids").forEach(id -> msgIds.add((String) id));
+                api.getEventManager().handle(
+                        new MessageBulkDeleteEvent(
+                                api, responseNumber,
+                                channel, msgIds));
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
@@ -21,10 +21,11 @@ import net.dv8tion.jda.events.Event;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class InterfacedEventManager implements IEventManager
 {
-    private final List<EventListener> listeners = new LinkedList<>();
+    private final CopyOnWriteArrayList<EventListener> listeners = new CopyOnWriteArrayList<>();
 
     public InterfacedEventManager()
     {
@@ -56,8 +57,7 @@ public class InterfacedEventManager implements IEventManager
     @Override
     public void handle(Event event)
     {
-        List<EventListener> listenerCopy = new LinkedList<>(listeners);
-        for (EventListener listener : listenerCopy)
+        for (EventListener listener : listeners)
         {
             try
             {

--- a/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/hooks/InterfacedEventManager.java
@@ -51,7 +51,7 @@ public class InterfacedEventManager implements IEventManager
     @Override
     public List<Object> getRegisteredListeners()
     {
-        return Collections.unmodifiableList(listeners);
+        return Collections.unmodifiableList(new LinkedList<>(listeners));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -37,6 +37,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onReconnect(ReconnectedEvent event) {}
     public void onDisconnect(DisconnectEvent event) {}
     public void onShutdown(ShutdownEvent event) {}
+    public void onStatusChange(StatusChangeEvent event) {}
 
     //User Events
     public void onUserNameUpdate(UserNameUpdateEvent event) {}
@@ -156,6 +157,8 @@ public abstract class ListenerAdapter implements EventListener
             onDisconnect((DisconnectEvent) event);
         else if (event instanceof ShutdownEvent)
             onShutdown((ShutdownEvent) event);
+        else if (event instanceof StatusChangeEvent)
+            onStatusChange((StatusChangeEvent) event);
 
         //Message Events
         //Guild (TextChannel) Message Events

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -60,6 +60,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onMessageReceived(MessageReceivedEvent event) {}
     public void onMessageUpdate(MessageUpdateEvent event) {}
     public void onMessageDelete(MessageDeleteEvent event) {}
+    public void onMessageBulkDelete(MessageBulkDeleteEvent event) {}
     public void onMessageEmbed(MessageEmbedEvent event) {}
 
     public void onInviteReceived(InviteReceivedEvent event) {}
@@ -182,6 +183,8 @@ public abstract class ListenerAdapter implements EventListener
             onMessageUpdate((MessageUpdateEvent) event);
         else if (event instanceof MessageDeleteEvent)
             onMessageDelete((MessageDeleteEvent) event);
+        else if (event instanceof MessageBulkDeleteEvent)
+            onMessageBulkDelete((MessageBulkDeleteEvent) event);
         else if (event instanceof MessageEmbedEvent)
             onMessageEmbed((MessageEmbedEvent) event);
         //Invite Messages

--- a/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/hooks/ListenerAdapter.java
@@ -76,6 +76,8 @@ public abstract class ListenerAdapter implements EventListener
     public void onVoiceChannelDelete(VoiceChannelDeleteEvent event) {}
     public void onVoiceChannelUpdateName(VoiceChannelUpdateNameEvent event) {}
     public void onVoiceChannelUpdatePosition(VoiceChannelUpdatePositionEvent event) {}
+    public void onVoiceChannelUpdateUserLimit(VoiceChannelUpdateUserLimitEvent event) {}
+    public void onVoiceChannelUpdateBitrate(VoiceChannelUpdateBitrateEvent event) {}
     public void onVoiceChannelUpdatePermissions(VoiceChannelUpdatePermissionsEvent event) {}
     public void onVoiceChannelCreate(VoiceChannelCreateEvent event) {}
 
@@ -221,6 +223,10 @@ public abstract class ListenerAdapter implements EventListener
             onVoiceChannelUpdateName((VoiceChannelUpdateNameEvent) event);
         else if (event instanceof VoiceChannelUpdatePositionEvent)
             onVoiceChannelUpdatePosition((VoiceChannelUpdatePositionEvent) event);
+        else if (event instanceof VoiceChannelUpdateUserLimitEvent)
+            onVoiceChannelUpdateUserLimit((VoiceChannelUpdateUserLimitEvent) event);
+        else if (event instanceof VoiceChannelUpdateBitrateEvent)
+            onVoiceChannelUpdateBitrate((VoiceChannelUpdateBitrateEvent) event);
         else if (event instanceof VoiceChannelUpdatePermissionsEvent)
             onVoiceChannelUpdatePermissions((VoiceChannelUpdatePermissionsEvent) event);
         else if (event instanceof VoiceChannelDeleteEvent)

--- a/src/main/java/net/dv8tion/jda/managers/AccountManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/AccountManager.java
@@ -49,7 +49,7 @@ public class AccountManager
      * Avatars can get generated through the methods of {@link net.dv8tion.jda.utils.AvatarUtil AvatarUtil}
      *
      * @param avatar
-     *      a Avatar object, null to keep current Avatar or {@link net.dv8tion.jda.utils.AvatarUtil#DELETE_AVATAR AvatarUtil#DELETE_AVATAR} to remove the avatar
+     *      an Avatar object, null to keep current Avatar or {@link net.dv8tion.jda.utils.AvatarUtil#DELETE_AVATAR AvatarUtil#DELETE_AVATAR} to remove the avatar
      * @return
      *      this
      */
@@ -117,7 +117,7 @@ public class AccountManager
      * This change will be applied <b>immediately</b>
      *
      * @param idle
-     *      weather the account should be displayed as idle o not
+     *      whether the account should be displayed as idle or not
      */
     public void setIdle(boolean idle)
     {

--- a/src/main/java/net/dv8tion/jda/managers/AccountManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/AccountManager.java
@@ -33,10 +33,10 @@ import org.json.JSONObject;
 public class AccountManager
 {
 
-    private AvatarUtil.Avatar avatar = null;
-    private String username = null;
+    protected AvatarUtil.Avatar avatar = null;
+    protected String username = null;
 
-    private final JDAImpl api;
+    protected final JDAImpl api;
 
     public AccountManager(JDAImpl api)
     {
@@ -179,7 +179,7 @@ public class AccountManager
             this.username = null;
     }
 
-    private void updateStatusAndGame()
+    protected void updateStatusAndGame()
     {
         SelfInfo selfInfo = api.getSelfInfo();
         JSONObject game = null;

--- a/src/main/java/net/dv8tion/jda/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/GuildManager.java
@@ -712,6 +712,36 @@ public class GuildManager
     }
 
     /**
+     * Deafens a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_DEAF_OTHERS VOICE_DEAF_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be deafened.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#undeafen(User)
+     */
+    public void deafen(User user)
+    {
+        this.deafen(user, true);
+    }
+
+    /**
+     * Mutes a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_MUTE_OTHERS VOICE_MUTE_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be muted.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#unmute(User)
+     */
+    public void mute(User user)
+    {
+        this.mute(user, true);
+    }
+
+    /**
      * Gets an unmodifiable list of the currently banned {@link net.dv8tion.jda.entities.User Users}.<br>
      * If you wish to ban or unban a user, please use one of the ban or unban methods of this Manager
      *
@@ -785,6 +815,36 @@ public class GuildManager
     }
 
     /**
+     * Undeafens a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_DEAF_OTHERS VOICE_DEAF_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be undeafened.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#deafen(User)
+     */
+    public void undeafen(User user)
+    {
+        this.deafen(user, false);
+    }
+    
+    /**
+     * Unmutes a {@link net.dv8tion.jda.entities.User User} in this {@link net.dv8tion.jda.entities.Guild Guild}.
+     * Requires the {@link net.dv8tion.jda.Permission#VOICE_MUTE_OTHERS VOICE_MUTE_OTHERS} permission.
+     * 
+     * @param user
+     *      The user who should be unmuted.
+     * @throws net.dv8tion.jda.exceptions.GuildUnavailableException
+     *      if the guild is temporarily unavailable
+     * @see GuildManager#mute(User)
+     */
+    public void unmute(User user)
+    {
+        this.mute(user, false);
+    }
+
+    /**
      * Leaves this {@link net.dv8tion.jda.entities.Guild Guild}.
      * If the logged in {@link net.dv8tion.jda.entities.User User} is the owner of
      * this {@link net.dv8tion.jda.entities.Guild Guild}, this method will throw an {@link net.dv8tion.jda.exceptions.PermissionException PermissionException}.
@@ -808,6 +868,36 @@ public class GuildManager
         ((JDAImpl) guild.getJDA()).getRequester().delete(Requester.DISCORD_API_PREFIX + "users/@me/guilds/" + guild.getId());
     }
 
+    private void deafen(User user, boolean deafen)
+    {
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+
+        checkPermission(Permission.VOICE_DEAF_OTHERS);
+
+        String url = Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/" + user.getId();
+
+        ((JDAImpl) guild.getJDA()).getRequester()
+                .patch(url, new JSONObject().put("deaf", deafen));
+    }
+    
+    private void mute(User user, boolean mute)
+    {
+        if (!guild.isAvailable())
+        {
+            throw new GuildUnavailableException();
+        }
+
+        checkPermission(Permission.VOICE_MUTE_OTHERS);
+
+        String url = Requester.DISCORD_API_PREFIX + "guilds/" + guild.getId() + "/members/" + user.getId();
+
+        ((JDAImpl) guild.getJDA()).getRequester()
+                .patch(url, new JSONObject().put("mute", mute));
+    }
+
     private JSONObject getFrame()
     {
         return new JSONObject().put("name", guild.getName());
@@ -822,7 +912,6 @@ public class GuildManager
     {
         if (!PermissionUtil.checkPermission(getGuild().getJDA().getSelfInfo(), perm, getGuild()))
             throw new PermissionException(perm);
-
     }
 
     private void checkPosition(User u)

--- a/src/main/java/net/dv8tion/jda/managers/RoleManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/RoleManager.java
@@ -37,6 +37,7 @@ public class RoleManager
     private String name = null;
     private int color = -1;
     private Boolean grouped = null;
+    private Boolean mentionable;
     private int perms;
 
     public RoleManager(Role role)
@@ -172,6 +173,32 @@ public class RoleManager
         else
         {
             this.grouped = group;
+        }
+        return this;
+    }
+
+    /**
+     * Sets, whether this Role should be mentionable.
+     * This change will only be applied, if {@link #update()} is called.
+     * So multiple changes can be made at once.
+     *
+     * @param group
+     *      Whether or not this should be mentionable, or null to keep current grouping status
+     * @return
+     *      this
+     */
+    public RoleManager setMentionable(Boolean mention)
+    {
+        checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
+
+        if (mention == null || mention == role.isMentionable())
+        {
+            this.mentionable = null;
+        }
+        else
+        {
+            this.mentionable = mention;
         }
         return this;
     }
@@ -317,6 +344,8 @@ public class RoleManager
             frame.put("color", color);
         if(grouped != null)
             frame.put("hoist", grouped.booleanValue());
+        if(mentionable != null)
+            frame.put("mentionable", mentionable.booleanValue());
         update(frame);
     }
 

--- a/src/main/java/net/dv8tion/jda/managers/RoleManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/RoleManager.java
@@ -82,6 +82,32 @@ public class RoleManager
     }
 
     /**
+     * Sets the <code>int</code> representation of the permissions for this {@link net.dv8tion.jda.entities.Role Role}.<br>
+     * This change will only be applied, if {@link #update()} is called.
+     * So multiple changes can be made at once.
+     *
+     * @param perms
+     *      int containing offset permissions of this role
+     * @return
+     *      this
+     * @see
+     *      <a href="https://discordapp.com/developers/docs/topics/permissions">Discord Permission Documentation</a>
+     */
+    public RoleManager setPermissionsRaw(int perms)
+    {
+        checkPermission(Permission.MANAGE_ROLES);
+        checkPosition();
+
+        for (Permission perm : Permission.getPermissions(perms))
+        {
+            checkPermission(perm);   
+        }
+
+        this.perms = perms;
+        return this;
+    }
+
+    /**
      * Sets the color of this Role.
      * This change will only be applied, if {@link #update()} is called.
      * So multiple changes can be made at once.

--- a/src/main/java/net/dv8tion/jda/managers/impl/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/managers/impl/AudioManagerImpl.java
@@ -37,18 +37,18 @@ public class AudioManagerImpl implements AudioManager
     public static boolean AUDIO_SUPPORTED;
     public static String OPUS_LIB_NAME;
 
-    private static boolean initialized = false;
+    protected static boolean initialized = false;
 
-    private final JDAImpl api;
-    private final Guild guild;
-    private AudioConnection audioConnection = null;
-    private VoiceChannel queuedAudioConnection = null;
-    private VoiceChannel unexpectedDisconnectedChannel = null;
+    protected final JDAImpl api;
+    protected final Guild guild;
+    protected AudioConnection audioConnection = null;
+    protected VoiceChannel queuedAudioConnection = null;
+    protected VoiceChannel unexpectedDisconnectedChannel = null;
 
-    private AudioSendHandler sendHandler;
-    private AudioReceiveHandler receiveHandler;
+    protected AudioSendHandler sendHandler;
+    protected AudioReceiveHandler receiveHandler;
 
-    private long timeout = DEFAULT_CONNECTION_TIMEOUT;
+    protected long timeout = DEFAULT_CONNECTION_TIMEOUT;
 
     public AudioManagerImpl(Guild guild)
     {

--- a/src/main/java/net/dv8tion/jda/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/requests/Requester.java
@@ -35,7 +35,7 @@ public class Requester
     public static String USER_AGENT = "JDA DiscordBot (" + JDAInfo.GITHUB + ", " + JDAInfo.VERSION + ")";
     public static final String DISCORD_API_PREFIX = "https://discordapp.com/api/";
 
-    private final JDAImpl api;
+    protected final JDAImpl api;
 
     public Requester(JDAImpl api)
     {
@@ -82,7 +82,7 @@ public class Requester
         return exec(addHeaders(Unirest.put(url)).body(body.toString()));
     }
 
-    private Response exec(BaseRequest request)
+    protected Response exec(BaseRequest request)
     {
         HttpResponse<String> ret = null;
         try
@@ -114,7 +114,7 @@ public class Requester
         }
     }
 
-    private <T extends HttpRequest> T addHeaders(T request)
+    protected <T extends HttpRequest> T addHeaders(T request)
     {
         //adding token to all requests to the discord api or cdn pages
         //can't check for startsWith(DISCORD_API_PREFIX) due to cdn endpoints
@@ -137,14 +137,14 @@ public class Requester
         public final int code;
         public final String responseText;
 
-        private Response(int code, String response)
+        protected Response(int code, String response)
         {
             this.code = code;
             this.responseText = response;
             this.exception = null;
         }
 
-        private Response(Exception exception)
+        protected Response(Exception exception)
         {
             this.code = connectionErrCode;
             this.responseText = null;

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -610,6 +610,9 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 case "MESSAGE_DELETE":
                     new MessageDeleteHandler(api, responseTotal).handle(raw);
                     break;
+                case "MESSAGE_DELETE_BULK":
+                    new MessageBulkDeleteHandler(api, responseTotal).handle(raw);
+                    break;
                 case "VOICE_STATE_UPDATE":
                     new VoiceChangeHandler(api, responseTotal).handle(raw);
                     break;

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -396,7 +396,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                         .put("token", api.getAuthToken())
                         .put("properties", new JSONObject()
                                 .put("$os", System.getProperty("os.name"))
-                                .put("$browser", "Java Discord API")
+                                .put("$browser", "JDA")
                                 .put("$device", "")
                                 .put("$referring_domain", "")
                                 .put("$referrer", "")

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -46,31 +46,31 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDASocket");
 
-    private final JDAImpl api;
+    protected final JDAImpl api;
 
-    private final int[] sharding;
-    private final HttpHost proxy;
-    private WebSocket socket;
-    private String gatewayUrl = null;
+    protected final int[] sharding;
+    protected final HttpHost proxy;
+    protected WebSocket socket;
+    protected String gatewayUrl = null;
 
-    private String sessionId = null;
+    protected String sessionId = null;
 
-    private Thread keepAliveThread;
-    private boolean connected;
+    protected Thread keepAliveThread;
+    protected boolean connected;
 
-    private boolean initiating;             //cache all events?
-    private final List<JSONObject> cachedEvents = new LinkedList<>();
+    protected boolean initiating;             //cache all events?
+    protected final List<JSONObject> cachedEvents = new LinkedList<>();
 
-    private boolean shouldReconnect = true;
-    private int reconnectTimeoutS = 2;
+    protected boolean shouldReconnect = true;
+    protected int reconnectTimeoutS = 2;
 
-    private final List<VoiceChannel> dcAudioConnections = new LinkedList<>();
-    private final Map<String, AudioSendHandler> audioSendHandlers = new HashMap<>();
-    private final Map<String, AudioReceiveHandler> audioReceivedHandlers = new HashMap<>();
+    protected final List<VoiceChannel> dcAudioConnections = new LinkedList<>();
+    protected final Map<String, AudioSendHandler> audioSendHandlers = new HashMap<>();
+    protected final Map<String, AudioReceiveHandler> audioReceivedHandlers = new HashMap<>();
 
-    private boolean firstInit = true;
+    protected boolean firstInit = true;
 
-    private WebSocketCustomHandler customHandler;
+    protected WebSocketCustomHandler customHandler;
 
     public WebSocketClient(JDAImpl api, HttpHost proxy, int[] sharding)
     {
@@ -164,7 +164,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         ### Start Internal methods ###
      */
 
-    private void connect()
+    protected void connect()
     {
         initiating = true;
         WebSocketFactory factory = new WebSocketFactory();
@@ -196,7 +196,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
     }
 
-    private String getGateway()
+    protected String getGateway()
     {
         try
         {
@@ -266,7 +266,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
     }
 
-    private void reconnect()
+    protected void reconnect()
     {
         LOG.warn("Got disconnected from WebSocket (Internet?!)... Attempting to reconnect in " + reconnectTimeoutS + "s");
         while(shouldReconnect)
@@ -328,7 +328,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
     }
 
-    private void setupKeepAlive(long timeout)
+    protected void setupKeepAlive(long timeout)
     {
         keepAliveThread = new Thread(() -> {
             while (connected) {
@@ -347,12 +347,12 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         keepAliveThread.start();
     }
 
-    private void sendKeepAlive()
+    protected void sendKeepAlive()
     {
         send(new JSONObject().put("op", 1).put("d", api.getResponseTotal()).toString());
     }
 
-    private void sendIdentify()
+    protected void sendIdentify()
     {
         LOG.debug("Sending Identify-packet...");
         JSONObject identify = new JSONObject()
@@ -376,7 +376,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         send(identify.toString()); //Used to make the READY event be given as compressed binary data when over a certain size. TY @ShadowLordAlpha
     }
 
-    private void sendResume()
+    protected void sendResume()
     {
         LOG.debug("Sending Resume-packet...");
         send(new JSONObject()
@@ -388,7 +388,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 .toString());
     }
 
-    private void invalidate()
+    protected void invalidate()
     {
         sessionId = null;
 
@@ -419,7 +419,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         TextChannelImpl.AsyncMessageSender.stopAll(api);
     }
 
-    private void restoreAudioHandlers()
+    protected void restoreAudioHandlers()
     {
         LOG.trace("Restoring cached AudioHandlers.");
 
@@ -457,7 +457,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         LOG.trace("Finished restoring cached AudioHandlers");
     }
 
-    private void reconnectAudioConnections()
+    protected void reconnectAudioConnections()
     {
         if (dcAudioConnections.size() == 0)
             return;
@@ -509,7 +509,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         dcAudioConnections.clear();
     }
 
-    private void handleEvent(JSONObject raw)
+    protected void handleEvent(JSONObject raw)
     {
         String type = raw.getString("t");
         int responseTotal = api.getResponseTotal();

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.audio.AudioSendHandler;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
+import net.dv8tion.jda.entities.impl.TextChannelImpl;
 import net.dv8tion.jda.events.*;
 import net.dv8tion.jda.handle.*;
 import net.dv8tion.jda.managers.AudioManager;
@@ -415,6 +416,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         new ReadyHandler(api, 0).clearCache();
         EventCache.get(api).clear();
         GuildLock.get(api).clear();
+        TextChannelImpl.AsyncMessageSender.stopAll(api);
     }
 
     private void restoreAudioHandlers()

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -346,6 +346,9 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 }
             }
         });
+        keepAliveThread.setName("JDA MainWS-KeepAlive" + (sharding != null
+                    ? " Shard [" + sharding[0] + " / " + sharding[1] + "]"
+                    : ""));
         keepAliveThread.setPriority(Thread.MAX_PRIORITY);
         keepAliveThread.setDaemon(true);
         keepAliveThread.start();

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -250,7 +250,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 AudioManagerImpl mngImpl = (AudioManagerImpl) mng;
                 VoiceChannel channel = null;
                 if (mngImpl.isConnected())
+                {
+                    //This causes the AudioDisconnectEvent to be fired.. maybe we should reevaluate that.
                     channel = mng.getConnectedChannel();
+                    mngImpl.closeAudioConnection();
+                }
                 else if (mngImpl.isAttemptingToConnect())
                     channel = mng.getQueuedAudioConnection();
                 else if (mngImpl.wasUnexpectedlyDisconnected())

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -99,7 +99,6 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     public void ready()
     {
-        api.setStatus(JDA.Status.CONNECTED);
         if (initiating)
         {
             initiating = false;
@@ -136,6 +135,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             JDAImpl.LOG.info("Successfully resumed Session!");
             api.getEventManager().handle(new ResumedEvent(api, api.getResponseTotal()));
         }
+        api.setStatus(JDA.Status.CONNECTED);
         LOG.debug("Resending " + cachedEvents.size() + " cached events...");
         handle(cachedEvents);
         LOG.debug("Sending of cached events finished.");

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketCustomHandler.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketCustomHandler.java
@@ -21,7 +21,7 @@ public interface WebSocketCustomHandler
 {
     /**
      * Handles discord events passed to it. If this handler does not handle the event provided
-     * this should return true.
+     * this should return false.
      *
      * @param obj
      *          The Discord event which needs to be handled

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -106,7 +106,7 @@ public class ApplicationUtil
      */
     public ApplicationUtil(String email, String password) throws LoginException
     {
-        api = new JDAImpl(false, true, true);
+        api = new JDAImpl(false, false, false);
         api.setAuthToken(login(email, password));
     }
 

--- a/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/ApplicationUtil.java
@@ -106,7 +106,7 @@ public class ApplicationUtil
      */
     public ApplicationUtil(String email, String password) throws LoginException
     {
-        api = new JDAImpl(false, true);
+        api = new JDAImpl(false, true, true);
         api.setAuthToken(login(email, password));
     }
 

--- a/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
@@ -305,10 +305,9 @@ public class InviteUtil
         private final int uses;
         //TODO what happens if the inviter left the server (and therefore is unknown for the api)?
         private final User inviter;
-        private final boolean revoked;
 
         private AdvancedInvite(String code, String humanCode, String guildName, String guildId, String channelName, String channelId, boolean isTextChannel, InviteDuration duration, String guildSplashHash, boolean temporary,
-                int maxUses, OffsetDateTime createdAt, int uses, User inviter, boolean revoked) {
+                int maxUses, OffsetDateTime createdAt, int uses, User inviter) {
             super(code, humanCode, guildName, guildId, channelName, channelId, isTextChannel);
             this.duration = duration;
             this.guildSplashHash = guildSplashHash;
@@ -317,7 +316,6 @@ public class InviteUtil
             this.createdAt = createdAt;
             this.uses = uses;
             this.inviter = inviter;
-            this.revoked = revoked;
         }
 
         public InviteDuration getDuration()
@@ -355,11 +353,6 @@ public class InviteUtil
             return inviter;
         }
 
-        public boolean isRevoked()
-        {
-            return revoked;
-        }
-
         private static AdvancedInvite fromJson(JSONObject object, JDA jda)
         {
             JSONObject guild = object.getJSONObject("guild");
@@ -380,8 +373,7 @@ public class InviteUtil
                     object.getInt("max_uses"),
                     OffsetDateTime.parse(object.getString("created_at")),
                     object.getInt("uses"),
-                    jda.getUserById(inviter.getString("id")),
-                    object.getBoolean("revoked"));
+                    jda.getUserById(inviter.getString("id")));
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
@@ -54,7 +54,7 @@ public class InviteUtil
             String[] split = code.split("/");
             code = split[split.length - 1];
         }
-        JSONObject object = new JDAImpl(false, false).getRequester().get(Requester.DISCORD_API_PREFIX + "invite/" + code).getObject();
+        JSONObject object = new JDAImpl(false, false, false).getRequester().get(Requester.DISCORD_API_PREFIX + "invite/" + code).getObject();
         if (object != null && object.has("code") && object.has("guild"))
         {
             JSONObject guild = object.getJSONObject("guild");

--- a/src/main/java/net/dv8tion/jda/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/PermissionUtil.java
@@ -49,6 +49,10 @@ public class PermissionUtil
             return false;
         List<Role> issuerRoles = guild.getRolesForUser(issuer);
         List<Role> targetRoles = guild.getRolesForUser(target);
+        if (issuerRoles == null)
+            throw new IllegalArgumentException("Issuer user is not in the provided guild!");
+        if (targetRoles == null)
+            throw new IllegalArgumentException("Target user is not in the provided guild!");
         return !issuerRoles.isEmpty() && (targetRoles.isEmpty() || canInteract(issuerRoles.get(0), targetRoles.get(0)));
     }
 
@@ -68,6 +72,8 @@ public class PermissionUtil
         if(target.getGuild().getOwner() == issuer)
             return true;
         List<Role> issuerRoles = target.getGuild().getRolesForUser(issuer);
+        if (issuerRoles == null)
+            throw new IllegalArgumentException("Issuer User is not in the guild that the target Role is a part of!");
         return !issuerRoles.isEmpty() && canInteract(issuerRoles.get(0), target);
     }
     
@@ -156,6 +162,8 @@ public class PermissionUtil
      */
     public static boolean checkPermission(User user, Permission perm, Guild guild)
     {
+        if (guild.getRolesForUser(user) == null)
+            throw new IllegalArgumentException("Provided user is not in the provided guild");
         return guild.getOwnerId().equals(user.getId())
                 || guild.getPublicRole().hasPermission(Permission.ADMINISTRATOR)
                 || guild.getPublicRole().hasPermission(perm)
@@ -212,6 +220,8 @@ public class PermissionUtil
         //Default to binary OR of all global permissions in this guild
         int permission = guild.getPublicRole().getPermissionsRaw();
         List<Role> rolesOfUser = guild.getRolesForUser(user);
+        if (rolesOfUser == null)
+            throw new IllegalArgumentException("Provided user is not in the provided guild");
         for (Role role : rolesOfUser)
         {
             permission = permission | role.getPermissionsRaw();


### PR DESCRIPTION
**++** Added support for Discord Gateway v5
**++** Added MessageBuilder#appendFormat(String, Object...). Works just like String.format(String, Object...) does, but with JDA specific token support as well! Checkout the javadoc for more information!
**++** Added a Status enum and Status event to JDA. Now you can better track the state JDA is in!
**++** All events now have Class-level javadoc!  #77 
**+** Added naming to all threads spawned by JDA, useful for thread tracking. Names for everyone!
**+** Added support for retrieving or deleting individual messages based on their ID. 
**+** Added support for bulk message deletion
**+** Added support for message pinning.
**+** MessageChannel now has #getJDA() and #getId()
**+** Added Guild#isMember(User) to determine if a User is in a guild in O(1) (constant) time.
**+** Added javadoc to FilePlayer and URLPlayer. #78 
**+** Added RoleManager#setMentionable(boolean)
**+** Added Guild#getColorDeterminantRoleForUser(User);
**+** Added Guild#createCopyOfRole(Role)
**+** Added shortcut method: SelfInfo#getAuthUrl(Permission...). It is shortcut to ApplicationUtil#getAuthUrl(JDA, Permission...)

**Fixed a very long time (yet unseen) bug in JDA having to deal with incorrect Guild instances due to TextChannels and VoiceChannels not being purged from the internal cache. More info here: http://hastebin.com/heqitebano.xml Thanks @jagrosh 
*Fixed possible ConcurrencyModificationExceptions due to checking of permissions and other list based properties from a different thread.
*Changes the `browser` field in the identify packet to be `JDA` instead of `Java Discord API`
*JDA now only checks for verification before sending if the logged in account is not a bot. (JDA-Client)

*-* Removed AdvancedInvite#isRevoked() because discord now automatically removes revoked invites and this field no longer exists.