### PR TITLE
Fixed an Exception caused by casting an Array to Permission[]

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/Permission.java
+++ b/src/main/java/net/dv8tion/jda/core/Permission.java
@@ -171,6 +171,6 @@ public enum Permission
 
     public static long getRaw(Collection<Permission> permissions)
     {
-        return getRaw(permissions.stream().toArray(Permission[]::new));
+        return getRaw(permissions.toArray(new Permission[permissions.size()]));
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/Permission.java
+++ b/src/main/java/net/dv8tion/jda/core/Permission.java
@@ -171,6 +171,6 @@ public enum Permission
 
     public static long getRaw(Collection<Permission> permissions)
     {
-        return getRaw((Permission[]) permissions.toArray());
+        return getRaw(permissions.stream().toArray(Permission[]::new));
     }
 }


### PR DESCRIPTION
Java doesn't really like when you cast a Permission collection to an array..
```
java.lang.ClassCastException: [Ljava.lang.Object; cannot be cast to [Lnet.dv8tion.jda.core.Permission;
    at net.dv8tion.jda.core.Permission.getRaw(Permission.java:174)
```