### PR TITLE
Fixed AudioConnection and added callbacks to Players

### DIFF
--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -126,14 +126,14 @@ public class AudioConnection
 
     public void setSendingHandler(AudioSendHandler handler)
     {
-        setupSendThread();
         this.sendHandler = handler;
+        setupSendThread();
     }
 
     public void setReceivingHandler(AudioReceiveHandler handler)
     {
-        setupReceiveThread();
         this.receiveHandler = handler;
+        setupReceiveThread();
     }
 
     public void setQueueTimeout(long queueTimeout)

--- a/src/main/java/net/dv8tion/jda/audio/player/Player.java
+++ b/src/main/java/net/dv8tion/jda/audio/player/Player.java
@@ -33,6 +33,8 @@ public abstract class Player implements AudioSendHandler
 
     protected float amplitude = 1.0F;
 
+    protected Runnable callback = null;
+
     public abstract void play();
     public abstract void pause();
     public abstract void stop();
@@ -96,6 +98,11 @@ public abstract class Player implements AudioSendHandler
         }
     }
 
+    public void setCallback(Runnable callback)
+    {
+        this.callback = callback;
+    }
+
     @Override
     public boolean canProvide()
     {
@@ -121,6 +128,8 @@ public abstract class Player implements AudioSendHandler
             {
                 stop();
                 audioSource.close();
+                if (callback != null)
+                    callback.run();
                 return null;
             }
         }


### PR DESCRIPTION
AudioConnection.java's setupSendThread() was being called before the sendHandler being set, causing it to skip over the if condition on line 205.