### PR TITLE
Added new PaginationAction and moved OrderAction to its own package.

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.core.entities.impl.MessageImpl;
 import net.dv8tion.jda.core.exceptions.AccountTypeException;
 import net.dv8tion.jda.core.requests.*;
 import net.dv8tion.jda.core.utils.IOUtil;
+import net.dv8tion.jda.core.utils.MiscUtil;
 import org.apache.http.util.Args;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -32,8 +33,6 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -893,15 +892,7 @@ public interface MessageChannel extends ISnowflake
         Args.notEmpty(unicode, "Provided Unicode");
         Args.containsNoBlanks(unicode, "Provided Unicode");
 
-        String encoded;
-        try
-        {
-            encoded = URLEncoder.encode(unicode, "UTF-8");
-        }
-        catch (UnsupportedEncodingException e)
-        {
-            throw new RuntimeException(e); //thanks JDK 1.4
-        }
+        String encoded = MiscUtil.encodeUTF8(unicode);
         Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, encoded);
         return new RestAction<Void>(getJDA(), route, null)
         {

--- a/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
@@ -31,6 +31,8 @@ import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.requests.Route;
 import net.dv8tion.jda.core.requests.restaction.*;
+import net.dv8tion.jda.core.requests.restaction.order.ChannelOrderAction;
+import net.dv8tion.jda.core.requests.restaction.order.RoleOrderAction;
 import net.dv8tion.jda.core.utils.PermissionUtil;
 import org.apache.http.util.Args;
 import org.json.JSONArray;
@@ -1713,8 +1715,8 @@ public class GuildController
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.core.entities.Guild#getTextChannels() Guild.getTextChannels()}
      * using a specific {@link net.dv8tion.jda.core.requests.RestAction RestAction} extension to allow moving Channels
-     * {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveDown(int) down}
-     * or {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveTo(int) to} a specific position.
+     * {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveDown(int) down}
+     * or {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveTo(int) to} a specific position.
      * <br>This uses <b>ascending</b> order with a 0 based index.
      *
      * <p>Possible {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} include:
@@ -1726,7 +1728,7 @@ public class GuildController
      *     <br>The currently logged in account was removed from the Guild</li>
      * </ul>
      *
-     * @return {@link net.dv8tion.jda.core.requests.restaction.ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     * @return {@link net.dv8tion.jda.core.requests.restaction.order.ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
      */
     public ChannelOrderAction<TextChannel> modifyTextChannelPositions()
     {
@@ -1736,8 +1738,8 @@ public class GuildController
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.core.entities.Guild#getVoiceChannels() Guild.getVoiceChannels()}
      * using a specific {@link net.dv8tion.jda.core.requests.RestAction RestAction} extension to allow moving Channels
-     * {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveDown(int) down}
-     * or {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveTo(int) to} a specific position.
+     * {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveDown(int) down}
+     * or {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveTo(int) to} a specific position.
      * <br>This uses <b>ascending</b> order with a 0 based index.
      *
      * <p>Possible {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} include:
@@ -1749,7 +1751,7 @@ public class GuildController
      *     <br>The currently logged in account was removed from the Guild</li>
      * </ul>
      *
-     * @return {@link net.dv8tion.jda.core.requests.restaction.ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel}
+     * @return {@link net.dv8tion.jda.core.requests.restaction.order.ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel}
      */
     public ChannelOrderAction<VoiceChannel> modifyVoiceChannelPositions()
     {
@@ -1759,8 +1761,8 @@ public class GuildController
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.core.entities.Guild#getRoles() Guild.getRoles()}
      * using a specific {@link net.dv8tion.jda.core.requests.RestAction RestAction} extension to allow moving Roles
-     * {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveDown(int) down}
-     * or {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveTo(int) to} a specific position.
+     * {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveDown(int) down}
+     * or {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveTo(int) to} a specific position.
      *
      * <p>This uses the ordering defined by Discord, which is <b>descending</b>!
      * <br>This means the highest role appears at index {@code 0} and the lower role at index {@code n - 1}.
@@ -1778,7 +1780,7 @@ public class GuildController
      *     <br>The currently logged in account was removed from the Guild</li>
      * </ul>
      *
-     * @return {@link net.dv8tion.jda.core.requests.restaction.RoleOrderAction RoleOrderAction}
+     * @return {@link net.dv8tion.jda.core.requests.restaction.order.RoleOrderAction RoleOrderAction}
      */
     public RoleOrderAction modifyRolePositions()
     {
@@ -1788,8 +1790,8 @@ public class GuildController
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.core.entities.Guild#getRoles() Guild.getRoles()}
      * using a specific {@link net.dv8tion.jda.core.requests.RestAction RestAction} extension to allow moving Roles
-     * {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveDown(int) down}
-     * or {@link net.dv8tion.jda.core.requests.restaction.OrderAction#moveTo(int) to} a specific position.
+     * {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveUp(int) up}/{@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveDown(int) down}
+     * or {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction#moveTo(int) to} a specific position.
      *
      * <p>Possible {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} include:
      * <ul>
@@ -1808,7 +1810,7 @@ public class GuildController
      *         <br>As a note: {@link net.dv8tion.jda.core.entities.Member#getRoles() Member.getRoles()}
      *         and {@link net.dv8tion.jda.core.entities.Guild#getRoles() Guild.getRoles()} are both in descending order.
      *
-     * @return {@link net.dv8tion.jda.core.requests.restaction.RoleOrderAction RoleOrderAction}
+     * @return {@link net.dv8tion.jda.core.requests.restaction.order.RoleOrderAction RoleOrderAction}
      */
     public RoleOrderAction modifyRolePositions(boolean useDiscordOrder)
     {

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -78,7 +78,7 @@ public abstract class RestAction<T>
     };
 
     protected final JDAImpl api;
-    protected final Route.CompiledRoute route;
+    protected Route.CompiledRoute route;
     protected Object data;
 
     /**
@@ -152,6 +152,7 @@ public abstract class RestAction<T>
     public void queue(Consumer<T> success, Consumer<Throwable> failure)
     {
         finalizeData();
+        finalizeRoute();
         if (success == null)
             success = DEFAULT_SUCCESS;
         if (failure == null)
@@ -188,6 +189,7 @@ public abstract class RestAction<T>
     public Future<T> submit(boolean shouldQueue)
     {
         finalizeData();
+        finalizeRoute();
         return new RequestFuture<T>(this, shouldQueue);
     }
 
@@ -266,6 +268,8 @@ public abstract class RestAction<T>
     }
 
     protected void finalizeData() { }
+
+    protected void finalizeRoute() { }
 
     protected abstract void handleResponse(Response response, Request request);
 

--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -142,9 +142,10 @@ public class Route
         public static final Route REMOVE_PINNED_MESSAGE = new Route(DELETE, "channels/{channel_id}/pins/{message_id}",     "channel_id");
 
         public static final Route ADD_REACTION =         new Route(PUT,    new RateLimit(1, 250), "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/@me",           "channel_id");
-        public static final Route REMOVE_REACTION =      new Route(DELETE,                        "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}",     "channel_id");
-        public static final Route REMOVE_ALL_REACTIONS = new Route(DELETE,                        "channels/{channel_id}/messages/{message_id}/reactions",                               "channel_id");
-        public static final Route GET_REACTION_USERS =   new Route(GET,                           "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}?limit={limit}", "channel_id");
+        public static final Route REMOVE_REACTION =      new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}",     "channel_id");
+        public static final Route REMOVE_ALL_REACTIONS = new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions",                               "channel_id");
+        public static final Route GET_REACTION_USERS_LIMIT =   new Route(GET, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}?limit={limit}", "channel_id");
+        public static final Route GET_REACTION_USERS_AFTER =   new Route(GET, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}?limit={limit}&after={after}", "channel_id");
 
         public static final Route GET_MESSAGE_HISTORY =        new Route(GET, "channels/{channel_id}/messages?limit={}",           "channel_id");
         public static final Route GET_MESSAGE_HISTORY_BEFORE = new Route(GET, "channels/{channel_id}/messages?limit={}&before={}", "channel_id");

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/order/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/order/ChannelOrderAction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.dv8tion.jda.core.requests.restaction;
+package net.dv8tion.jda.core.requests.restaction.order;
 
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.*;
@@ -27,7 +27,7 @@ import org.json.JSONObject;
 import java.util.Collection;
 
 /**
- * Implementation of {@link net.dv8tion.jda.core.requests.restaction.OrderAction OrderAction}
+ * Implementation of {@link OrderAction OrderAction}
  * to modify the order of {@link net.dv8tion.jda.core.entities.Channel Channels} for a {@link net.dv8tion.jda.core.entities.Guild Guild}.
  * <br>To apply the changes you must finish the {@link net.dv8tion.jda.core.requests.RestAction RestAction}
  *

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/order/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/order/OrderAction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.dv8tion.jda.core.requests.restaction;
+package net.dv8tion.jda.core.requests.restaction.order;
 
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.requests.Request;

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/order/RoleOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/order/RoleOrderAction.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package net.dv8tion.jda.core.requests.restaction;
+package net.dv8tion.jda.core.requests.restaction.order;
 
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Guild;
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Implementation of {@link net.dv8tion.jda.core.requests.restaction.OrderAction OrderAction}
+ * Implementation of {@link OrderAction OrderAction}
  * designed to modify the order of {@link net.dv8tion.jda.core.entities.Role Roles} of the
  * specified {@link net.dv8tion.jda.core.entities.Guild Guild}.
  * <br>To apply the changes you must finish the {@link net.dv8tion.jda.core.requests.RestAction RestAction}

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/order/package-info.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/order/package-info.java
@@ -1,0 +1,30 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * {@link net.dv8tion.jda.core.requests.RestAction RestAction} extensions
+ * specifically designed to change the order of discord entities.
+ * <br>Such as:
+ * <ul>
+ *     <li>{@link net.dv8tion.jda.core.requests.restaction.order.ChannelOrderAction Channels}</li>
+ *     <li>{@link net.dv8tion.jda.core.requests.restaction.order.RoleOrderAction Roles}</li>
+ * </ul>
+ *
+ * <p>Abstract base implementation can be found at {@link net.dv8tion.jda.core.requests.restaction.order.OrderAction OrderAction}
+ *
+ * @since 3.0
+ */
+package net.dv8tion.jda.core.requests.restaction.order;

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/PaginationAction.java
@@ -1,0 +1,307 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.requests.restaction.pagination;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.requests.Request;
+import net.dv8tion.jda.core.requests.Response;
+import net.dv8tion.jda.core.requests.RestAction;
+import org.apache.http.util.Args;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * {@link net.dv8tion.jda.core.requests.RestAction RestAction} specification used
+ * to retrieve entities for paginated endpoints (before, after, limit).
+ *
+ * @param  <M>
+ *         The current implementation used as chaining return value
+ * @param  <T>
+ *         The type of entity to paginate
+ *
+ * @since  3.1
+ * @author Florian Spieß
+ */
+public abstract class PaginationAction<T, M extends PaginationAction<T, M>> extends RestAction<List<T>> implements Iterable<T>
+{
+
+    protected final List<T> cached = new CopyOnWriteArrayList<>();
+    protected final int maxLimit;
+    protected final int minLimit;
+    protected final AtomicInteger limit;
+
+    /**
+     * Creates a new PaginationAction instance
+     *
+     * @param api
+     *        The current JDA instance
+     * @param maxLimit
+     *        The inclusive maximum limit that can be used in {@link #limit(int)}
+     * @param minLimit
+     *        The inclusive minimum limit that can be used in {@link #limit(int)}
+     * @param initialLimit
+     *        The initial limit to use on the pagination endpoint
+     */
+    public PaginationAction(JDA api, int minLimit, int maxLimit, int initialLimit)
+    {
+        super(api, null, null);
+        this.maxLimit = maxLimit;
+        this.minLimit = minLimit;
+        this.limit = new AtomicInteger(initialLimit);
+    }
+
+    /**
+     * Creates a new PaginationAction instance
+     * <br>This is used for PaginationActions that should not deal with
+     * {@link #limit(int)}
+     *
+     * @param api
+     *        The current JDA instance
+     */
+    public PaginationAction(JDA api)
+    {
+        super(api, null, null);
+        this.maxLimit = 0;
+        this.minLimit = 0;
+        this.limit = new AtomicInteger(0);
+    }
+
+    /**
+     * The current amount of cached entities for this PaginationAction
+     *
+     * @return int size of cached entities
+     */
+    public int recentSize()
+    {
+        return cached.size();
+    }
+
+    /**
+     * Whether the cache of this PaginationAction is empty.
+     * <br>Logically equivalent to {@code recentSie() == 0}.
+     *
+     * @return True, if no entities have been retrieve yet.
+     */
+    public boolean isEmpty()
+    {
+        return cached.isEmpty();
+    }
+
+    /**
+     * The currently cached entities of recent execution tasks.
+     * <br>Every {@link net.dv8tion.jda.core.requests.RestAction RestAction} success
+     * adds to this List. (Thread-Safe due to {@link java.util.concurrent.CopyOnWriteArrayList CopyOnWriteArrayList})
+     *
+     * @return Immutable {@link java.util.List List} containing all currently cached entities for this PaginationAction
+     */
+    public List<T> getRecent()
+    {
+        return Collections.unmodifiableList(cached);
+    }
+
+    /**
+     * The most recent entity retrieved by this PaginationAction instance
+     *
+     * @throws java.util.NoSuchElementException
+     *         If no entities have been retrieved yet (see {@link #isEmpty()})
+     *
+     * @return The most recent cached entity
+     */
+    public T getLast()
+    {
+        if (cached.isEmpty())
+            throw new NoSuchElementException("No entities have been retrieved yet.");
+        return cached.get(cached.size() - 1);
+    }
+
+    /**
+     * The first cached entity retrieved by this PaginationAction instance
+     *
+     * @throws java.util.NoSuchElementException
+     *         If no entities have been retrieved yet (see {@link #isEmpty()})
+     *
+     * @return The very first cached entity
+     */
+    public T getFirst()
+    {
+        if (cached.isEmpty())
+            throw new NoSuchElementException("No entities have been retrieved yet.");
+        return cached.get(0);
+    }
+
+    /**
+     * Sets the limit that should be used in the next RestAction completion
+     * call or by the next iterator retrieve call.
+     *
+     * @param  limit
+     *         The limit to use
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided limit is out of range
+     *
+     * @return The current PaginationAction implementation instance
+     */
+    public M limit(int limit)
+    {
+        Args.check(maxLimit == 0 || limit <= maxLimit, "Limit must not exceed %d!", maxLimit);
+        Args.check(minLimit == 0 || limit >= minLimit, "Limit must be greater or equal to %d", minLimit);
+
+        this.limit.set(limit);
+        return (M) this;
+    }
+
+    /**
+     * The maximum limit that can be used for this PaginationAction
+     * <br>Limits provided to {@link #limit(int)} must not be greater
+     * than the returned value.
+     * <br>If no maximum limit is used this will return {@code 0}.
+     * That means there is no upper border for limiting this PaginationAction
+     *
+     * @return The maximum limit
+     */
+    public final int getMaxLimit()
+    {
+        return maxLimit;
+    }
+
+    /**
+     * The minimum limit that can be used for this PaginationAction
+     * <br>Limits provided to {@link #limit(int)} must not be less
+     * than the returned value.
+     * <br>If no minimum limit is used this will return {@code 0}.
+     * That means there is no lower border for limiting this PaginationAction
+     *
+     * @return The minimum limit
+     */
+    public final int getMinLimit()
+    {
+        return minLimit;
+    }
+
+    /**
+     * The currently used limit.
+     * <br>If this PaginationAction does not use limitation
+     * this will return {@code 0}
+     *
+     * @return limit
+     */
+    public final int getLimit()
+    {
+        return limit.get();
+    }
+
+    /**
+     * {@link net.dv8tion.jda.core.requests.restaction.pagination.PaginationAction.PaginationIterator PaginationIterator}
+     * that will iterate over all entities for this PaginationAction.
+     *
+     * @return new PaginationIterator
+     */
+    @Override
+    public PaginationIterator iterator()
+    {
+        return new PaginationIterator();
+    }
+
+    @Override
+    public Spliterator<T> spliterator()
+    {
+        return Spliterators.spliteratorUnknownSize(iterator(), Spliterator.IMMUTABLE);
+    }
+
+    /**
+     * A sequential {@link java.util.stream.Stream Stream} with this PaginationAction as its source.
+     *
+     * @return a sequential {@code Stream} over the elements in this PaginationAction
+     */
+    public Stream<T> stream()
+    {
+        return StreamSupport.stream(spliterator(), false);
+    }
+
+    /**
+     * Returns a possibly parallel {@link java.util.stream.Stream Stream} with this PaginationAction as its
+     * source. It is allowable for this method to return a sequential stream.
+     *
+     * @return a sequential {@code Stream} over the elements in this PaginationAction
+     */
+    public Stream<T> parallelStream()
+    {
+        return StreamSupport.stream(spliterator(), true);
+    }
+
+    protected abstract void finalizeRoute();
+    protected abstract void handleResponse(Response response, Request request);
+
+    /**
+     * Iterator implementation for a {@link net.dv8tion.jda.core.requests.restaction.pagination.PaginationAction PaginationAction}.
+     * <br>This iterator will first iterate over all currently cached entities and continue to retrieve new entities
+     * as needed.
+     *
+     * <p>To retrieve new entities after reaching the end of the current cache, this iterator will
+     * request a List of new entities through a call of {@link net.dv8tion.jda.core.requests.RestAction#complete() RestAction.complete()}.
+     * <br><b>It is recommended to use the highest possible limit for this task. (see {@link #limit(int)})</b>
+     */
+    public class PaginationIterator implements Iterator<T>
+    {
+        protected int current = 0;
+
+        @Override
+        public boolean hasNext()
+        {
+            if (current < 0)
+                return false;
+
+            if (hitEnd())
+            {
+                synchronized (limit)
+                {
+                    final int tmp = limit.getAndSet(maxLimit);
+                    complete();
+                    limit.set(tmp);
+                }
+
+                if (!hitEnd())
+                    return true;
+
+                // -1 indicates that the real end has been reached
+                current = -1;
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public T next()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException("Reached End of pagination task!");
+            return cached.get(current++);
+        }
+
+        protected boolean hitEnd()
+        {
+            return current < 0 || current >= cached.size();
+        }
+
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/ReactionPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/ReactionPaginationAction.java
@@ -1,0 +1,118 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.requests.restaction.pagination;
+
+import net.dv8tion.jda.core.entities.EntityBuilder;
+import net.dv8tion.jda.core.entities.MessageReaction;
+import net.dv8tion.jda.core.entities.User;
+import net.dv8tion.jda.core.requests.Request;
+import net.dv8tion.jda.core.requests.Response;
+import net.dv8tion.jda.core.requests.Route;
+import net.dv8tion.jda.core.utils.MiscUtil;
+import org.json.JSONArray;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * {@link net.dv8tion.jda.core.requests.restaction.pagination.PaginationAction PaginationAction}
+ * that paginates the endpoints:
+ * <ul>
+ *     <li>{@link net.dv8tion.jda.core.requests.Route.Messages#GET_REACTION_USERS_LIMIT Route.Messages.GET_REACTION_USERS_LIMIT}</li>
+ *     <li>{@link net.dv8tion.jda.core.requests.Route.Messages#GET_REACTION_USERS_AFTER Route.Messages.GET_REACTION_USERS_AFTER}</li>
+ * </ul>
+ *
+ * <p><b>Must provide not-null {@link net.dv8tion.jda.core.entities.MessageReaction MessageReaction} to compile a valid
+ * pagination route.</b>
+ *
+ * @since  3.1
+ * @author Florian Spieß
+ */
+public class ReactionPaginationAction extends PaginationAction<User, ReactionPaginationAction>
+{
+
+    protected final MessageReaction reaction;
+    protected final String code;
+
+    /**
+     * Creates a new PaginationAction instance
+     *
+     * @param reaction
+     *        The target {@link net.dv8tion.jda.core.entities.MessageReaction MessageReaction}
+     */
+    public ReactionPaginationAction(MessageReaction reaction)
+    {
+        super(reaction.getJDA(), 1, 100, 100);
+        this.reaction = reaction;
+
+        MessageReaction.ReactionEmote emote = reaction.getEmote();
+        code = emote.isEmote()
+            ? emote.getName() + ":" + emote.getId()
+            : MiscUtil.encodeUTF8(emote.getName());
+    }
+
+    /**
+     * The current target {@link net.dv8tion.jda.core.entities.MessageReaction MessageReaction}
+     *
+     * @return The current MessageReaction
+     */
+    public MessageReaction getReaction()
+    {
+        return reaction;
+    }
+
+
+    @Override
+    protected void finalizeRoute()
+    {
+        String after = null;
+        String limit = String.valueOf(getLimit());
+        if (recentSize() > 0)
+            after = getLast().getId();
+
+        String channel = reaction.getChannel().getId();
+        String message = reaction.getMessageId();
+
+        if (after != null)
+            route = Route.Messages.GET_REACTION_USERS_AFTER.compile(channel, message, code, limit, after);
+        else
+            route = Route.Messages.GET_REACTION_USERS_LIMIT.compile(channel, message, code, limit);
+    }
+
+    @Override
+    protected void handleResponse(Response response, Request request)
+    {
+        if (!response.isOk())
+        {
+            request.onFailure(response);
+            return;
+        }
+
+        final EntityBuilder builder = EntityBuilder.get(api);
+        final JSONArray array = response.getArray();
+        final List<User> users = new LinkedList<>();
+        for (int i = 0; i < array.length(); i++)
+        {
+            final User user = builder.createFakeUser(array.getJSONObject(i), false);
+            cached.add(user);
+            users.add(user);
+        }
+
+        request.onSuccess(users);
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/package-info.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/package-info.java
@@ -1,0 +1,26 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Extensions of {@link net.dv8tion.jda.core.requests.RestAction RestAction} that allow
+ * to access paginated discord endpoints like {@link net.dv8tion.jda.core.requests.Route.Messages#GET_REACTION_USERS_LIMIT Route.Messages.GET_REACTION_USERS_LIMIT}
+ * <br>The {@link net.dv8tion.jda.core.requests.restaction.pagination.PaginationAction PaginationAction} is designed to work
+ * as an {@link java.lang.Iterable Iterable} of the specified endpoint. Each implementation specifies the endpoints it will
+ * use in the class-level javadoc
+ *
+ * @since 3.1
+ */
+package net.dv8tion.jda.core.requests.restaction.pagination;

--- a/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
@@ -17,7 +17,9 @@ package net.dv8tion.jda.core.utils;
 
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
+import java.net.URLEncoder;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -91,5 +93,29 @@ public class MiscUtil
     public static String getDateTimeString(OffsetDateTime time)
     {
         return time.format(dtFormatter);
+    }
+
+    /**
+     * URL-Encodes the given String to UTF-8 after
+     * form-data specifications (space {@literal ->} +)
+     *
+     * @param  chars
+     *         The characters to encode
+     *
+     * @throws java.lang.RuntimeException
+     *         If somehow the encoding fails
+     *
+     * @return The encoded String
+     */
+    public static String encodeUTF8(String chars)
+    {
+        try
+        {
+            return URLEncoder.encode(chars, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            throw new RuntimeException(e); // thanks JDK 1.4
+        }
     }
 }


### PR DESCRIPTION
The `PaginationAction` is iterable!
Example:
```java
MessageReaction reaction = message.getReactions().get(0);
for (User user : reaction.getUsers())
{
    System.out.printf("%s#%s%n", user.getName(), user.getDiscriminator());
}
```
Where **MessageReaction#getUsers()** returns a `ReactionPaginationAction : PaginationAction<User, ReactionPaginationAction>`

The `PaginationAction` itself is a `RestAction` but defines a `List` of the specified entity: `RestAction<List<T>>`

The `PaginationAction.PaginationIterator` iterates over all cached entities and retrieves a new list of entities as needed.
That way you can seamlessly iterate over all entities of an endpoint!