### PR TITLE
Fixed bug in MessageHistory#retrievePast 

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/core/MessageHistory.java
@@ -90,9 +90,6 @@ public class MessageHistory implements net.dv8tion.jda.core.hooks.EventListener
                 for (int i = 0; i < historyJson.length(); i++)
                     msgs.add(builder.createMessage(historyJson.getJSONObject(i)));
 
-                if (history.isEmpty())
-
-
                 msgs.forEach(msg -> history.put(msg.getId(), msg));
                 request.onSuccess(msgs);
             }


### PR DESCRIPTION
Messages wouldn't be added if the cached history is not empty