### PR TITLE
`/channels/{channel.id}/messages/bulk_delete` is deprecated

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -124,7 +124,7 @@ public class Route
 
         //Bot only
         public static final Route GET_MESSAGE =     new Route(GET, "channels/{channel_id}/messages/{message_id}", "channel_id");
-        public static final Route DELETE_MESSAGES = new Route(POST, "channels/{channel_id}/messages/bulk_delete",  "channel_id");
+        public static final Route DELETE_MESSAGES = new Route(POST, "channels/{channel_id}/messages/bulk-delete",  "channel_id");
     }
 
     public static class Invites


### PR DESCRIPTION
This endpoint has been deprecated. Use `/channels/{channel.id}/messages/bulk-delete` instead.

https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages