### PR TITLE
Release of v2.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 1, revision: 3)
+def versionObj = new Version(major: 2, minor: 2, revision: 0)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 2, revision: 0)
+def versionObj = new Version(major: 2, minor: 2, revision: 1)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-def versionObj = new Version(major: 2, minor: 1, revision: 2)
+def versionObj = new Version(major: 2, minor: 1, revision: 3)
 group = "net.dv8tion"
 archivesBaseName = "JDA"
 version = "$versionObj"

--- a/src/main/java/net/dv8tion/jda/JDA.java
+++ b/src/main/java/net/dv8tion/jda/JDA.java
@@ -421,7 +421,7 @@ public interface JDA
      * Installs an auxiliary cable into your system.
      * 
      * @param port the port
-     * @throws UnsupportedOperationException
+     * @throws UnsupportedOperationException if JDA can't manipulate your hardware
      */
     void installAuxiliaryCable(int port) throws UnsupportedOperationException;
 }

--- a/src/main/java/net/dv8tion/jda/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/MessageBuilder.java
@@ -125,14 +125,14 @@ public class MessageBuilder
      * Example: <br>
      * If you placed the following code in an method handling a
      * {@link net.dv8tion.jda.events.message.MessageReceivedEvent MessageReceivedEvent}<br>
-     * <p>
+     *
      * <pre>{@code
      * User user = event.getAuthor();
      * MessageBuilder builder = new MessageBuilder();
      * builder.appendFormat("%U% is really cool!", user);
      * builder.build();
      * }</pre>
-     * <p>
+     *
      * It would build a message that mentions the author and says that he is really cool!. If the user's
      * name was "Bob", it would say:<br>
      * <pre>  "Bob is really cool!"</pre>

--- a/src/main/java/net/dv8tion/jda/Permission.java
+++ b/src/main/java/net/dv8tion/jda/Permission.java
@@ -35,6 +35,7 @@ public enum Permission
     MESSAGE_ATTACH_FILES(15, true, true),
     MESSAGE_HISTORY(16, true, true),
     MESSAGE_MENTION_EVERYONE(17, true, true),
+    MESSAGE_EXT_EMOJI(18, true, true),
 
     VOICE_CONNECT(20, true, true),
     VOICE_SPEAK(21, true, true),

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -290,13 +290,13 @@ public class AudioConnection
                                 //We've been asked to stop. The next iteration will kill the loop. 
                             }
                         }
-                        if (System.currentTimeMillis() > lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
+                        if (System.currentTimeMillis() < lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
                         {
                             lastFrameSent += OPUS_FRAME_TIME_AMOUNT; // incrase lastFrameSent
                         }
                         else
                         {
-                            lastFrameSent=System.currentTimeMillis(); // else reset lastFrameSent to current time
+                            lastFrameSent = System.currentTimeMillis(); // else reset lastFrameSent to current time
                         }
                     }
                 }

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -372,19 +372,28 @@ public class AudioConnection
 //                                                receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
 //                                            }
                                             short[] decodedAudio = decoder.decodeFromOpus(decryptedPacket);
-                                            if (receiveHandler.canReceiveUser())
+
+                                            //If decodedAudio is null, then the Opus decode failed, so throw away the packet.
+                                            if (decodedAudio == null)
                                             {
-                                                receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+                                                  LOG.trace("Received audio data but Opus failed to properly decode, instead it returned an error");
                                             }
-                                            if (receiveHandler.canReceiveCombined())
+                                            else
                                             {
-                                                Queue<Pair<Long, short[]>> queue = combinedQueue.get(user);
-                                                if (queue == null)
+                                                if (receiveHandler.canReceiveUser())
                                                 {
-                                                    queue = new ConcurrentLinkedQueue<>();
-                                                    combinedQueue.put(user, queue);
+                                                    receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
                                                 }
-                                                queue.add(Pair.<Long, short[]>of(System.currentTimeMillis(), decodedAudio));
+                                                if (receiveHandler.canReceiveCombined())
+                                                {
+                                                    Queue<Pair<Long, short[]>> queue = combinedQueue.get(user);
+                                                    if (queue == null)
+                                                    {
+                                                        queue = new ConcurrentLinkedQueue<>();
+                                                        combinedQueue.put(user, queue);
+                                                    }
+                                                    queue.add(Pair.<Long, short[]>of(System.currentTimeMillis(), decodedAudio));
+                                                }
                                             }
                                         }
                                     }

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -56,7 +56,7 @@ public class AudioConnection
     private volatile HashMap<Integer, String> ssrcMap = new HashMap<>();
     private volatile HashMap<Integer, Decoder> opusDecoders = new HashMap<>();
     private volatile HashMap<User, Queue<Pair<Long, short[]>>> combinedQueue = new HashMap<>();
-    private ScheduledExecutorService combinedAudioExecutor = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService combinedAudioExecutor;
 
     private Thread sendThread;
     private Thread receiveThread;
@@ -81,7 +81,7 @@ public class AudioConnection
 
     public void ready(long timeout)
     {
-        Thread readyThread = new Thread()
+        Thread readyThread = new Thread("AudioConnection Ready Guild: " + channel.getGuild().getId())
         {
             @Override
             public void run()
@@ -111,7 +111,6 @@ public class AudioConnection
                     AudioConnection.this.udpSocket = webSocket.getUdpSocket();
                     setupSendThread();
                     setupReceiveThread();
-                    setupCombinedExecutor();
                     api.getEventManager().handle(new AudioConnectEvent(api, AudioConnection.this.channel));
                 }
                 else
@@ -127,11 +126,13 @@ public class AudioConnection
 
     public void setSendingHandler(AudioSendHandler handler)
     {
+        setupSendThread();
         this.sendHandler = handler;
     }
 
     public void setReceivingHandler(AudioReceiveHandler handler)
     {
+        setupReceiveThread();
         this.receiveHandler = handler;
     }
 
@@ -201,281 +202,298 @@ public class AudioConnection
 
     private void setupSendThread()
     {
-        sendThread = new Thread("AudioConnection SendThread Guild: " + channel.getGuild().getId())
+        if (sendThread == null && udpSocket != null && sendHandler != null)
         {
-            @Override
-            public void run()
+            sendThread = new Thread("AudioConnection SendThread Guild: " + channel.getGuild().getId())
             {
-                char seq = 0;           //Sequence of audio packets. Used to determine the order of the packets.
-                int timestamp = 0;      //Used to sync up our packets within the same timeframe of other people talking.
-                long lastFrameSent = System.currentTimeMillis();
-                boolean sentSilenceOnConnect = false;
-                while (!udpSocket.isClosed() && !this.isInterrupted())
+                @Override
+                public void run()
                 {
-                    try
+                    char seq = 0;           //Sequence of audio packets. Used to determine the order of the packets.
+                    int timestamp = 0;      //Used to sync up our packets within the same timeframe of other people talking.
+                    long lastFrameSent = System.currentTimeMillis();
+                    boolean sentSilenceOnConnect = false;
+                    while (!udpSocket.isClosed() && !this.isInterrupted())
                     {
-                        //WE NEED TO CONSIDER BUFFERING STUFF BECAUSE REASONS.
-                        //Consider storing 40-60ms of encoded audio as a buffer.
-                        if (sentSilenceOnConnect && sendHandler != null && sendHandler.canProvide())
+                        try
                         {
-                            silenceCounter = -1;
-                            byte[] rawAudio = sendHandler.provide20MsAudio();
-                            if (rawAudio == null || rawAudio.length == 0)
+                            //WE NEED TO CONSIDER BUFFERING STUFF BECAUSE REASONS.
+                            //Consider storing 40-60ms of encoded audio as a buffer.
+                            if (sentSilenceOnConnect && sendHandler != null && sendHandler.canProvide())
                             {
-                                if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
-                                    setSpeaking(false);
-                            }
-                            else
-                            {
-                                if (!sendHandler.isOpus())
+                                silenceCounter = -1;
+                                byte[] rawAudio = sendHandler.provide20MsAudio();
+                                if (rawAudio == null || rawAudio.length == 0)
                                 {
-                                    rawAudio = encodeToOpus(rawAudio);
+                                    if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
+                                        setSpeaking(false);
                                 }
-                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), rawAudio);
-                                if (!speaking)
-                                    setSpeaking(true);
+                                else
+                                {
+                                    if (!sendHandler.isOpus())
+                                    {
+                                        rawAudio = encodeToOpus(rawAudio);
+                                    }
+                                    AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), rawAudio);
+                                    if (!speaking)
+                                        setSpeaking(true);
+                                    udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
+            
+                                    if (seq + 1 > Character.MAX_VALUE)
+                                        seq = 0;
+                                    else
+                                        seq++;
+                                }
+                            }
+                            else if (silenceCounter > -1)
+                            {
+                                AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), silenceBytes);
                                 udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
-
+            
                                 if (seq + 1 > Character.MAX_VALUE)
                                     seq = 0;
                                 else
                                     seq++;
+            
+                                if (++silenceCounter > 10)
+                                {
+                                    silenceCounter = -1;
+                                    sentSilenceOnConnect = true;
+                                }
                             }
+                            else if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
+                                setSpeaking(false);
                         }
-                        else if (silenceCounter > -1)
+                        catch (NoRouteToHostException e)
                         {
-                            AudioPacket packet = new AudioPacket(seq, timestamp, webSocket.getSSRC(), silenceBytes);
-                            udpSocket.send(packet.asEncryptedUdpPacket(webSocket.getAddress(), webSocket.getSecretKey()));
-
-                            if (seq + 1 > Character.MAX_VALUE)
-                                seq = 0;
+                            LOG.warn("Closing AudioConnection due to inability to send audio packets.");
+                            LOG.warn("Cannot send audio packet because JDA cannot navigate the route to Discord.\n" +
+                                    "Are you sure you have internet connection? It is likely that you've lost connection.");
+                            webSocket.close(true, -1);
+                        }
+                        catch (SocketException e)
+                        {
+                            //Most likely the socket has been closed due to the audio connection be closed. Next iteration will kill loop.
+                        }
+                        catch (Exception e)
+                        {
+                            LOG.log(e);
+                        }
+                        finally
+                        {
+                            timestamp += OPUS_FRAME_SIZE;
+                            long sleepTime = (OPUS_FRAME_TIME_AMOUNT) - (System.currentTimeMillis() - lastFrameSent);
+                            if (sleepTime > 0)
+                            {
+                                try
+                                {
+                                    Thread.sleep(sleepTime);
+                                } catch (InterruptedException e)
+                                {
+                                    //We've been asked to stop. The next iteration will kill the loop. 
+                                }
+                            }
+                            if (System.currentTimeMillis() < lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
+                            {
+                                lastFrameSent += OPUS_FRAME_TIME_AMOUNT; // incrase lastFrameSent
+                            }
                             else
-                                seq++;
-
-                            if (++silenceCounter > 10)
                             {
-                                silenceCounter = -1;
-                                sentSilenceOnConnect = true;
+                                lastFrameSent = System.currentTimeMillis(); // else reset lastFrameSent to current time
                             }
-                        }
-                        else if (speaking && (System.currentTimeMillis() - lastFrameSent) > OPUS_FRAME_TIME_AMOUNT)
-                            setSpeaking(false);
-                    }
-                    catch (NoRouteToHostException e)
-                    {
-                        LOG.warn("Closing AudioConnection due to inability to send audio packets.");
-                        LOG.warn("Cannot send audio packet because JDA cannot navigate the route to Discord.\n" +
-                                "Are you sure you have internet connection? It is likely that you've lost connection.");
-                        webSocket.close(true, -1);
-                    }
-                    catch (SocketException e)
-                    {
-                        //Most likely the socket has been closed due to the audio connection be closed. Next iteration will kill loop.
-                    }
-                    catch (Exception e)
-                    {
-                        LOG.log(e);
-                    }
-                    finally
-                    {
-                        timestamp += OPUS_FRAME_SIZE;
-                        long sleepTime = (OPUS_FRAME_TIME_AMOUNT) - (System.currentTimeMillis() - lastFrameSent);
-                        if (sleepTime > 0)
-                        {
-                            try
-                            {
-                                Thread.sleep(sleepTime);
-                            } catch (InterruptedException e)
-                            {
-                                //We've been asked to stop. The next iteration will kill the loop. 
-                            }
-                        }
-                        if (System.currentTimeMillis() < lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
-                        {
-                            lastFrameSent += OPUS_FRAME_TIME_AMOUNT; // incrase lastFrameSent
-                        }
-                        else
-                        {
-                            lastFrameSent = System.currentTimeMillis(); // else reset lastFrameSent to current time
                         }
                     }
                 }
-            }
-        };
-        sendThread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);
-        sendThread.setDaemon(true);
-        sendThread.start();
+            };
+            sendThread.setPriority((Thread.NORM_PRIORITY + Thread.MAX_PRIORITY) / 2);
+            sendThread.setDaemon(true);
+            sendThread.start();
+        }
     }
 
     private void setupReceiveThread()
     {
-        receiveThread = new Thread("AudioConnection ReceiveThread Guild: " + channel.getGuild().getId())
-        {
-            @Override
-            public void run()
+        if (receiveHandler != null && udpSocket != null)
+    	{
+            if (receiveThread == null)
             {
-                try
+                receiveThread = new Thread("AudioConnection ReceiveThread Guild: " + channel.getGuild().getId())
                 {
-                    udpSocket.setSoTimeout(100);
-                }
-                catch (SocketException e)
-                {
-                    LOG.log(e);
-                }
-                while (!udpSocket.isClosed() && !this.isInterrupted())
-                {
-                    DatagramPacket receivedPacket = new DatagramPacket(new byte[1920], 1920);
-                    try
+                    @Override
+                    public void run()
                     {
-                        udpSocket.receive(receivedPacket);
-
-                        if (receiveHandler != null && (receiveHandler.canReceiveUser() || receiveHandler.canReceiveCombined()) && webSocket.getSecretKey() != null)
+                        try
                         {
-                            if (!couldReceive)
+                            udpSocket.setSoTimeout(100);
+                        }
+                        catch (SocketException e)
+                        {
+                            LOG.log(e);
+                        }
+                        while (!udpSocket.isClosed() && !this.isInterrupted())
+                        {
+                            DatagramPacket receivedPacket = new DatagramPacket(new byte[1920], 1920);
+                            try
                             {
-                                couldReceive = true;
-                                sendSilentPackets();
-                            }
-                            AudioPacket decryptedPacket = AudioPacket.decryptAudioPacket(receivedPacket, webSocket.getSecretKey());
-
-                            String userId = ssrcMap.get(decryptedPacket.getSSRC());
-                            Decoder decoder = opusDecoders.get(decryptedPacket.getSSRC());
-                            if (userId == null)
-                            {
-                                byte[] audio = decryptedPacket.getEncodedAudio();
-                                if (!Arrays.equals(audio, silenceBytes))
-                                    LOG.debug("Received audio data with an unknown SSRC id.");
-                            }
-                            else if (decoder == null)
-                                LOG.warn("Received audio data with known SSRC, but opus decoder for this SSRC was null. uh..HOW?!");
-                            else if (!decoder.isInOrder(decryptedPacket.getSequence()))
-                                LOG.trace("Got out-of-order audio packet. Ignoring.");
-                            else
-                            {
-                                User user = getJDA().getUserById(userId);
-                                if (user == null)
-                                    LOG.warn("Received audio data with a known SSRC, but the userId associate with the SSRC is unknown to JDA!");
-                                else
+                                udpSocket.receive(receivedPacket);
+                
+                                if (receiveHandler != null && (receiveHandler.canReceiveUser() || receiveHandler.canReceiveCombined()) && webSocket.getSecretKey() != null)
                                 {
-//                                    if (decoder.wasPacketLost(decryptedPacket.getSequence()))
-//                                    {
-//                                        LOG.debug("Packet(s) missed. Using Opus packetloss-compensation.");
-//                                        short[] decodedAudio = decoder.decodeFromOpus(null);
-//                                        receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
-//                                    }
-                                    short[] decodedAudio = decoder.decodeFromOpus(decryptedPacket);
-                                    if (receiveHandler.canReceiveUser())
+                                    if (!couldReceive)
                                     {
-                                        receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+                                        couldReceive = true;
+                                        sendSilentPackets();
                                     }
-                                    if (receiveHandler.canReceiveCombined())
+                                    AudioPacket decryptedPacket = AudioPacket.decryptAudioPacket(receivedPacket, webSocket.getSecretKey());
+                
+                                    String userId = ssrcMap.get(decryptedPacket.getSSRC());
+                                    Decoder decoder = opusDecoders.get(decryptedPacket.getSSRC());
+                                    if (userId == null)
                                     {
-                                        Queue<Pair<Long, short[]>> queue = combinedQueue.get(user);
-                                        if (queue == null)
+                                        byte[] audio = decryptedPacket.getEncodedAudio();
+                                        if (!Arrays.equals(audio, silenceBytes))
+                                            LOG.debug("Received audio data with an unknown SSRC id.");
+                                    }
+                                    else if (decoder == null)
+                                        LOG.warn("Received audio data with known SSRC, but opus decoder for this SSRC was null. uh..HOW?!");
+                                    else if (!decoder.isInOrder(decryptedPacket.getSequence()))
+                                        LOG.trace("Got out-of-order audio packet. Ignoring.");
+                                    else
+                                    {
+                                        User user = getJDA().getUserById(userId);
+                                        if (user == null)
+                                            LOG.warn("Received audio data with a known SSRC, but the userId associate with the SSRC is unknown to JDA!");
+                                        else
                                         {
-                                            queue = new ConcurrentLinkedQueue<>();
-                                            combinedQueue.put(user, queue);
+//                                            if (decoder.wasPacketLost(decryptedPacket.getSequence()))
+//                                            {
+//                                                LOG.debug("Packet(s) missed. Using Opus packetloss-compensation.");
+//                                                short[] decodedAudio = decoder.decodeFromOpus(null);
+//                                                receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+//                                            }
+                                            short[] decodedAudio = decoder.decodeFromOpus(decryptedPacket);
+                                            if (receiveHandler.canReceiveUser())
+                                            {
+                                                receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
+                                            }
+                                            if (receiveHandler.canReceiveCombined())
+                                            {
+                                                Queue<Pair<Long, short[]>> queue = combinedQueue.get(user);
+                                                if (queue == null)
+                                                {
+                                                    queue = new ConcurrentLinkedQueue<>();
+                                                    combinedQueue.put(user, queue);
+                                                }
+                                                queue.add(Pair.<Long, short[]>of(System.currentTimeMillis(), decodedAudio));
+                                            }
                                         }
-                                        queue.add(Pair.<Long, short[]>of(System.currentTimeMillis(), decodedAudio));
                                     }
                                 }
+                                else if (couldReceive)
+                                {
+                                    couldReceive = false;
+                                    sendSilentPackets();
+                                }
+                            }
+                            catch (SocketTimeoutException e)
+                            {
+                                //Ignore. We set a low timeout so that we wont block forever so we can properly shutdown the loop.
+                            }
+                            catch (SocketException e)
+                            {
+                                //The socket was closed while we were listening for the next packet.
+                                //This is expected. Ignore the exception. The thread will exit during the next while
+                                // iteration because the udpSocket.isClosed() will return true.
+                            }
+                            catch (Exception e)
+                            {
+                                LOG.log(e);
                             }
                         }
-                        else if (couldReceive)
-                        {
-                            couldReceive = false;
-                            sendSilentPackets();
-                        }
                     }
-                    catch (SocketTimeoutException e)
-                    {
-                        //Ignore. We set a low timeout so that we wont block forever so we can properly shutdown the loop.
-                    }
-                    catch (SocketException e)
-                    {
-                        //The socket was closed while we were listening for the next packet.
-                        //This is expected. Ignore the exception. The thread will exit during the next while
-                        // iteration because the udpSocket.isClosed() will return true.
-                    }
-                    catch (Exception e)
-                    {
-                        LOG.log(e);
-                    }
-                }
+                };
+                receiveThread.setDaemon(true);
+                receiveThread.start();
+    	    }
+            if (receiveHandler.canReceiveCombined())
+            {
+                setupCombinedExecutor();
             }
-        };
-        receiveThread.setDaemon(true);
-        receiveThread.start();
+		}
     }
 
     private void setupCombinedExecutor()
     {
-        combinedAudioExecutor.scheduleAtFixedRate(() ->
+        if (combinedAudioExecutor == null)
         {
-            try
+            combinedAudioExecutor = Executors.newSingleThreadScheduledExecutor( r -> new Thread(r, "AudioConnection CombinedAudio Guild: " + channel.getGuild().getId()));
+            combinedAudioExecutor.scheduleAtFixedRate(() ->
             {
-                List<User> users = new LinkedList<>();
-                List<short[]> audioParts = new LinkedList<>();
-                if (receiveHandler != null && receiveHandler.canReceiveCombined())
+                try
                 {
-                    long currentTime = System.currentTimeMillis();
-                    for (Map.Entry<User, Queue<Pair<Long, short[]>>> entry : combinedQueue.entrySet())
+                    List<User> users = new LinkedList<>();
+                    List<short[]> audioParts = new LinkedList<>();
+                    if (receiveHandler != null && receiveHandler.canReceiveCombined())
                     {
-                        User user = entry.getKey();
-                        Queue<Pair<Long, short[]>> queue = entry.getValue();
-
-                        if (queue.isEmpty())
-                            continue;
-
-                        Pair<Long, short[]> audioData = queue.poll();
-                        //Make sure the audio packet is younger than 100ms
-                        while (audioData != null && currentTime - audioData.getLeft() > queueTimeout)
+                        long currentTime = System.currentTimeMillis();
+                        for (Map.Entry<User, Queue<Pair<Long, short[]>>> entry : combinedQueue.entrySet())
                         {
-                            audioData = queue.poll();
-                        }
-
-                        //If none of the audio packets were younger than 100ms, then there is nothing to add.
-                        if (audioData == null)
-                        {
-                            continue;
-                        }
-                        users.add(user);
-                        audioParts.add(audioData.getRight());
-                    }
-
-                    if (!audioParts.isEmpty())
-                    {
-                        int audioLength = audioParts.get(0).length;
-                        short[] mix = new short[1920];  //960 PCM samples for each channel
-                        int sample;
-                        for (int i = 0; i < audioLength; i++)
-                        {
-                            sample = 0;
-                            for (short[] audio : audioParts)
+                            User user = entry.getKey();
+                            Queue<Pair<Long, short[]>> queue = entry.getValue();
+            
+                            if (queue.isEmpty())
+                                continue;
+            
+                            Pair<Long, short[]> audioData = queue.poll();
+                            //Make sure the audio packet is younger than 100ms
+                            while (audioData != null && currentTime - audioData.getLeft() > queueTimeout)
                             {
-                                sample += audio[i];
+                                audioData = queue.poll();
                             }
-                            if (sample > Short.MAX_VALUE)
-                                mix[i] = Short.MAX_VALUE;
-                            else if (sample < Short.MIN_VALUE)
-                                mix[i] = Short.MIN_VALUE;
-                            else
-                                mix[i] = (short) sample;
+            
+                            //If none of the audio packets were younger than 100ms, then there is nothing to add.
+                            if (audioData == null)
+                            {
+                                continue;
+                            }
+                            users.add(user);
+                            audioParts.add(audioData.getRight());
                         }
-                        receiveHandler.handleCombinedAudio(new CombinedAudio(users, mix));
-                    }
-                    else
-                    {
-                        //No audio to mix, provide 20 MS of silence. (960 PCM samples for each channel)
-                        receiveHandler.handleCombinedAudio(new CombinedAudio(new LinkedList(), new short[1920]));
+            
+                        if (!audioParts.isEmpty())
+                        {
+                            int audioLength = audioParts.get(0).length;
+                            short[] mix = new short[1920];  //960 PCM samples for each channel
+                            int sample;
+                            for (int i = 0; i < audioLength; i++)
+                            {
+                                sample = 0;
+                                for (short[] audio : audioParts)
+                                {
+                                    sample += audio[i];
+                                }
+                                if (sample > Short.MAX_VALUE)
+                                    mix[i] = Short.MAX_VALUE;
+                                else if (sample < Short.MIN_VALUE)
+                                    mix[i] = Short.MIN_VALUE;
+                                else
+                                    mix[i] = (short) sample;
+                            }
+                            receiveHandler.handleCombinedAudio(new CombinedAudio(users, mix));
+                        }
+                        else
+                        {
+                            //No audio to mix, provide 20 MS of silence. (960 PCM samples for each channel)
+                            receiveHandler.handleCombinedAudio(new CombinedAudio(new LinkedList(), new short[1920]));
+                        }
                     }
                 }
-            }
-            catch (Exception e)
-            {
-                LOG.log(e);
-            }
-        }, 0, 20, TimeUnit.MILLISECONDS);
+                catch (Exception e)
+                {
+                    LOG.log(e);
+                }
+            }, 0, 20, TimeUnit.MILLISECONDS);
+        }
     }
 
     private byte[] encodeToOpus(byte[] rawAudio)

--- a/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/audio/AudioConnection.java
@@ -240,7 +240,7 @@ public class AudioConnection
                                     seq = 0;
                                 else
                                     seq++;
-							}
+                            }
                         }
                         else if (silenceCounter > -1)
                         {
@@ -290,7 +290,14 @@ public class AudioConnection
                                 //We've been asked to stop. The next iteration will kill the loop. 
                             }
                         }
-                        lastFrameSent += OPUS_FRAME_TIME_AMOUNT;
+                        if (System.currentTimeMillis() > lastFrameSent + 60) // If the sending didn't took longer than 60ms (3 times the time frame)
+                        {
+                            lastFrameSent += OPUS_FRAME_TIME_AMOUNT; // incrase lastFrameSent
+                        }
+                        else
+                        {
+                            lastFrameSent=System.currentTimeMillis(); // else reset lastFrameSent to current time
+                        }
                     }
                 }
             }

--- a/src/main/java/net/dv8tion/jda/audio/Decoder.java
+++ b/src/main/java/net/dv8tion/jda/audio/Decoder.java
@@ -76,6 +76,10 @@ public class Decoder
                     AudioConnection.OPUS_FRAME_SIZE, 0);
         }
 
+        //If we get a result that is less than 0, then there was an error. Return null as a signifier.
+        if (result < 0)
+            return null;
+
         short[] audio = new short[result * 2];
         decoded.get(audio);
         return audio;

--- a/src/main/java/net/dv8tion/jda/audio/player/FilePlayer.java
+++ b/src/main/java/net/dv8tion/jda/audio/player/FilePlayer.java
@@ -23,10 +23,9 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * <p>This implementation of an {@link net.dv8tion.jda.audio.AudioSendHandler AudioSendHandler} is able to send audio to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} from a local file.
- * <br/>For that the user has to provide a valid {@link java.io.File File} in a supported audio format.<br/>
+ * This implementation of an {@link net.dv8tion.jda.audio.AudioSendHandler AudioSendHandler} is able to send audio to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} from a local file.
+ * <br>For that the user has to provide a valid {@link java.io.File File} in a supported audio format.<br>
  * <p><b>To use external files that are uploaded to a service use: {@link URLPlayer URLPlayer}</b></p>
- * </p>
  */
 public class FilePlayer extends Player
 {
@@ -38,7 +37,7 @@ public class FilePlayer extends Player
 
 	/**
      * Creates a new instance of a {@link FilePlayer}.
-     * <p>To directly set a source file: </br>
+     * <p>To directly set a source file: <br>
      * <pre><code>   new {@link #FilePlayer(File)}</code></pre></p>
      */
     public FilePlayer() {}

--- a/src/main/java/net/dv8tion/jda/audio/player/URLPlayer.java
+++ b/src/main/java/net/dv8tion/jda/audio/player/URLPlayer.java
@@ -31,10 +31,9 @@ import java.net.URL;
 import java.net.URLConnection;
 
 /**
- * <p>This implementation of an {@link net.dv8tion.jda.audio.AudioSendHandler AudioSendHandler} is able to send audio to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} from an external source.
- * <br/> For that the user has to provide a valid {@link java.net.URL URL} to an audio file (like an mp3 file on a cloud).<br/>
+ * This implementation of an {@link net.dv8tion.jda.audio.AudioSendHandler AudioSendHandler} is able to send audio to a {@link net.dv8tion.jda.entities.VoiceChannel VoiceChannel} from an external source.
+ * <br> For that the user has to provide a valid {@link java.net.URL URL} to an audio file (like an mp3 file on a cloud).<br>
  * <p><b>However, it is unable to process audio sources that come from websites like Youtube/Soundcloud.</b></p>
- * </p>
  */
 public class URLPlayer extends Player
 {
@@ -54,8 +53,8 @@ public class URLPlayer extends Player
     protected boolean stopped = true;
 
     /**
-     * Creates a new instance of {@link URLPlayer}.<br/>
-     * To directly set a source URL use <br/><pre><code>    new {@link #URLPlayer(JDA, URL)}</code></pre>
+     * Creates a new instance of {@link URLPlayer}.<br>
+     * To directly set a source URL use <br><pre><code>    new {@link #URLPlayer(JDA, URL)}</code></pre>
      * @param api
      *        The JDA instance
      */

--- a/src/main/java/net/dv8tion/jda/entities/Channel.java
+++ b/src/main/java/net/dv8tion/jda/entities/Channel.java
@@ -95,6 +95,8 @@ public interface Channel
     int getPositionRaw();
 
     /**
+     * <b><u>This method is deprecated and going to be removed. Please use {@link #checkPermission(User, Permission...)} instead!</u></b>
+     * <p>
      * Checks if the given {@link net.dv8tion.jda.entities.User User} has the given {@link net.dv8tion.jda.Permission Permission}
      * in this Channel
      *
@@ -105,7 +107,21 @@ public interface Channel
      * @return
      *      if the given User has the given Permission in this Channel
      */
+    @Deprecated
     boolean checkPermission(User user, Permission permission);
+
+    /**
+     * Checks if the given {@link net.dv8tion.jda.entities.User User} has the given {@link net.dv8tion.jda.Permission Permissions}
+     * in this Channel
+     *
+     * @param user
+     *          the User to check the Permission against
+     * @param permissions
+     *          the varargs Permissions to check for
+     * @return
+     *      if the given User has the given Permissions in this Channel
+     */
+    boolean checkPermission(User user, Permission... permissions);
 
     /**
      * Returns the {@link net.dv8tion.jda.managers.ChannelManager ChannelManager} for this Channel.

--- a/src/main/java/net/dv8tion/jda/entities/Channel.java
+++ b/src/main/java/net/dv8tion/jda/entities/Channel.java
@@ -95,22 +95,6 @@ public interface Channel
     int getPositionRaw();
 
     /**
-     * <b><u>This method is deprecated and going to be removed. Please use {@link #checkPermission(User, Permission...)} instead!</u></b>
-     * <p>
-     * Checks if the given {@link net.dv8tion.jda.entities.User User} has the given {@link net.dv8tion.jda.Permission Permission}
-     * in this Channel
-     *
-     * @param user
-     *          the User to check the Permission against
-     * @param permission
-     *          the Permission to check for
-     * @return
-     *      if the given User has the given Permission in this Channel
-     */
-    @Deprecated
-    boolean checkPermission(User user, Permission permission);
-
-    /**
      * Checks if the given {@link net.dv8tion.jda.entities.User User} has the given {@link net.dv8tion.jda.Permission Permissions}
      * in this Channel
      *

--- a/src/main/java/net/dv8tion/jda/entities/ChannelType.java
+++ b/src/main/java/net/dv8tion/jda/entities/ChannelType.java
@@ -1,0 +1,47 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.entities;
+
+public enum ChannelType
+{
+    TEXT(0),
+    PRIVATE(1),
+    VOICE(2),
+    GROUP(3),
+    UNKNOWN(-1);
+
+    protected final int id;
+
+    ChannelType(int id)
+    {
+        this.id = id;
+    }
+
+    public int getId()
+    {
+        return id;
+    }
+
+    public static ChannelType fromId(int id)
+    {
+        for (ChannelType type : values())
+        {
+            if (type.id == id)
+                return type;
+        }
+        return UNKNOWN;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/entities/Emote.java
@@ -57,7 +57,7 @@ public interface Emote
     String getImageUrl();
 
     /**
-     * Return a formatted usable version of this emote (<:name:id>)
+     * Return a formatted usable version of this emote (&lt;:name:id&gt;)
      *
      * @return A formatted version of this emote.
      */

--- a/src/main/java/net/dv8tion/jda/entities/Game.java
+++ b/src/main/java/net/dv8tion/jda/entities/Game.java
@@ -49,6 +49,11 @@ public interface Game
 
     /**
      * Checks if a given String is a valid Twitch url (ie, one that will display "Streaming" on the Discord client.
+     *
+     * @param url
+     *      The url to check
+     * @return
+     *      True if url is not null and is a valid Twitch url
      */
     static boolean isValidStreamingUrl(String url)
     {

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -384,6 +384,46 @@ public interface Guild
     List<AdvancedInvite> getInvites();
 
     /**
+     * Provides a {@link net.dv8tion.jda.entities.User User} with the provided ID
+     *
+     * @param id
+     *      The id of the user
+     * @return
+     *      the {@link net.dv8tion.jda.entities.User User} with the provided ID, or null if the user isn't in the {@link net.dv8tion.jda.entities.Guild Guild}.
+     */
+    User getUserById(String id);
+
+    /**
+     * Provides an immutable list of all {@link net.dv8tion.jda.entities.User Users} with the provided username
+     *
+     * @param username
+     *      The username that is being checked
+     * @return
+     *      Never-null list of all users with the provided username
+     */
+    List<User> getUsersByName(String username);
+
+    /**
+     * Provides an immutable list of all {@link net.dv8tion.jda.entities.Role Roles} with the provided name
+     *
+     * @param roleName
+     *      The name of the roles to be returned
+     * @return
+     *      A never null list of all roles with the provided name
+     */
+    List<Role> getRolesByName(String roleName);
+
+    /**
+     * Returns the user's nickname in this guild, or their username if they don't have one
+     *
+     * @param user
+     *      The user whose name will be retrieved
+     * @return
+     *      The nickname for the user, or the user's username if they have no nickname
+     */
+    String getEffectiveNameForUser(User user);
+
+    /**
      * Represents the Verification-Level of the Guild.
      * The Verification-Level determines what requirement you have to meet to be able to speak in this Guild.<br>
      * None   -&gt; everyone can talk.<br>

--- a/src/main/java/net/dv8tion/jda/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/entities/Guild.java
@@ -240,6 +240,12 @@ public interface Guild
      * Provides the {@link net.dv8tion.jda.entities.Role Role} that determines the color for the provided {@link net.dv8tion.jda.entities.User User}
      * 
      * If the {@link net.dv8tion.jda.entities.User User} has the default color, this returns the same as getPublicRole();
+     *
+     * @param user
+     *      The user for which the coloring Role should be determined
+     *
+     * @return
+     *      The {@link net.dv8tion.jda.entities.Role Role}, which determines the {@link net.dv8tion.jda.entities.User User's} name-coloring
      */
     Role getColorDeterminantRoleForUser(User user);
 

--- a/src/main/java/net/dv8tion/jda/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/entities/Message.java
@@ -263,6 +263,15 @@ public interface Message
     boolean unpin();
 
     /**
+     * This specifies the type of Message sent. Messages can represent more than just simple text sent by Users.<br>
+     * Messages can also be sent as special actions like Calls, GroupIcon changes and more.
+     *
+     * @return
+     *      The type of message this is.
+     */
+    MessageType getType();
+
+    /**
      * Represents a {@link net.dv8tion.jda.entities.Message Message} file attachment.
      */
     class Attachment

--- a/src/main/java/net/dv8tion/jda/entities/MessageType.java
+++ b/src/main/java/net/dv8tion/jda/entities/MessageType.java
@@ -1,0 +1,48 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.entities;
+
+public enum MessageType
+{
+    DEFAULT(0),
+    RECIPIENT_ADD(1),
+    RECIPIENT_REMOVE(2),
+    CALL(3),
+    CHANNEL_ICON_CHANGE(4),
+    CHANNEL_NAME_CHANGE(5),
+    UNKNOWN(-1);
+
+    protected final int id;
+    MessageType(int id)
+    {
+        this.id = id;
+    }
+
+    public int getId()
+    {
+        return id;
+    }
+
+    public static MessageType fromId(int id)
+    {
+        for (MessageType type : values())
+        {
+            if (type.id == id)
+                return type;
+        }
+        return UNKNOWN;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/entities/TextChannel.java
@@ -63,7 +63,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
     void deleteMessages(Collection<Message> messages);
 
     /**
-     * Bulk deletes a list of messages. <b>This is not the same as calling {@link net.dv8tion.jda.entities.MessageChannel#deleteMessageById(String) in a loop.</b> <br>
+     * Bulk deletes a list of messages. <b>This is not the same as calling {@link net.dv8tion.jda.entities.MessageChannel#deleteMessageById(String)} in a loop.</b> <br>
      * This is much more efficient, but it has a different ratelimit. You may call this once per second per Guild.
      * <p>
      * Must be at least 2 messages and not be more than 100 messages at a time.<br>

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -43,7 +43,7 @@ public class GuildImpl implements Guild
     private String name;
     private String iconId;
     private String afkChannelId;
-    private String ownerId;
+    private User owner;
     private int afkTimeout;
     private Region region;
     private final Map<String, TextChannel> textChannels = new HashMap<>();
@@ -106,13 +106,13 @@ public class GuildImpl implements Guild
     @Override
     public String getOwnerId()
     {
-        return ownerId;
+        return owner.getId();
     }
 
     @Override
     public User getOwner()
     {
-        return api.getUserById(ownerId);
+        return owner;
     }
 
     @Override
@@ -413,9 +413,9 @@ public class GuildImpl implements Guild
         return this;
     }
 
-    public GuildImpl setOwnerId(String ownerId)
+    public GuildImpl setOwner(User owner)
     {
-        this.ownerId = ownerId;
+        this.owner = owner;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/GuildImpl.java
@@ -36,6 +36,7 @@ import org.json.JSONObject;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class GuildImpl implements Guild
 {
@@ -524,5 +525,29 @@ public class GuildImpl implements Guild
     public List<AdvancedInvite> getInvites()
     {
         return InviteUtil.getInvites(this);
+    }
+
+    @Override
+    public User getUserById(String id)
+    {
+        return userRoles.containsKey(api.getUserById(id)) ? api.getUserById(id) : null;
+    }
+
+    @Override
+    public List<User> getUsersByName(String username)
+    {
+        return Collections.unmodifiableList(userRoles.keySet().parallelStream().filter(user -> user.getUsername().equals(username)).collect(Collectors.toList()));
+    }
+
+    @Override
+    public List<Role> getRolesByName(String roleName)
+    {
+        return Collections.unmodifiableList(roles.values().parallelStream().filter(role -> role.getName().equals(roleName)).collect(Collectors.toList()));
+    }
+
+    @Override
+    public String getEffectiveNameForUser(User user)
+    {
+        return nickMap.containsKey(user) ? nickMap.get(user) : user.getUsername();
     }
 }

--- a/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/MessageImpl.java
@@ -35,6 +35,7 @@ public class MessageImpl implements Message
 {
     private final JDAImpl api;
     private final String id;
+    private final MessageType type;
     private boolean mentionsEveryone = false;
     private boolean isTTS = false;
     private boolean isPrivate;
@@ -54,8 +55,14 @@ public class MessageImpl implements Message
 
     public MessageImpl(String id, JDAImpl api)
     {
+        this(id, api, MessageType.DEFAULT);
+    }
+
+    public MessageImpl(String id, JDAImpl api, MessageType type)
+    {
         this.id = id;
         this.api = api;
+        this.type = type;
     }
 
     @Override
@@ -92,6 +99,12 @@ public class MessageImpl implements Message
         if (result)
             this.pinned = false;
         return result;
+    }
+
+    @Override
+    public MessageType getType()
+    {
+        return type;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/PrivateChannelImpl.java
@@ -15,6 +15,8 @@
  */
 package net.dv8tion.jda.entities.impl;
 
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.body.MultipartBody;
@@ -143,17 +145,32 @@ public class PrivateChannelImpl implements PrivateChannel
             String dbg = String.format("Requesting %s -> %s\n\tPayload: file: %s, message: %s, tts: %s\n\tResponse: ",
                     body.getHttpRequest().getHttpMethod().name(), body.getHttpRequest().getUrl(),
                     file.getAbsolutePath(), message == null ? "null" : message.getRawContent(), message == null ? "N/A" : message.isTTS());
-            String requestBody = body.asString().getBody();
+            HttpResponse<JsonNode> response = body.asJson();
             Requester.LOG.trace(dbg + body);
 
             try
             {
-                JSONObject messageJson = new JSONObject(requestBody);
-                return new EntityBuilder(api).createMessage(messageJson);
+                int status = response.getStatus();
+
+                if (status >= 200 && status < 300)
+                {
+                    return new EntityBuilder(api).createMessage(response.getBody().getObject());
+                }
+                else if (response.getStatus() == 429)
+                {
+                    long retryAfter = response.getBody().getObject().getLong("retry_after");
+                    api.setMessageTimeout(RATE_LIMIT_IDENTIFIER, retryAfter);
+                    throw new RateLimitedException(retryAfter);
+                }
+                else
+                {
+                    throw new RuntimeException("An unknown status code was returned when attempting to upload file. Status: " + status + " JSON: " + response.getBody().toString());
+                }
+
             }
             catch (JSONException e)
             {
-                Requester.LOG.fatal("Following json caused an exception: " + requestBody);
+                Requester.LOG.fatal("Following json caused an exception: " + response.getBody().toString());
                 Requester.LOG.log(e);
             }
         }
@@ -169,7 +186,17 @@ public class PrivateChannelImpl implements PrivateChannel
     {
         Thread thread = new Thread(() ->
         {
-            Message messageReturn = sendFile(file, message);
+            Message messageReturn;
+            try
+            {
+                messageReturn = sendFile(file, message);
+            }
+            catch (RateLimitedException e)
+            {
+                JDAImpl.LOG.warn("Got ratelimited when trying to upload file. Providing null to callback.");
+                messageReturn = null;
+            }
+
             if (callback != null)
                 callback.accept(messageReturn);
         });

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -411,9 +411,16 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
+    @Deprecated
     public boolean checkPermission(User user, Permission perm)
     {
         return PermissionUtil.checkPermission(user, perm, this);
+    }
+
+    @Override
+    public boolean checkPermission(User user, Permission... permissions)
+    {
+        return PermissionUtil.checkPermission(this, user, permissions);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/TextChannelImpl.java
@@ -390,7 +390,7 @@ public class TextChannelImpl implements TextChannel
     public List<Message> getPinnedMessages()
     {
         if (!checkPermission(getJDA().getSelfInfo(), Permission.MESSAGE_READ))
-            new PermissionException(Permission.MESSAGE_READ, "Cannot get the pinned message of a channel without MESSAGE_READ access.");
+            throw new PermissionException(Permission.MESSAGE_READ, "Cannot get the pinned message of a channel without MESSAGE_READ access.");
 
         List<Message> pinnedMessages = new LinkedList<>();
         Requester.Response response = ((JDAImpl) getJDA()).getRequester().get(
@@ -408,13 +408,6 @@ public class TextChannelImpl implements TextChannel
             throw new RateLimitedException(response.getObject().getInt("retry_after"));
         else
             throw new RuntimeException("An unknown error occured attempting to get pinned messages. Ask devs for help.\n" + response);
-    }
-
-    @Override
-    @Deprecated
-    public boolean checkPermission(User user, Permission perm)
-    {
-        return PermissionUtil.checkPermission(user, perm, this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -130,13 +130,6 @@ public class VoiceChannelImpl implements VoiceChannel
     }
 
     @Override
-    @Deprecated
-    public boolean checkPermission(User user, Permission perm)
-    {
-        return PermissionUtil.checkPermission(user, perm, this);
-    }
-
-    @Override
     public boolean checkPermission(User user, Permission... permissions)
     {
         return PermissionUtil.checkPermission(this, user, permissions);

--- a/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/entities/impl/VoiceChannelImpl.java
@@ -130,9 +130,16 @@ public class VoiceChannelImpl implements VoiceChannel
     }
 
     @Override
+    @Deprecated
     public boolean checkPermission(User user, Permission perm)
     {
         return PermissionUtil.checkPermission(user, perm, this);
+    }
+
+    @Override
+    public boolean checkPermission(User user, Permission... permissions)
+    {
+        return PermissionUtil.checkPermission(this, user, permissions);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/events/ReconnectedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ReconnectedEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 
 /**
  * <b><u>ReconnectedEvent</u></b><br>
- * Fired if JDA successfully re-established it's connection to the WebSocket.<br/>
- * All Objects have been replaced when this is fired and events were likely missed in the downtime.<br/>
- * <br/>
+ * Fired if JDA successfully re-established it's connection to the WebSocket.<br>
+ * All Objects have been replaced when this is fired and events were likely missed in the downtime.<br>
+ * <br>
  * Use: This marks the continuation of event flow stopped by the {@link net.dv8tion.jda.events.DisconnectEvent DisconnectEvent}. User should replace any cached Objects (like User/Guild objects).
  */
 public class ReconnectedEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/ResumedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/ResumedEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 
 /**
  * <b><u>ResumedEvent</u></b><br>
- * Fired if JDA successfully re-established it's connection to the WebSocket.<br/>
- * All Objects are still in place and events are replayed.<br/>
- * <br/>
+ * Fired if JDA successfully re-established it's connection to the WebSocket.<br>
+ * All Objects are still in place and events are replayed.<br>
+ * <br>
  * Use: This marks the continuation of event flow stopped by the {@link net.dv8tion.jda.events.DisconnectEvent DisconnectEvent}.
  */
 public class ResumedEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/StatusChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/StatusChangeEvent.java
@@ -19,7 +19,7 @@ import net.dv8tion.jda.JDA;
 
 /**
  * <b><u>StatusChangedEvent</u></b><br>
- * Fired if our {@link net.dv8tion.jda.JDA.Status Status} changed. (Example: SHUTTING_DOWN -> SHUTDOWN)<br>
+ * Fired if our {@link net.dv8tion.jda.JDA.Status Status} changed. (Example: SHUTTING_DOWN -&gt; SHUTDOWN)<br>
  * <br>
  * Use: Detect internal status changes. Possibly to log or forward on user's end.
  */

--- a/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelCreateEvent.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>PrivateChannelCreateEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.PrivateChannel Private Channel} was created.<br/>
- * <br/>
+ * <b><u>PrivateChannelCreateEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.PrivateChannel Private Channel} was created.<br>
+ * <br>
  * Use: Retrieve the freshly created private channel and it's {@link net.dv8tion.jda.entities.User User}.
  */
 public class PrivateChannelCreateEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/priv/PrivateChannelDeleteEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>PrivateChannelDeleteEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.PrivateChannel Private Channel} was deleted.<br/>
- * <br/>
+ * <b><u>PrivateChannelDeleteEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.PrivateChannel Private Channel} was deleted.<br>
+ * <br>
  * Use: Retrieve the issuing {@link net.dv8tion.jda.entities.User User}.
  */
 public class PrivateChannelDeleteEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelCreateEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
 /**
- * <b><u>VoiceChannelCreateEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel} is created.<br/>
- * <br/>
+ * <b><u>VoiceChannelCreateEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel} is created.<br>
+ * <br>
  * Use: Get affected VoiceChannel.
  */
 public class VoiceChannelCreateEvent extends GenericVoiceChannelEvent

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelDeleteEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
 /**
- * <b><u>VoiceChannelDeleteEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel} is deleted.<br/>
- * <br/>
+ * <b><u>VoiceChannelDeleteEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel} is deleted.<br>
+ * <br>
  * Use: Get affected VoiceChannel(likely to be null) or affected Guild.
  */
 public class VoiceChannelDeleteEvent extends GenericVoiceChannelEvent

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateBitrateEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
 /**
- * <b><u>VoiceChannelUpdateBitrateEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel}'s bitrate changes.<br/>
- * <br/>
+ * <b><u>VoiceChannelUpdateBitrateEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s bitrate changes.<br>
+ * <br>
  * Use: Get affected VoiceChannel, affected Guild and previous bitrate.
  */
 public class VoiceChannelUpdateBitrateEvent extends GenericVoiceChannelUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateNameEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
 /**
- * <b><u>VoiceChannelUpdateNameEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel}'s name changes.<br/>
- * <br/>
+ * <b><u>VoiceChannelUpdateNameEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s name changes.<br>
+ * <br>
  * Use: Get affected VoiceChannel, affected Guild and previous name.
  */
 public class VoiceChannelUpdateNameEvent extends GenericVoiceChannelUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePermissionsEvent.java
@@ -23,9 +23,9 @@ import net.dv8tion.jda.entities.VoiceChannel;
 import java.util.List;
 
 /**
- * <b><u>VoiceChannelUpdatePermissionsEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel}'s permission overrides change.<br/>
- * <br/>
+ * <b><u>VoiceChannelUpdatePermissionsEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s permission overrides change.<br>
+ * <br>
  * Use: Get affected VoiceChannel, affected Guild and affected {@link net.dv8tion.jda.entities.Role Roles}/{@link net.dv8tion.jda.entities.User Users}.
  */
 public class VoiceChannelUpdatePermissionsEvent extends GenericVoiceChannelUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdatePositionEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
 /**
- * <b><u>VoiceChannelUpdatePositionEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel}'s position changes.<br/>
- * <br/>
+ * <b><u>VoiceChannelUpdatePositionEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s position changes.<br>
+ * <br>
  * Use: Get affected VoiceChannel, affected Guild and previous position.
  */
 public class VoiceChannelUpdatePositionEvent extends GenericVoiceChannelUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/channel/voice/VoiceChannelUpdateUserLimitEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceChannel;
 
 /**
- * <b><u>VoiceChannelUpdateUserLimitEvent</u></b><br/>
- * Fired if a {@link VoiceChannel VoiceChannel}'s user limit changes.<br/>
- * <br/>
+ * <b><u>VoiceChannelUpdateUserLimitEvent</u></b><br>
+ * Fired if a {@link VoiceChannel VoiceChannel}'s user limit changes.<br>
+ * <br>
  * Use: Get affected VoiceChannel, affected Guild and previous user limit.
  */
 public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildAvailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildAvailableEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
 /**
- * <b><u>GuildAvailableEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Guild Guild} becomes available.<br/>
- * <br/>
+ * <b><u>GuildAvailableEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Guild Guild} becomes available.<br>
+ * <br>
  * Use: This indicates that a Guild will now start sending events and can be interacted with.
  */
 public class GuildAvailableEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildJoinEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
 /**
- * <b><u>GuildJoinEvent</u></b><br/>
- * Fired if a you join a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
- * <br/>
+ * <b><u>GuildJoinEvent</u></b><br>
+ * Fired if a you join a {@link net.dv8tion.jda.entities.Guild Guild}.<br>
+ * <br>
  * Warning: Discord already triggered a mass amount of these events due to a downtime. Be careful!
  */
 public class GuildJoinEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildLeaveEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
 /**
- * <b><u>GuildLeaveEvent</u></b><br/>
- * Fired if a you leave a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
- * <br/>
+ * <b><u>GuildLeaveEvent</u></b><br>
+ * Fired if a you leave a {@link net.dv8tion.jda.entities.Guild Guild}.<br>
+ * <br>
  * Use: Detect when you leave a Guild.
  */
 public class GuildLeaveEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildUnavailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildUnavailableEvent.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
 /**
- * <b><u>GuildUnavailableEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Guild Guild} becomes unavailable.<br/>
- * Possibly due to a downtime.<br/>
- * <br/>
+ * <b><u>GuildUnavailableEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Guild Guild} becomes unavailable.<br>
+ * Possibly due to a downtime.<br>
+ * <br>
  * Use: This indicates that a Guild stopped responding.
  */
 public class GuildUnavailableEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/GuildUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/GuildUpdateEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Guild;
 
 /**
- * <b><u>GuildUpdateEvent</u></b><br/>
- * Fired whenever a {@link net.dv8tion.jda.entities.Guild Guild} updates.<br/>
- * <br/>
+ * <b><u>GuildUpdateEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Guild Guild} updates.<br>
+ * <br>
  * Use: Detect what Guild updated.
  */
 public class GuildUpdateEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/UnavailableGuildJoinedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/UnavailableGuildJoinedEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>UnavailableGuildJoinedEvent</u></b><br/>
- * Fired if you joined a {@link net.dv8tion.jda.entities.Guild Guild} that is not yet available.<br/>
- * <br/>
+ * <b><u>UnavailableGuildJoinedEvent</u></b><br>
+ * Fired if you joined a {@link net.dv8tion.jda.entities.Guild Guild} that is not yet available.<br>
+ * <br>
  * Use: Retrieve id of unavailable Guild.
  */
 public class UnavailableGuildJoinedEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberBanEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberBanEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>GuildMemberBanEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.User User} is banned from a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
- * <br/>
+ * <b><u>GuildMemberBanEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} is banned from a {@link net.dv8tion.jda.entities.Guild Guild}.<br>
+ * <br>
  * Use: Retrieve user who was banned (if available) and triggering guild.
  */
 public class GuildMemberBanEvent extends GuildMemberLeaveEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberJoinEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>GuildMemberJoinEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.User User} joins a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
- * <br/>
+ * <b><u>GuildMemberJoinEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} joins a {@link net.dv8tion.jda.entities.Guild Guild}.<br>
+ * <br>
  * Use: Retrieve user who joined (if available) and affected guild.
  */
 public class GuildMemberJoinEvent extends GenericGuildMemberEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberLeaveEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>GuildMemberLeaveEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.User User} leaves a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
- * <br/>
+ * <b><u>GuildMemberLeaveEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} leaves a {@link net.dv8tion.jda.entities.Guild Guild}.<br>
+ * <br>
  * Use: Retrieve user who left (if available) and triggering guild.
  */
 public class GuildMemberLeaveEvent extends GenericGuildMemberEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberNickChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberNickChangeEvent.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>GuildMemberNickChangeEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.User User} updates their {@link net.dv8tion.jda.entities.Guild Guild} nickname.<br/>
- * <br/>
+ * <b><u>GuildMemberNickChangeEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} updates their {@link net.dv8tion.jda.entities.Guild Guild} nickname.<br>
+ * <br>
  * Use: Retrieve user who changed their nickname, triggering guild, the old nick and the new nick.
  */
 public class GuildMemberNickChangeEvent extends GenericGuildMemberEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleAddEvent.java
@@ -25,9 +25,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * <b><u>GuildMemberRoleAddEvent</u></b><br/>
- * Fired if one or more {@link net.dv8tion.jda.entities.Role Roles} are assigned to a {@link net.dv8tion.jda.entities.User User}.<br/>
- * <br/>
+ * <b><u>GuildMemberRoleAddEvent</u></b><br>
+ * Fired if one or more {@link net.dv8tion.jda.entities.Role Roles} are assigned to a {@link net.dv8tion.jda.entities.User User}.<br>
+ * <br>
  * Use: Retrieve affected user and guild. Provides a list of added roles.
  */
 public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberRoleRemoveEvent.java
@@ -25,9 +25,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * <b><u>GuildMemberRoleRemoveEvent</u></b><br/>
- * Fired if one or more {@link net.dv8tion.jda.entities.Role Roles} are removed from a {@link net.dv8tion.jda.entities.User User}.<br/>
- * <br/>
+ * <b><u>GuildMemberRoleRemoveEvent</u></b><br>
+ * Fired if one or more {@link net.dv8tion.jda.entities.Role Roles} are removed from a {@link net.dv8tion.jda.entities.User User}.<br>
+ * <br>
  * Use: Retrieve affected user and guild. Provides a list of removed roles.
  */
 public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberUnbanEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/member/GuildMemberUnbanEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>GuildMemberBanEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.User User} is unbanned from a {@link net.dv8tion.jda.entities.Guild Guild}.<br/>
- * <br/>
+ * <b><u>GuildMemberBanEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} is unbanned from a {@link net.dv8tion.jda.entities.Guild Guild}.<br>
+ * <br>
  * Use: Retrieve user who was unbanned (if available) and the guild which they were unbanned from.
  */
 public class GuildMemberUnbanEvent extends GenericGuildMemberEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleCreateEvent.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
 /**
- * <b><u>GuildRoleCreateEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role} is created.<br/>
- * <br/>
+ * <b><u>GuildRoleCreateEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role} is created.<br>
+ * <br>
  * Use: Retrieve created Role and it's Guild.
  */
 public class GuildRoleCreateEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleDeleteEvent.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.guild.GenericGuildEvent;
 
 /**
- * <b><u>GuildRoleDeleteEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role} is deleted.<br/>
- * <br/>
+ * <b><u>GuildRoleDeleteEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role} is deleted.<br>
+ * <br>
  * Use: Retrieve deleted Role and it's Guild.
  */
 public class GuildRoleDeleteEvent extends GenericGuildEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateColorEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateColorEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
 /**
- * <b><u>GuildRoleUpdateColorEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s color changes.<br/>
- * <br/>
+ * <b><u>GuildRoleUpdateColorEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s color changes.<br>
+ * <br>
  * Use: Retrieve affected Role and Guild.
  */
 public class GuildRoleUpdateColorEvent extends GenericGuildRoleUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Role;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>GuildRoleUpdateEvent</u></b><br/>
- * Fired whenever a {@link net.dv8tion.jda.entities.Role Role} is updated.<br/>
- * <br/>
+ * <b><u>GuildRoleUpdateEvent</u></b><br>
+ * Fired whenever a {@link net.dv8tion.jda.entities.Role Role} is updated.<br>
+ * <br>
  * Use: Retrieve affected Role. <i>(No real use for JDA user)</i>
  */
 public class GuildRoleUpdateEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateGroupedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateGroupedEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
 /**
- * <b><u>GuildRoleUpdateGroupedEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s grouped property changes.<br/>
- * <br/>
+ * <b><u>GuildRoleUpdateGroupedEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s grouped property changes.<br>
+ * <br>
  * Use: Retrieve affected Role.
  */
 public class GuildRoleUpdateGroupedEvent extends GenericGuildRoleUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdateNameEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
 /**
- * <b><u>GuildRoleUpdateNameEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s name changes.<br/>
- * <br/>
+ * <b><u>GuildRoleUpdateNameEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s name changes.<br>
+ * <br>
  * Use: Retrieve affected Role.
  */
 public class GuildRoleUpdateNameEvent extends GenericGuildRoleUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePermissionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePermissionEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
 /**
- * <b><u>GuildRoleUpdatePermissionEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s permissions change.<br/>
- * <br/>
+ * <b><u>GuildRoleUpdatePermissionEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s permissions change.<br>
+ * <br>
  * Use: Retrieve affected Role.
  */
 public class GuildRoleUpdatePermissionEvent extends GenericGuildRoleUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/guild/role/GuildRoleUpdatePositionEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.Role;
 
 /**
- * <b><u>GuildRoleUpdatePositionEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s position changes.<br/>
- * <br/>
+ * <b><u>GuildRoleUpdatePositionEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.Role Role}'s position changes.<br>
+ * <br>
  * Use: Retrieve affected Role.
  */
 public class GuildRoleUpdatePositionEvent extends GenericGuildRoleUpdateEvent

--- a/src/main/java/net/dv8tion/jda/events/message/MessageBulkDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageBulkDeleteEvent.java
@@ -23,9 +23,9 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * <b><u>MessageBulkDeleteEvent</u></b><br/>
- * Fired if a bulk deletion is executed in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br/>
- * <br/>
+ * <b><u>MessageBulkDeleteEvent</u></b><br>
+ * Fired if a bulk deletion is executed in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br>
+ * <br>
  * Use: This event indicates that a large chunk of Messages is deleted in a TextChannel. Providing a list of Message IDs and the specific TextChannel.
  */
 public class MessageBulkDeleteEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/message/MessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageDeleteEvent.java
@@ -23,9 +23,9 @@ import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>MessageDeleteEvent</u></b><br/>
- * Fired if a Message was deleted in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
- * <br/>
+ * <b><u>MessageDeleteEvent</u></b><br>
+ * Fired if a Message was deleted in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br>
+ * <br>
  * Use: Detect when a Message is deleted. No matter if private or guild.
  */
 public class MessageDeleteEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/message/MessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageEmbedEvent.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.events.Event;
 import java.util.List;
 
 /**
- * <b><u>MessageEmbedEvent</u></b><br/>
- * Fired if a Message contains an {@link net.dv8tion.jda.entities.MessageEmbed Embed} in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
- * <br/>
+ * <b><u>MessageEmbedEvent</u></b><br>
+ * Fired if a Message contains an {@link net.dv8tion.jda.entities.MessageEmbed Embed} in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br>
+ * <br>
  * Use: Grab MessageEmbeds from any message. No matter if private or guild.
  */
 public class MessageEmbedEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageReceivedEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>MessageReceivedEvent</u></b><br/>
- * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
- * <br/>
+ * <b><u>MessageReceivedEvent</u></b><br>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br>
+ * <br>
  * Use: This event indicates that a Message is sent in either a private or guild channel. Providing a MessageChannel and Message.
  */
 public class MessageReceivedEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/message/MessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/MessageUpdateEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.*;
 import net.dv8tion.jda.events.Event;
 
 /**
- * <b><u>MessageUpdateEvent</u></b><br/>
- * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br/>
- * <br/>
+ * <b><u>MessageUpdateEvent</u></b><br>
+ * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.MessageChannel MessageChannel}.<br>
+ * <br>
  * Use: This event indicates that a Message is edited in either a private or guild channel. Providing a MessageChannel and Message.
  */
 public class MessageUpdateEvent extends Event

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageDeleteEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.TextChannel;
 
 /**
- * <b><u>GuildMessageDeleteEvent</u></b><br/>
- * Fired if a Guild Message was deleted.<br/>
- * <br/>
+ * <b><u>GuildMessageDeleteEvent</u></b><br>
+ * Fired if a Guild Message was deleted.<br>
+ * <br>
  * Use: Retrieve affected TextChannel and the id of the deleted Message.
  */
 public class GuildMessageDeleteEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageEmbedEvent.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.entities.TextChannel;
 import java.util.List;
 
 /**
- * <b><u>GuildMessageEmbedEvent</u></b><br/>
- * Fired if a Guild Message contains one or more {@link net.dv8tion.jda.entities.MessageEmbed Embeds}.<br/>
- * <br/>
+ * <b><u>GuildMessageEmbedEvent</u></b><br>
+ * Fired if a Guild Message contains one or more {@link net.dv8tion.jda.entities.MessageEmbed Embeds}.<br>
+ * <br>
  * Use: Retrieve affected TextChannel, the id of the affected Message and a list of MessageEmbeds.
  */
 public class GuildMessageEmbedEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageReceivedEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.TextChannel;
 
 /**
- * <b><u>GuildMessageReceivedEvent</u></b><br/>
- * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br/>
- * <br/>
+ * <b><u>GuildMessageReceivedEvent</u></b><br>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br>
+ * <br>
  * Use: Retrieve affected TextChannel and Message.
  */
 public class GuildMessageReceivedEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/guild/GuildMessageUpdateEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.TextChannel;
 
 /**
- * <b><u>GuildMessageReceivedEvent</u></b><br/>
- * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br/>
- * <br/>
+ * <b><u>GuildMessageReceivedEvent</u></b><br>
+ * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.TextChannel TextChannel}.<br>
+ * <br>
  * Use: Retrieve affected TextChannel and Message.
  */
 public class GuildMessageUpdateEvent extends GenericGuildMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageDeleteEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.PrivateChannel;
 
 /**
- * <b><u>PrivateMessageDeleteEvent</u></b><br/>
- * Fired if a Message is deleted in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
- * <br/>
+ * <b><u>PrivateMessageDeleteEvent</u></b><br>
+ * Fired if a Message is deleted in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br>
+ * <br>
  * Use: Retrieve affected PrivateChannel and the ID of the deleted Message.
  */
 public class PrivateMessageDeleteEvent extends GenericPrivateMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageEmbedEvent.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.entities.PrivateChannel;
 import java.util.List;
 
 /**
- * <b><u>PrivateMessageEmbedEvent</u></b><br/>
- * Fired if a Message contains {@link net.dv8tion.jda.entities.MessageEmbed Embeds} in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
- * <br/>
+ * <b><u>PrivateMessageEmbedEvent</u></b><br>
+ * Fired if a Message contains {@link net.dv8tion.jda.entities.MessageEmbed Embeds} in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br>
+ * <br>
  * Use: Retrieve affected PrivateChannel, the ID of the deleted Message and a list of MessageEmbeds.
  */
 public class PrivateMessageEmbedEvent extends GenericPrivateMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageReceivedEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
 
 /**
- * <b><u>PrivateMessageReceivedEvent</u></b><br/>
- * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
- * <br/>
+ * <b><u>PrivateMessageReceivedEvent</u></b><br>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br>
+ * <br>
  * Use: Retrieve affected PrivateChannel and Message.
  */
 public class PrivateMessageReceivedEvent extends GenericPrivateMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/message/priv/PrivateMessageUpdateEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Message;
 import net.dv8tion.jda.entities.PrivateChannel;
 
 /**
- * <b><u>PrivateMessageUpdateEvent</u></b><br/>
- * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br/>
- * <br/>
+ * <b><u>PrivateMessageUpdateEvent</u></b><br>
+ * Fired if a Message is edited in a {@link net.dv8tion.jda.entities.PrivateChannel PrivateChannel}.<br>
+ * <br>
  * Use: Retrieve affected PrivateChannel and edited Message.
  */
 public class PrivateMessageUpdateEvent extends GenericPrivateMessageEvent

--- a/src/main/java/net/dv8tion/jda/events/user/UserAvatarUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserAvatarUpdateEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>UserAvatarUpdateEvent</u></b><br/>
- * Fired if the Avatar of a {@link net.dv8tion.jda.entities.User User} changes.<br/>
- * <br/>
+ * <b><u>UserAvatarUpdateEvent</u></b><br>
+ * Fired if the Avatar of a {@link net.dv8tion.jda.entities.User User} changes.<br>
+ * <br>
  * Use: Retrieve the User who's Avatar changed and their previous Avatar ID/URL.
  */
 public class UserAvatarUpdateEvent extends GenericUserEvent

--- a/src/main/java/net/dv8tion/jda/events/user/UserGameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserGameUpdateEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.Game;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>UserGameUpdateEvent</u></b><br/>
- * Fired if the {@link net.dv8tion.jda.entities.Game Game} of a {@link net.dv8tion.jda.entities.User User} changes.<br/>
- * <br/>
+ * <b><u>UserGameUpdateEvent</u></b><br>
+ * Fired if the {@link net.dv8tion.jda.entities.Game Game} of a {@link net.dv8tion.jda.entities.User User} changes.<br>
+ * <br>
  * Use: Retrieve the User who's Game changed and their previous Game.
  */
 public class UserGameUpdateEvent extends GenericUserEvent

--- a/src/main/java/net/dv8tion/jda/events/user/UserNameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserNameUpdateEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>UserNameUpdateEvent</u></b><br/>
- * Fired if the username of a {@link net.dv8tion.jda.entities.User User} changes. (Not Nickname)<br/>
- * <br/>
+ * <b><u>UserNameUpdateEvent</u></b><br>
+ * Fired if the username of a {@link net.dv8tion.jda.entities.User User} changes. (Not Nickname)<br>
+ * <br>
  * Use: Retrieve the User who's username changed and their previous username.
  */
 public class UserNameUpdateEvent extends GenericUserEvent

--- a/src/main/java/net/dv8tion/jda/events/user/UserOnlineStatusUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserOnlineStatusUpdateEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.OnlineStatus;
 import net.dv8tion.jda.entities.User;
 
 /**
- * <b><u>UserOnlineStatusUpdateEvent</u></b><br/>
- * Fired if the {@link OnlineStatus OnlineStatus} of a {@link net.dv8tion.jda.entities.User User} changes.<br/>
- * <br/>
+ * <b><u>UserOnlineStatusUpdateEvent</u></b><br>
+ * Fired if the {@link OnlineStatus OnlineStatus} of a {@link net.dv8tion.jda.entities.User User} changes.<br>
+ * <br>
  * Use: Retrieve the User who's status changed and their previous status.
  */
 public class UserOnlineStatusUpdateEvent extends GenericUserEvent

--- a/src/main/java/net/dv8tion/jda/events/user/UserTypingEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/user/UserTypingEvent.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.entities.User;
 import java.time.OffsetDateTime;
 
 /**
- * <b><u>UserTypingUpdateEvent</u></b><br/>
- * Fired if a {@link net.dv8tion.jda.entities.User User} starts typing. (Similar to the typing indicator in the Discord client)<br/>
- * <br/>
+ * <b><u>UserTypingUpdateEvent</u></b><br>
+ * Fired if a {@link net.dv8tion.jda.entities.User User} starts typing. (Similar to the typing indicator in the Discord client)<br>
+ * <br>
  * Use: Retrieve the User who started typing and when and in which MessageChannel they started typing.
  */
 public class UserTypingEvent extends GenericUserEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceDeafEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceDeafEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceDeafEvent</u></b><br/>
- * Fired if we are (un-)deafened. <br/>
- * This can indicate both deafen and un-deafen and can be caused by both us or the server.<br/>
+ * <b><u>VoiceDeafEvent</u></b><br>
+ * Fired if we are (un-)deafened. <br>
+ * This can indicate both deafen and un-deafen and can be caused by both us or the server.<br>
  * {@link net.dv8tion.jda.events.voice.VoiceSelfDeafEvent} and {@link net.dv8tion.jda.events.voice.VoiceServerDeafEvent} are specifications of this event.
  */
 public class VoiceDeafEvent extends GenericVoiceEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceJoinEvent.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceJoinEvent</u></b><br/>
- * Fired if we successfully joined a VoiceChannel.<br/><br/>
+ * <b><u>VoiceJoinEvent</u></b><br>
+ * Fired if we successfully joined a VoiceChannel.<br><br>
  * Use: Retrieve VoiceChannel we connected to.
  */
 public class VoiceJoinEvent extends GenericVoiceEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceLeaveEvent.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.entities.VoiceChannel;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceLeaveEvent</u></b><br/>
- * Fired if we successfully left a VoiceChannel.<br/>
- * <br/>
+ * <b><u>VoiceLeaveEvent</u></b><br>
+ * Fired if we successfully left a VoiceChannel.<br>
+ * <br>
  * Use: Retrieve previous VoiceChannel.
  */
 public class VoiceLeaveEvent extends GenericVoiceEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceMuteEvent.java
@@ -19,9 +19,9 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceMuteEvent</u></b><br/>
- * Fired if we are (un-)muted. <br/>
- * This can indicate both mute and un-mute and can be caused by both us or the server.<br/>
+ * <b><u>VoiceMuteEvent</u></b><br>
+ * Fired if we are (un-)muted. <br>
+ * This can indicate both mute and un-mute and can be caused by both us or the server.<br>
  * {@link net.dv8tion.jda.events.voice.VoiceSelfMuteEvent} and {@link net.dv8tion.jda.events.voice.VoiceServerMuteEvent} are specifications of this event.
  */
 public class VoiceMuteEvent extends GenericVoiceEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfDeafEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfDeafEvent.java
@@ -19,8 +19,8 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceSelfDeafEvent</u></b><br/>
- * Fired if we (un-)deafen us. <br/>
+ * <b><u>VoiceSelfDeafEvent</u></b><br>
+ * Fired if we (un-)deafen us. <br>
  * This can indicate both deafen and un-deafen and can <u>only</u> be caused by us.
  */
 public class VoiceSelfDeafEvent extends VoiceDeafEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceSelfMuteEvent.java
@@ -19,8 +19,8 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceSelfMuteEvent</u></b><br/>
- * Fired if we (un-)mute us. <br/>
+ * <b><u>VoiceSelfMuteEvent</u></b><br>
+ * Fired if we (un-)mute us. <br>
  * This can indicate both mute and un-mute and can <u>only</u> be caused by us.
  */
 public class VoiceSelfMuteEvent extends VoiceMuteEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceServerDeafEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceServerDeafEvent.java
@@ -19,8 +19,8 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceServerDeafEvent</u></b><br/>
- * Fired if we are (un-)deafened by the server. <br/>
+ * <b><u>VoiceServerDeafEvent</u></b><br>
+ * Fired if we are (un-)deafened by the server. <br>
  * This can indicate both deafen and un-deafen and can <u>only</u> be caused by the server.
  */
 public class VoiceServerDeafEvent extends VoiceDeafEvent

--- a/src/main/java/net/dv8tion/jda/events/voice/VoiceServerMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/events/voice/VoiceServerMuteEvent.java
@@ -19,8 +19,8 @@ import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.entities.VoiceStatus;
 
 /**
- * <b><u>VoiceServerMuteEvent</u></b><br/>
- * Fired if we are (un-)muted by the server. <br/>
+ * <b><u>VoiceServerMuteEvent</u></b><br>
+ * Fired if we are (un-)muted by the server. <br>
  * This can indicate both muted and un-muted and can <u>only</u> be caused by the server.
  */
 public class VoiceServerMuteEvent extends VoiceMuteEvent

--- a/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelCreateHandler.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.handle;
 
+import net.dv8tion.jda.entities.PrivateChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.channel.priv.PrivateChannelCreateEvent;
 import net.dv8tion.jda.events.channel.text.TextChannelCreateEvent;
@@ -61,10 +62,18 @@ public class ChannelCreateHandler extends SocketHandler
         }
         else if (type.equalsIgnoreCase("private"))
         {
-            api.getEventManager().handle(
-                    new PrivateChannelCreateEvent(
-                            api, responseNumber,
-                            new EntityBuilder(api).createPrivateChannel(content).getUser()));
+            PrivateChannel pc = new EntityBuilder(api).createPrivateChannel(content);
+            if (pc == null)
+            {
+                JDAImpl.LOG.warn("Discord API sent us a Private CREATE_CHANNEL for a user we can't see, ignoring event.");
+            }
+            else
+            {
+                api.getEventManager().handle(
+                        new PrivateChannelCreateEvent(
+                                api, responseNumber,
+                                pc.getUser()));
+            }
         }
         else
         {

--- a/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ChannelUpdateHandler.java
@@ -54,9 +54,10 @@ public class ChannelUpdateHandler extends SocketHandler
         String name = content.getString("name");
         int position = content.getInt("position");
         JSONArray permOverwrites = content.getJSONArray("permission_overwrites");
-        switch (content.getString("type"))
+        ChannelType type = ChannelType.fromId(content.getInt("type"));
+        switch (type)
         {
-            case "text":
+            case TEXT:
             {
                 String topic = content.isNull("topic") ? null : content.getString("topic");
                 TextChannelImpl channel = (TextChannelImpl) api.getChannelMap().get(content.getString("id"));
@@ -133,7 +134,7 @@ public class ChannelUpdateHandler extends SocketHandler
                 }
                 break;  //Finish the TextChannelUpdate case
             }
-            case "voice":
+            case VOICE:
             {
                 VoiceChannelImpl channel = (VoiceChannelImpl) api.getVoiceChannelMap().get(content.getString("id"));
                 int userLimit = content.getInt("user_limit");

--- a/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/handle/EntityBuilder.java
@@ -82,7 +82,6 @@ public class EntityBuilder
             .setIconId(guild.isNull("icon") ? null : guild.getString("icon"))
             .setRegion(Region.fromKey(guild.getString("region")))
             .setName(guild.getString("name"))
-            .setOwnerId(guild.getString("owner_id"))
             .setAfkTimeout(guild.getInt("afk_timeout"))
             .setAfkChannelId(guild.isNull("afk_channel_id") ? null : guild.getString("afk_channel_id"))
             .setVerificationLevel(Guild.VerificationLevel.fromKey(guild.getInt("verification_level")));
@@ -102,6 +101,10 @@ public class EntityBuilder
             JSONArray members = guild.getJSONArray("members");
             createGuildMemberPass(guildObj, members);
         }
+
+        User owner = api.getUserById(guild.getString("owner_id"));
+        if (owner != null)
+            guildObj.setOwner(owner);
 
         if (guild.has("presences"))
         {
@@ -241,6 +244,13 @@ public class EntityBuilder
         {
             createGuildMemberPass(guildObj, chunk);
         }
+
+        User owner = api.getUserById(guildJson.getString("owner_id"));
+        if (owner != null)
+            guildObj.setOwner(owner);
+
+        if (guildObj.getOwner() == null)
+            JDAImpl.LOG.fatal("Never set the Owner of the Guild: " + guildObj.getId() + " because we don't have the owner User object! How?!");
 
         JSONArray channels = guildJson.getJSONArray("channels");
         createGuildChannelPass(guildObj, channels);

--- a/src/main/java/net/dv8tion/jda/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/GuildUpdateHandler.java
@@ -17,10 +17,12 @@ package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.Region;
 import net.dv8tion.jda.entities.Guild;
+import net.dv8tion.jda.entities.User;
 import net.dv8tion.jda.entities.impl.GuildImpl;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.guild.GuildUpdateEvent;
 import net.dv8tion.jda.requests.GuildLock;
+import net.dv8tion.jda.requests.WebSocketClient;
 import org.json.JSONObject;
 
 public class GuildUpdateHandler extends SocketHandler
@@ -40,7 +42,7 @@ public class GuildUpdateHandler extends SocketHandler
         }
 
         GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("id"));
-        String ownerId = content.getString("owner_id");
+        User owner = api.getUserById(content.getString("owner_id"));
         String name = content.getString("name");
         String iconId = content.isNull("icon") ? null : content.getString("icon");
         String afkChannelId = content.isNull("afk_channel_id") ? null : content.getString("afk_channel_id");
@@ -48,8 +50,11 @@ public class GuildUpdateHandler extends SocketHandler
         int afkTimeout = content.getInt("afk_timeout");
         Guild.VerificationLevel verificationLevel = Guild.VerificationLevel.fromKey(content.getInt("verification_level"));
 
+        if (owner == null)
+            WebSocketClient.LOG.fatal("Attempted to update Guild but the ownerId provided referenced an unknown User! JSON: " + content.toString());
+
         guild.setName(name)
-                .setOwnerId(ownerId)
+                .setOwner(owner)
                 .setIconId(iconId)
                 .setAfkChannelId(afkChannelId)
                 .setRegion(region)

--- a/src/main/java/net/dv8tion/jda/handle/MessageDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageDeleteHandler.java
@@ -64,7 +64,7 @@ public class MessageDeleteHandler extends SocketHandler
         api.getEventManager().handle(
                 new MessageDeleteEvent(
                         api, responseNumber,
-                        messageId, channelId, channel != null));
+                        messageId, channelId, channel == null));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageEmbedHandler.java
@@ -82,7 +82,7 @@ public class MessageEmbedHandler extends SocketHandler
         api.getEventManager().handle(
                 new MessageEmbedEvent(
                         api, responseNumber,
-                        messageId, channelId, embeds, channel != null));
+                        messageId, channelId, embeds, channel == null));
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/MessageReceivedHandler.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.entities.Message;
+import net.dv8tion.jda.entities.MessageType;
 import net.dv8tion.jda.entities.TextChannel;
 import net.dv8tion.jda.entities.impl.JDAImpl;
 import net.dv8tion.jda.events.InviteReceivedEvent;
@@ -40,6 +41,20 @@ public class MessageReceivedHandler extends SocketHandler
 
     @Override
     protected String handleInternally(JSONObject content)
+    {
+        MessageType type = MessageType.fromId(content.getInt("type"));
+
+        switch (type)
+        {
+            case DEFAULT:
+                return handleDefaultMessage(content);
+            default:
+                JDAImpl.LOG.debug("JDA received a message of unknown type. Type: " + type + "  JSON: " + content);
+        }
+        return null;
+    }
+
+    private String handleDefaultMessage(JSONObject content)
     {
         Message message;
         try

--- a/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/handle/ReadyHandler.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.handle;
 
 import net.dv8tion.jda.JDA;
 import net.dv8tion.jda.OnlineStatus;
+import net.dv8tion.jda.entities.ChannelType;
 import net.dv8tion.jda.entities.Game;
 import net.dv8tion.jda.entities.Guild;
 import net.dv8tion.jda.entities.impl.JDAImpl;
@@ -132,7 +133,15 @@ public class ReadyHandler extends SocketHandler
         JSONArray priv_chats = content.getJSONArray("private_channels");
         for (int i = 0; i < priv_chats.length(); i++)
         {
-            builder.createPrivateChannel(priv_chats.getJSONObject(i));
+            JSONObject privateChannel = priv_chats.getJSONObject(i);
+            ChannelType type = ChannelType.fromId(privateChannel.getInt("type"));
+
+            if (type == ChannelType.PRIVATE)
+                builder.createPrivateChannel(privateChannel);
+            else if (type == ChannelType.GROUP)
+                JDAImpl.LOG.debug("Received a group channel in the READY packet, but GROUPS aren't supported by JDA (JDA-Client only)");
+            else
+                JDAImpl.LOG.fatal("Received a private channel in the READY packet that is of an unknown type!");
         }
         api.getClient().ready();
     }

--- a/src/main/java/net/dv8tion/jda/hooks/EventListener.java
+++ b/src/main/java/net/dv8tion/jda/hooks/EventListener.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.hooks;
 
 import net.dv8tion.jda.events.Event;
 
+@FunctionalInterface
 public interface EventListener
 {
 

--- a/src/main/java/net/dv8tion/jda/managers/RoleManager.java
+++ b/src/main/java/net/dv8tion/jda/managers/RoleManager.java
@@ -182,7 +182,7 @@ public class RoleManager
      * This change will only be applied, if {@link #update()} is called.
      * So multiple changes can be made at once.
      *
-     * @param group
+     * @param mention
      *      Whether or not this should be mentionable, or null to keep current grouping status
      * @return
      *      this

--- a/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/requests/WebSocketClient.java
@@ -204,7 +204,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     {
         try
         {
-            return api.getRequester().get(Requester.DISCORD_API_PREFIX + "gateway").getObject().getString("url") + "?encoding=json&v=5";
+            return api.getRequester().get(Requester.DISCORD_API_PREFIX + "gateway").getObject().getString("url") + "?encoding=json&v=6";
         }
         catch (Exception ex)
         {

--- a/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
+++ b/src/main/java/net/dv8tion/jda/utils/InviteUtil.java
@@ -59,15 +59,15 @@ public class InviteUtil
         {
             JSONObject guild = object.getJSONObject("guild");
             JSONObject channel = object.getJSONObject("channel");
-            return new Invite(object.getString("code"), object.isNull("xkcdpass") ? null : object.getString("xkcdpass"), guild.getString("name"), guild.getString("id"),
+            return new Invite(object.getString("code"), guild.getString("name"), guild.getString("id"),
                     channel.getString("name"), channel.getString("id"), channel.getString("type").equals("text"));
         }
         return null;
     }
 
     /**
-     * Creates a standard-invite (valid for 24hrs, infinite usages, permanent access and not human-readable).
-     * To create a customized Invite, use {@link #createInvite(Channel, InviteDuration, int, boolean, boolean)} instead.
+     * Creates a standard-invite (valid for 24hrs, infinite usages, permanent access).
+     * To create a customized Invite, use {@link #createInvite(Channel, InviteDuration, int, boolean)} instead.
      *
      * @param chan
      *      The channel to create the invite for.
@@ -79,7 +79,7 @@ public class InviteUtil
      */
     public static AdvancedInvite createInvite(Channel chan)
     {
-        return createInvite(chan, InviteDuration.ONE_DAY, 0, false, false);
+        return createInvite(chan, InviteDuration.ONE_DAY, 0, false);
     }
 
     /**
@@ -93,15 +93,13 @@ public class InviteUtil
      *      The maximum amount of usages of this invite. 0 means infinite usages.
      * @param temporary
      *      Whether or not the invite should only grant temporary access to the Guild (members will get removed after they log out, unless they get a role assigned).
-     * @param humanReadable
-     *      Wheter or not the invite should be in human-readable form.
      * @return
      *      The created AdvancedInvite object.
      * @throws net.dv8tion.jda.exceptions.PermissionException
      *      If the account connected to the provided JDA object does not have
      *      {@link net.dv8tion.jda.Permission#CREATE_INSTANT_INVITE Permission.CREATE_INSTANT_INVITE} for the provided channel.
      */
-    public static AdvancedInvite createInvite(Channel chan, InviteDuration duration, int maxUses, boolean temporary, boolean humanReadable)
+    public static AdvancedInvite createInvite(Channel chan, InviteDuration duration, int maxUses, boolean temporary)
     {
         JDA jda = chan.getJDA();
         if (!chan.checkPermission(jda.getSelfInfo(), Permission.CREATE_INSTANT_INVITE))
@@ -112,8 +110,7 @@ public class InviteUtil
                 new JSONObject()
                         .put("max_age", duration.getDuration())
                         .put("temporary", temporary)
-                        .put("max_uses", maxUses)
-                        .put("xkcdpass", humanReadable)).getObject();
+                        .put("max_uses", maxUses)).getObject();
         if (object != null && object.has("code"))
         {
             return AdvancedInvite.fromJson(object, jda);
@@ -238,15 +235,13 @@ public class InviteUtil
     public static class Invite
     {
         private final String code;
-        private final String humanCode;
         private final String guildName, guildId;
         private final String channelName, channelId;
         private final boolean isTextChannel;
 
-        private Invite(String code, String humanCode, String guildName, String guildId, String channelName, String channelId, boolean isTextChannel)
+        private Invite(String code, String guildName, String guildId, String channelName, String channelId, boolean isTextChannel)
         {
             this.code = code;
-            this.humanCode = humanCode;
             this.guildName = guildName;
             this.guildId = guildId;
             this.channelName = channelName;
@@ -257,16 +252,6 @@ public class InviteUtil
         public String getCode()
         {
             return code;
-        }
-
-        public String getHumanCode()
-        {
-            return humanCode;
-        }
-
-        public String getUrl()
-        {
-            return "https://discord.gg/" + (humanCode == null ? code : humanCode);
         }
 
         public String getGuildName()
@@ -306,9 +291,9 @@ public class InviteUtil
         //TODO what happens if the inviter left the server (and therefore is unknown for the api)?
         private final User inviter;
 
-        private AdvancedInvite(String code, String humanCode, String guildName, String guildId, String channelName, String channelId, boolean isTextChannel, InviteDuration duration, String guildSplashHash, boolean temporary,
+        private AdvancedInvite(String code, String guildName, String guildId, String channelName, String channelId, boolean isTextChannel, InviteDuration duration, String guildSplashHash, boolean temporary,
                 int maxUses, OffsetDateTime createdAt, int uses, User inviter) {
-            super(code, humanCode, guildName, guildId, channelName, channelId, isTextChannel);
+            super(code, guildName, guildId, channelName, channelId, isTextChannel);
             this.duration = duration;
             this.guildSplashHash = guildSplashHash;
             this.temporary = temporary;
@@ -361,7 +346,6 @@ public class InviteUtil
 
             return new AdvancedInvite(
                     object.getString("code"),
-                    object.isNull("xkcdpass") ? null : object.getString("xkcdpass"),
                     guild.getString("name"),
                     guild.getString("id"),
                     channel.getString("name"),


### PR DESCRIPTION
**+** Added support for Discord Gateway v6 
**+** Added support for custom Emotes
**+** Made EventListener an @FunctionalInterface
**+** Added RatelimitException information to `MessageChannel#sendFile` and `#sendFileAsync`
**+** Added convenience methods to Guild similar to JDA #103 
**+** Added Level specific log files. `SimpleLog#addLogFile(Level, File)`

**Changed how JDA validates tokens. Speeds up login time a __LOT__ on larger bots.
*Now store Guild Owner's User object in the guild instead of doing Runtime lookup. Fixes issues related to `GuildLeaveEvent#getGuild()#getOwner()`
*Fixed thread leak relating to audio receiving.
*Fixed possible JSONException dealing with DMs
*Cleaned up Javadoc warnings/errors

-Removed heartbeat ack checking to manually kill WS if time between heartbeaks was too long. Was causing large issues.
-Removed usage of Email-Pass in ApplicationUtil. Changed to requiring user auth token.