### PR TITLE
Compensate for null icon in ApplicationInfo JSON

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -1195,7 +1195,7 @@ public class EntityBuilder
     {
         final String description = object.getString("description");
         final boolean doesBotRequireCodeGrant = object.getBoolean("bot_require_code_grant");
-        final String iconId = object.has("icon") ? object.getString("icon") : null;
+        final String iconId = object.has("icon") && !object.isNull("icon") ? object.getString("icon") : null;
         final String id = object.getString("id");
         final String name = object.getString("name");
         final boolean isBotPublic = object.getBoolean("bot_public");


### PR DESCRIPTION
I was playing around with making a Discord bot, and I got a crash when trying to grab the invite URL. I boiled it down to the fact that in the `ApplicationInfo` JSON, `icon` may be present, but still `null`. I coded up a quick fix.