### PR TITLE
Release of v2.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 1, revision: 2)
+def versionObj = new Version(major: 2, minor: 1, revision: 3)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -141,8 +141,10 @@ public class AudioConnection
     public void close(boolean regionChange)
     {
 //        setSpeaking(false);
-        sendThread.interrupt();
-        receiveThread.interrupt();
+        if (sendThread != null)
+            sendThread.interrupt();
+        if (receiveThread != null)
+            receiveThread.interrupt();
         webSocket.close(regionChange, -1);
     }
 

--- a/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.handle;
 
+import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.channel.priv.PrivateChannelCreateEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelCreateEvent;
@@ -61,10 +62,18 @@ public class ChannelCreateHandler extends SocketHandler
         }
         else if (type.equalsIgnoreCase("private"))
         {
-            api.getEventManager().handle(
-                    new PrivateChannelCreateEvent(
-                            api, responseNumber,
-                            new EntityBuilder(api).createPrivateChannel(content).getUser()));
+            PrivateChannel pc = new EntityBuilder(api).createPrivateChannel(content);
+            if (pc == null)
+            {
+                JDAImpl.LOG.warn("Discord API sent us a Private CREATE_CHANNEL for a user we can't see, ignoring event.");
+            }
+            else
+            {
+                api.getEventManager().handle(
+                        new PrivateChannelCreateEvent(
+                                api, responseNumber,
+                                pc.getUser()));
+            }
         }
         else
         {


### PR DESCRIPTION
**Fixed issue when JDA received a CHANNEL_CREATE event for a Private channel. Due to old code that depended on now invalid return methodology, our detection of whether or not the create event was for a private channel broke. This has been fixed by using the `is_private` variable that was introduced :+1:
*Fixed possible NPE when closing an audio connection before it was done connecting.
*Fixed NPE explosion when receiving a CHANNEL_CREATE for a private channel for an unknown user. This has to do with the Relationship (friends) system, which is not yet supported. Now prints a log message instead.