### PR TITLE
Embed-Related Changes / Embedbuilder; Append to description

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -183,7 +183,7 @@ public class EmbedBuilder
     /**
      * The {@link java.lang.StringBuilder StringBuilder} used to
      * build the description for the embed.
-     * <br>Note: To reset the description use {@link #setDescription(String) setDescription(null)}
+     * <br>Note: To reset the description use {@link #setDescription(CharSequence) setDescription(null)}
      *
      * @return StringBuilder with current description context
      */

--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.core;
 
 import net.dv8tion.jda.core.entities.MessageEmbed;
 import net.dv8tion.jda.core.entities.impl.MessageEmbedImpl;
+import org.apache.http.util.Args;
 
 import java.awt.Color;
 import java.time.DateTimeException;
@@ -210,7 +211,33 @@ public class EmbedBuilder
         }
         return this;
     }
-    
+	/**
+	 * Appends to the description of the embed. This is where the main chunk of text for an embed is typically placed.
+	 *
+	 * <p><b><a href="http://i.imgur.com/lbchtwk.png">Example</a></b>
+	 *
+	 * @param  description
+	 *         the string to append to the description of the embed
+	 *
+	 * @throws java.lang.IllegalArgumentException
+	 *         <ul>
+	 *             <li>If the provided {@code description} String is null</li>
+	 *             <li>If the length of {@code description} is greater than {@link net.dv8tion.jda.core.EmbedBuilder#TEXT_MAX_LENGTH}.</li>
+	 *         </ul>
+	 *
+	 * @return the builder after the description has been set
+	 */
+    public EmbedBuilder appendDescription(String description)
+    {
+		Args.notNull(description, "description");
+		if(((this.description == null) && (description.length() > TEXT_MAX_LENGTH))
+				|| ((this.description != null) && ((this.description.length() + description.length()) > TEXT_MAX_LENGTH))){
+			throw new IllegalArgumentException("Description cannot be longer than " + TEXT_MAX_LENGTH + " characters.");
+		}
+    	this.description = this.description == null ? description : this.description + description;
+		return this;
+	}
+
     /**
      * Sets the Timestamp of the embed.
      *
@@ -250,7 +277,7 @@ public class EmbedBuilder
                 LocalDateTime ldt = LocalDateTime.from(temporal);
                 this.timestamp = OffsetDateTime.of(ldt, offset);
             }
-            catch (DateTimeException ignore) 
+            catch (DateTimeException ignore)
             {
                 try
                 {
@@ -497,11 +524,11 @@ public class EmbedBuilder
         this.fields.add(new MessageEmbed.Field(ZERO_WIDTH_SPACE, ZERO_WIDTH_SPACE, inline));
         return this;
     }
-    
+
     /**
-     * Clears all fields from the embed, such as those created with the 
+     * Clears all fields from the embed, such as those created with the
      * {@link net.dv8tion.jda.core.EmbedBuilder#EmbedBuilder(net.dv8tion.jda.core.entities.MessageEmbed) EmbedBuilder(MessageEmbed)}
-     * constructor or via the 
+     * constructor or via the
      * {@link net.dv8tion.jda.core.EmbedBuilder#addField(net.dv8tion.jda.core.entities.MessageEmbed.Field) addField} methods.
      *
      * @return the builder after the field has been added
@@ -511,7 +538,7 @@ public class EmbedBuilder
         this.fields.clear();
         return this;
     }
-    
+
     private void urlCheck(String url)
     {
         if (url == null)

--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -292,7 +292,7 @@ public interface Message extends ISnowflake
      *         the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.</li>
      *
      *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
-     *         The edit was attempted after the Message had been deleted.</li>
+     *     <br>The edit was attempted after the Message had been deleted.</li>
      * </ul>
      *
      * @param  newContent
@@ -302,10 +302,42 @@ public interface Message extends ISnowflake
      *         If the message attempting to be edited was not created by the currently logged in account, or if
      *         {@code newContent}'s length is 0 or greater than 2000.
      *
-     * @return a new Message-Object for the edited message
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message Message}
+     *     <br>The {@link net.dv8tion.jda.core.entities.Message Message} with the updated content
      */
     RestAction<Message> editMessage(String newContent);
 
+    /**
+     * Edits this Message's content to the provided {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed}.
+     * <br><b>Messages can only be edited by the account that sent them!</b>.
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The edit was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The edit was attempted after the account lost {@link net.dv8tion.jda.core.Permission#MESSAGE_WRITE Permission.MESSAGE_WRITE} in
+     *         the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The edit was attempted after the Message had been deleted.</li>
+     * </ul>
+     *
+     * @param  newContent
+     *         the new content of the Message
+     *
+     * @throws java.lang.IllegalStateException
+     *         If the message attempting to be edited was not created by the currently logged in account, or
+     *         if the passed-in embed is null
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message Message}
+     *     <br>The {@link net.dv8tion.jda.core.entities.Message Message} with the updated content
+     */
+    RestAction<Message> editMessage(MessageEmbed newContent); 
+    
     /**
      * Edits this Message's content to the provided {@link net.dv8tion.jda.core.entities.Message Message}.
      * <br><b>Messages can only be edited by the account that sent them!</b>.
@@ -322,7 +354,7 @@ public interface Message extends ISnowflake
      *         the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.</li>
      *
      *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
-     *         The edit was attempted after the Message had been deleted.</li>
+     *     <br>The edit was attempted after the Message had been deleted.</li>
      * </ul>
      *
      * @param  newContent
@@ -332,7 +364,8 @@ public interface Message extends ISnowflake
      *         If the message attempting to be edited was not created by the currently logged in account, or if
      *         {@code newContent}'s length is 0 or greater than 2000.
      *
-     * @return a new Message-Object for the edited message
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message Message}
+     *     <br>The {@link net.dv8tion.jda.core.entities.Message Message} with the updated content
      */
     RestAction<Message> editMessage(Message newContent);
 

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -401,17 +401,7 @@ public interface MessageChannel extends ISnowflake
         body.field("file", data, fileName);
 
         if (message != null)
-        {
-            if (message.getEmbeds().isEmpty())
-            {
-                body.field("content", message.getRawContent());
-                body.field("tts", message.isTTS());
-            }
-            else
-            {
-                body.field("payload_json", ((MessageImpl) message).toJSONObject().toString()); 
-            }
-        }
+            body.field("payload_json", ((MessageImpl) message).toJSONObject().toString());
 
         return new RestAction<Message>(getJDA(), route, body)
         {
@@ -472,17 +462,7 @@ public interface MessageChannel extends ISnowflake
         body.field("file", data, fileName);
 
         if (message != null)
-        {
-            if (message.getEmbeds().isEmpty())
-            {
-                body.field("content", message.getRawContent());
-                body.field("tts", message.isTTS());
-            }
-            else
-            {
-                body.field("payload_json", ((MessageImpl) message).toJSONObject().toString());
-            }
-        }
+            body.field("payload_json", ((MessageImpl) message).toJSONObject().toString());
 
         return new RestAction<Message>(getJDA(), route, body)
         {

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -1241,4 +1241,49 @@ public interface MessageChannel extends ISnowflake
             }
         };
     }
+
+    /**
+     * Attempts to edit a message by its id in this MessageChannel.
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#INVALID_AUTHOR_EDIT INVALID_AUTHOR_EDIT}
+     *     <br>Attempted to edit a message that was not sent by the currently logged in account.
+     *         Discord does not allow editing of other users' Messages!</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id referencing the Message that should be edited
+     * @param  newEmbed
+     *         The new {@link net.dv8tion.jda.core.entities.MessageEmbed MessageEmbed} for the edited message
+     *
+     * @throws IllegalArgumentException
+     *         If provided {@code messageId} is {@code null} or empty
+     * @throws IllegalStateException
+     *         If the provided MessageEmbed is {@code null}
+     * @throws net.dv8tion.jda.core.exceptions.PermissionException
+     *         If this is a TextChannel and this account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         or {@link net.dv8tion.jda.core.Permission#MESSAGE_WRITE Permission.MESSAGE_WRITE}
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message}
+     *         <br>The modified Message
+     */
+    default RestAction<Message> editMessageById(String messageId, MessageEmbed newEmbed)
+    {
+        return editMessageById(messageId, new MessageBuilder().setEmbed(newEmbed).build());
+    }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -402,8 +402,15 @@ public interface MessageChannel extends ISnowflake
 
         if (message != null)
         {
-            body.field("content", message.getRawContent());
-            body.field("tts", message.isTTS());
+            if (message.getEmbeds().isEmpty())
+            {
+                body.field("content", message.getRawContent());
+                body.field("tts", message.isTTS());
+            }
+            else
+            {
+                body.field("payload_json", ((MessageImpl) message).toJSONObject().toString()); 
+            }
         }
 
         return new RestAction<Message>(getJDA(), route, body)
@@ -466,8 +473,15 @@ public interface MessageChannel extends ISnowflake
 
         if (message != null)
         {
-            body.field("content", message.getRawContent());
-            body.field("tts", message.isTTS());
+            if (message.getEmbeds().isEmpty())
+            {
+                body.field("content", message.getRawContent());
+                body.field("tts", message.isTTS());
+            }
+            else
+            {
+                body.field("payload_json", ((MessageImpl) message).toJSONObject().toString());
+            }
         }
 
         return new RestAction<Message>(getJDA(), route, body)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -438,6 +438,12 @@ public class MessageImpl implements Message
     {
         return editMessage(new MessageBuilder().append(newContent).build());
     }
+    
+    @Override
+    public RestAction<Message> editMessage(MessageEmbed newContent)
+    {
+        return editMessage(new MessageBuilder().setEmbed(newContent).build()); 
+    }
 
     @Override
     public RestAction<Message> editMessage(Message newContent)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -446,6 +446,21 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
+    public RestAction<Message> editMessageById(String id, Message newContent)
+    {
+        Args.notNull(newContent, "Message");
+
+        //checkVerification(); no verification needed to edit a message 
+        checkPermission(Permission.MESSAGE_READ);
+        checkPermission(Permission.MESSAGE_WRITE);
+        if (newContent.getRawContent().isEmpty() && !newContent.getEmbeds().isEmpty())
+            checkPermission(Permission.MESSAGE_EMBED_LINKS);
+
+        //Call MessageChannel's default
+        return TextChannel.super.editMessageById(id, newContent);
+    }
+    
+    @Override
     public RestAction<PermissionOverride> createPermissionOverride(Member member)
     {
         checkPermission(Permission.MANAGE_PERMISSIONS);


### PR DESCRIPTION
This merges #259 and #260
> __jagrosh__
> can use more temporal accessors
> edit message with embed only
> send embeds with a file
> permissions check for editing a message
> clear embeds from embedbuilder

> __Kaaz__
> A method to append to the description of an embed. 

In addition I made `description` use a `StringBuilder`