### PR TITLE
Fix ConcurrentModification in GuildManager

### DIFF
--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -56,7 +56,7 @@ public class AudioConnection
     private volatile HashMap<Integer, String> ssrcMap = new HashMap<>();
     private volatile HashMap<Integer, Decoder> opusDecoders = new HashMap<>();
     private volatile HashMap<User, Queue<Pair<Long, short[]>>> combinedQueue = new HashMap<>();
-    private ScheduledExecutorService combinedAudioExecutor = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService combinedAudioExecutor;
 
     private Thread sendThread;
     private Thread receiveThread;
@@ -81,7 +81,7 @@ public class AudioConnection
 
     public void ready(long timeout)
     {
-        Thread readyThread = new Thread()
+        Thread readyThread = new Thread("AudioConnection Ready Guild: " + channel.getGuild().getId())
         {
             @Override
             public void run()
@@ -111,7 +111,6 @@ public class AudioConnection
                     AudioConnection.this.udpSocket = webSocket.getUdpSocket();
                     setupSendThread();
                     setupReceiveThread();
-                    setupCombinedExecutor();
                     api.getEventManager().handle(new AudioConnectEvent(api, AudioConnection.this.channel));
                 }
                 else
@@ -127,11 +126,13 @@ public class AudioConnection
 
     public void setSendingHandler(AudioSendHandler handler)
     {
+        setupSendThread();
         this.sendHandler = handler;
     }
 
     public void setReceivingHandler(AudioReceiveHandler handler)
     {
+        setupReceiveThread();
         this.receiveHandler = handler;
     }
 
@@ -201,281 +202,298 @@ public class AudioConnection
 
     private void setupSendThread()
     {
-        sendThread = new Thread("AudioConnection SendThread Guild: " + channel.getGuild().getId())
+        if (sendThread == null && udpSocket != null && sendHandler != null)
         {
-            @Override
-            public void run()
+            sendThread = new Thread("AudioConnection SendThread Guild: " + channel.getGuild().getId())
             {
-                char seq = 0;           //Sequence of audio packets. Used to determine the order of the packets.
-                int timestamp = 0;      //Used to sync up our packets within the same timeframe of other people talking.
-                long lastFrameSent = System.currentTimeMillis();
-                boolean sentSilenceOnConnect = false;
-                while (!udpSocket.isClosed() && !this.isInterrupted())
+                @Override
+                public void run()
                 {
-                    try
+                    char seq = 0;           //Sequence of audio packets. Used to determine the order of the packets.
+                    int timestamp = 0;      //Used to sync up our packets within the same timeframe of other people talking.
+                    long lastFrameSent = System.currentTimeMillis();
+                    boolean sentSilenceOnConnect = false;
+                    while (!udpSocket.isClosed() && !this.isInterrupted())
                     {
-                        //WE NEED TO CONSIDER BUFFERING STUFF BECAUSE REASONS.
-                        //Consider storing 40-60ms of encoded audio as a buffer.
-                        if (sentSilenceOnConnect && sendHandler != null && sendHandler.canProvide())
+                        try
                         {
-                            silenceCounter = -1;
-                            byte[] rawAudio = sendHandler.provide20MsAudio();
-                            if (rawAudio == null || rawAudio.length == 0)
+                            //WE NEED TO CONSIDER BUFFERING STUFF BECAUSE REASONS.
+                            //Consider storing 40-60ms of encoded audio as a buffer.
+                            if (sentSilenceOnConnect && sendHandler != null && sendHandler.canProvide())
                             {
-                                if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
-                                    setSpeaking(false);
-                            }
-                            else
-                            {
-                                if (!sendHandler.isOpus())
+                                silenceCounter = -1;
+                                byte[] rawAudio = sendHandler.provide20MsAudio();
+                                if (rawAudio == null || rawAudio.length == 0)
                                 {
-                                    rawAudio = encodeToOpus(rawAudio);
+                                    if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
+                                        setSpeaking(false);
                                 }
-                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), rawAudio);
-                                if (!speaking)
-                                    setSpeaking(true);
+                                else
+                                {
+                                    if (!sendHandler.isOpus())
+                                    {
+                                        rawAudio = encodeToOpus(rawAudio);
+                                    }
+                                    AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), rawAudio);
+                                    if (!speaking)
+                                        setSpeaking(true);
+                                    udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
+            
+                                    if (seq + 1 > Character.MAX_VALUE)
+                                        seq = 0;
+                                    else
+                                        seq++;
+                                }
+                            }
+                            else if (silenceCounter > -1)
+                            {
+                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), silenceBytes);
                                 udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
-
+            
                                 if (seq + 1 > Character.MAX_VALUE)
                                     seq = 0;
                                 else
                                     seq++;
+            
+                                if (++silenceCounter > 10)
+                                {
+                                    silenceCounter = -1;
+                                    sentSilenceOnConnect = true;
+                                }
                             }
+                            else if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
+                                setSpeaking(false);
                         }
-                        else if (silenceCounter > -1)
+                        catch (NoRouteToHostException e)
                         {
-                            AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), silenceBytes);
-                            udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
-
-                            if (seq + 1 > Character.MAX_VALUE)
-                                seq = 0;
+                            LOG.warn("Closing AudioConnection due to inability to send audio packets.");
+                            LOG.warn("Cannot send audio packet because JDA cannot navigate the route to Discord.\n" +
+                                    "Are you sure you have internet connection? It is likely that you've lost connection.");
+                            webSocket.close(true, -1);
+                        }
+                        catch (SocketException e)
+                        {
+                            //Most likely the socket has been closed due to the audio connection be closed. Next iteration will kill loop.
+                        }
+                        catch (Exception e)
+                        {
+                            LOG.log(e);
+                        }
+                        finally
+                        {
+                            timestamp += OPUS_FRAME_SIZE;
+                            long sleepTime = (OPUS_FRAME_TIME_AMOUNT) - (System.currentTimeMillis() - lastFrameSent);
+                            if (sleepTime > 0)
+                            {
+                                try
+                                {
+                                    Thread.sleep(sleepTime);
+                                } catch (InterruptedException e)
+                                {
+                                    //We've been asked to stop. The next iteration will kill the loop. 
+                                }
+                            }
+                            if (System.currentTimeMillis() < lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
+                            {
+                                lastFrameSent += OPUS_FRAME_TIME_AMOUNT; // incrase lastFrameSent
+                            }
                             else
-                                seq++;
-
-                            if (++silenceCounter > 10)
                             {
-                                silenceCounter = -1;
-                                sentSilenceOnConnect = true;
+                                lastFrameSent = System.currentTimeMillis(); // else reset lastFrameSent to current time
                             }
-                        }
-                        else if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
-                            setSpeaking(false);
-                    }
-                    catch (NoRouteToHostException e)
-                    {
-                        LOG.warn("Closing AudioConnection due to inability to send audio packets.");
-                        LOG.warn("Cannot send audio packet because JDA cannot navigate the route to Discord.\n" +
-                                "Are you sure you have internet connection? It is likely that you've lost connection.");
-                        webSocket.close(true, -1);
-                    }
-                    catch (SocketException e)
-                    {
-                        //Most likely the socket has been closed due to the audio connection be closed. Next iteration will kill loop.
-                    }
-                    catch (Exception e)
-                    {
-                        LOG.log(e);
-                    }
-                    finally
-                    {
-                        timestamp += OPUS_FRAME_SIZE;
-                        long sleepTime = (OPUS_FRAME_TIME_AMOUNT) - (System.currentTimeMillis() - lastFrameSent);
-                        if (sleepTime > 0)
-                        {
-                            try
-                            {
-                                Thread.sleep(sleepTime);
-                            } catch (InterruptedException e)
-                            {
-                                //We've been asked to stop. The next iteration will kill the loop. 
-                            }
-                        }
-                        if (System.currentTimeMillis() < lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
-                        {
-                            lastFrameSent += OPUS_FRAME_TIME_AMOUNT; // incrase lastFrameSent
-                        }
-                        else
-                        {
-                            lastFrameSent = System.currentTimeMillis(); // else reset lastFrameSent to current time
                         }
                     }
                 }
-            }
-        };
-        sendThread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);
-        sendThread.setDaemon(true);
-        sendThread.start();
+            };
+            sendThread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);
+            sendThread.setDaemon(true);
+            sendThread.start();
+        }
     }
 
     private void setupReceiveThread()
     {
-        receiveThread = new Thread("AudioConnection ReceiveThread Guild: " + channel.getGuild().getId())
-        {
-            @Override
-            public void run()
+        if (receiveHandler != null && udpSocket != null)
+    	{
+            if (receiveThread == null)
             {
-                try
+                receiveThread = new Thread("AudioConnection ReceiveThread Guild: " + channel.getGuild().getId())
                 {
-                    udpSocket.setSoTimeout(100);
-                }
-                catch (SocketException e)
-                {
-                    LOG.log(e);
-                }
-                while (!udpSocket.isClosed() && !this.isInterrupted())
-                {
-                    DatagramPacket receivedPacket = new DatagramPacket(new byte[1920], 1920);
-                    try
+                    @Override
+                    public void run()
                     {
-                        udpSocket.receive(receivedPacket);
-
-                        if (receiveHandler != null && (receiveHandler.canReceiveUser() || receiveHandler.canReceiveCombined()) && webSocket.getSecretKey() != null)
+                        try
                         {
-                            if (!couldReceive)
+                            udpSocket.setSoTimeout(100);
+                        }
+                        catch (SocketException e)
+                        {
+                            LOG.log(e);
+                        }
+                        while (!udpSocket.isClosed() && !this.isInterrupted())
+                        {
+                            DatagramPacket receivedPacket = new DatagramPacket(new byte[1920], 1920);
+                            try
                             {
-                                couldReceive = true;
-                                sendSilentPackets();
-                            }
-                            AudioPacket decryptedPacket = AudioPacket.decryptAudioPacket(receivedPacket, webSocket.getSecretKey());
-
-                            String userId = ssrcMap.get(decryptedPacket.getSSRC());
-                            Decoder decoder = opusDecoders.get(decryptedPacket.getSSRC());
-                            if (userId == null)
-                            {
-                                byte[] audio = decryptedPacket.getEncodedAudio();
-                                if (!Arrays.equals(audio, silenceBytes))
-                                    LOG.debug("Received audio data with an unknown SSRC id.");
-                            }
-                            else if (decoder == null)
-                                LOG.warn("Received audio data with known SSRC, but opus decoder for this SSRC was null. uh..HOW?!");
-                            else if (!decoder.isInOrder(decryptedPacket.getSequence()))
-                                LOG.trace("Got out-of-order audio packet. Ignoring.");
-                            else
-                            {
-                                User user = getJDA().getUserById(userId);
-                                if (user == null)
-                                    LOG.warn("Received audio data with a known SSRC, but the userId associate with the SSRC is unknown to JDA!");
-                                else
+                                udpSocket.receive(receivedPacket);
+                
+                                if (receiveHandler != null && (receiveHandler.canReceiveUser() || receiveHandler.canReceiveCombined()) && webSocket.getSecretKey() != null)
                                 {
-//                                    if (decoder.wasPacketLost(decryptedPacket.getSequence()))
-//                                    {
-//                                        LOG.debug("Packet(s) missed. Using Opus packetloss-compensation.");
-//                                        short[] decodedAudio = decoder.decodeFromOpus(null);
-//                                        receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
-//                                    }
-                                    short[] decodedAudio = decoder.decodeFromOpus(decryptedPacket);
-                                    if (receiveHandler.canReceiveUser())
+                                    if (!couldReceive)
                                     {
-                                        receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+                                        couldReceive = true;
+                                        sendSilentPackets();
                                     }
-                                    if (receiveHandler.canReceiveCombined())
+                                    AudioPacket decryptedPacket = AudioPacket.decryptAudioPacket(receivedPacket, webSocket.getSecretKey());
+                
+                                    String userId = ssrcMap.get(decryptedPacket.getSSRC());
+                                    Decoder decoder = opusDecoders.get(decryptedPacket.getSSRC());
+                                    if (userId == null)
                                     {
-                                        Queue<Pair<Long, short[]>> queue = combinedQueue.get(user);
-                                        if (queue == null)
+                                        byte[] audio = decryptedPacket.getEncodedAudio();
+                                        if (!Arrays.equals(audio, silenceBytes))
+                                            LOG.debug("Received audio data with an unknown SSRC id.");
+                                    }
+                                    else if (decoder == null)
+                                        LOG.warn("Received audio data with known SSRC, but opus decoder for this SSRC was null. uh..HOW?!");
+                                    else if (!decoder.isInOrder(decryptedPacket.getSequence()))
+                                        LOG.trace("Got out-of-order audio packet. Ignoring.");
+                                    else
+                                    {
+                                        User user = getJDA().getUserById(userId);
+                                        if (user == null)
+                                            LOG.warn("Received audio data with a known SSRC, but the userId associate with the SSRC is unknown to JDA!");
+                                        else
                                         {
-                                            queue = new ConcurrentLinkedQueue<>();
-                                            combinedQueue.put(user, queue);
+//                                            if (decoder.wasPacketLost(decryptedPacket.getSequence()))
+//                                            {
+//                                                LOG.debug("Packet(s) missed. Using Opus packetloss-compensation.");
+//                                                short[] decodedAudio = decoder.decodeFromOpus(null);
+//                                                receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+//                                            }
+                                            short[] decodedAudio = decoder.decodeFromOpus(decryptedPacket);
+                                            if (receiveHandler.canReceiveUser())
+                                            {
+                                                receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+                                            }
+                                            if (receiveHandler.canReceiveCombined())
+                                            {
+                                                Queue<Pair<Long, short[]>> queue = combinedQueue.get(user);
+                                                if (queue == null)
+                                                {
+                                                    queue = new ConcurrentLinkedQueue<>();
+                                                    combinedQueue.put(user, queue);
+                                                }
+                                                queue.add(Pair.<Long, short[]>of(System.currentTimeMillis(), decodedAudio));
+                                            }
                                         }
-                                        queue.add(Pair.<Long, short[]>of(System.currentTimeMillis(), decodedAudio));
                                     }
                                 }
+                                else if (couldReceive)
+                                {
+                                    couldReceive = false;
+                                    sendSilentPackets();
+                                }
+                            }
+                            catch (SocketTimeoutException e)
+                            {
+                                //Ignore. We set a low timeout so that we wont block forever so we can properly shutdown the loop.
+                            }
+                            catch (SocketException e)
+                            {
+                                //The socket was closed while we were listening for the next packet.
+                                //This is expected. Ignore the exception. The thread will exit during the next while
+                                // iteration because the udpSocket.isClosed() will return true.
+                            }
+                            catch (Exception e)
+                            {
+                                LOG.log(e);
                             }
                         }
-                        else if (couldReceive)
-                        {
-                            couldReceive = false;
-                            sendSilentPackets();
-                        }
                     }
-                    catch (SocketTimeoutException e)
-                    {
-                        //Ignore. We set a low timeout so that we wont block forever so we can properly shutdown the loop.
-                    }
-                    catch (SocketException e)
-                    {
-                        //The socket was closed while we were listening for the next packet.
-                        //This is expected. Ignore the exception. The thread will exit during the next while
-                        // iteration because the udpSocket.isClosed() will return true.
-                    }
-                    catch (Exception e)
-                    {
-                        LOG.log(e);
-                    }
-                }
+                };
+                receiveThread.setDaemon(true);
+                receiveThread.start();
+    	    }
+            if (receiveHandler.canReceiveCombined())
+            {
+                setupCombinedExecutor();
             }
-        };
-        receiveThread.setDaemon(true);
-        receiveThread.start();
+		}
     }
 
     private void setupCombinedExecutor()
     {
-        combinedAudioExecutor.scheduleAtFixedRate(() ->
+        if (combinedAudioExecutor == null)
         {
-            try
+            combinedAudioExecutor = Executors.newSingleThreadScheduledExecutor( r -> new Thread(r, "AudioConnection CombinedAudio Guild: " + channel.getGuild().getId()));
+            combinedAudioExecutor.scheduleAtFixedRate(() ->
             {
-                List<User> users = new LinkedList<>();
-                List<short[]> audioParts = new LinkedList<>();
-                if (receiveHandler != null && receiveHandler.canReceiveCombined())
+                try
                 {
-                    long currentTime = System.currentTimeMillis();
-                    for (Map.Entry<User, Queue<Pair<Long, short[]>>> entry : combinedQueue.entrySet())
+                    List<User> users = new LinkedList<>();
+                    List<short[]> audioParts = new LinkedList<>();
+                    if (receiveHandler != null && receiveHandler.canReceiveCombined())
                     {
-                        User user = entry.getKey();
-                        Queue<Pair<Long, short[]>> queue = entry.getValue();
-
-                        if (queue.isEmpty())
-                            continue;
-
-                        Pair<Long, short[]> audioData = queue.poll();
-                        //Make sure the audio packet is younger than 100ms
-                        while (audioData != null && currentTime - audioData.getLeft() > queueTimeout)
+                        long currentTime = System.currentTimeMillis();
+                        for (Map.Entry<User, Queue<Pair<Long, short[]>>> entry : combinedQueue.entrySet())
                         {
-                            audioData = queue.poll();
-                        }
-
-                        //If none of the audio packets were younger than 100ms, then there is nothing to add.
-                        if (audioData == null)
-                        {
-                            continue;
-                        }
-                        users.add(user);
-                        audioParts.add(audioData.getRight());
-                    }
-
-                    if (!audioParts.isEmpty())
-                    {
-                        int audioLength = audioParts.get(0).length;
-                        short[] mix = new short[1920];  //960 PCM samples for each channel
-                        int sample;
-                        for (int i = 0; i < audioLength; i++)
-                        {
-                            sample = 0;
-                            for (short[] audio : audioParts)
+                            User user = entry.getKey();
+                            Queue<Pair<Long, short[]>> queue = entry.getValue();
+            
+                            if (queue.isEmpty())
+                                continue;
+            
+                            Pair<Long, short[]> audioData = queue.poll();
+                            //Make sure the audio packet is younger than 100ms
+                            while (audioData != null && currentTime - audioData.getLeft() > queueTimeout)
                             {
-                                sample += audio[i];
+                                audioData = queue.poll();
                             }
-                            if (sample > Short.MAX_VALUE)
-                                mix[i] = Short.MAX_VALUE;
-                            else if (sample < Short.MIN_VALUE)
-                                mix[i] = Short.MIN_VALUE;
-                            else
-                                mix[i] = (short) sample;
+            
+                            //If none of the audio packets were younger than 100ms, then there is nothing to add.
+                            if (audioData == null)
+                            {
+                                continue;
+                            }
+                            users.add(user);
+                            audioParts.add(audioData.getRight());
                         }
-                        receiveHandler.handleCombinedAudio(new CombinedAudio(users, mix));
-                    }
-                    else
-                    {
-                        //No audio to mix, provide 20 MS of silence. (960 PCM samples for each channel)
-                        receiveHandler.handleCombinedAudio(new CombinedAudio(new LinkedList(), new short[1920]));
+            
+                        if (!audioParts.isEmpty())
+                        {
+                            int audioLength = audioParts.get(0).length;
+                            short[] mix = new short[1920];  //960 PCM samples for each channel
+                            int sample;
+                            for (int i = 0; i < audioLength; i++)
+                            {
+                                sample = 0;
+                                for (short[] audio : audioParts)
+                                {
+                                    sample += audio[i];
+                                }
+                                if (sample > Short.MAX_VALUE)
+                                    mix[i] = Short.MAX_VALUE;
+                                else if (sample < Short.MIN_VALUE)
+                                    mix[i] = Short.MIN_VALUE;
+                                else
+                                    mix[i] = (short) sample;
+                            }
+                            receiveHandler.handleCombinedAudio(new CombinedAudio(users, mix));
+                        }
+                        else
+                        {
+                            //No audio to mix, provide 20 MS of silence. (960 PCM samples for each channel)
+                            receiveHandler.handleCombinedAudio(new CombinedAudio(new LinkedList(), new short[1920]));
+                        }
                     }
                 }
-            }
-            catch (Exception e)
-            {
-                LOG.log(e);
-            }
-        }, 0, 20, TimeUnit.MILLISECONDS);
+                catch (Exception e)
+                {
+                    LOG.log(e);
+                }
+            }, 0, 20, TimeUnit.MILLISECONDS);
+        }
     }
 
     private byte[] encodeToOpus(byte[] rawAudio)

--- a/src/main/java/net/dv8tion/jda/handle/MessageDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageDeleteHandler.java
@@ -64,7 +64,7 @@ public class MessageDeleteHandler extends SocketHandler
         api.getEventManager().handle(
                 new MessageDeleteEvent(
                         api, responseNumber,
-                        messageId, channelId, channel != null));
+                        messageId, channelId, channel == null));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
@@ -82,7 +82,7 @@ public class MessageEmbedHandler extends SocketHandler
         api.getEventManager().handle(
                 new MessageEmbedEvent(
                         api, responseNumber,
-                        messageId, channelId, embeds, channel != null));
+                        messageId, channelId, embeds, channel == null));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/hooks/EventListener.java
+++ b/src/main/java/net/dv8tion/jda/hooks/EventListener.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.hooks;
 
 import net.dv8tion.jda.events.Event;
 
+@FunctionalInterface
 public interface EventListener
 {
 


### PR DESCRIPTION
Since GuildManager's update() performs network requests while iterating, it's reasonably likely for another thread to call a role changing method while update() is waiting on its network requests which will cause it to throw a ConcurrentModificationException if rolesAdded has been modified. 

I've implemented a naive solution with synchronized blocks to fix this. If performance is an issue, an updateAsync() method could be added.