### PR TITLE
Switched Method for DELETE_MESSAGES to POST

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -108,7 +108,7 @@ public class Route
 
         //Bot only
         public static final Route GET_MESSAGE =     new Route(GET, "channels/{channel_id}/messages/{message_id}", "channel_id");
-        public static final Route DELETE_MESSAGES = new Route(PUT, "channels/{channel_id}/messages/bulk_delete",  "channel_id");
+        public static final Route DELETE_MESSAGES = new Route(POST, "channels/{channel_id}/messages/bulk_delete",  "channel_id");
     }
 
     public static class Invites


### PR DESCRIPTION
This will fix the reported 405 response on **TextChannel#deleteMessagesById**.

If this was already fixed in your local workspace, feel free to close this pull request.