### PR TITLE
EmbedBuilder Improvements

### DIFF
--- a/src/main/java/net/dv8tion/jda/client/entities/impl/GroupImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/GroupImpl.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import net.dv8tion.jda.core.entities.MessageEmbed;
 
 public class GroupImpl implements Group
 {
@@ -157,6 +158,12 @@ public class GroupImpl implements Group
     public RestAction<Message> sendMessage(String text)
     {
         return sendMessage(new MessageBuilder().appendString(text).build());
+    }
+    
+    @Override
+    public RestAction<Message> sendMessage(MessageEmbed embed)
+    {
+        return sendMessage(new MessageBuilder().setEmbed(embed).build());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -16,7 +16,10 @@
 package net.dv8tion.jda.core;
 
 import java.awt.Color;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAccessor;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -29,6 +32,7 @@ public class EmbedBuilder
     public final static int VALUE_MAX_LENGTH = 1024;
     public final static int TEXT_MAX_LENGTH = 2048;
     public final static int URL_MAX_LENGTH = 2000;
+    public final static String ZERO_WIDTH_SPACE = "\u200E";
     public final static Pattern URL_PATTERN = Pattern.compile("\\s*https?:\\/\\/.+\\..{2,}\\s*", Pattern.CASE_INSENSITIVE);
     public final static Pattern HTTPS_URL_PATTERN = Pattern.compile("\\s*https:\\/\\/.+\\..{2,}\\s*", Pattern.CASE_INSENSITIVE);
     
@@ -156,13 +160,16 @@ public class EmbedBuilder
     
     /**
      * Sets the Timestamp of the embed.
-     * @param timestamp the timestamp of the embed
+     * @param temporal the temporal accessor of the timestamp
      * @return the builder after the timestamp has been set
      */
-    public EmbedBuilder setTimestamp(OffsetDateTime timestamp)
+    public EmbedBuilder setTimestamp(TemporalAccessor temporal)
     {
-        this.timestamp = timestamp;
-        return this;
+        if (temporal == null)
+            this.timestamp = null;
+        else
+            this.timestamp = OffsetDateTime.from(temporal);
+        return this; 
     }
     
     /**
@@ -315,7 +322,22 @@ public class EmbedBuilder
             throw new IllegalArgumentException("Name cannot be longer than " + TITLE_MAX_LENGTH + " characters.");
         else if (value.length() > VALUE_MAX_LENGTH)
             throw new IllegalArgumentException("Value cannot be longer than " + VALUE_MAX_LENGTH + " characters.");
+        if (name.isEmpty())
+            name = ZERO_WIDTH_SPACE;
+        if (value.isEmpty())
+            value = ZERO_WIDTH_SPACE;
         this.fields.add(new MessageEmbed.Field(name, value, inline));
+        return this;
+    }
+    
+    /**
+     * Adds a blank (empty) Field to the embed.
+     * @param inline whether or not this field should display inline
+     * @return the builder after the field has been added
+     */
+    public EmbedBuilder addBlankField(boolean inline)
+    {
+        this.fields.add(new MessageEmbed.Field(ZERO_WIDTH_SPACE, ZERO_WIDTH_SPACE, inline));
         return this;
     }
     

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -88,6 +88,31 @@ public interface MessageChannel extends ISnowflake
      *      and you do not meet the required verification-level of the guild.
      */
     RestAction<Message> sendMessage(String text);
+    
+    /**
+     * Sends a {@link net.dv8tion.jda.core.entities.Message Message} containing a rich embed to this channel.
+     * This will fail if the account of the api does not have the {@link net.dv8tion.jda.core.Permission#MESSAGE_WRITE Write-Permission}
+     * for this channel set
+     * After the Message has been sent, the created {@link net.dv8tion.jda.core.entities.Message Message} object is returned
+     * This Object will be null, if the sending failed.
+     * When the Rate-limit is reached (10 Messages in 10 secs), a {@link net.dv8tion.jda.core.exceptions.RateLimitedException RateLimitedException} is thrown
+     *
+     * @param embed
+     *          the embed to send
+     * @return
+     *      the Message created by this function
+     * @throws net.dv8tion.jda.core.exceptions.RateLimitedException
+     *      when rate-imit is reached
+     * @throws net.dv8tion.jda.core.exceptions.PermissionException
+     *      If this is a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} and the logged in account does
+     *      not have {@link net.dv8tion.jda.core.Permission#MESSAGE_WRITE Permission.MESSAGE_WRITE}.
+     * @throws net.dv8tion.jda.core.exceptions.BlockedException
+     *      If this is a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} and PMs are blocked
+     * @throws VerificationLevelException
+     *      If this is a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *      and you do not meet the required verification-level of the guild.
+     */
+    RestAction<Message> sendMessage(MessageEmbed embed);
 
     /**
      * Sends a given {@link net.dv8tion.jda.core.entities.Message Message} to this Channel

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
@@ -79,6 +79,12 @@ public class PrivateChannelImpl implements PrivateChannel
     {
         return sendMessage(new MessageBuilder().appendString(text).build());
     }
+    
+    @Override
+    public RestAction<Message> sendMessage(MessageEmbed embed)
+    {
+        return sendMessage(new MessageBuilder().setEmbed(embed).build());
+    }
 
     @Override
     public RestAction<Message> sendMessage(Message msg)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -182,6 +182,12 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
+    public RestAction<Message> sendMessage(MessageEmbed embed)
+    {
+        return sendMessage(new MessageBuilder().setEmbed(embed).build());
+    }
+    
+    @Override
     public RestAction<Message> sendMessage(Message msg)
     {
         Args.notNull(msg, "Message");


### PR DESCRIPTION
more options for setting timestamp (temporal, instant)
can add a blank field (and setting empty, non-null values automatically converts to a ZWSP)
sendMessage(MessageEmbed)

Please comment on this PR with any additional improvements