### PR TITLE
First pass on Presence controller/holder

### DIFF
--- a/src/main/java/net/dv8tion/jda/client/JDAClient.java
+++ b/src/main/java/net/dv8tion/jda/client/JDAClient.java
@@ -16,10 +16,7 @@
 
 package net.dv8tion.jda.client;
 
-import net.dv8tion.jda.client.entities.Friend;
-import net.dv8tion.jda.client.entities.Group;
-import net.dv8tion.jda.client.entities.Relationship;
-import net.dv8tion.jda.client.entities.RelationshipType;
+import net.dv8tion.jda.client.entities.*;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.User;
@@ -48,4 +45,6 @@ public interface JDAClient
     Friend getFriend(User user);
     Friend getFriend(Member member);
     Friend getFriendById(String id);
+
+    UserSettings getSettings();
 }

--- a/src/main/java/net/dv8tion/jda/client/entities/UserSettings.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/UserSettings.java
@@ -1,0 +1,48 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.client.entities;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.OnlineStatus;
+import net.dv8tion.jda.core.entities.Guild;
+
+import java.util.List;
+import java.util.Locale;
+
+public interface UserSettings
+{
+
+    JDA getJDA();
+
+    OnlineStatus getStatus();
+    Locale getLocale();
+    //getTheme() : ?
+
+    List<Guild> getGuildPositions();
+    List<Guild> getRestrictedGuilds();
+
+    boolean isAllowEmailFriendRequest();
+    boolean isConvertEmoticons();
+    boolean isDetectPlatformAccounts();
+    boolean isDeveloperMode();
+    boolean isEnableTTS();
+    boolean isShowCurrentGame();
+    boolean isRenderEmbeds();
+    boolean isMessageDisplayCompact();
+    boolean isInlineEmbedMedia();
+    boolean isInlineAttachmentMedia();
+}

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
@@ -18,14 +18,11 @@ package net.dv8tion.jda.client.entities.impl;
 
 import net.dv8tion.jda.client.JDAClient;
 import net.dv8tion.jda.client.entities.*;
-import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
-import org.apache.http.HttpHost;
 
-import javax.management.relation.Relation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,10 +35,12 @@ public class JDAClientImpl implements JDAClient
     protected final HashMap<String, Group> groups = new HashMap<>();
     protected final HashMap<String, Relationship> relationships = new HashMap<>();
     protected final HashMap<String, CallUser> callUsers = new HashMap<>();
+    protected UserSettingsImpl userSettings;
 
     public JDAClientImpl(JDAImpl api)
     {
         this.api = api;
+        this.userSettings = new UserSettingsImpl(api);
     }
 
     @Override
@@ -170,6 +169,12 @@ public class JDAClientImpl implements JDAClient
     public Friend getFriendById(String id)
     {
         return (Friend) getRelationshipById(id, RelationshipType.FRIEND);
+    }
+
+    @Override
+    public UserSettings getSettings()
+    {
+        return userSettings;
     }
 
     public HashMap<String, Group> getGroupMap()

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/UserSettingsImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/UserSettingsImpl.java
@@ -1,0 +1,157 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.client.entities.impl;
+
+import net.dv8tion.jda.client.entities.UserSettings;
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.OnlineStatus;
+import net.dv8tion.jda.core.entities.Guild;
+
+import java.util.List;
+import java.util.Locale;
+
+public class UserSettingsImpl implements UserSettings
+{
+
+    private final JDA api;
+
+    private OnlineStatus status = OnlineStatus.UNKNOWN;
+
+    public UserSettingsImpl(JDA api)
+    {
+        this.api = api;
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+
+    @Override
+    public OnlineStatus getStatus()
+    {
+        return status;
+    }
+
+    @Override
+    public Locale getLocale()
+    {
+        return null;
+    }
+
+    @Override
+    public List<Guild> getGuildPositions()
+    {
+        return null;
+    }
+
+    @Override
+    public List<Guild> getRestrictedGuilds()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean isAllowEmailFriendRequest()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isConvertEmoticons()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDetectPlatformAccounts()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isDeveloperMode()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isEnableTTS()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isShowCurrentGame()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isRenderEmbeds()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isMessageDisplayCompact()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isInlineEmbedMedia()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isInlineAttachmentMedia()
+    {
+        return false;
+    }
+
+    /* -- Setters -- */
+
+    public UserSettingsImpl setStatus(OnlineStatus status)
+    {
+        this.status = status;
+        return this;
+    }
+
+    /* -- Object overrides -- */
+
+    @Override
+    public int hashCode()
+    {
+        return getJDA().getSelfInfo().getId().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj instanceof UserSettingsImpl && getJDA().equals(((UserSettingsImpl) obj).getJDA());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "UserSettings(" + getJDA().getSelfInfo() + ")";
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -462,5 +462,11 @@ public interface JDA
 
     ShardInfo getShardInfo();
 
+    /**
+     * The {@link net.dv8tion.jda.core.managers.Presence Presence} of the current session
+     *
+     * @return
+     *      The never-null {@link net.dv8tion.jda.core.managers.Presence Presence} of this session
+     */
     Presence getPresence();
 }

--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.bot.JDABot;
 import net.dv8tion.jda.client.JDAClient;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.hooks.IEventManager;
+import net.dv8tion.jda.core.managers.Presence;
 import net.dv8tion.jda.core.requests.ratelimit.IBucket;
 import org.apache.http.HttpHost;
 
@@ -460,4 +461,6 @@ public interface JDA
     JDABot asBot();
 
     ShardInfo getShardInfo();
+
+    Presence getPresence();
 }

--- a/src/main/java/net/dv8tion/jda/core/OnlineStatus.java
+++ b/src/main/java/net/dv8tion/jda/core/OnlineStatus.java
@@ -35,6 +35,18 @@ public enum OnlineStatus
     }
 
     /**
+     * The valid API key for this OnlineStatus
+     *
+     * @return
+     *      String representation of the valid API key for this OnlineStatus
+     * @see <a href="https://discordapp.com/developers/docs/topics/gateway#presence-update">PRESENCE_UPDATE</a>
+     */
+    public String getKey()
+    {
+        return key;
+    }
+
+    /**
      * Will get the {@link net.dv8tion.jda.core.OnlineStatus OnlineStatus} from the provided key.<br>
      * If the provided key does no match a presence, this will return {@link net.dv8tion.jda.core.OnlineStatus#UNKNOWN UNKONWN}
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/Game.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Game.java
@@ -15,6 +15,9 @@
  */
 package net.dv8tion.jda.core.entities;
 
+import net.dv8tion.jda.core.entities.impl.GameImpl;
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Represents a Discord {@link net.dv8tion.jda.core.entities.Game Game}. This should contain all information provided from Discord about a Game.
  */
@@ -45,6 +48,44 @@ public interface Game
      */
     GameType getType();
 
+    /**
+     * Creates a new Game instance with the specified name.
+     *
+     * @param name
+     *      The not-null name of the newly created game
+     * @return
+     *      A valid Game instance with the provided name with {@link GameType#DEFAULT}
+     * @throws IllegalArgumentException
+     *      if the specified name is null or empty
+     */
+    static Game of(String name)
+    {
+        return of(name, null);
+    }
+
+    /**
+     * Creates a new Game instance with the specified name and url.
+     *
+     * @param name
+     *      The not-null name of the newly created game
+     * @param url
+     *      The streaming url to use, invalid for {@link GameType#DEFAULT GameType#DEFAULT}
+     * @return
+     *      A valid Game instance with the provided name and url
+     * @throws IllegalArgumentException
+     *      if the specified name is null or empty
+     * @see #isValidStreamingUrl(String)
+     */
+    static Game of(String name, String url)
+    {
+        if (StringUtils.isEmpty(name))
+            throw new IllegalArgumentException("Game name may not be null or empty.");
+        GameType type;
+        if (isValidStreamingUrl(url))
+            type = GameType.TWITCH;
+        else type = GameType.DEFAULT;
+        return new GameImpl(name, url, type);
+    }
 
     /**
      * Checks if a given String is a valid Twitch url (ie, one that will display "Streaming" on the Discord client).

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.core.exceptions.RateLimitedException;
 import net.dv8tion.jda.core.hooks.IEventManager;
 import net.dv8tion.jda.core.hooks.InterfacedEventManager;
 import net.dv8tion.jda.core.managers.Presence;
+import net.dv8tion.jda.core.managers.impl.PresenceImpl;
 import net.dv8tion.jda.core.requests.*;
 import net.dv8tion.jda.core.requests.ratelimit.IBucket;
 import net.dv8tion.jda.core.utils.SimpleLog;
@@ -37,7 +38,10 @@ import org.json.JSONObject;
 
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class JDAImpl implements JDA
@@ -54,6 +58,7 @@ public class JDAImpl implements JDA
     protected final HashMap<String, PrivateChannel> fakePrivateChannels = new HashMap<>();
 
     protected final AccountType accountType;
+    protected final PresenceImpl presence;
     protected final JDAClient jdaClient;
     protected final JDABot jdaBot;
 
@@ -64,7 +69,6 @@ public class JDAImpl implements JDA
     protected Status status = Status.INITIALIZING;
     protected SelfInfo selfInfo;
     protected ShardInfo shardInfo;
-    protected Presence presence;
     protected String token = null;
     protected boolean audioEnabled;
     protected boolean useShutdownHook;
@@ -74,6 +78,7 @@ public class JDAImpl implements JDA
 
     public JDAImpl(AccountType accountType, HttpHost proxy, boolean autoReconnect, boolean audioEnabled, boolean useShutdownHook, boolean bulkDeleteSplittingEnabled)
     {
+        this.presence = new PresenceImpl(this);
         this.accountType = accountType;
         this.proxy = proxy;
         this.autoReconnect = autoReconnect;
@@ -493,8 +498,6 @@ public class JDAImpl implements JDA
     @Override
     public Presence getPresence()
     {
-        if (presence == null)
-            presence = new Presence(this);
         return presence;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.core.exceptions.AccountTypeException;
 import net.dv8tion.jda.core.exceptions.RateLimitedException;
 import net.dv8tion.jda.core.hooks.IEventManager;
 import net.dv8tion.jda.core.hooks.InterfacedEventManager;
+import net.dv8tion.jda.core.managers.Presence;
 import net.dv8tion.jda.core.requests.*;
 import net.dv8tion.jda.core.requests.ratelimit.IBucket;
 import net.dv8tion.jda.core.utils.SimpleLog;
@@ -63,6 +64,7 @@ public class JDAImpl implements JDA
     protected Status status = Status.INITIALIZING;
     protected SelfInfo selfInfo;
     protected ShardInfo shardInfo;
+    protected Presence presence;
     protected String token = null;
     protected boolean audioEnabled;
     protected boolean useShutdownHook;
@@ -486,6 +488,14 @@ public class JDAImpl implements JDA
     public ShardInfo getShardInfo()
     {
         return shardInfo;
+    }
+
+    @Override
+    public Presence getPresence()
+    {
+        if (presence == null)
+            presence = new Presence(this);
+        return presence;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ReadyHandler.java
@@ -17,9 +17,10 @@
 package net.dv8tion.jda.core.handle;
 
 import net.dv8tion.jda.client.entities.Relationship;
-import net.dv8tion.jda.client.entities.RelationshipType;
 import net.dv8tion.jda.client.entities.impl.FriendImpl;
+import net.dv8tion.jda.client.entities.impl.UserSettingsImpl;
 import net.dv8tion.jda.core.AccountType;
+import net.dv8tion.jda.core.OnlineStatus;
 import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.EntityBuilder;
 import net.dv8tion.jda.core.entities.Guild;
@@ -28,11 +29,8 @@ import net.dv8tion.jda.core.requests.WebSocketClient;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.TimeZone;
 
 public class ReadyHandler extends SocketHandler
 {
@@ -57,6 +55,16 @@ public class ReadyHandler extends SocketHandler
         JSONObject selfJson = content.getJSONObject("user");
 
         builder.createSelfInfo(selfJson);
+
+        if (api.getAccountType() == AccountType.CLIENT && !content.isNull("user_settings"))
+        {
+            // handle user settings
+            JSONObject userSettingsJson = content.getJSONObject("user_settings");
+            UserSettingsImpl userSettingsObj = (UserSettingsImpl) api.asClient().getSettings();
+            userSettingsObj
+                    // TODO: set all information and handle updates
+                    .setStatus(userSettingsJson.isNull("status") ? OnlineStatus.ONLINE : OnlineStatus.fromKey(userSettingsJson.getString("status")));
+        }
 
         //Keep a list of all guilds in incompleteGuilds that need to be setup (GuildMemberChunk / GuildSync)
         //Send all guilds to the EntityBuilder's first pass to setup caching for when GUILD_CREATE comes

--- a/src/main/java/net/dv8tion/jda/core/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ReadyHandler.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.EntityBuilder;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.managers.impl.PresenceImpl;
 import net.dv8tion.jda.core.requests.WebSocketClient;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -64,6 +65,9 @@ public class ReadyHandler extends SocketHandler
             userSettingsObj
                     // TODO: set all information and handle updates
                     .setStatus(userSettingsJson.isNull("status") ? OnlineStatus.ONLINE : OnlineStatus.fromKey(userSettingsJson.getString("status")));
+            // update presence information unless the status is ONLINE
+            if (userSettingsObj.getStatus() != OnlineStatus.ONLINE)
+                ((PresenceImpl) api.getPresence()).setCacheStatus(userSettingsObj.getStatus());
         }
 
         //Keep a list of all guilds in incompleteGuilds that need to be setup (GuildMemberChunk / GuildSync)

--- a/src/main/java/net/dv8tion/jda/core/managers/Presence.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/Presence.java
@@ -16,40 +16,23 @@
 
 package net.dv8tion.jda.core.managers;
 
-import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.OnlineStatus;
 import net.dv8tion.jda.core.entities.Game;
-import net.dv8tion.jda.core.entities.impl.JDAImpl;
-import org.json.JSONObject;
 
 /**
  * The Presence associated with the provided JDA instance
  */
-public class Presence
+public interface Presence
 {
 
-    private final JDAImpl api;
-    private boolean idle = false;
-    private Game game = null;
-    private OnlineStatus status = OnlineStatus.ONLINE;
-
     /**
-     * Creates a new Presence representation for the provided JDAImpl instance
+     * The JDA instance of this Presence
      *
-     * @param jda
-     *      The not-null JDAImpl instance to use
+     * @return
+     *      The current JDA instance
      */
-    public Presence(JDAImpl jda)
-    {
-        this.api = jda;
-        if (jda.getAccountType() == AccountType.CLIENT)
-            status = jda.asClient().getSettings().getStatus();
-    }
-
-
-    /* -- Getters -- */
-
+    JDA getJDA();
 
     /**
      * The current OnlineStatus for this session.<br>
@@ -58,10 +41,7 @@ public class Presence
      * @return
      *      The {@link net.dv8tion.jda.core.OnlineStatus OnlineStatus} of the current session
      */
-    public OnlineStatus getStatus()
-    {
-        return status;
-    }
+    OnlineStatus getStatus();
 
     /**
      * The current Game for this session.<br>
@@ -70,10 +50,7 @@ public class Presence
      * @return
      *      The {@link net.dv8tion.jda.core.entities.Game Game} of the current session
      */
-    public Game getGame()
-    {
-        return game;
-    }
+    Game getGame();
 
     /**
      * Whether the current session is marked as afk or not
@@ -81,25 +58,7 @@ public class Presence
      * @return
      *      true if this session is marked as afk
      */
-    public boolean isIdle()
-    {
-        return idle;
-    }
-
-    /**
-     * The JDA instance of this Presence
-     *
-     * @return
-     *      The current JDA instance
-     */
-    public JDA getJDA()
-    {
-        return api;
-    }
-
-
-    /* -- Setters -- */
-
+    boolean isIdle();
 
     /**
      * Sets the {@link net.dv8tion.jda.core.OnlineStatus OnlineStatus} for this session
@@ -109,17 +68,7 @@ public class Presence
      * @throws IllegalArgumentException
      *      if the provided OnlineStatus is {@link net.dv8tion.jda.core.OnlineStatus#UNKNOWN UNKNOWN}
      */
-    public void setStatus(OnlineStatus status)
-    {
-        if (status == OnlineStatus.UNKNOWN)
-            throw new IllegalArgumentException("Cannot set the presence status to an unknown OnlineStatus!");
-        if (status == OnlineStatus.OFFLINE || status == null)
-            status = OnlineStatus.INVISIBLE;
-        JSONObject object = getFullPresence();
-        object.put("status", status.getKey());
-        update(object);
-        this.status = status;
-    }
+    void setStatus(OnlineStatus status);
 
     /**
      * Sets the {@link net.dv8tion.jda.core.entities.Game Game} for this session
@@ -129,20 +78,7 @@ public class Presence
      * @see net.dv8tion.jda.core.entities.Game#of(String)
      * @see net.dv8tion.jda.core.entities.Game#of(String, String)
      */
-    public void setGame(Game game)
-    {
-        JSONObject gameObj = getGameJson(game);
-        if (gameObj == null)
-        {
-            update(getFullPresence().put("game", JSONObject.NULL));
-            this.game = null;
-            return;
-        }
-        JSONObject object = getFullPresence();
-        object.put("game", gameObj);
-        update(object);
-        this.game = game;
-    }
+    void setGame(Game game);
 
     /**
      * Sets whether this session should be marked as afk or not
@@ -150,50 +86,6 @@ public class Presence
      * @param idle
      *      boolean
      */
-    public void setIdle(boolean idle)
-    {
-        JSONObject object = getFullPresence();
-        object.put("afk", idle);
-        update(object);
-        this.idle = idle;
-    }
-
-
-    /* -- Private Methods -- */
-
-
-    private JSONObject getFullPresence()
-    {
-        JSONObject game = getGameJson(this.game);
-        return new JSONObject()
-              .put("afk", idle)
-              .put("since", System.currentTimeMillis())
-              .put("game", game == null ? JSONObject.NULL : game)
-              .put("status", getStatus().getKey());
-    }
-
-    private JSONObject getGameJson(Game game)
-    {
-        if (game == null || game.getName() == null || game.getType() == null)
-            return null;
-        JSONObject gameObj = new JSONObject();
-        gameObj.put("name", game.getName());
-        gameObj.put("type", game.getType().getKey());
-        if (game.getType() == Game.GameType.TWITCH && game.getUrl() != null)
-            gameObj.put("url", game.getUrl());
-
-        return gameObj;
-    }
-
-
-    /* -- Terminal -- */
-
-
-    protected void update(JSONObject data)
-    {
-        api.getClient().send(new JSONObject()
-            .put("d", data)
-            .put("op", 3).toString());
-    }
+    void setIdle(boolean idle);
 
 }

--- a/src/main/java/net/dv8tion/jda/core/managers/Presence.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/Presence.java
@@ -1,0 +1,199 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.managers;
+
+import net.dv8tion.jda.core.AccountType;
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.OnlineStatus;
+import net.dv8tion.jda.core.entities.Game;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import org.json.JSONObject;
+
+/**
+ * The Presence associated with the provided JDA instance
+ */
+public class Presence
+{
+
+    private final JDAImpl api;
+    private boolean idle = false;
+    private Game game = null;
+    private OnlineStatus status = OnlineStatus.ONLINE;
+
+    /**
+     * Creates a new Presence representation for the provided JDAImpl instance
+     *
+     * @param jda
+     *      The not-null JDAImpl instance to use
+     */
+    public Presence(JDAImpl jda)
+    {
+        this.api = jda;
+        if (jda.getAccountType() == AccountType.CLIENT)
+            status = jda.asClient().getSettings().getStatus();
+    }
+
+
+    /* -- Getters -- */
+
+
+    /**
+     * The current OnlineStatus for this session.<br>
+     * This might not be what the Discord Client displays due to session clashing!
+     *
+     * @return
+     *      The {@link net.dv8tion.jda.core.OnlineStatus OnlineStatus} of the current session
+     */
+    public OnlineStatus getStatus()
+    {
+        return status;
+    }
+
+    /**
+     * The current Game for this session.<br>
+     * This might not be what the Discord Client displays due to session clashing!
+     *
+     * @return
+     *      The {@link net.dv8tion.jda.core.entities.Game Game} of the current session
+     */
+    public Game getGame()
+    {
+        return game;
+    }
+
+    /**
+     * Whether the current session is marked as afk or not
+     *
+     * @return
+     *      true if this session is marked as afk
+     */
+    public boolean isIdle()
+    {
+        return idle;
+    }
+
+    /**
+     * The JDA instance of this Presence
+     *
+     * @return
+     *      The current JDA instance
+     */
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+
+    /* -- Setters -- */
+
+
+    /**
+     * Sets the {@link net.dv8tion.jda.core.OnlineStatus OnlineStatus} for this session
+     *
+     * @param status
+     *      the {@link net.dv8tion.jda.core.OnlineStatus OnlineStatus} to be used (OFFLINE/null -> INVISIBLE)
+     * @throws IllegalArgumentException
+     *      if the provided OnlineStatus is {@link net.dv8tion.jda.core.OnlineStatus#UNKNOWN UNKNOWN}
+     */
+    public void setStatus(OnlineStatus status)
+    {
+        if (status == OnlineStatus.UNKNOWN)
+            throw new IllegalArgumentException("Cannot set the presence status to an unknown OnlineStatus!");
+        if (status == OnlineStatus.OFFLINE || status == null)
+            status = OnlineStatus.INVISIBLE;
+        JSONObject object = getFullPresence();
+        object.put("status", status.getKey());
+        update(object);
+        this.status = status;
+    }
+
+    /**
+     * Sets the {@link net.dv8tion.jda.core.entities.Game Game} for this session
+     *
+     * @param game
+     *      A {@link net.dv8tion.jda.core.entities.Game Game} instance or null to reset
+     * @see net.dv8tion.jda.core.entities.Game#of(String)
+     * @see net.dv8tion.jda.core.entities.Game#of(String, String)
+     */
+    public void setGame(Game game)
+    {
+        JSONObject gameObj = getGameJson(game);
+        if (gameObj == null)
+        {
+            update(getFullPresence().put("game", JSONObject.NULL));
+            this.game = null;
+            return;
+        }
+        JSONObject object = getFullPresence();
+        object.put("game", gameObj);
+        update(object);
+        this.game = game;
+    }
+
+    /**
+     * Sets whether this session should be marked as afk or not
+     *
+     * @param idle
+     *      boolean
+     */
+    public void setIdle(boolean idle)
+    {
+        JSONObject object = getFullPresence();
+        object.put("afk", idle);
+        update(object);
+        this.idle = idle;
+    }
+
+
+    /* -- Private Methods -- */
+
+
+    private JSONObject getFullPresence()
+    {
+        JSONObject game = getGameJson(this.game);
+        return new JSONObject()
+              .put("afk", idle)
+              .put("since", System.currentTimeMillis())
+              .put("game", game == null ? JSONObject.NULL : game)
+              .put("status", getStatus().getKey());
+    }
+
+    private JSONObject getGameJson(Game game)
+    {
+        if (game == null || game.getName() == null || game.getType() == null)
+            return null;
+        JSONObject gameObj = new JSONObject();
+        gameObj.put("name", game.getName());
+        gameObj.put("type", game.getType().getKey());
+        if (game.getType() == Game.GameType.TWITCH && game.getUrl() != null)
+            gameObj.put("url", game.getUrl());
+
+        return gameObj;
+    }
+
+
+    /* -- Terminal -- */
+
+
+    protected void update(JSONObject data)
+    {
+        api.getClient().send(new JSONObject()
+            .put("d", data)
+            .put("op", 3).toString());
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/core/managers/impl/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/impl/PresenceImpl.java
@@ -1,0 +1,182 @@
+/*
+ *     Copyright 2015-2016 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.managers.impl;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.OnlineStatus;
+import net.dv8tion.jda.core.entities.Game;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.managers.Presence;
+import org.json.JSONObject;
+
+/**
+ * The Presence associated with the provided JDA instance
+ */
+public class PresenceImpl implements Presence
+{
+
+    private final JDAImpl api;
+    private boolean idle = false;
+    private Game game = null;
+    private OnlineStatus status = OnlineStatus.ONLINE;
+
+    /**
+     * Creates a new Presence representation for the provided JDAImpl instance
+     *
+     * @param jda
+     *      The not-null JDAImpl instance to use
+     */
+    public PresenceImpl(JDAImpl jda)
+    {
+        this.api = jda;
+    }
+
+
+    /* -- Public Getters -- */
+
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public OnlineStatus getStatus()
+    {
+        return status;
+    }
+
+    @Override
+    public Game getGame()
+    {
+        return game;
+    }
+
+    @Override
+    public boolean isIdle()
+    {
+        return idle;
+    }
+
+
+    /* -- Public Setters -- */
+
+
+    @Override
+    public void setStatus(OnlineStatus status)
+    {
+        if (status == OnlineStatus.UNKNOWN)
+            throw new IllegalArgumentException("Cannot set the presence status to an unknown OnlineStatus!");
+        if (status == OnlineStatus.OFFLINE || status == null)
+            status = OnlineStatus.INVISIBLE;
+        JSONObject object = getFullPresence();
+        object.put("status", status.getKey());
+        update(object);
+        this.status = status;
+    }
+
+    @Override
+    public void setGame(Game game)
+    {
+        JSONObject gameObj = getGameJson(game);
+        if (gameObj == null)
+        {
+            update(getFullPresence().put("game", JSONObject.NULL));
+            this.game = null;
+            return;
+        }
+        JSONObject object = getFullPresence();
+        object.put("game", gameObj);
+        update(object);
+        this.game = game;
+    }
+
+    @Override
+    public void setIdle(boolean idle)
+    {
+        JSONObject object = getFullPresence();
+        object.put("afk", idle);
+        update(object);
+        this.idle = idle;
+    }
+
+
+    /* -- Impl Setters -- */
+
+
+    public PresenceImpl setCacheStatus(OnlineStatus status)
+    {
+        if (status == null)
+            throw new NullPointerException("Null OnlineStatus is not allowed.");
+        if (status == OnlineStatus.OFFLINE)
+            status = OnlineStatus.INVISIBLE;
+        this.status = status;
+        return this;
+    }
+
+    public PresenceImpl setCacheGame(Game game)
+    {
+        this.game = game;
+        return this;
+    }
+
+    public PresenceImpl setCacheIdle(boolean idle)
+    {
+        this.idle = idle;
+        return this;
+    }
+
+
+    /* -- Internal Methods -- */
+
+
+    public JSONObject getFullPresence()
+    {
+        JSONObject game = getGameJson(this.game);
+        return new JSONObject()
+              .put("afk", idle)
+              .put("since", System.currentTimeMillis())
+              .put("game", game == null ? JSONObject.NULL : game)
+              .put("status", getStatus().getKey());
+    }
+
+    private JSONObject getGameJson(Game game)
+    {
+        if (game == null || game.getName() == null || game.getType() == null)
+            return null;
+        JSONObject gameObj = new JSONObject();
+        gameObj.put("name", game.getName());
+        gameObj.put("type", game.getType().getKey());
+        if (game.getType() == Game.GameType.TWITCH && game.getUrl() != null)
+            gameObj.put("url", game.getUrl());
+
+        return gameObj;
+    }
+
+
+    /* -- Terminal -- */
+
+
+    protected void update(JSONObject data)
+    {
+        api.getClient().send(new JSONObject()
+            .put("d", data)
+            .put("op", 3).toString());
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -41,6 +41,9 @@ public class Route
         public static final Route GET_PRIVATE_CHANNELS =   new Route(GET,    "users/@me/channels");
         public static final Route CREATE_PRIVATE_CHANNEL = new Route(POST,   "users/@me/channels");
         public static final Route GATEWAY =                new Route(GET,    "gateway");
+
+        // Client-only
+        public static final Route USER_SETTINGS =          new Route(GET,    "users/@me/settings");
     }
 
     public static class Users

--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.core.events.ReadyEvent;
 import net.dv8tion.jda.core.events.ReconnectedEvent;
 import net.dv8tion.jda.core.events.ResumedEvent;
 import net.dv8tion.jda.core.handle.*;
+import net.dv8tion.jda.core.managers.impl.PresenceImpl;
 import net.dv8tion.jda.core.utils.SimpleLog;
 import org.apache.http.HttpHost;
 import org.json.JSONArray;
@@ -398,9 +399,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected void sendIdentify()
     {
         LOG.debug("Sending Identify-packet...");
+        PresenceImpl presenceObj = (PresenceImpl) api.getPresence();
         JSONObject identify = new JSONObject()
                 .put("op", 2)
                 .put("d", new JSONObject()
+                        .put("presence", presenceObj.getFullPresence())
                         .put("token", api.getToken())
                         .put("properties", new JSONObject()
                                 .put("$os", System.getProperty("os.name"))


### PR DESCRIPTION
Presence is not called PresenceController because it is also holding the session presence information.
It is also not stored in `entities` because it allows setting presence fields directly.

I added UsersSettings(Impl) for the default status information saved in UserSettings.
This might well be changed in the future once we pass a proper UserSettings system.