### PR TITLE
Added MessageChannel#getLatestMessageId and associated methods

### DIFF
--- a/src/main/java/net/dv8tion/jda/client/entities/impl/GroupImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/GroupImpl.java
@@ -41,11 +41,27 @@ public class GroupImpl implements Group
     private User owner;
     private String name;
     private String iconId;
+    private String lastMessageId;
 
     public GroupImpl(String id, JDAImpl api)
     {
         this.id = id;
         this.api = api;
+    }
+
+    @Override
+    public String getLatestMessageId()
+    {
+        String messageId = lastMessageId;
+        if (messageId == null)
+            throw new IllegalStateException("No last message id found.");
+        return messageId;
+    }
+
+    @Override
+    public boolean hasLatestMessage()
+    {
+        return lastMessageId != null;
     }
 
     @Override
@@ -190,6 +206,12 @@ public class GroupImpl implements Group
     public GroupImpl setIconId(String iconId)
     {
         this.iconId = iconId;
+        return this;
+    }
+
+    public GroupImpl setLastMessageId(String lastMessageId)
+    {
+        this.lastMessageId = lastMessageId;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -601,6 +601,7 @@ public class EntityBuilder
         }
 
         return channel
+                .setLastMessageId(json.isNull("last_message_id") ? null : json.getString("last_message_id"))
                 .setName(json.getString("name"))
                 .setTopic(json.isNull("topic") ? "" : json.getString("topic"))
                 .setRawPosition(json.getInt("position"));
@@ -650,7 +651,8 @@ public class EntityBuilder
             user = (UserImpl) createFakeUser(recipient, true);
         }
 
-        PrivateChannelImpl priv = new PrivateChannelImpl(privatechat.getString("id"), user);
+        PrivateChannelImpl priv = new PrivateChannelImpl(privatechat.getString("id"), user)
+                .setLastMessageId(privatechat.isNull("last_message_id") ? null : privatechat.getString("last_message_id"));
         user.setPrivateChannel(priv);
 
         if (user.isFake())
@@ -1101,6 +1103,7 @@ public class EntityBuilder
         String ownerId = groupJson.getString("owner_id");
         String name = !groupJson.isNull("name") ? groupJson.getString("name") : null;
         String iconId = !groupJson.isNull("icon") ? groupJson.getString("icon") : null;
+        String lastMessage = !groupJson.isNull("last_message_id") ? groupJson.getString("last_message_id") : null;
 
         GroupImpl group = (GroupImpl) api.asClient().getGroupById(groupId);
         if (group == null)
@@ -1124,7 +1127,9 @@ public class EntityBuilder
             throw new IllegalArgumentException("Attempted to build a Group, but could not find user by provided owner id." +
                     "This should not be possible because the owner should be IN the group!");
 
-        return group.setOwner(owner)
+        return group
+                .setOwner(owner)
+                .setLastMessageId(lastMessage)
                 .setName(name)
                 .setIconId(iconId);
     }

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -673,65 +673,6 @@ public interface MessageChannel extends ISnowflake
     }
 
     /**
-     * Retrieves the most recent {@link net.dv8tion.jda.core.entities.Message Message}
-     * sent in this MessageChannel
-     * <br><b>Only use if {@link #hasLatestMessage()} is {@code true}</b>
-     *
-     * <p>Possible {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} include:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
-     *     <br>If the message for the {@link #getLatestMessageId() most recent id} has been removed</li>
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
-     *     <br>If this channel has been removed before finishing the RestAction task</li>
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
-     *     <br>If we lost access to this channel before finishing the RestAction task (possibly kicked)</li>
-     * </ul>
-     *
-     * @throws java.lang.IllegalStateException
-     *         If this MessageChannel has no tracked latest message id. See {@link #hasLatestMessage()}
-     * @throws net.dv8tion.jda.core.exceptions.PermissionException
-     *         If this is a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}  and the currently logged in account
-     *         does not have the {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY MESSAGE_HISTORY} Permissions
-     *
-     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message Message}
-     *         <br>The most recent message sent in this MessageChannel
-     *
-     * @see    #hasLatestMessage()
-     * @see    #getLatestMessageId()
-     */
-    default RestAction<Message> getLatestMessage()
-    {
-        final String id = getLatestMessageId();
-        if (getJDA().getAccountType() == AccountType.BOT)
-            return getMessageById(id);
-
-        Route.CompiledRoute route = Route.Messages.GET_MESSAGE_HISTORY.compile(getId(), String.valueOf(1));
-        return new RestAction<Message>(getJDA(), route, null)
-        {
-            @Override
-            protected void handleResponse(Response response, Request request)
-            {
-                if (!response.isOk())
-                {
-                    request.onFailure(response);
-                    return;
-                }
-
-                JSONArray array = response.getArray();
-                if (array.length() < 1)
-                {
-                    request.onFailure(
-                        new IllegalStateException(String.format("MessageHistory for MessageChannel with ID: %s is empty!", getId())));
-                    return;
-                }
-                Message msg = EntityBuilder.get(api).createMessage(array.getJSONObject(0), MessageChannel.this, false);
-
-                request.onSuccess(msg);
-            }
-        };
-    }
-
-    /**
      * Creates a new {@link MessageHistory MessageHistory} object for each call of this method.
      * <br>MessageHistory is <b>NOT</b> an internal message cache, but rather it queries the Discord servers for previously sent messages.
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
@@ -16,8 +16,8 @@
 
 package net.dv8tion.jda.core.entities;
 
+import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.exceptions.PermissionException;
 import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
@@ -37,7 +37,6 @@ import java.util.*;
  */
 public class MessageHistory
 {
-    protected final JDAImpl api;
     protected final MessageChannel channel;
 
     protected ListOrderedMap<String, Message> history = new ListOrderedMap<>();
@@ -50,11 +49,20 @@ public class MessageHistory
      */
     public MessageHistory(MessageChannel channel)
     {
-        this.api = (JDAImpl) channel.getJDA();
         this.channel = channel;
         if (channel instanceof TextChannel &&
-                !((TextChannel) channel).getGuild().getMember(api.getSelfUser()).hasPermission(Permission.MESSAGE_HISTORY))
+                !((TextChannel) channel).getGuild().getSelfMember().hasPermission(Permission.MESSAGE_HISTORY))
             throw new PermissionException(Permission.MESSAGE_HISTORY);
+    }
+
+    /**
+     * The corresponding JDA instance for this MessageHistory
+     *
+     * @return The corresponding JDA instance
+     */
+    public JDA getJDA()
+    {
+        return channel.getJDA();
     }
 
     /**
@@ -130,7 +138,7 @@ public class MessageHistory
             route = Route.Messages.GET_MESSAGE_HISTORY.compile(channel.getId(), Integer.toString(amount));
         else
             route = Route.Messages.GET_MESSAGE_HISTORY_BEFORE.compile(channel.getId(), Integer.toString(amount), history.lastKey());
-        return new RestAction<List<Message>>(api, route, null)
+        return new RestAction<List<Message>>(getJDA(), route, null)
         {
             @Override
             protected void handleResponse(Response response, Request request)
@@ -207,7 +215,7 @@ public class MessageHistory
             throw new IllegalStateException("No messages have been retrieved yet, so there is no message to act as a marker to retrieve more recent messages based on.");
 
         Route.CompiledRoute route = Route.Messages.GET_MESSAGE_HISTORY_AFTER.compile(channel.getId(), Integer.toString(amount), history.firstKey());
-        return new RestAction<List<Message>>(api, route, null)
+        return new RestAction<List<Message>>(getJDA(), route, null)
         {
             @Override
             protected void handleResponse(Response response, Request request)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
@@ -31,6 +31,7 @@ public class PrivateChannelImpl implements PrivateChannel
     private final String id;
     private final User user;
 
+    private String lastMessageId;
     private Call currentCall = null;
     private boolean fake = false;
 
@@ -44,6 +45,21 @@ public class PrivateChannelImpl implements PrivateChannel
     public User getUser()
     {
         return user;
+    }
+
+    @Override
+    public String getLatestMessageId()
+    {
+        String messageId = lastMessageId;
+        if (messageId == null)
+            throw new IllegalStateException("No last message id found.");
+        return messageId;
+    }
+
+    @Override
+    public boolean hasLatestMessage()
+    {
+        return lastMessageId != null;
     }
 
     @Override
@@ -114,6 +130,12 @@ public class PrivateChannelImpl implements PrivateChannel
     public PrivateChannelImpl setCurrentCall(Call currentCall)
     {
         this.currentCall = currentCall;
+        return this;
+    }
+
+    public PrivateChannelImpl setLastMessageId(String id)
+    {
+        this.lastMessageId = id;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -322,13 +322,6 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
-    public RestAction<Message> getLatestMessage()
-    {
-        checkPermission(Permission.MESSAGE_HISTORY);
-        return TextChannel.super.getLatestMessage();
-    }
-
-    @Override
     public RestAction<MessageHistory> getHistoryAround(String messageId, int limit)
     {
         checkPermission(Permission.MESSAGE_READ);

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -53,6 +53,7 @@ public class TextChannelImpl implements TextChannel
 
     private String name;
     private String topic;
+    private String lastMessageId;
     private int rawPosition;
 
     public TextChannelImpl(String id, Guild guild)
@@ -188,6 +189,21 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
+    public String getLatestMessageId()
+    {
+        String messageId = lastMessageId;
+        if (messageId == null)
+            throw new IllegalStateException("No last message id found.");
+        return messageId;
+    }
+
+    @Override
+    public boolean hasLatestMessage()
+    {
+        return lastMessageId != null;
+    }
+
+    @Override
     public String getName()
     {
         return name;
@@ -303,6 +319,13 @@ public class TextChannelImpl implements TextChannel
 
         //Call MessageChannel's default method
         return TextChannel.super.deleteMessageById(messageId);
+    }
+
+    @Override
+    public RestAction<Message> getLatestMessage()
+    {
+        checkPermission(Permission.MESSAGE_HISTORY);
+        return TextChannel.super.getLatestMessage();
     }
 
     @Override
@@ -550,6 +573,12 @@ public class TextChannelImpl implements TextChannel
     public TextChannelImpl setRawPosition(int rawPosition)
     {
         this.rawPosition = rawPosition;
+        return this;
+    }
+
+    public TextChannelImpl setLastMessageId(String id)
+    {
+        this.lastMessageId = id;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageCreateHandler.java
@@ -15,12 +15,14 @@
  */
 package net.dv8tion.jda.core.handle;
 
+import net.dv8tion.jda.client.entities.impl.GroupImpl;
 import net.dv8tion.jda.client.events.message.group.GroupMessageReceivedEvent;
 import net.dv8tion.jda.core.entities.EntityBuilder;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageType;
-import net.dv8tion.jda.core.entities.TextChannel;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.entities.impl.PrivateChannelImpl;
+import net.dv8tion.jda.core.entities.impl.TextChannelImpl;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.core.events.message.priv.PrivateMessageReceivedEvent;
@@ -92,11 +94,12 @@ public class MessageCreateHandler extends SocketHandler
         {
             case TEXT:
             {
-                TextChannel channel = message.getTextChannel();
+                TextChannelImpl channel = (TextChannelImpl) message.getTextChannel();
                 if (GuildLock.get(api).isLocked(channel.getGuild().getId()))
                 {
                     return channel.getGuild().getId();
                 }
+                channel.setLastMessageId(message.getId());
                 api.getEventManager().handle(
                         new GuildMessageReceivedEvent(
                                 api, responseNumber,
@@ -105,6 +108,8 @@ public class MessageCreateHandler extends SocketHandler
             }
             case PRIVATE:
             {
+                PrivateChannelImpl channel = (PrivateChannelImpl) message.getPrivateChannel();
+                channel.setLastMessageId(message.getId());
                 api.getEventManager().handle(
                         new PrivateMessageReceivedEvent(
                                 api, responseNumber,
@@ -113,6 +118,8 @@ public class MessageCreateHandler extends SocketHandler
             }
             case GROUP:
             {
+                GroupImpl channel = (GroupImpl) message.getGroup();
+                channel.setLastMessageId(message.getId());
                 api.getEventManager().handle(
                         new GroupMessageReceivedEvent(
                                 api, responseNumber,

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageDeleteHandler.java
@@ -68,7 +68,7 @@ public class MessageDeleteHandler extends SocketHandler
             {
                 return tChan.getGuild().getId();
             }
-            if (!tChan.hasLatestMessage() && messageId.equals(tChan.getLatestMessageId()))
+            if (tChan.hasLatestMessage() && messageId.equals(tChan.getLatestMessageId()))
                 tChan.setLastMessageId(null); // Reset latest message id as it was deleted.
             api.getEventManager().handle(
                     new GuildMessageDeleteEvent(
@@ -78,7 +78,7 @@ public class MessageDeleteHandler extends SocketHandler
         else if (channel instanceof PrivateChannel)
         {
             PrivateChannelImpl pChan = (PrivateChannelImpl) channel;
-            if (!channel.hasLatestMessage() && messageId.equals(channel.getId()))
+            if (channel.hasLatestMessage() && messageId.equals(channel.getLatestMessageId()))
                 pChan.setLastMessageId(null); // Reset latest message id as it was deleted.
             api.getEventManager().handle(
                     new PrivateMessageDeleteEvent(
@@ -88,7 +88,7 @@ public class MessageDeleteHandler extends SocketHandler
         else
         {
             GroupImpl group = (GroupImpl) channel;
-            if (!channel.hasLatestMessage() && messageId.equals(channel.getId()))
+            if (channel.hasLatestMessage() && messageId.equals(channel.getLatestMessageId()))
                 group.setLastMessageId(null); // Reset latest message id as it was deleted.
             api.getEventManager().handle(
                     new GroupMessageDeleteEvent(


### PR DESCRIPTION
Includes:

* MessageChannel#getLatestMessageId() : `String`
* MessageChannel#hasLatestMessage() : `boolean`
* ~~MessageChannel#getLatestMessage() : `RestAction<Message>`~~

It is not possible to keep track of the latest message when it is deleted as we do not provide cached messages in JDA and thus
are unable to go back in history to look for the next most recent message.

As a substitute it is always possible to simply use a `MessageHistory` instance