### PR TITLE
Fixed bugs for rich message parsing and partial data

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.core.requests.GuildLock;
 import net.dv8tion.jda.core.requests.WebSocketClient;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.awt.*;
@@ -774,17 +775,18 @@ public class EntityBuilder
 
     public MessageEmbed createMessageEmbed(JSONObject messageEmbed)
     {
+        if (messageEmbed.isNull("type"))
+            throw new JSONException("Encountered embed object with missing/null type field for Json: " + messageEmbed);
+        EmbedType type = EmbedType.fromKey(messageEmbed.getString("type"));
+       /* if (type == EmbedType.UNKNOWN)
+            throw new JSONException("Discord provided us an unknown embed type.  Json: " + messageEmbed);*/
         MessageEmbedImpl embed = new MessageEmbedImpl()
-                .setUrl(messageEmbed.getString("url"))
+                .setType(type)
+                .setUrl(messageEmbed.isNull("url") ? null : messageEmbed.getString("url"))
                 .setTitle(messageEmbed.isNull("title") ? null : messageEmbed.getString("title"))
                 .setDescription(messageEmbed.isNull("description") ? null : messageEmbed.getString("description"))
                 .setColor(messageEmbed.isNull("color") || messageEmbed.getInt("color") == 0 ? null : new Color(messageEmbed.getInt("color")))
                 .setTimestamp(messageEmbed.isNull("timestamp") ? null : OffsetDateTime.parse(messageEmbed.getString("timestamp")));
-
-        EmbedType type = EmbedType.fromKey(messageEmbed.getString("type"));
-//        if (type.equals(EmbedType.UNKNOWN))
-//            throw new IllegalArgumentException("Discord provided us an unknown embed type.  Json: " + messageEmbed);
-        embed.setType(type);
 
         if (messageEmbed.has("thumbnail"))
         {
@@ -848,7 +850,7 @@ public class EntityBuilder
                 fields.add(new Field(
                         fieldJson.isNull("name") ? null : fieldJson.getString("name"),
                         fieldJson.isNull("value") ? null : fieldJson.getString("value"),
-                        fieldJson.isNull("inline") ? false : fieldJson.getBoolean("inline")));
+                        !fieldJson.isNull("inline") && fieldJson.getBoolean("inline")));
             }
             embed.setFields(fields);
         }

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -592,7 +592,9 @@ public class EntityBuilder
 
     public PrivateChannel createPrivateChannel(JSONObject privatechat)
     {
-        JSONObject recipient = privatechat.getJSONArray("recipients").getJSONObject(0);
+        JSONObject recipient = privatechat.has("recipients") ? 
+            privatechat.getJSONArray("recipients").getJSONObject(0) :
+            privatechat.getJSONObject("recipient");
         UserImpl user = ((UserImpl) api.getUserMap().get(recipient.getString("id")));
         if (user == null)
         {   //The API can give us private channels connected to Users that we can no longer communicate with.

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageCreateHandler.java
@@ -77,7 +77,7 @@ public class MessageCreateHandler extends SocketHandler
                 }
                 case EntityBuilder.MISSING_USER:
                 {
-                    EventCache.get(api).cache(EventCache.Type.USER, content.getJSONObject("user").getString("id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.USER, content.getJSONObject("author").getString("id"), () ->
                     {
                         handle(responseNumber, allContent);
                     });

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageUpdateHandler.java
@@ -98,7 +98,7 @@ public class MessageUpdateHandler extends SocketHandler
                 }
                 case EntityBuilder.MISSING_USER:
                 {
-                    EventCache.get(api).cache(EventCache.Type.USER, content.getJSONObject("user").getString("id"), () ->
+                    EventCache.get(api).cache(EventCache.Type.USER, content.getJSONObject("author").getString("id"), () ->
                     {
                         handle(responseNumber, allContent);
                     });


### PR DESCRIPTION
One of our users received an `MESSAGE_UPDATE` dispatch with this object:
```json
{
    "author": {
        "bot": true,
        "id": "236892566870687745",
        "avatar": "27ae7496b3b30cddab2feaaed06d862a",
        "username": "GitHub",
        "discriminator": "0000"
    },
    "id": "241237427157467137",
    "embeds": [...],
    "channel_id": "236881236876984320"
}
```
The embeds array did contain one object which I removed for readability.
This fix should also be done in 2.x