### PR TITLE
Moved to primitive longs as primary snowflake storage type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.apache.commons:commons-collections4:4.1'
     compile 'org.json:json:20160810'
+    compile 'net.sf.trove4j:trove4j:3.0.3'
 
     //Native Library Support
     compile 'net.java.dev.jna:jna:4.2.2'

--- a/src/main/java/com/iwebpp/crypto/TweetNaclFast.java
+++ b/src/main/java/com/iwebpp/crypto/TweetNaclFast.java
@@ -10,7 +10,6 @@ package com.iwebpp.crypto;
 import java.io.UnsupportedEncodingException;
 import java.security.SecureRandom;
 import java.util.Base64;
-import java.lang.System;
 import java.util.concurrent.atomic.AtomicLong;
 
 /*

--- a/src/main/java/net/dv8tion/jda/bot/entities/impl/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/bot/entities/impl/ApplicationInfoImpl.java
@@ -16,26 +16,28 @@
 
 package net.dv8tion.jda.bot.entities.impl;
 
-import java.util.Arrays;
-import java.util.Collection;
 import net.dv8tion.jda.bot.entities.ApplicationInfo;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.User;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 public class ApplicationInfoImpl implements ApplicationInfo
 {
     private final JDA api;
 
-    private final String description;
+
     private final boolean doesBotRequireCodeGrant;
-    private final String iconId;
-    private final String id;
     private final boolean isBotPublic;
+    private final long id;
+    private final String iconId;
+    private final String description;
     private final String name;
     private final User owner;
 
-    public ApplicationInfoImpl(JDA api, String description, boolean doesBotRequireCodeGrant, String iconId, String id,
+    public ApplicationInfoImpl(JDA api, String description, boolean doesBotRequireCodeGrant, String iconId, long id,
             boolean isBotPublic, String name, User owner)
     {
         this.api = api;
@@ -57,7 +59,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
     @Override
     public boolean equals(final Object obj)
     {
-        return obj instanceof ApplicationInfoImpl && this.id.equals(((ApplicationInfoImpl) obj).id);
+        return obj instanceof ApplicationInfoImpl && this.id == ((ApplicationInfoImpl) obj).id;
     }
 
     @Override
@@ -80,7 +82,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return this.id;
     }
@@ -143,7 +145,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
     @Override
     public int hashCode()
     {
-        return this.id.hashCode();
+        return Long.hashCode(this.id);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/bot/entities/impl/JDABotImpl.java
+++ b/src/main/java/net/dv8tion/jda/bot/entities/impl/JDABotImpl.java
@@ -52,7 +52,7 @@ public class JDABotImpl implements JDABot
         return new RestAction<ApplicationInfo>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<ApplicationInfo> request)
             {
                 if (!response.isOk())
                 {

--- a/src/main/java/net/dv8tion/jda/client/JDAClient.java
+++ b/src/main/java/net/dv8tion/jda/client/JDAClient.java
@@ -19,7 +19,6 @@ package net.dv8tion.jda.client;
 import net.dv8tion.jda.client.entities.*;
 import net.dv8tion.jda.client.requests.restaction.ApplicationAction;
 import net.dv8tion.jda.core.JDA;
-import net.dv8tion.jda.core.entities.Invite;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.requests.RestAction;
@@ -33,6 +32,7 @@ public interface JDAClient
     List<Group> getGroups();
     List<Group> getGroupsByName(String name, boolean ignoreCase);
     Group getGroupById(String id);
+    Group getGroupById(long id);
 
     List<Relationship> getRelationships();
     List<Relationship> getRelationships(RelationshipType type);
@@ -41,13 +41,16 @@ public interface JDAClient
     Relationship getRelationship(User user);
     Relationship getRelationship(Member member);
     Relationship getRelationshipById(String id);
+    Relationship getRelationshipById(long id);
     Relationship getRelationshipById(String id, RelationshipType type);
+    Relationship getRelationshipById(long id, RelationshipType type);
 
     List<Friend> getFriends();
     List<Friend> getFriendsByName(String name, boolean ignoreCase);
     Friend getFriend(User user);
     Friend getFriend(Member member);
     Friend getFriendById(String id);
+    Friend getFriendById(long id);
 
     UserSettings getSettings();
 

--- a/src/main/java/net/dv8tion/jda/client/entities/Call.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/Call.java
@@ -30,6 +30,7 @@ public interface Call extends AudioChannel
     Group getGroup();
     PrivateChannel getPrivateChannel();
     String getMessageId();
+    long getMessageIdLong();
 
     List<CallUser> getRingingUsers();
     List<CallUser> getConnectedUsers();

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/ApplicationImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/ApplicationImpl.java
@@ -66,7 +66,7 @@ public class ApplicationImpl implements Application
         return new RestAction<Application.Bot>(this.api, Route.Applications.CREATE_BOT.compile(getId()), null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Application.Bot> request)
             {
                 if (response.isOk())
                     request.onSuccess(ApplicationImpl.this.bot = new BotImpl(response.getObject()));
@@ -82,7 +82,7 @@ public class ApplicationImpl implements Application
         return new RestAction<Void>(this.api, Route.Applications.DELETE_APPLICATION.compile(getId()), null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -222,7 +222,7 @@ public class ApplicationImpl implements Application
         return new RestAction<Application>(this.api, route, null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Application> request)
             {
                 if (response.isOk())
                     request.onSuccess(ApplicationImpl.this.updateFromJson(response.getObject()));
@@ -395,7 +395,7 @@ public class ApplicationImpl implements Application
             return new RestAction<Bot>(getJDA(), route, null)
             {
                 @Override
-                protected void handleResponse(final Response response, final Request request)
+                protected void handleResponse(final Response response, final Request<Bot> request)
                 {
                     if (response.isOk())
                         request.onSuccess(BotImpl.this.updateFromJson(response.getObject()));

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/ApplicationImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/ApplicationImpl.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.client.entities.impl;
 
-import java.util.*;
 import net.dv8tion.jda.client.entities.Application;
 import net.dv8tion.jda.client.managers.ApplicationManager;
 import net.dv8tion.jda.client.managers.ApplicationManagerUpdatable;
@@ -28,6 +27,8 @@ import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.requests.Route;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.util.*;
 
 public class ApplicationImpl implements Application
 {
@@ -42,7 +43,7 @@ public class ApplicationImpl implements Application
     private boolean doesBotRequireCodeGrant;
     private int flags;
     private String iconId;
-    private String id;
+    private long id;
     private boolean isBotPublic;
     private String name;
     private List<String> redirectUris;
@@ -62,7 +63,7 @@ public class ApplicationImpl implements Application
         if (this.hasBot())
             return new RestAction.EmptyRestAction<>(this.bot);
 
-        return new RestAction<Application.Bot>(this.api, Route.Applications.CREATE_BOT.compile(this.id), null)
+        return new RestAction<Application.Bot>(this.api, Route.Applications.CREATE_BOT.compile(getId()), null)
         {
             @Override
             protected void handleResponse(final Response response, final Request request)
@@ -78,7 +79,7 @@ public class ApplicationImpl implements Application
     @Override
     public RestAction<Void> delete()
     {
-        return new RestAction<Void>(this.api, Route.Applications.DELETE_APPLICATION.compile(this.id), null)
+        return new RestAction<Void>(this.api, Route.Applications.DELETE_APPLICATION.compile(getId()), null)
         {
             @Override
             protected void handleResponse(final Response response, final Request request)
@@ -100,7 +101,7 @@ public class ApplicationImpl implements Application
     @Override
     public boolean equals(final Object obj)
     {
-        return obj instanceof ApplicationImpl && this.id.equals(((ApplicationImpl) obj).id);
+        return obj instanceof ApplicationImpl && this.id == ((ApplicationImpl) obj).id;
     }
 
     @Override
@@ -135,7 +136,7 @@ public class ApplicationImpl implements Application
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return this.id;
     }
@@ -217,7 +218,7 @@ public class ApplicationImpl implements Application
     @Override
     public RestAction<Application> resetSecret()
     {
-        Route.CompiledRoute route = Route.Applications.RESET_BOT_TOKEN.compile(this.id);
+        Route.CompiledRoute route = Route.Applications.RESET_BOT_TOKEN.compile(getId());
         return new RestAction<Application>(this.api, route, null)
         {
             @Override
@@ -258,7 +259,7 @@ public class ApplicationImpl implements Application
         this.description = object.getString("description");
         this.flags = object.getInt("flags");
         this.iconId = object.has("icon") ? object.getString("icon") : null;
-        this.id = object.getString("id");
+        this.id = object.getLong("id");
         this.name = object.getString("name");
 
         final JSONArray redirectUriArray = object.getJSONArray("redirect_uris");
@@ -279,9 +280,9 @@ public class ApplicationImpl implements Application
 
     public class BotImpl implements Application.Bot
     {
+        private long id;
         private String avatarId;
         private String discriminator;
-        private String id;
         private String name;
         private String token;
 
@@ -293,7 +294,7 @@ public class ApplicationImpl implements Application
         @Override
         public boolean equals(final Object obj)
         {
-            return obj instanceof BotImpl && this.id.equals(((BotImpl) obj).id);
+            return obj instanceof BotImpl && this.id == ((BotImpl) obj).id;
         }
 
         @Override
@@ -322,7 +323,7 @@ public class ApplicationImpl implements Application
         }
 
         @Override
-        public String getId()
+        public long getIdLong()
         {
             return this.id;
         }
@@ -384,13 +385,13 @@ public class ApplicationImpl implements Application
         @Override
         public int hashCode()
         {
-            return this.id.hashCode();
+            return Long.hashCode(this.id);
         }
 
         @Override
         public RestAction<Bot> resetToken()
         {
-            Route.CompiledRoute route = Route.Applications.RESET_BOT_TOKEN.compile(this.id);
+            Route.CompiledRoute route = Route.Applications.RESET_BOT_TOKEN.compile(getId());
             return new RestAction<Bot>(getJDA(), route, null)
             {
                 @Override
@@ -415,7 +416,7 @@ public class ApplicationImpl implements Application
             this.name = object.getString("username");
             this.discriminator = object.getString("discriminator");
             this.token = object.getString("token");
-            this.id = object.getString("id");
+            this.id = object.getLong("id");
             this.avatarId = object.has("avatar") ? object.getString("avatar") : null;
 
             return this;

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/AuthorizedApplicationImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/AuthorizedApplicationImpl.java
@@ -58,7 +58,7 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
         return new RestAction<Void>(this.api, route, null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/AuthorizedApplicationImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/AuthorizedApplicationImpl.java
@@ -31,15 +31,15 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
 {
     private final JDA api;
 
-    private final String authId;
+    private final long id;
+    private final long authId;
     private final String description;
     private final String iconId;
-    private final String id;
     private final String name;
     private final List<String> scopes;
 
-    public AuthorizedApplicationImpl(final JDA api, final String authId, final String description, final String iconId,
-            final String id, final String name, final List<String> scopes)
+    public AuthorizedApplicationImpl(final JDA api, final long authId, final String description, final String iconId,
+            final long id, final String name, final List<String> scopes)
     {
         this.api = api;
         this.authId = authId;
@@ -53,7 +53,7 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
     @Override
     public RestAction<Void> delete()
     {
-        CompiledRoute route = Route.Applications.DELETE_AUTHORIZED_APPLICATION.compile(this.authId);
+        CompiledRoute route = Route.Applications.DELETE_AUTHORIZED_APPLICATION.compile(getAuthId());
 
         return new RestAction<Void>(this.api, route, null)
         {
@@ -71,13 +71,13 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
     @Override
     public boolean equals(final Object obj)
     {
-        return obj instanceof AuthorizedApplicationImpl && this.id.equals(((AuthorizedApplicationImpl) obj).id);
+        return obj instanceof AuthorizedApplicationImpl && this.id == ((AuthorizedApplicationImpl) obj).id;
     }
 
     @Override
     public String getAuthId()
     {
-        return this.authId;
+        return String.valueOf(this.authId);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return this.id;
     }
@@ -126,7 +126,7 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
     @Override
     public int hashCode()
     {
-        return this.id.hashCode();
+        return Long.hashCode(id);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/BlockedUserImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/BlockedUserImpl.java
@@ -51,7 +51,7 @@ public class BlockedUserImpl implements BlockedUser
     @Override
     public String toString()
     {
-        return "BlockedUser:" + user.getName() + "(" + user.getId() + ")";
+        return "BlockedUser:" + user.getName() + "(" + user.getIdLong() + ")";
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/CallImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/CallImpl.java
@@ -16,27 +16,31 @@
 
 package net.dv8tion.jda.client.entities.impl;
 
+import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.client.entities.Call;
 import net.dv8tion.jda.client.entities.CallUser;
 import net.dv8tion.jda.client.entities.CallableChannel;
 import net.dv8tion.jda.client.entities.Group;
 import net.dv8tion.jda.core.Region;
 import net.dv8tion.jda.core.entities.PrivateChannel;
+import net.dv8tion.jda.core.utils.MiscUtil;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public class CallImpl implements Call
 {
     private final CallableChannel callableChannel;
-    private final String messageId;
+    private final long messageId;
 
-    private HashMap<String, CallUser> callUsers = new HashMap<>();
-    private HashMap<String, CallUser> callUserHistory = new HashMap<>();
+    private TLongObjectMap<CallUser> callUsers = MiscUtil.newLongMap();
+    private TLongObjectMap<CallUser> callUserHistory = MiscUtil.newLongMap();
 
     private Region region;
 
-    public CallImpl(CallableChannel callableChannel, String messageId)
+    public CallImpl(CallableChannel callableChannel, long messageId)
     {
         this.callableChannel = callableChannel;
         this.messageId = messageId;
@@ -75,21 +79,27 @@ public class CallImpl implements Call
     @Override
     public String getMessageId()
     {
+        return String.valueOf(messageId);
+    }
+
+    @Override
+    public long getMessageIdLong()
+    {
         return messageId;
     }
 
     @Override
     public List<CallUser> getRingingUsers()
     {
-        return Collections.unmodifiableList(callUsers.values().stream()
-                .filter(cu -> cu.isRinging())
+        return Collections.unmodifiableList(callUsers.valueCollection().stream()
+                .filter(CallUser::isRinging)
                 .collect(Collectors.toList()));
     }
 
     @Override
     public List<CallUser> getConnectedUsers()
     {
-        return Collections.unmodifiableList(callUsers.values().stream()
+        return Collections.unmodifiableList(callUsers.valueCollection().stream()
                 .filter(cu -> cu.getVoiceState().isInCall())
                 .collect(Collectors.toList()));
     }
@@ -98,26 +108,26 @@ public class CallImpl implements Call
     public List<CallUser> getCallUserHistory()
     {
         return Collections.unmodifiableList(
-                new ArrayList<>(callUserHistory.values()));
+                new ArrayList<>(callUserHistory.valueCollection()));
     }
 
     @Override
     public List<CallUser> getAllCallUsers()
     {
         return Collections.unmodifiableList(
-                new ArrayList<>(callUsers.values()));
+                new ArrayList<>(callUsers.valueCollection()));
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
-        return callableChannel.getId();
+        return callableChannel.getIdLong();
     }
 
     @Override
     public String toString()
     {
-        return "Call(" + getId() + ")";
+        return "Call(" + getIdLong() + ")";
     }
 
     @Override
@@ -127,7 +137,7 @@ public class CallImpl implements Call
             return false;
 
         Call oCall = (Call) o;
-        return getId().equals(oCall.getId()) && Objects.equals(messageId, oCall.getMessageId());
+        return getIdLong() == oCall.getIdLong() && messageId == oCall.getMessageIdLong();
     }
 
     @Override
@@ -142,12 +152,12 @@ public class CallImpl implements Call
         return this;
     }
 
-    public HashMap<String, CallUser> getCallUserMap()
+    public TLongObjectMap<CallUser> getCallUserMap()
     {
         return callUsers;
     }
 
-    public HashMap<String, CallUser> getCallUserHistoryMap()
+    public TLongObjectMap<CallUser> getCallUserHistoryMap()
     {
         return callUserHistory;
     }

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
@@ -261,7 +261,7 @@ public class JDAClientImpl implements JDAClient
         return new RestAction<List<Application>>(api, route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<List<Application>> request)
             {
                 if (response.isOk())
                 {
@@ -291,7 +291,7 @@ public class JDAClientImpl implements JDAClient
         return new RestAction<Application>(api, route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Application> request)
             {
                 if (response.isOk())
                     request.onSuccess(EntityBuilder.get(getJDA()).createApplication(response.getObject()));
@@ -308,7 +308,7 @@ public class JDAClientImpl implements JDAClient
         return new RestAction<List<AuthorizedApplication>>(api, route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<List<AuthorizedApplication>> request)
             {
                 if (response.isOk())
                 {
@@ -338,7 +338,7 @@ public class JDAClientImpl implements JDAClient
         return new RestAction<AuthorizedApplication>(api, route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<AuthorizedApplication> request)
             {
                 if (response.isOk())
                     request.onSuccess(EntityBuilder.get(getJDA()).createAuthorizedApplication(response.getObject()));

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/UserSettingsImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/UserSettingsImpl.java
@@ -140,7 +140,7 @@ public class UserSettingsImpl implements UserSettings
     @Override
     public int hashCode()
     {
-        return getJDA().getSelfUser().getId().hashCode();
+        return Long.hashCode(getJDA().getSelfUser().getIdLong());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/handle/CallDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/CallDeleteHandler.java
@@ -36,9 +36,9 @@ public class CallDeleteHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String channelId = content.getString("channel_id");
+        final long channelId = content.getLong("channel_id");
         CallableChannel channel = api.asClient().getGroupById(channelId);
         if (channel == null)
             channel = api.getPrivateChannelMap().get(channelId);
@@ -61,17 +61,18 @@ public class CallDeleteHandler extends SocketHandler
         {
             GroupImpl group = (GroupImpl) channel;
             group.setCurrentCall(null);
-            call.getCallUserMap().forEach((userId, cUser) ->
+            call.getCallUserMap().forEachKey(userId ->
             {
                 ((JDAClientImpl) api.asClient()).getCallUserMap().remove(userId);
+                return true;
             });
         }
         else
         {
             PrivateChannelImpl priv = (PrivateChannelImpl) channel;
             priv.setCurrentCall(null);
-            ((JDAClientImpl) api.asClient()).getCallUserMap().remove(priv.getUser().getId());
-            ((JDAClientImpl) api.asClient()).getCallUserMap().remove(api.getSelfUser().getId());
+            ((JDAClientImpl) api.asClient()).getCallUserMap().remove(priv.getUser().getIdLong());
+            ((JDAClientImpl) api.asClient()).getCallUserMap().remove(api.getSelfUser().getIdLong());
         }
 
         api.getEventManager().handle(

--- a/src/main/java/net/dv8tion/jda/client/handle/CallUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/CallUpdateHandler.java
@@ -41,9 +41,9 @@ public class CallUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String channelId = content.getString("channel_id");
+        final long channelId = content.getLong("channel_id");
         JSONArray ringing = content.getJSONArray("ringing");
         Region region = Region.fromKey(content.getString("region"));
 
@@ -78,13 +78,13 @@ public class CallUpdateHandler extends SocketHandler
         //Deal with CallUser ringing status changes
         if (ringing.length() > 0)
         {
-            List<String> givenRingingIds = toStringList(ringing);
+            List<Long> givenRingingIds = toLongList(ringing);
             List<CallUser> stoppedRingingUsers = new ArrayList<>();
             List<CallUser> startedRingingUsers = new ArrayList<>();
 
             for (CallUser cUser : call.getRingingUsers())
             {
-                String userId = cUser.getUser().getId();
+                final long userId = cUser.getUser().getIdLong();
 
                 //If the ringing user is no longer ringing, change the ringing status
                 if (!givenRingingIds.contains(userId))
@@ -93,11 +93,13 @@ public class CallUpdateHandler extends SocketHandler
                     stoppedRingingUsers.add(cUser);
                 }
                 else
+                {
                     givenRingingIds.remove(userId);
+                }
             }
 
             //Any Ids that are users that have started ringing, so we need to set their ringing status as such
-            for (String userId : givenRingingIds)
+            for (long userId : givenRingingIds)
             {
                 CallUserImpl cUser = (CallUserImpl) call.getCallUserMap().get(userId);
                 cUser.setRinging(true);
@@ -115,12 +117,12 @@ public class CallUpdateHandler extends SocketHandler
         return null;
     }
 
-    private List<String> toStringList(JSONArray array)
+    private List<Long> toLongList(JSONArray array)
     {
-        List<String> strings = new ArrayList<>();
+        List<Long> longs = new ArrayList<>();
         for (int i = 0; i < array.length(); i++)
-            strings.add(array.getString(i));
+            longs.add(Long.parseLong(array.getString(i)));
 
-        return strings;
+        return longs;
     }
 }

--- a/src/main/java/net/dv8tion/jda/client/handle/ChannelRecipientAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/ChannelRecipientAddHandler.java
@@ -35,29 +35,26 @@ public class ChannelRecipientAddHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String groupId = content.getString("channel_id");
+        final long groupId = content.getLong("channel_id");
         JSONObject userJson = content.getJSONObject("user");
 
         GroupImpl group = (GroupImpl) api.asClient().getGroupById(groupId);
         if (group == null)
         {
-            EventCache.get(api).cache(EventCache.Type.CHANNEL, groupId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.CHANNEL, groupId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a CHANNEL_RECIPIENT_ADD for a group that is not yet cached! JSON: " + content);
             return null;
         }
 
         User user = EntityBuilder.get(api).createFakeUser(userJson, true);
-        group.getUserMap().put(user.getId(), user);
+        group.getUserMap().put(user.getIdLong(), user);
 
         CallImpl call = (CallImpl) group.getCurrentCall();
         if (call != null)
         {
-            call.getCallUserMap().put(user.getId(), new CallUserImpl(call, user));
+            call.getCallUserMap().put(user.getIdLong(), new CallUserImpl(call, user));
         }
 
         api.getEventManager().handle(
@@ -65,7 +62,7 @@ public class ChannelRecipientAddHandler extends SocketHandler
                         api, responseNumber,
                         group, user));
 
-        EventCache.get(api).playbackCache(EventCache.Type.USER, user.getId());
+        EventCache.get(api).playbackCache(EventCache.Type.USER, user.getIdLong());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/client/handle/ChannelRecipientRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/ChannelRecipientRemoveHandler.java
@@ -33,18 +33,15 @@ public class ChannelRecipientRemoveHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String groupId = content.getString("channel_id");
-        String userId = content.getJSONObject("user").getString("id");
+        final long groupId = content.getLong("channel_id");
+        final long userId = content.getJSONObject("user").getLong("id");
 
         GroupImpl group = (GroupImpl) api.asClient().getGroupById(groupId);
         if (group == null)
         {
-            EventCache.get(api).cache(EventCache.Type.CHANNEL, groupId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.CHANNEL, groupId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a CHANNEL_RECIPIENT_REMOVE for a group that is not yet cached! JSON: " + content);
             return null;
         }
@@ -52,10 +49,7 @@ public class ChannelRecipientRemoveHandler extends SocketHandler
         User user = group.getUserMap().remove(userId);
         if (user == null)
         {
-            EventCache.get(api).cache(EventCache.Type.USER, userId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.USER, userId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a CHANNEL_RECIPIENT_REMOVE for a user that is not yet cached in the group! JSON: " + content);
             return null;
         }
@@ -72,7 +66,7 @@ public class ChannelRecipientRemoveHandler extends SocketHandler
         if (user.isFake()
                 && !user.hasPrivateChannel()
                 && api.asClient().getRelationshipById(userId) == null
-                && api.asClient().getGroups().stream().allMatch(g -> !g.getUsers().contains(user)))
+                && api.asClient().getGroups().stream().noneMatch(g -> g.getUsers().contains(user)))
         {
             api.getFakeUserMap().remove(userId);
         }

--- a/src/main/java/net/dv8tion/jda/client/handle/RelationshipAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/RelationshipAddHandler.java
@@ -36,7 +36,7 @@ public class RelationshipAddHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         Relationship relationship = EntityBuilder.get(api).createRelationship(content);
         if (relationship == null)
@@ -74,8 +74,8 @@ public class RelationshipAddHandler extends SocketHandler
                 WebSocketClient.LOG.warn("Received a RELATIONSHIP_ADD with an unknown type! JSON: " + content);
                 return null;
         }
-        EventCache.get(api).playbackCache(EventCache.Type.RELATIONSHIP, relationship.getUser().getId());
-        EventCache.get(api).playbackCache(EventCache.Type.USER, relationship.getUser().getId());
+        EventCache.get(api).playbackCache(EventCache.Type.RELATIONSHIP, relationship.getUser().getIdLong());
+        EventCache.get(api).playbackCache(EventCache.Type.USER, relationship.getUser().getIdLong());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/client/managers/ApplicationManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/client/managers/ApplicationManagerUpdatable.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.requests.Route;
 import org.apache.http.util.Args;
 import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/net/dv8tion/jda/client/managers/ApplicationManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/client/managers/ApplicationManagerUpdatable.java
@@ -352,7 +352,7 @@ public class ApplicationManagerUpdatable
         return new RestAction<Void>(this.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Void> request)
             {
                 if (response.isOk())
                 {

--- a/src/main/java/net/dv8tion/jda/client/managers/EmoteManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/client/managers/EmoteManagerUpdatable.java
@@ -217,7 +217,7 @@ public class EmoteManagerUpdatable
         return new RestAction<Void>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/client/requests/restaction/ApplicationAction.java
+++ b/src/main/java/net/dv8tion/jda/client/requests/restaction/ApplicationAction.java
@@ -63,7 +63,7 @@ public class ApplicationAction extends RestAction<Application>
     }
 
     @Override
-    protected void handleResponse(final Response response, final Request request)
+    protected void handleResponse(final Response response, final Request<Application> request)
     {
         if (response.isOk())
         {

--- a/src/main/java/net/dv8tion/jda/client/requests/restaction/ApplicationAction.java
+++ b/src/main/java/net/dv8tion/jda/client/requests/restaction/ApplicationAction.java
@@ -20,8 +20,10 @@ import net.dv8tion.jda.client.entities.Application;
 import net.dv8tion.jda.core.entities.EntityBuilder;
 import net.dv8tion.jda.core.entities.Icon;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
-import net.dv8tion.jda.core.requests.*;
-
+import net.dv8tion.jda.core.requests.Request;
+import net.dv8tion.jda.core.requests.Response;
+import net.dv8tion.jda.core.requests.RestAction;
+import net.dv8tion.jda.core.requests.Route;
 import org.json.JSONObject;
 
 /**

--- a/src/main/java/net/dv8tion/jda/client/requests/restaction/pagination/MentionPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/client/requests/restaction/pagination/MentionPaginationAction.java
@@ -147,7 +147,7 @@ public class MentionPaginationAction extends PaginationAction<Message, MentionPa
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<List<Message>> request)
     {
         if(!response.isOk())
         {

--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -20,11 +20,7 @@ import net.dv8tion.jda.core.entities.impl.MessageEmbedImpl;
 import org.apache.http.util.Args;
 
 import java.awt.Color;
-import java.time.DateTimeException;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.temporal.TemporalAccessor;
 import java.util.LinkedList;
 import java.util.List;
@@ -38,7 +34,7 @@ import java.util.regex.Pattern;
  * @since  3.0
  * @author John A. Grosh
  */
-public class EmbedBuilder 
+public class EmbedBuilder
 {
     public final static String ZERO_WIDTH_SPACE = "\u200E";
     public final static Pattern URL_PATTERN = Pattern.compile("\\s*(https?|attachment):\\/\\/.+\\..{2,}\\s*", Pattern.CASE_INSENSITIVE);
@@ -187,7 +183,7 @@ public class EmbedBuilder
     {
         return description;
     }
-    
+
     /**
      * Sets the Description of the embed. This is where the main chunk of text for an embed is typically placed.
      *
@@ -299,16 +295,7 @@ public class EmbedBuilder
     
     /**
      * Sets the Color of the embed.
-     *
-     * <p><b><a href="http://i.imgur.com/2YnxnRM.png">Example</a></b>
-     *
-     * <p><b>Hint:</b> You can use a predefined color like {@link java.awt.Color#BLUE} or you can define
-     * your own color using one of Color's constructors.
-     * <br>Example: {@link java.awt.Color#Color(int, int, int) new Color(0, 0, 255)}. This is the same as {@link java.awt.Color#BLUE}
-     *
-     * @param  color
-     *         the color of the embed
-     *
+     * @param color the color of the embed
      * @return the builder after the color has been set
      */
     public EmbedBuilder setColor(Color color)
@@ -476,7 +463,7 @@ public class EmbedBuilder
      *
      * <p><b><a href="http://i.imgur.com/gnjzCoo.png">Example of Inline</a></b>
      * <p><b><a href="http://i.imgur.com/Ky0KlsT.png">Example if Non-inline</a></b>
-     * 
+     *
      * @param  name
      *         the name of the Field, displayed in bold above the {@code value}.
      * @param  value

--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -22,7 +22,6 @@ import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.hooks.IEventManager;
 import net.dv8tion.jda.core.managers.Presence;
 import net.dv8tion.jda.core.requests.RestAction;
-import net.dv8tion.jda.core.requests.ratelimit.IBucket;
 import org.apache.http.HttpHost;
 
 import java.util.Collection;
@@ -208,6 +207,8 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.User User} with matching id.
      */
     User getUserById(String id);
+    //todo docs
+    User getUserById(long id);
 
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.Guild Guilds} that contain all given users as their members.
@@ -298,6 +299,8 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Guild Guild} with matching id.
      */
     Guild getGuildById(String id);
+    //todo docs
+    Guild getGuildById(long id);
 
     /**
      * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.Guild Guilds} that have the same name as the one provided.
@@ -312,6 +315,13 @@ public interface JDA
      *      the provided name.
      */
     List<Guild> getGuildsByName(String name, boolean ignoreCase);
+    //todo docs
+    List<Role> getRoles();
+    //todo docs
+    Role getRoleById(String id);
+    Role getRoleById(long id);
+    //todo docs
+    List<Role> getRolesByName(String name, boolean ignoreCase);
 
     /**
      * An unmodifiable List of all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} of all connected
@@ -344,6 +354,8 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} with matching id.
      */
     TextChannel getTextChannelById(String id);
+    //todo docs
+    TextChannel getTextChannelById(long id);
 
     /**
      * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} that have the same name as the one provided.
@@ -383,6 +395,8 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel} with matching id.
      */
     VoiceChannel getVoiceChannelById(String id);
+    //todo docs
+    VoiceChannel getVoiceChannelById(long id);
 
     /**
      * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels} that have the same name as the one provided.
@@ -416,6 +430,8 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} with matching id.
      */
     PrivateChannel getPrivateChannelById(String id);
+    //todo docs
+    PrivateChannel getPrivateChannelById(long id);
 
     /**
      * A collection of all to us known emotes (managed/restricted included).
@@ -437,6 +453,8 @@ public interface JDA
      * @return An {@link net.dv8tion.jda.core.entities.Emote Emote} represented by this id or null if none is found in our cache.
      */
     Emote getEmoteById(String id);
+    //todo docs
+    Emote getEmoteById(long id);
 
     /**
      * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.Emote Emotes} that have the same name as the one provided.
@@ -558,6 +576,13 @@ public interface JDA
      * @param  free If true, shuts down JDA's rest system permanently for all current and future instances.
      */
     void shutdown(boolean free);
+
+    /**
+     * The time between the WebSocket keepAlive message and its ack response by Discord.
+     *
+     * @return Time in milliseconds between discord and the local JDA WebSocketClient
+     */
+    long getPing();
 
     /**
      * Installs an auxiliary cable into your system.

--- a/src/main/java/net/dv8tion/jda/core/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/MessageBuilder.java
@@ -403,7 +403,7 @@ public class MessageBuilder implements Appendable
         if (message.length() > 2000)
             throw new IllegalStateException("Cannot build a Message with more than 2000 characters. Please limit your input.");
 
-        return new MessageImpl("", null, false).setContent(message).setTTS(isTTS)
+        return new MessageImpl(-1, null, false).setContent(message).setTTS(isTTS)
                 .setEmbeds(embed == null ? new LinkedList<>() : Collections.singletonList(embed));
     }
 
@@ -849,7 +849,7 @@ public class MessageBuilder implements Appendable
 
     protected Message build(int beginIndex, int endIndex)
     {
-        return new MessageImpl("", null, false).setContent(builder.substring(beginIndex, endIndex)).setTTS(isTTS);
+        return new MessageImpl(-1, null, false).setContent(builder.substring(beginIndex, endIndex)).setTTS(isTTS);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/ChannelType.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ChannelType.java
@@ -23,7 +23,7 @@ public enum ChannelType
     /**
      * A {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}, Guild-Only.
      */
-    TEXT(0),
+    TEXT(0, true),
     /**
      * A {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}.
      */
@@ -31,7 +31,7 @@ public enum ChannelType
     /**
      * A {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel}, Guild-Only.
      */
-    VOICE(2),
+    VOICE(2, true),
     /**
      * A {@link net.dv8tion.jda.client.entities.Group Group}. {@link net.dv8tion.jda.core.AccountType#CLIENT AccountType.CLIENT} only.
      */
@@ -43,10 +43,17 @@ public enum ChannelType
     UNKNOWN(-1);
 
     protected final int id;
+    protected final boolean isGuild;
 
     ChannelType(int id)
     {
+        this(id, false);
+    }
+
+    ChannelType(int id, boolean isGuild)
+    {
         this.id = id;
+        this.isGuild = isGuild;
     }
 
     /**
@@ -57,6 +64,16 @@ public enum ChannelType
     public int getId()
     {
         return id;
+    }
+
+    /**
+     * Whether this ChannelType is present for a Guild {@link net.dv8tion.jda.core.entities.Channel Channel}
+     *
+     * @return Whether or not this a Guild Channel
+     */
+    public boolean isGuild()
+    {
+        return isGuild;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Emote.java
@@ -159,7 +159,7 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
     @Override
     default String getAsMention()
     {
-        return "<:" + getName() + ":" + getId() + ">";
+        return "<:" + getName() + ":" + getIdLong() + ">";
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.core.entities;
 
+import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.bot.entities.ApplicationInfo;
 import net.dv8tion.jda.bot.entities.impl.ApplicationInfoImpl;
 import net.dv8tion.jda.client.entities.*;
@@ -31,8 +32,7 @@ import net.dv8tion.jda.core.handle.GuildMembersChunkHandler;
 import net.dv8tion.jda.core.handle.ReadyHandler;
 import net.dv8tion.jda.core.requests.GuildLock;
 import net.dv8tion.jda.core.requests.WebSocketClient;
-
-import org.apache.commons.lang3.StringUtils;
+import net.dv8tion.jda.core.utils.MiscUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -54,8 +54,8 @@ public class EntityBuilder
     private static final Pattern channelMentionPattern = Pattern.compile("<#(\\d+)>");
 
     protected final JDAImpl api;
-    protected final HashMap<String, JSONObject> cachedGuildJsons = new HashMap<>();
-    protected final HashMap<String, Consumer<Guild>> cachedGuildCallbacks = new HashMap<>();
+    protected final TLongObjectMap<JSONObject> cachedGuildJsons = MiscUtil.newLongMap();
+    protected final TLongObjectMap<Consumer<Guild>> cachedGuildCallbacks = MiscUtil.newLongMap();
 
     public static EntityBuilder get(JDA api)
     {
@@ -78,12 +78,13 @@ public class EntityBuilder
         SelfUserImpl selfUser = ((SelfUserImpl) api.getSelfUser());
         if (selfUser == null)
         {
-            selfUser = new SelfUserImpl(self.getString("id"), api);
+            final long id = self.getLong("id");
+            selfUser = new SelfUserImpl(id, api);
             api.setSelfUser(selfUser);
         }
-        if (!api.getUserMap().containsKey(selfUser.getId()))
+        if (!api.getUserMap().containsKey(selfUser.getIdLong()))
         {
-            api.getUserMap().put(selfUser.getId(), selfUser);
+            api.getUserMap().put(selfUser.getIdLong(), selfUser);
         }
         return (SelfUser) selfUser
                 .setVerified(self.getBoolean("verified"))
@@ -97,7 +98,7 @@ public class EntityBuilder
 
     public void createGuildFirstPass(JSONObject guild, Consumer<Guild> secondPassCallback)
     {
-        String id = guild.getString("id");
+        final long id = guild.getLong("id");
         GuildImpl guildObj = ((GuildImpl) api.getGuildMap().get(id));
         if (guildObj == null)
         {
@@ -148,21 +149,21 @@ public class EntityBuilder
         JSONArray roles = guild.getJSONArray("roles");
         for (int i = 0; i < roles.length(); i++)
         {
-            Role role = createRole(roles.getJSONObject(i), guildObj.getId());
-            guildObj.getRolesMap().put(role.getId(), role);
-            if (role.getId().equals(guildObj.getId()))
+            Role role = createRole(roles.getJSONObject(i), guildObj.getIdLong());
+            guildObj.getRolesMap().put(role.getIdLong(), role);
+            if (role.getIdLong() == guildObj.getIdLong())
                 guildObj.setPublicRole(role);
         }
 
         if (!guild.isNull("emojis"))
         {
             JSONArray array = guild.getJSONArray("emojis");
-            Map<String, Emote> emoteMap = guildObj.getEmoteMap();
+            TLongObjectMap<Emote> emoteMap = guildObj.getEmoteMap();
             for (int i = 0; i < array.length(); i++)
             {
                 JSONObject object = array.getJSONObject(i);
                 JSONArray emoteRoles = object.getJSONArray("roles");
-                String emoteId = object.getString("id");
+                final long emoteId = object.getLong("id");
 
                 EmoteImpl emoteObj = new EmoteImpl(emoteId, guildObj);
                 Set<Role> roleSet = emoteObj.getRoleSet();
@@ -182,7 +183,7 @@ public class EntityBuilder
         }
 
         //This could be null for Client accounts. Will be fixed by GUILD_SYNC
-        Member owner = guildObj.getMemberById(guild.getString("owner_id"));
+        Member owner = guildObj.getMemberById(guild.getLong("owner_id"));
         if (owner != null)
             guildObj.setOwner(owner);
 
@@ -192,7 +193,7 @@ public class EntityBuilder
             for (int i = 0; i < presences.length(); i++)
             {
                 JSONObject presence = presences.getJSONObject(i);
-                String userId = presence.getJSONObject("user").getString("id");
+                final long userId = presence.getJSONObject("user").getLong("id");
                 MemberImpl member = (MemberImpl) guildObj.getMembersMap().get(userId);
 
                 if (member == null)
@@ -212,13 +213,13 @@ public class EntityBuilder
                 ChannelType type = ChannelType.fromId(channel.getInt("type"));
                 if (type == ChannelType.TEXT)
                 {
-                    TextChannel newChannel = createTextChannel(channel, guildObj.getId(), false);
-                    if (newChannel.getId().equals(guildObj.getId()))
+                    TextChannel newChannel = createTextChannel(channel, guildObj.getIdLong(), false);
+                    if (newChannel.getIdLong() == guildObj.getIdLong())
                         guildObj.setPublicChannel(newChannel);
                 }
                 else if (type == ChannelType.VOICE)
                 {
-                    VoiceChannel newChannel = createVoiceChannel(channel, guildObj.getId(), false);
+                    VoiceChannel newChannel = createVoiceChannel(channel, guildObj.getIdLong(), false);
                     if (!guild.isNull("afk_channel_id")
                             && newChannel.getId().equals(guild.getString("afk_channel_id")))
                         guildObj.setAfkChannel(newChannel);
@@ -295,12 +296,12 @@ public class EntityBuilder
         JSONArray voiceStates = guild.getJSONArray("voice_states");
         createGuildVoiceStatePass(guildObj, voiceStates);
 
-        GuildLock.get(api).unlock(guildObj.getId());
+        GuildLock.get(api).unlock(guildObj.getIdLong());
         if (secondPassCallback != null)
             secondPassCallback.accept(guildObj);
     }
 
-    public void createGuildSecondPass(String guildId, List<JSONArray> memberChunks)
+    public void createGuildSecondPass(long guildId, List<JSONArray> memberChunks)
     {
         JSONObject guildJson = cachedGuildJsons.remove(guildId);
         Consumer<Guild> secondPassCallback = cachedGuildCallbacks.remove(guildId);
@@ -320,7 +321,7 @@ public class EntityBuilder
             createGuildMemberPass(guildObj, chunk);
         }
 
-        Member owner = guildObj.getMemberById(guildJson.getString("owner_id"));
+        Member owner = guildObj.getMemberById(guildJson.getLong("owner_id"));
         if (owner != null)
             guildObj.setOwner(owner);
 
@@ -348,7 +349,7 @@ public class EntityBuilder
         for (int i = 0; i < presences.length(); i++)
         {
             JSONObject presenceJson = presences.getJSONObject(i);
-            String userId = presenceJson.getJSONObject("user").getString("id");
+            final long userId = presenceJson.getJSONObject("user").getLong("id");
 
             MemberImpl member = (MemberImpl) guild.getMembersMap().get(userId);
             if (member == null)
@@ -376,11 +377,11 @@ public class EntityBuilder
             Channel channelObj = null;
             if (type == ChannelType.TEXT)
             {
-                channelObj = api.getTextChannelById(channel.getString("id"));
+                channelObj = api.getTextChannelById(channel.getLong("id"));
             }
             else if (type == ChannelType.VOICE)
             {
-                channelObj = api.getVoiceChannelById(channel.getString("id"));
+                channelObj = api.getVoiceChannelById(channel.getLong("id"));
             }
             else
                 WebSocketClient.LOG.fatal("Received a channel for a guild that isn't a text or voice channel (ChannelPass). JSON: " + channel);
@@ -413,7 +414,8 @@ public class EntityBuilder
         for (int i = 0; i < voiceStates.length(); i++)
         {
             JSONObject voiceStateJson = voiceStates.getJSONObject(i);
-            Member member = guildObj.getMembersMap().get(voiceStateJson.getString("user_id"));
+            final long userId = voiceStateJson.getLong("user_id");
+            Member member = guildObj.getMembersMap().get(userId);
             if (member == null)
             {
                 WebSocketClient.LOG.fatal("Received a VoiceState for a unknown Member! GuildId: "
@@ -421,9 +423,10 @@ public class EntityBuilder
                 continue;
             }
 
+            final long channelId = voiceStateJson.getLong("channel_id");
             VoiceChannelImpl voiceChannel =
-                    (VoiceChannelImpl) guildObj.getVoiceChannelMap().get(voiceStateJson.getString("channel_id"));
-            voiceChannel.getConnectedMembersMap().put(member.getUser().getId(), member);
+                    (VoiceChannelImpl) guildObj.getVoiceChannelMap().get(channelId);
+            voiceChannel.getConnectedMembersMap().put(member.getUser().getIdLong(), member);
 
             GuildVoiceStateImpl voiceState = (GuildVoiceStateImpl) member.getVoiceState();
             voiceState.setSelfMuted(voiceStateJson.getBoolean("self_mute"))
@@ -440,7 +443,7 @@ public class EntityBuilder
     public User createUser(JSONObject user)     { return createUser(user, false, true); }
     private User createUser(JSONObject user, boolean fake, boolean modifyCache)
     {
-        String id = user.getString("id");
+        final long id = user.getLong("id");
         UserImpl userObj;
 
         userObj = (UserImpl) api.getUserMap().get(id);
@@ -453,13 +456,13 @@ public class EntityBuilder
                 {
                     api.getFakeUserMap().remove(id);
                     userObj.setFake(false);
-                    api.getUserMap().put(userObj.getId(), userObj);
+                    api.getUserMap().put(userObj.getIdLong(), userObj);
                     if (userObj.hasPrivateChannel())
                     {
                         PrivateChannelImpl priv = (PrivateChannelImpl) userObj.getPrivateChannel();
                         priv.setFake(false);
-                        api.getFakePrivateChannelMap().remove(priv.getId());
-                        api.getPrivateChannelMap().put(priv.getId(), priv);
+                        api.getFakePrivateChannelMap().remove(priv.getIdLong());
+                        api.getPrivateChannelMap().put(priv.getIdLong(), priv);
                     }
                 }
             }
@@ -490,7 +493,7 @@ public class EntityBuilder
         if (member == null)
         {
             member = new MemberImpl(guild, user);
-            guild.getMembersMap().put(user.getId(), member);
+            guild.getMembersMap().put(user.getIdLong(), member);
         }
 
         ((GuildVoiceStateImpl) member.getVoiceState())
@@ -505,7 +508,7 @@ public class EntityBuilder
         JSONArray rolesJson = memberJson.getJSONArray("roles");
         for (int k = 0; k < rolesJson.length(); k++)
         {
-            String roleId = rolesJson.getString(k);
+            final long roleId = Long.parseLong(rolesJson.getString(k));
             Role r = guild.getRolesMap().get(roleId);
             if (r == null)
             {
@@ -574,14 +577,14 @@ public class EntityBuilder
             throw new IllegalArgumentException("An object was provided to EntityBuilder#createPresence that wasn't a Member or Friend. JSON: " + presenceJson);
     }
 
-    public TextChannel createTextChannel(JSONObject json, String guildId)
+    public TextChannel createTextChannel(JSONObject json, long guildId)
     {
         return createTextChannel(json, guildId, true);
 
     }
-    public TextChannel createTextChannel(JSONObject json, String guildId, boolean guildIsLoaded)
+    public TextChannel createTextChannel(JSONObject json, long guildId, boolean guildIsLoaded)
     {
-        String id = json.getString("id");
+        final long id = json.getLong("id");
         TextChannelImpl channel = (TextChannelImpl) api.getTextChannelMap().get(id);
         if (channel == null)
         {
@@ -606,13 +609,13 @@ public class EntityBuilder
                 .setRawPosition(json.getInt("position"));
     }
 
-    public VoiceChannel createVoiceChannel(JSONObject json, String guildId)
+    public VoiceChannel createVoiceChannel(JSONObject json, long guildId)
     {
         return createVoiceChannel(json, guildId, true);
     }
-    public VoiceChannel createVoiceChannel(JSONObject json, String guildId, boolean guildIsLoaded)
+    public VoiceChannel createVoiceChannel(JSONObject json, long guildId, boolean guildIsLoaded)
     {
-        String id = json.getString("id");
+        final long id = json.getLong("id");
         VoiceChannelImpl channel = ((VoiceChannelImpl) api.getVoiceChannelMap().get(id));
         if (channel == null)
         {
@@ -643,29 +646,31 @@ public class EntityBuilder
         JSONObject recipient = privatechat.has("recipients") ? 
             privatechat.getJSONArray("recipients").getJSONObject(0) :
             privatechat.getJSONObject("recipient");
-        UserImpl user = ((UserImpl) api.getUserMap().get(recipient.getString("id")));
+        final long userId = recipient.getLong("id");
+        UserImpl user = ((UserImpl) api.getUserMap().get(userId));
         if (user == null)
         {   //The API can give us private channels connected to Users that we can no longer communicate with.
             // As such, make a fake user and fake private channel.
             user = (UserImpl) createFakeUser(recipient, true);
         }
 
-        PrivateChannelImpl priv = new PrivateChannelImpl(privatechat.getString("id"), user);
+        final long channelId = privatechat.getLong("id");
+        PrivateChannelImpl priv = new PrivateChannelImpl(channelId, user);
         user.setPrivateChannel(priv);
 
         if (user.isFake())
         {
             priv.setFake(true);
-            api.getFakePrivateChannelMap().put(priv.getId(), priv);
+            api.getFakePrivateChannelMap().put(channelId, priv);
         }
         else
-            api.getPrivateChannelMap().put(priv.getId(), priv);
+            api.getPrivateChannelMap().put(channelId, priv);
         return priv;
     }
 
-    public Role createRole(JSONObject roleJson, String guildId)
+    public Role createRole(JSONObject roleJson, long guildId)
     {
-        String id = roleJson.getString("id");
+        final long id = roleJson.getLong("id");
         GuildImpl guild = ((GuildImpl) api.getGuildMap().get(guildId));
         RoleImpl role = ((RoleImpl) guild.getRolesMap().get(id));
         if (role == null)
@@ -685,7 +690,8 @@ public class EntityBuilder
     public Message createMessage(JSONObject jsonObject) { return createMessage(jsonObject, false); }
     public Message createMessage(JSONObject jsonObject, boolean exceptionOnMissingUser)
     {
-        String channelId = jsonObject.getString("channel_id");
+        final long channelId = jsonObject.getLong("channel_id");
+
         MessageChannel chan = api.getTextChannelById(channelId);
         if (chan == null)
             chan = api.getPrivateChannelById(channelId);
@@ -700,11 +706,11 @@ public class EntityBuilder
     }
     public Message createMessage(JSONObject jsonObject, MessageChannel chan, boolean exceptionOnMissingUser)
     {
-        String id = jsonObject.getString("id");
+        final long id = jsonObject.getLong("id");
         String content = !jsonObject.isNull("content") ? jsonObject.getString("content") : "";
 
         JSONObject author = jsonObject.getJSONObject("author");
-        String authorId = author.getString("id");
+        final long authorId = author.getLong("id");
         boolean fromWebhook = jsonObject.has("webhook_id");
 
         MessageImpl message = new MessageImpl(id, chan, fromWebhook)
@@ -715,7 +721,7 @@ public class EntityBuilder
                 .setPinned(!jsonObject.isNull("pinned") && jsonObject.getBoolean("pinned"));
         if (chan instanceof PrivateChannel)
         {
-            if (StringUtils.equals(authorId, api.getSelfUser().getId()))
+            if (authorId == api.getSelfUser().getIdLong())
                 message.setAuthor(api.getSelfUser());
             else
                 message.setAuthor(((PrivateChannel) chan).getUser());
@@ -799,7 +805,7 @@ public class EntityBuilder
                 JSONObject obj = reactions.getJSONObject(i);
                 JSONObject emoji = obj.getJSONObject("emoji");
 
-                String emojiId = emoji.isNull("id") ? null : emoji.getString("id");
+                final Long emojiId = emoji.isNull("id") ? null : emoji.getLong("id");
                 String emojiName = emoji.getString("name");
 
                 boolean self = obj.has("self") && obj.getBoolean("self");
@@ -816,7 +822,7 @@ public class EntityBuilder
                     reactionEmote = new MessageReaction.ReactionEmote(emojiName, null, api);
                 else
                     reactionEmote = new MessageReaction.ReactionEmote(emote);
-                list.add(new MessageReaction(chan, reactionEmote, message.getId(), self, count));
+                list.add(new MessageReaction(chan, reactionEmote, message.getIdLong(), self, count));
             }
             message.setReactions(list);
         }
@@ -831,7 +837,7 @@ public class EntityBuilder
                 for (int i = 0; i < mentions.length(); i++)
                 {
                     JSONObject mention = mentions.getJSONObject(i);
-                    User u = api.getUserMap().get(mention.getString("id"));
+                    User u = api.getUserById(mention.getLong("id"));
                     if (u != null)
                     {
                         //We do this to properly order the mentions. The array given by discord is out of order sometimes.
@@ -864,11 +870,11 @@ public class EntityBuilder
             message.setMentionedRoles(new LinkedList<Role>(mentionedRoles.values()));
 
             List<TextChannel> mentionedChannels = new LinkedList<>();
-            Map<String, TextChannel> chanMap = ((GuildImpl) textChannel.getGuild()).getTextChannelsMap();
+            TLongObjectMap<TextChannel> chanMap = ((GuildImpl) textChannel.getGuild()).getTextChannelsMap();
             Matcher matcher = channelMentionPattern.matcher(content);
             while (matcher.find())
             {
-                TextChannel channel = chanMap.get(matcher.group(1));
+                TextChannel channel = chanMap.get(Long.parseLong(matcher.group(1)));
                 if(channel != null && !mentionedChannels.contains(channel))
                 {
                     mentionedChannels.add(channel);
@@ -976,7 +982,7 @@ public class EntityBuilder
     public PermissionOverride createPermissionOverride(JSONObject override, Channel chan)
     {
         PermissionOverrideImpl permOverride = null;
-        String id = override.getString("id");
+        final long id = override.getLong("id");
         long allow = override.getLong("allow");
         long deny = override.getLong("deny");
 
@@ -1021,10 +1027,10 @@ public class EntityBuilder
 
     public Webhook createWebhook(JSONObject object)
     {
-        String id = object.getString("id");
+        final long id = object.getLong("id");
+        final long guildId = object.getLong("guild_id");
+        final long channelId = object.getLong("channel_id");
         String token = !object.isNull("token") ? object.getString("token") : null;
-        String guildId = object.getString("guild_id");
-        String channelId = object.getString("channel_id");
 
         TextChannel channel = api.getTextChannelById(channelId);
         if (channel == null)
@@ -1042,7 +1048,7 @@ public class EntityBuilder
         User defaultUser = createFakeUser(fakeUser, false);
 
         JSONObject ownerJson = object.getJSONObject("user");
-        String userId = ownerJson.getString("id");
+        final long userId = ownerJson.getLong("id");
 
         User owner = api.getUserById(userId);
         if (owner == null)
@@ -1066,7 +1072,7 @@ public class EntityBuilder
         else
             user = createFakeUser(relationshipJson.getJSONObject("user"), true);
 
-        Relationship relationship = api.asClient().getRelationshipById(user.getId(), type);
+        Relationship relationship = api.asClient().getRelationshipById(user.getIdLong(), type);
         if (relationship == null)
         {
             switch (type)
@@ -1086,7 +1092,7 @@ public class EntityBuilder
                 default:
                     return null;
             }
-            ((JDAClientImpl) api.asClient()).getRelationshipMap().put(user.getId(), relationship);
+            ((JDAClientImpl) api.asClient()).getRelationshipMap().put(user.getIdLong(), relationship);
         }
         return relationship;
     }
@@ -1096,9 +1102,9 @@ public class EntityBuilder
         if (api.getAccountType() != AccountType.CLIENT)
             throw new AccountTypeException(AccountType.CLIENT, "Attempted to create a Group but the logged in account is not a CLIENT!");
 
-        String groupId = groupJson.getString("id");
+        final long groupId = groupJson.getLong("id");
         JSONArray recipients = groupJson.getJSONArray("recipients");
-        String ownerId = groupJson.getString("owner_id");
+        final long ownerId = groupJson.getLong("owner_id");
         String name = !groupJson.isNull("name") ? groupJson.getString("name") : null;
         String iconId = !groupJson.isNull("icon") ? groupJson.getString("icon") : null;
 
@@ -1109,12 +1115,12 @@ public class EntityBuilder
             ((JDAClientImpl) api.asClient()).getGroupMap().put(groupId, group);
         }
 
-        HashMap<String, User> groupUsers = group.getUserMap();
-        groupUsers.put(api.getSelfUser().getId(), api.getSelfUser());
+        TLongObjectMap<User> groupUsers = group.getUserMap();
+        groupUsers.put(api.getSelfUser().getIdLong(), api.getSelfUser());
         for (int i = 0; i < recipients.length(); i++)
         {
             JSONObject groupUser = recipients.getJSONObject(i);
-            groupUsers.put(groupUser.getString("id"), createFakeUser(groupUser, true));
+            groupUsers.put(groupUser.getLong("id"), createFakeUser(groupUser, true));
         }
 
         User owner = api.getUserMap().get(ownerId);
@@ -1142,7 +1148,7 @@ public class EntityBuilder
             : channelTypeName.equals("voice")
                 ? ChannelType.VOICE
                 : ChannelType.UNKNOWN;
-        final String channelId = channelObject.getString("id");
+        final long channelId = channelObject.getLong("id");
         final String channelName = channelObject.getString("name");
 
         final Invite.Channel channel = new InviteImpl.ChannelImpl(channelId, channelName, channelType);
@@ -1150,7 +1156,7 @@ public class EntityBuilder
         final JSONObject guildObject = object.getJSONObject("guild");
 
         final String guildIconId = guildObject.isNull("icon") ? null : guildObject.getString("icon");
-        final String guildId = guildObject.getString("id");
+        final long guildId = guildObject.getLong("id");
         final String guildName = guildObject.getString("name");
         final String guildSplashId = guildObject.isNull("splash") ? null : guildObject.getString("splash");
 
@@ -1195,8 +1201,8 @@ public class EntityBuilder
     {
         final String description = object.getString("description");
         final boolean doesBotRequireCodeGrant = object.getBoolean("bot_require_code_grant");
-        final String iconId = object.has("icon") && !object.isNull("icon") ? object.getString("icon") : null;
-        final String id = object.getString("id");
+        final String iconId = !object.isNull("icon") ? object.getString("icon") : null;
+        final long id = object.getLong("id");
         final String name = object.getString("name");
         final boolean isBotPublic = object.getBoolean("bot_public");
         final User owner = createFakeUser(object.getJSONObject("owner"), false);
@@ -1211,7 +1217,7 @@ public class EntityBuilder
 
     public AuthorizedApplication createAuthorizedApplication(JSONObject object)
     {
-        final String authId = object.getString("id");
+        final long authId = object.getLong("id");
 
         JSONArray scopeArray = object.getJSONArray("scopes");
         List<String> scopes = new ArrayList<>(scopeArray.length());
@@ -1223,7 +1229,7 @@ public class EntityBuilder
 
         final String description = application.getString("description");
         final String iconId = application.has("icon") ? application.getString("icon") : null;
-        final String id = application.getString("id");
+        final long id = application.getLong("id");
         final String name = application.getString("name");
 
         return new AuthorizedApplicationImpl(api, authId, description, iconId, id, name, scopes);

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -180,6 +180,8 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Member Member} with the related {@code userId}.
      */
     Member getMemberById(String userId);
+    //todo docs
+    Member getMemberById(long userId);
 
     /**
      * A list of all {@link net.dv8tion.jda.core.entities.Member Members} in this Guild.
@@ -277,6 +279,8 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} with matching id.
      */
     TextChannel getTextChannelById(String id);
+    //todo docs
+    TextChannel getTextChannelById(long id);
 
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
@@ -313,6 +317,8 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel} with matching id.
      */
     VoiceChannel getVoiceChannelById(String id);
+    //todo docs
+    VoiceChannel getVoiceChannelById(long id);
 
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
@@ -348,6 +354,8 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Role Role} with matching id.
      */
     Role getRoleById(String id);
+    //todo docs
+    Role getRoleById(long id);
 
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.Role Roles} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
@@ -383,6 +391,8 @@ public interface Guild extends ISnowflake
      * @return An Emote matching the specified Id.
      */
     Emote getEmoteById(String id);
+    //todo docs
+    Emote getEmoteById(long id);
 
     /**
      * Gets all custom {@link net.dv8tion.jda.core.entities.Emote Emotes} belonging to this {@link net.dv8tion.jda.core.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
@@ -32,17 +32,28 @@ public interface ISnowflake
      *
      * @return Never-null String containing the Id.
      */
-    String getId();
+    default String getId()
+    {
+        return String.valueOf(getIdLong());
+    }
 
     /**
-     * The time this entity was created. Calculated through the Snowflake in {@link #getId}.
+     * The Snowflake id of this entity. This is unique to every entity and will never change.
+     *
+     * @return Long containing the Id.
+     */
+    long getIdLong();
+
+    /**
+     * The time this entity was created. Calculated through the Snowflake in {@link #getIdLong}.
      *
      * @return OffsetDateTime - Time this entity was created at.
      *
-     * @see    net.dv8tion.jda.core.utils.MiscUtil#getCreationTime(Object)
+     * @see    net.dv8tion.jda.core.utils.MiscUtil#getCreationTime(long)
      */
     default OffsetDateTime getCreationTime()
     {
-        return MiscUtil.getCreationTime(getId());
+        return MiscUtil.getCreationTime(getIdLong());
     }
+
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -232,7 +232,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Message>(getJDA(), route, json)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Message> request)
             {
                 if (response.isOk())
                 {
@@ -435,7 +435,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Message>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Message> request)
             {
                 if (response.isOk())
                     request.onSuccess(EntityBuilder.get(api).createMessage(response.getObject(), MessageChannel.this, false));
@@ -512,7 +512,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Message>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Message> request)
             {
                 if (response.isOk())
                     request.onSuccess(EntityBuilder.get(api).createMessage(response.getObject(), MessageChannel.this, false));
@@ -571,7 +571,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Message>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Message> request)
             {
                 if (response.isOk())
                 {
@@ -583,6 +583,12 @@ public interface MessageChannel extends ISnowflake
 
             }
         };
+    }
+
+    default RestAction<Message> getMessageById(long messageId)
+    {
+        Args.notNegative(messageId, "Message ID");
+        return getMessageById(String.valueOf(messageId));
     }
 
     /**
@@ -630,16 +636,20 @@ public interface MessageChannel extends ISnowflake
         Route.CompiledRoute route = Route.Messages.DELETE_MESSAGE.compile(getId(), messageId);
         return new RestAction<Void>(getJDA(), route, null) {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
                 else
-                {
                     request.onFailure(response);
-                }
             }
         };
+    }
+    //todo docs
+    default RestAction<Void> deleteMessageById(long messageId)
+    {
+        Args.notNegative(messageId, "Message ID");
+        return deleteMessageById(String.valueOf(messageId));
     }
 
     /**
@@ -787,7 +797,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<MessageHistory>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<MessageHistory> request)
             {
                 if (!response.isOk())
                 {
@@ -804,10 +814,17 @@ public interface MessageChannel extends ISnowflake
                 for (int i = 0; i < historyJson.length(); i++)
                     msgs.add(builder.createMessage(historyJson.getJSONObject(i), MessageChannel.this, false));
 
-                msgs.forEach(msg -> mHistory.history.put(msg.getId(), msg));
+                msgs.forEach(msg -> mHistory.history.put(msg.getIdLong(), msg));
                 request.onSuccess(mHistory);
             }
         };
+    }
+
+    //todo docs
+    default RestAction<MessageHistory> getHistoryAround(long messageId, int limit)
+    {
+        Args.notNegative(messageId, "Message ID");
+        return getHistoryAround(String.valueOf(messageId), limit);
     }
 
     /**
@@ -845,7 +862,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -935,7 +952,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -943,6 +960,12 @@ public interface MessageChannel extends ISnowflake
                     request.onFailure(response);
             }
         };
+    }
+    //todo docs
+    default RestAction<Void> addReactionById(long messageId, String unicode)
+    {
+        Args.notNegative(messageId, "Message ID");
+        return addReactionById(String.valueOf(messageId), unicode);
     }
 
     /**
@@ -1008,7 +1031,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -1016,6 +1039,12 @@ public interface MessageChannel extends ISnowflake
                     request.onFailure(response);
             }
         };
+    }
+    //todo docs
+    default RestAction<Void> addReactionById(long messageId, Emote emote)
+    {
+        Args.notNegative(messageId, "Message ID");
+        return addReactionById(String.valueOf(messageId), emote);
     }
 
     /**
@@ -1064,7 +1093,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -1072,6 +1101,12 @@ public interface MessageChannel extends ISnowflake
                     request.onFailure(response);
             }
         };
+    }
+    //todo docs
+    default RestAction<Void> pinMessageById(long messageId)
+    {
+        Args.notNegative(messageId, "Message ID");
+        return pinMessageById(String.valueOf(messageId));
     }
 
     /**
@@ -1120,7 +1155,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -1128,6 +1163,11 @@ public interface MessageChannel extends ISnowflake
                     request.onFailure(response);
             }
         };
+    }
+    //todo docs
+    default RestAction<Void> unpinMessageById(long messageId)
+    {
+        return unpinMessageById(String.valueOf(messageId));
     }
 
     /**
@@ -1159,7 +1199,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<List<Message>>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<List<Message>> request)
             {
                 if (response.isOk())
                 {
@@ -1293,7 +1333,7 @@ public interface MessageChannel extends ISnowflake
         return new RestAction<Message>(getJDA(), route, json)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Message> request)
             {
                 if (response.isOk())
                 {
@@ -1306,6 +1346,12 @@ public interface MessageChannel extends ISnowflake
                 }
             }
         };
+    }
+    //todo docs
+    default RestAction<Message> editMessageById(long id, Message newContent)
+    {
+        Args.notNegative(id, "Message ID");
+        return editMessageById(String.valueOf(id), newContent);
     }
 
     /**
@@ -1355,5 +1401,11 @@ public interface MessageChannel extends ISnowflake
     default RestAction<Message> editMessageById(String messageId, MessageEmbed newEmbed)
     {
         return editMessageById(messageId, new MessageBuilder().setEmbed(newEmbed).build());
+    }
+    //todo docs
+    default RestAction<Message> editMessageById(long id, MessageEmbed newEmbed)
+    {
+        Args.notNegative(id, "Message ID");
+        return editMessageById(String.valueOf(id), newEmbed);
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
@@ -46,7 +46,7 @@ import java.util.List;
 public class EmoteImpl implements Emote
 {
 
-    private final String id;
+    private final long id;
     private final Guild guild;
     private final JDA api;
 
@@ -58,7 +58,7 @@ public class EmoteImpl implements Emote
     private HashSet<Role> roles = null;
     private String name;
 
-    public EmoteImpl(String id,  Guild guild)
+    public EmoteImpl(long id,  Guild guild)
     {
         this.id = id;
         this.guild = guild;
@@ -66,7 +66,7 @@ public class EmoteImpl implements Emote
         this.roles = new HashSet<>();
     }
 
-    public EmoteImpl(String id,  JDA api)
+    public EmoteImpl(long id,  JDA api)
     {
         this.id = id;
         this.api = api;
@@ -106,7 +106,7 @@ public class EmoteImpl implements Emote
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return id;
     }
@@ -165,7 +165,7 @@ public class EmoteImpl implements Emote
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -201,23 +201,23 @@ public class EmoteImpl implements Emote
     @Override
     public boolean equals(Object obj)
     {
-        if (!(obj instanceof Emote))
+        if (!(obj instanceof EmoteImpl))
             return false;
 
-        Emote oEmote = (Emote) obj;
-        return getId().equals(oEmote.getId()) && getName().equals(oEmote.getName());
+        EmoteImpl oEmote = (EmoteImpl) obj;
+        return this.id == oEmote.id && getName().equals(oEmote.getName());
     }
 
 
     @Override
     public int hashCode()
     {
-        return getId().hashCode();
+        return Long.hashCode(id);
     }
 
     @Override
     public String toString()
     {
-        return "E:" + getName() + '(' + getId() + ')';
+        return "E:" + getName() + '(' + getIdLong() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/InviteImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/InviteImpl.java
@@ -72,7 +72,7 @@ public class InviteImpl implements Invite
         return new RestAction<Invite>(api, route, null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Invite> request)
             {
                 if (response.isOk())
                 {
@@ -95,7 +95,7 @@ public class InviteImpl implements Invite
         return new RestAction<Invite>(this.api, route, null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Invite> request)
             {
                 if (response.isOk())
                 {
@@ -116,7 +116,7 @@ public class InviteImpl implements Invite
         if (this.expanded)
             return new RestAction.EmptyRestAction<>(this);
 
-        final net.dv8tion.jda.core.entities.Guild guild = this.api.getGuildById(this.guild.getId());
+        final net.dv8tion.jda.core.entities.Guild guild = this.api.getGuildById(this.guild.getIdLong());
 
         if (guild == null)
             throw new UnsupportedOperationException("You're not in the guild this invite points to");
@@ -126,8 +126,8 @@ public class InviteImpl implements Invite
         CompiledRoute route;
 
         final net.dv8tion.jda.core.entities.Channel channel = this.channel.getType() == ChannelType.TEXT
-                ? guild.getTextChannelById(this.channel.getId())
-                : guild.getVoiceChannelById(this.channel.getId());
+                ? guild.getTextChannelById(this.channel.getIdLong())
+                : guild.getVoiceChannelById(this.channel.getIdLong());
 
         if (member.hasPermission(channel, Permission.MANAGE_CHANNEL))
         {
@@ -145,7 +145,7 @@ public class InviteImpl implements Invite
         return new RestAction<Invite>(this.api, route, null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<Invite> request)
             {
                 if (response.isOk())
                 {
@@ -254,10 +254,11 @@ public class InviteImpl implements Invite
 
     public static class ChannelImpl implements Channel
     {
-        private final String id, name;
+        private final long id;
+        private final String name;
         private final ChannelType type;
 
-        public ChannelImpl(final String id, final String name, final ChannelType type)
+        public ChannelImpl(final long id, final String name, final ChannelType type)
         {
             this.id = id;
             this.name = name;
@@ -265,9 +266,9 @@ public class InviteImpl implements Invite
         }
 
         @Override
-        public String getId()
+        public long getIdLong()
         {
-            return this.id;
+            return id;
         }
 
         @Override
@@ -287,9 +288,10 @@ public class InviteImpl implements Invite
     public static class GuildImpl implements Guild
     {
 
-        private final String id, iconId, name, splashId;
+        private final String iconId, name, splashId;
+        private final long id;
 
-        public GuildImpl(final String id, final String iconId, final String name, final String splashId)
+        public GuildImpl(final long id, final String iconId, final String name, final String splashId)
         {
             this.id = id;
             this.iconId = iconId;
@@ -311,9 +313,9 @@ public class InviteImpl implements Invite
         }
 
         @Override
-        public String getId()
+        public long getIdLong()
         {
-            return this.id;
+            return id;
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.core.entities.impl;
 
 import com.mashape.unirest.http.Unirest;
 import com.neovisionaries.ws.client.WebSocketFactory;
+import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.bot.JDABot;
 import net.dv8tion.jda.bot.entities.impl.JDABotImpl;
 import net.dv8tion.jda.client.JDAClient;
@@ -37,6 +38,7 @@ import net.dv8tion.jda.core.managers.AudioManager;
 import net.dv8tion.jda.core.managers.Presence;
 import net.dv8tion.jda.core.managers.impl.PresenceImpl;
 import net.dv8tion.jda.core.requests.*;
+import net.dv8tion.jda.core.utils.MiscUtil;
 import net.dv8tion.jda.core.utils.SimpleLog;
 import org.apache.http.HttpHost;
 import org.apache.http.util.Args;
@@ -51,16 +53,16 @@ public class JDAImpl implements JDA
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDA");
 
-    protected final HashMap<String, User> users = new HashMap<>(200);
-    protected final HashMap<String, Guild> guilds = new HashMap<>(10);
-    protected final HashMap<String, TextChannel> textChannels = new HashMap<>();
-    protected final HashMap<String, VoiceChannel> voiceChannels = new HashMap<>();
-    protected final HashMap<String, PrivateChannel> privateChannels = new HashMap<>();
+    protected final TLongObjectMap<User> users = MiscUtil.newLongMap();
+    protected final TLongObjectMap<Guild> guilds = MiscUtil.newLongMap();
+    protected final TLongObjectMap<TextChannel> textChannels = MiscUtil.newLongMap();
+    protected final TLongObjectMap<VoiceChannel> voiceChannels = MiscUtil.newLongMap();
+    protected final TLongObjectMap<PrivateChannel> privateChannels = MiscUtil.newLongMap();
 
-    protected final HashMap<String, User> fakeUsers = new HashMap<>();
-    protected final HashMap<String, PrivateChannel> fakePrivateChannels = new HashMap<>();
+    protected final TLongObjectMap<User> fakeUsers = MiscUtil.newLongMap();
+    protected final TLongObjectMap<PrivateChannel> fakePrivateChannels = MiscUtil.newLongMap();
 
-    protected final HashMap<String, AudioManager> audioManagers = new HashMap<>();
+    protected final TLongObjectMap<AudioManager> audioManagers = MiscUtil.newLongMap();
 
     protected final HttpHost proxy;
     protected final WebSocketFactory wsFactory;
@@ -82,6 +84,7 @@ public class JDAImpl implements JDA
     protected boolean bulkDeleteSplittingEnabled;
     protected boolean autoReconnect;
     protected long responseTotal;
+    protected long ping = -1;
 
     public JDAImpl(AccountType accountType, HttpHost proxy, WebSocketFactory wsFactory, boolean autoReconnect, boolean audioEnabled, boolean useShutdownHook, boolean bulkDeleteSplittingEnabled)
     {
@@ -149,7 +152,7 @@ public class JDAImpl implements JDA
         RestAction<JSONObject> login = new RestAction<JSONObject>(this, Route.Self.GET_SELF.compile(), null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<JSONObject> request)
             {
                 if (response.isOk())
                     request.onSuccess(response.getObject());
@@ -290,11 +293,17 @@ public class JDAImpl implements JDA
     @Override
     public List<User> getUsers()
     {
-        return Collections.unmodifiableList(new ArrayList<>(users.values()));
+        return Collections.unmodifiableList(new ArrayList<>(users.valueCollection()));
     }
 
     @Override
     public User getUserById(String id)
+    {
+        return users.get(Long.parseLong(id));
+    }
+
+    @Override
+    public User getUserById(long id)
     {
         return users.get(id);
     }
@@ -322,7 +331,7 @@ public class JDAImpl implements JDA
     @Override
     public List<User> getUsersByName(String name, boolean ignoreCase)
     {
-        return users.values().stream().filter(u ->
+        return users.valueCollection().stream().filter(u ->
             ignoreCase
             ? name.equalsIgnoreCase(u.getName())
             : name.equals(u.getName()))
@@ -345,7 +354,7 @@ public class JDAImpl implements JDA
         return new RestAction<User>(this, route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<User> request)
             {
                 if (!response.isOk())
                 {
@@ -361,11 +370,17 @@ public class JDAImpl implements JDA
     @Override
     public List<Guild> getGuilds()
     {
-        return Collections.unmodifiableList(new ArrayList<>(guilds.values()));
+        return Collections.unmodifiableList(new ArrayList<>(guilds.valueCollection()));
     }
 
     @Override
     public Guild getGuildById(String id)
+    {
+        return guilds.get(Long.parseLong(id));
+    }
+
+    @Override
+    public Guild getGuildById(long id)
     {
         return guilds.get(id);
     }
@@ -373,7 +388,7 @@ public class JDAImpl implements JDA
     @Override
     public List<Guild> getGuildsByName(String name, boolean ignoreCase)
     {
-        return guilds.values().stream().filter(g ->
+        return guilds.valueCollection().stream().filter(g ->
                 ignoreCase
                         ? name.equalsIgnoreCase(g.getName())
                         : name.equals(g.getName()))
@@ -381,13 +396,53 @@ public class JDAImpl implements JDA
     }
 
     @Override
+    public List<Role> getRoles()
+    {
+        return guilds.valueCollection().stream()
+                .flatMap(guild -> guild.getRoles().stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Role getRoleById(String id)
+    {
+        return getRoleById(Long.parseLong(id));
+    }
+
+    @Override
+    public Role getRoleById(long id)
+    {
+        for (Guild guild : guilds.valueCollection())
+        {
+            Role r = guild.getRoleById(id);
+            if (r != null)
+                return r;
+        }
+        return null;
+    }
+
+    @Override
+    public List<Role> getRolesByName(String name, boolean ignoreCase)
+    {
+        return guilds.valueCollection().stream()
+                .flatMap(guild -> guild.getRolesByName(name, ignoreCase).stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public List<TextChannel> getTextChannels()
     {
-        return Collections.unmodifiableList(new ArrayList<>(textChannels.values()));
+        return Collections.unmodifiableList(new ArrayList<>(textChannels.valueCollection()));
     }
 
     @Override
     public TextChannel getTextChannelById(String id)
+    {
+        return textChannels.get(Long.parseLong(id));
+    }
+
+    @Override
+    public TextChannel getTextChannelById(long id)
     {
         return textChannels.get(id);
     }
@@ -395,7 +450,7 @@ public class JDAImpl implements JDA
     @Override
     public List<TextChannel> getTextChannelsByName(String name, boolean ignoreCase)
     {
-        return textChannels.values().stream().filter(tc ->
+        return textChannels.valueCollection().stream().filter(tc ->
                 ignoreCase
                         ? name.equalsIgnoreCase(tc.getName())
                         : name.equals(tc.getName()))
@@ -405,11 +460,17 @@ public class JDAImpl implements JDA
     @Override
     public List<VoiceChannel> getVoiceChannels()
     {
-        return Collections.unmodifiableList(new ArrayList<>(voiceChannels.values()));
+        return Collections.unmodifiableList(new ArrayList<>(voiceChannels.valueCollection()));
     }
 
     @Override
     public VoiceChannel getVoiceChannelById(String id)
+    {
+        return voiceChannels.get(Long.parseLong(id));
+    }
+
+    @Override
+    public VoiceChannel getVoiceChannelById(long id)
     {
         return voiceChannels.get(id);
     }
@@ -417,7 +478,7 @@ public class JDAImpl implements JDA
     @Override
     public List<VoiceChannel> getVoiceChannelByName(String name, boolean ignoreCase)
     {
-        return voiceChannels.values().stream().filter(vc ->
+        return voiceChannels.valueCollection().stream().filter(vc ->
                 ignoreCase
                         ? name.equalsIgnoreCase(vc.getName())
                         : name.equals(vc.getName()))
@@ -427,11 +488,17 @@ public class JDAImpl implements JDA
     @Override
     public List<PrivateChannel> getPrivateChannels()
     {
-        return Collections.unmodifiableList(new ArrayList<>(privateChannels.values()));
+        return Collections.unmodifiableList(new ArrayList<>(privateChannels.valueCollection()));
     }
 
     @Override
     public PrivateChannel getPrivateChannelById(String id)
+    {
+        return privateChannels.get(Long.parseLong(id));
+    }
+
+    @Override
+    public PrivateChannel getPrivateChannelById(long id)
     {
         return privateChannels.get(id);
     }
@@ -439,21 +506,27 @@ public class JDAImpl implements JDA
     @Override
     public List<Emote> getEmotes()
     {
-        List<Emote> emotes = new ArrayList<>();
-        getGuilds().parallelStream().forEach(g -> emotes.addAll(g.getEmotes()));
-        return Collections.unmodifiableList(emotes);
+        return guilds.valueCollection().stream()
+                .flatMap(guild -> guild.getEmotes().stream())
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<Emote> getEmotesByName(String name, boolean ignoreCase)
     {
-        List<Emote> emotes = new ArrayList<>();
-        getGuilds().parallelStream().forEach(g -> emotes.addAll(g.getEmotesByName(name, ignoreCase)));
-        return Collections.unmodifiableList(emotes);
+        return guilds.valueCollection().stream()
+                .flatMap(guild -> guild.getEmotesByName(name, ignoreCase).stream())
+                .collect(Collectors.toList());
     }
 
     @Override
     public Emote getEmoteById(String id)
+    {
+        return getEmoteById(Long.parseLong(id));
+    }
+
+    @Override
+    public Emote getEmoteById(long id)
     {
         for (Guild guild : getGuilds())
         {
@@ -479,7 +552,8 @@ public class JDAImpl implements JDA
     public void shutdown(boolean free)
     {
         setStatus(Status.SHUTTING_DOWN);
-        audioManagers.forEach((guildId, mng) -> mng.closeAudioConnection());
+        getRequester().shutdown();
+        audioManagers.valueCollection().forEach(AudioManager::closeAudioConnection);
         if (AudioWebSocket.KEEP_ALIVE_POOLS.containsKey(this))
             AudioWebSocket.KEEP_ALIVE_POOLS.get(this).shutdownNow();
         getClient().setAutoReconnect(false);
@@ -495,6 +569,12 @@ public class JDAImpl implements JDA
             catch (IOException ignored) {}
         }
         setStatus(Status.SHUTDOWN);
+    }
+
+    @Override
+    public long getPing()
+    {
+        return ping;
     }
 
     @Override
@@ -602,42 +682,42 @@ public class JDAImpl implements JDA
         return client;
     }
 
-    public HashMap<String, User> getUserMap()
+    public TLongObjectMap<User> getUserMap()
     {
         return users;
     }
 
-    public HashMap<String, Guild> getGuildMap()
+    public TLongObjectMap<Guild> getGuildMap()
     {
         return guilds;
     }
 
-    public HashMap<String, TextChannel> getTextChannelMap()
+    public TLongObjectMap<TextChannel> getTextChannelMap()
     {
         return textChannels;
     }
 
-    public HashMap<String, VoiceChannel> getVoiceChannelMap()
+    public TLongObjectMap<VoiceChannel> getVoiceChannelMap()
     {
         return voiceChannels;
     }
 
-    public HashMap<String, PrivateChannel> getPrivateChannelMap()
+    public TLongObjectMap<PrivateChannel> getPrivateChannelMap()
     {
         return privateChannels;
     }
 
-    public HashMap<String, User> getFakeUserMap()
+    public TLongObjectMap<User> getFakeUserMap()
     {
         return fakeUsers;
     }
 
-    public HashMap<String, PrivateChannel> getFakePrivateChannelMap()
+    public TLongObjectMap<PrivateChannel> getFakePrivateChannelMap()
     {
         return fakePrivateChannels;
     }
 
-    public HashMap<String, AudioManager> getAudioManagerMap()
+    public TLongObjectMap<AudioManager> getAudioManagerMap()
     {
         return audioManagers;
     }
@@ -650,6 +730,11 @@ public class JDAImpl implements JDA
     public void setResponseTotal(int responseTotal)
     {
         this.responseTotal = responseTotal;
+    }
+
+    public void setPing(long ping)
+    {
+        this.ping = ping;
     }
 
     public String getIdentifierString()

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/PermissionOverrideImpl.java
@@ -170,7 +170,7 @@ public class PermissionOverrideImpl implements PermissionOverride
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
@@ -28,13 +28,13 @@ import net.dv8tion.jda.core.requests.Route;
 
 public class PrivateChannelImpl implements PrivateChannel
 {
-    private final String id;
+    private final long id;
     private final User user;
 
     private Call currentCall = null;
     private boolean fake = false;
 
-    public PrivateChannelImpl(String id, User user)
+    public PrivateChannelImpl(long id, User user)
     {
         this.id = id;
         this.user = user;
@@ -67,11 +67,11 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public RestAction<Void> close()
     {
-        Route.CompiledRoute route = Route.Channels.DELETE_CHANNEL.compile(id);
+        Route.CompiledRoute route = Route.Channels.DELETE_CHANNEL.compile(getId());
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -82,7 +82,7 @@ public class PrivateChannelImpl implements PrivateChannel
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return id;
     }
@@ -115,6 +115,28 @@ public class PrivateChannelImpl implements PrivateChannel
     {
         this.currentCall = currentCall;
         return this;
+    }
+
+    // -- Object --
+
+
+    @Override
+    public int hashCode()
+    {
+        return Long.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj instanceof PrivateChannelImpl
+                && this.id == ((PrivateChannelImpl) obj).id;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PC:" + getUser().getName() + '(' + id + ')';
     }
 
     private void checkNull(Object obj, String name)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/RoleImpl.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 public class RoleImpl implements Role
 {
-    private final String id;
+    private final long id;
     private final Guild guild;
 
     private volatile RoleManager manager;
@@ -54,7 +54,7 @@ public class RoleImpl implements Role
     private long rawPermissions;
     private int rawPosition;
 
-    public RoleImpl(String id, Guild guild)
+    public RoleImpl(long id, Guild guild)
     {
         this.id = id;
         this.guild = guild;
@@ -220,11 +220,11 @@ public class RoleImpl implements Role
         if (managed)
             throw new UnsupportedOperationException("Cannot delete a Role that is managed. ");
 
-        Route.CompiledRoute route = Route.Roles.DELETE_ROLE.compile(guild.getId(), id);
+        Route.CompiledRoute route = Route.Roles.DELETE_ROLE.compile(guild.getId(), getId());
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -247,7 +247,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return id;
     }
@@ -258,19 +258,19 @@ public class RoleImpl implements Role
         if (!(o instanceof Role))
             return false;
         Role oRole = (Role) o;
-        return this == oRole || this.getId().equals(oRole.getId());
+        return this == oRole || this.getIdLong() == oRole.getIdLong();
     }
 
     @Override
     public int hashCode()
     {
-        return getId().hashCode();
+        return Long.hashCode(id);
     }
 
     @Override
     public String toString()
     {
-        return "R:" + getName() + '(' + getId() + ')';
+        return "R:" + getName() + '(' + id + ')';
     }
 
     @Override
@@ -279,7 +279,7 @@ public class RoleImpl implements Role
         if (this == r)
             return 0;
 
-        if (this.getGuild() != r.getGuild())
+        if (!this.getGuild().equals(r.getGuild()))
             throw new IllegalArgumentException("Cannot compare roles that aren't from the same guild!");
 
         if (this.getPositionRaw() != r.getPositionRaw())

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/SelfUserImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/SelfUserImpl.java
@@ -35,7 +35,7 @@ public class SelfUserImpl extends UserImpl implements SelfUser
     //Client only
     private String email;
 
-    public SelfUserImpl(String id, JDAImpl api)
+    public SelfUserImpl(long id, JDAImpl api)
     {
         super(id, api);
     }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -38,14 +38,15 @@ import org.json.JSONObject;
 import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class TextChannelImpl implements TextChannel
 {
-    private final String id;
+    private final long id;
     private final GuildImpl guild;
-    private final HashMap<Member, PermissionOverride> memberOverrides = new HashMap<>();
-    private final HashMap<Role, PermissionOverride> roleOverrides = new HashMap<>();
+    private final Map<Member, PermissionOverride> memberOverrides = new ConcurrentHashMap<>();
+    private final Map<Role, PermissionOverride> roleOverrides = new ConcurrentHashMap<>();
 
     private volatile ChannelManager manager;
     private volatile ChannelManagerUpdatable managerUpdatable;
@@ -55,7 +56,7 @@ public class TextChannelImpl implements TextChannel
     private String topic;
     private int rawPosition;
 
-    public TextChannelImpl(String id, Guild guild)
+    public TextChannelImpl(long id, Guild guild)
     {
         this.id = id;
         this.guild = (GuildImpl) guild;
@@ -64,11 +65,11 @@ public class TextChannelImpl implements TextChannel
     @Override
     public String getAsMention()
     {
-        return "<#" + getId() + '>';
+        return "<#" + id + '>';
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return id;
     }
@@ -98,11 +99,11 @@ public class TextChannelImpl implements TextChannel
         }
 
         JSONObject body = new JSONObject().put("messages", messageIds);
-        Route.CompiledRoute route = Route.Messages.DELETE_MESSAGES.compile(id);
+        Route.CompiledRoute route = Route.Messages.DELETE_MESSAGES.compile(getId());
         return new RestAction<Void>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -117,11 +118,11 @@ public class TextChannelImpl implements TextChannel
     {
         checkPermission(Permission.MANAGE_WEBHOOKS);
 
-        Route.CompiledRoute route = Route.Channels.GET_WEBHOOKS.compile(id);
+        Route.CompiledRoute route = Route.Channels.GET_WEBHOOKS.compile(getId());
         return new RestAction<List<Webhook>>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<List<Webhook>> request)
             {
                 if (!response.isOk())
                 {
@@ -162,7 +163,7 @@ public class TextChannelImpl implements TextChannel
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -214,7 +215,7 @@ public class TextChannelImpl implements TextChannel
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(guild.getMembersMap().values().stream()
+        return Collections.unmodifiableList(guild.getMembersMap().valueCollection().stream()
                 .filter(m -> m.hasPermission(this, Permission.MESSAGE_READ))
                 .collect(Collectors.toList()));
     }
@@ -433,11 +434,11 @@ public class TextChannelImpl implements TextChannel
     {
         checkPermission(Permission.MANAGE_CHANNEL);
 
-        Route.CompiledRoute route = Route.Channels.DELETE_CHANNEL.compile(id);
+        Route.CompiledRoute route = Route.Channels.DELETE_CHANNEL.compile(getId());
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -472,7 +473,7 @@ public class TextChannelImpl implements TextChannel
         if (getMemberOverrideMap().containsKey(member))
             throw new IllegalStateException("Provided member already has a PermissionOverride in this channel!");
 
-        Route.CompiledRoute route = Route.Channels.CREATE_PERM_OVERRIDE.compile(id, member.getUser().getId());
+        Route.CompiledRoute route = Route.Channels.CREATE_PERM_OVERRIDE.compile(getId(), member.getUser().getId());
         return new PermissionOverrideAction(getJDA(), route, this, member);
     }
 
@@ -486,29 +487,29 @@ public class TextChannelImpl implements TextChannel
         if (getRoleOverrideMap().containsKey(role))
             throw new IllegalStateException("Provided role already has a PermissionOverride in this channel!");
 
-        Route.CompiledRoute route = Route.Channels.CREATE_PERM_OVERRIDE.compile(id, role.getId());
+        Route.CompiledRoute route = Route.Channels.CREATE_PERM_OVERRIDE.compile(getId(), role.getId());
         return new PermissionOverrideAction(getJDA(), route, this, role);
     }
 
     @Override
     public boolean equals(Object o)
     {
-        if (!(o instanceof TextChannel))
+        if (!(o instanceof TextChannelImpl))
             return false;
-        TextChannel oTChannel = (TextChannel) o;
-        return this == oTChannel || this.getId().equals(oTChannel.getId());
+        TextChannelImpl oTChannel = (TextChannelImpl) o;
+        return this == oTChannel || this.id == oTChannel.id;
     }
 
     @Override
     public int hashCode()
     {
-        return getId().hashCode();
+        return Long.hashCode(id);
     }
 
     @Override
     public String toString()
     {
-        return "TC:" + getName() + '(' + getId() + ')';
+        return "TC:" + getName() + '(' + id + ')';
     }
 
     @Override
@@ -517,7 +518,7 @@ public class TextChannelImpl implements TextChannel
         if (this == chan)
             return 0;
 
-        if (this.getGuild() != chan.getGuild())
+        if (!this.getGuild().equals(chan.getGuild()))
             throw new IllegalArgumentException("Cannot compare TextChannels that aren't from the same guild!");
 
         if (this.getPositionRaw() != chan.getPositionRaw())
@@ -554,12 +555,12 @@ public class TextChannelImpl implements TextChannel
 
     // -- Map Getters --
 
-    public HashMap<Member, PermissionOverride> getMemberOverrideMap()
+    public Map<Member, PermissionOverride> getMemberOverrideMap()
     {
         return memberOverrides;
     }
 
-    public HashMap<Role, PermissionOverride> getRoleOverrideMap()
+    public Map<Role, PermissionOverride> getRoleOverrideMap()
     {
         return roleOverrides;
     }
@@ -595,7 +596,7 @@ public class TextChannelImpl implements TextChannel
         return new RestAction<List<Invite>>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(final Response response, final Request request)
+            protected void handleResponse(final Response response, final Request<List<Invite>> request)
             {
                 if (response.isOk())
                 {

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/UserImpl.java
@@ -31,17 +31,17 @@ import java.util.List;
 
 public class UserImpl implements User
 {
-    protected final String id;
+    protected final long id;
     protected final JDAImpl api;
 
+    protected short discriminator;
     protected String name;
-    protected String discriminator;
     protected String avatarId;
     protected PrivateChannel privateChannel;
     protected boolean bot;
     protected boolean fake = false;
 
-    public UserImpl(String id, JDAImpl api)
+    public UserImpl(long id, JDAImpl api)
     {
         this.id = id;
         this.api = api;
@@ -56,7 +56,7 @@ public class UserImpl implements User
     @Override
     public String getDiscriminator()
     {
-        return discriminator;
+        return String.valueOf(discriminator);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class UserImpl implements User
     public RestAction<PrivateChannel> openPrivateChannel()
     {
         if (privateChannel != null)
-            return new RestAction.EmptyRestAction<PrivateChannel>(privateChannel);
+            return new RestAction.EmptyRestAction<>(privateChannel);
 
         if (fake)
             throw new IllegalStateException("Cannot open a PrivateChannel with a Fake user.");
@@ -111,7 +111,7 @@ public class UserImpl implements User
         return new RestAction<PrivateChannel>(api, route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<PrivateChannel> request)
             {
                 if (response.isOk())
                 {
@@ -157,11 +157,11 @@ public class UserImpl implements User
     @Override
     public String getAsMention()
     {
-        return "<@" + getId() + '>';
+        return "<@" + id + '>';
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return id;
     }
@@ -175,22 +175,22 @@ public class UserImpl implements User
     @Override
     public boolean equals(Object o)
     {
-        if (!(o instanceof User))
+        if (!(o instanceof UserImpl))
             return false;
-        User oUser = (User) o;
-        return this == oUser || this.getId().equals(oUser.getId());
+        UserImpl oUser = (UserImpl) o;
+        return this == oUser || this.id == oUser.id;
     }
 
     @Override
     public int hashCode()
     {
-        return getId().hashCode();
+        return Long.hashCode(id);
     }
 
     @Override
     public String toString()
     {
-        return "U:" + getName() + '(' + getId() + ')';
+        return "U:" + getName() + '(' + id + ')';
     }
 
     // -- Setters --
@@ -203,7 +203,7 @@ public class UserImpl implements User
 
     public UserImpl setDiscriminator(String discriminator)
     {
-        this.discriminator = discriminator;
+        this.discriminator = Short.parseShort(discriminator);
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
@@ -36,14 +36,14 @@ public class WebhookImpl implements Webhook
 
     private final Object mngLock = new Object();
     private final TextChannel channel;
-    private final String id;
+    private final long id;
 
     private Member owner;
     private User user;
     private String token;
 
 
-    public WebhookImpl(TextChannel channel, String id)
+    public WebhookImpl(TextChannel channel, long id)
     {
         this.channel = channel;
         this.id = id;
@@ -100,11 +100,11 @@ public class WebhookImpl implements Webhook
     @Override
     public RestAction<Void> delete()
     {
-        Route.CompiledRoute route = Route.Webhooks.DELETE_TOKEN_WEBHOOK.compile(id, token);
+        Route.CompiledRoute route = Route.Webhooks.DELETE_TOKEN_WEBHOOK.compile(getId(), token);
         return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -147,7 +147,7 @@ public class WebhookImpl implements Webhook
     }
 
     @Override
-    public String getId()
+    public long getIdLong()
     {
         return id;
     }
@@ -177,14 +177,14 @@ public class WebhookImpl implements Webhook
     @Override
     public int hashCode()
     {
-        return getId().hashCode();
+        return Long.hashCode(id);
     }
 
     @Override
     public boolean equals(Object obj)
     {
-        return obj instanceof Webhook
-                && ((Webhook) obj).getId().equals(id);
+        return obj instanceof WebhookImpl
+                && ((WebhookImpl) obj).id == this.id;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
@@ -42,34 +42,34 @@ public class ChannelDeleteHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         ChannelType type = ChannelType.fromId(content.getInt("type"));
-        if (type == ChannelType.TEXT || type == ChannelType.VOICE)
+
+        long guildId = 0;
+        if (type.isGuild())
         {
-            if (GuildLock.get(api).isLocked(content.getString("guild_id")))
-            {
-                return content.getString("guild_id");
-            }
+            guildId = content.getLong("guild_id");
+            if (GuildLock.get(api).isLocked(guildId))
+                return guildId;
         }
+
+        final long channelId = content.getLong("id");
 
         switch (type)
         {
             case TEXT:
             {
-                GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
-                TextChannel channel = api.getTextChannelMap().remove(content.getString("id"));
+                GuildImpl guild = (GuildImpl) api.getGuildMap().get(guildId);
+                TextChannel channel = api.getTextChannelMap().remove(channelId);
                 if (channel == null)
                 {
-                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a text channel that is not yet cached. JSON: " + content);
                     return null;
                 }
 
-                guild.getTextChannelsMap().remove(channel.getId());
+                guild.getTextChannelsMap().remove(channel.getIdLong());
                 api.getEventManager().handle(
                         new TextChannelDeleteEvent(
                                 api, responseNumber,
@@ -78,26 +78,23 @@ public class ChannelDeleteHandler extends SocketHandler
             }
             case VOICE:
             {
-                GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
-                VoiceChannel channel = guild.getVoiceChannelMap().remove(content.getString("id"));
+                GuildImpl guild = (GuildImpl) api.getGuildMap().get(guildId);
+                VoiceChannel channel = guild.getVoiceChannelMap().remove(channelId);
                 if (channel == null)
                 {
-                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a voice channel that is not yet cached. JSON: " + content);
                     return null;
                 }
 
                 //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
-                AudioManagerImpl manager = (AudioManagerImpl) api.getAudioManagerMap().get(guild.getId());
+                AudioManagerImpl manager = (AudioManagerImpl) api.getAudioManagerMap().get(guild.getIdLong());
                 if (manager != null && manager.isConnected()
-                        && manager.getConnectedChannel().getId().equals(channel.getId()))
+                        && manager.getConnectedChannel().getIdLong() == channel.getIdLong())
                 {
                     manager.closeAudioConnection(ConnectionStatus.DISCONNECTED_CHANNEL_DELETED);
                 }
-                guild.getVoiceChannelMap().remove(channel.getId());
+                guild.getVoiceChannelMap().remove(channel.getIdLong());
                 api.getEventManager().handle(
                         new VoiceChannelDeleteEvent(
                                 api, responseNumber,
@@ -106,23 +103,19 @@ public class ChannelDeleteHandler extends SocketHandler
             }
             case PRIVATE:
             {
-                String channelId = content.getString("id");
                 PrivateChannel channel = api.getPrivateChannelMap().remove(channelId);
 
                 if (channel == null)
                     channel = api.getFakePrivateChannelMap().remove(channelId);
                 if (channel == null)
                 {
-                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a private channel that is not yet cached. JSON: " + content);
                     return null;
                 }
 
                 if (channel.getUser().isFake())
-                    api.getFakeUserMap().remove(channel.getUser().getId());
+                    api.getFakeUserMap().remove(channel.getUser().getIdLong());
 
                 ((UserImpl) channel.getUser()).setPrivateChannel(null);
 
@@ -135,30 +128,29 @@ public class ChannelDeleteHandler extends SocketHandler
             case GROUP:
             {
                 //TODO: close call on group leave (kill audio manager)
-                String groupId = content.getString("id");
+                final long groupId = content.getLong("id");
                 GroupImpl group = (GroupImpl) ((JDAClientImpl) api.asClient()).getGroupMap().remove(groupId);
                 if (group == null)
                 {
-                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a group that is not yet cached. JSON: " + content);
                     return null;
                 }
 
-                group.getUserMap().forEach((userId, user) ->
+                group.getUserMap().forEachEntry((userId, user) ->
                 {
                     //User is fake, has no privateChannel, is not in a relationship, and is not in any other groups
                     // then we remove the fake user from the fake cache as it was only in this group
                     //Note: we getGroups() which gets all groups, however we already removed the current group above.
                     if (user.isFake()
                             && !user.hasPrivateChannel()
-                            && api.asClient().getRelationshipById(userId) == null
-                            && api.asClient().getGroups().stream().allMatch(g -> !g.getUsers().contains(user)))
+                            && ((JDAClientImpl) api.asClient()).getRelationshipMap().get(userId) == null
+                            && api.asClient().getGroups().stream().noneMatch(g -> g.getUsers().contains(user)))
                     {
                         api.getFakeUserMap().remove(userId);
                     }
+
+                    return true;
                 });
 
                 api.getEventManager().handle(

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildBanHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildBanHandler.java
@@ -35,18 +35,17 @@ public class GuildBanHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        if (GuildLock.get(api).isLocked(content.getString("guild_id")))
-        {
-            return content.getString("guild_id");
-        }
+        final long id = content.getLong("guild_id");
+        if (GuildLock.get(api).isLocked(id))
+            return id;
 
         JSONObject userJson = content.getJSONObject("user");
-        GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
+        GuildImpl guild = (GuildImpl) api.getGuildMap().get(id);
         if (guild == null)
         {
-            EventCache.get(api).cache(EventCache.Type.GUILD, content.getString("guild_id"), () ->
+            EventCache.get(api).cache(EventCache.Type.GUILD, id, () ->
             {
                 handle(responseNumber, allContent);
             });

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildCreateHandler.java
@@ -32,9 +32,9 @@ public class GuildCreateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        Guild g = api.getGuildById(content.getString("id"));
+        Guild g = api.getGuildById(content.getLong("id"));
         Boolean wasAvail = (g == null || g.getName() == null) ? null : g.isAvailable();
         EntityBuilder.get(api).createGuildFirstPass(content, guild ->
         {
@@ -52,7 +52,7 @@ public class GuildCreateHandler extends SocketHandler
                                 new GuildJoinEvent(
                                         api, responseNumber,
                                         guild));
-                        EventCache.get(api).playbackCache(EventCache.Type.GUILD, guild.getId());
+                        EventCache.get(api).playbackCache(EventCache.Type.GUILD, guild.getIdLong());
                     }
                     else if (!wasAvail)                     //was previously unavailable
                     {

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildDeleteHandler.java
@@ -16,6 +16,10 @@
 
 package net.dv8tion.jda.core.handle;
 
+import gnu.trove.iterator.TLongIterator;
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.client.entities.Group;
 import net.dv8tion.jda.client.entities.Relationship;
 import net.dv8tion.jda.client.entities.RelationshipType;
@@ -33,11 +37,6 @@ import net.dv8tion.jda.core.managers.impl.AudioManagerImpl;
 import net.dv8tion.jda.core.requests.GuildLock;
 import org.json.JSONObject;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-
 public class GuildDeleteHandler extends SocketHandler
 {
     public GuildDeleteHandler(JDAImpl api)
@@ -46,28 +45,26 @@ public class GuildDeleteHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.getString("id");
-        GuildImpl guild = (GuildImpl) api.getGuildMap().get(guildId);
+        final long id = content.getLong("id");
+        GuildImpl guild = (GuildImpl) api.getGuildMap().get(id);
 
         //If the event is attempting to mark the guild as unavailable, but it is already unavailable,
         // ignore the event
         if ((guild == null || !guild.isAvailable()) && content.has("unavailable") && content.getBoolean("unavailable"))
             return null;
 
-        if (GuildLock.get(api).isLocked(guildId))
-        {
-            return guildId;
-        }
+        if (GuildLock.get(api).isLocked(id))
+            return id;
 
-        AudioManagerImpl manager = (AudioManagerImpl) api.getAudioManagerMap().get(guild.getId());
+        AudioManagerImpl manager = (AudioManagerImpl) api.getAudioManagerMap().get(guild.getIdLong());
         if (manager != null)
             manager.closeAudioConnection(ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD);
 
         if (content.has("unavailable") && content.getBoolean("unavailable"))
         {
-            ((GuildImpl) guild).setAvailable(false);
+            guild.setAvailable(false);
             api.getEventManager().handle(
                     new GuildUnavailableEvent(
                             api, responseNumber,
@@ -77,19 +74,19 @@ public class GuildDeleteHandler extends SocketHandler
         }
 
         if (manager != null)
-            api.getAudioManagerMap().remove(guild.getId());
+            api.getAudioManagerMap().remove(guild.getIdLong());
 
         //cleaning up all users that we do not share a guild with anymore
         // Anything left in memberIds will be removed from the main userMap
         //Use a new HashSet so that we don't actually modify the Member map so it doesn't affect Guild#getMembers for the leave event.
-        Set<String> memberIds = new HashSet(guild.getMembersMap().keySet());
+        TLongSet memberIds = new TLongHashSet(guild.getMembersMap().keySet());
         for (Guild guildI : api.getGuilds())
         {
             GuildImpl g = (GuildImpl) guildI;
             if (g.equals(guild))
                 continue;
 
-            for (Iterator<String> it = memberIds.iterator(); it.hasNext();)
+            for (TLongIterator it = memberIds.iterator(); it.hasNext();)
             {
 
                 if (g.getMembersMap().containsKey(it.next()))
@@ -101,8 +98,8 @@ public class GuildDeleteHandler extends SocketHandler
         // Remember, everything left in memberIds is removed from the userMap
         if (api.getAccountType() == AccountType.CLIENT)
         {
-            HashMap<String, Relationship> relationships = ((JDAClientImpl) api.asClient()).getRelationshipMap();
-            for (Iterator<String> it = memberIds.iterator(); it.hasNext();)
+            TLongObjectMap<Relationship> relationships = ((JDAClientImpl) api.asClient()).getRelationshipMap();
+            for (TLongIterator it = memberIds.iterator(); it.hasNext();)
             {
                 Relationship rel = relationships.get(it.next());
                 if (rel != null && rel.getType() == RelationshipType.FRIEND)
@@ -110,7 +107,7 @@ public class GuildDeleteHandler extends SocketHandler
             }
         }
 
-        for (String memberId : memberIds)
+        memberIds.forEach(memberId ->
         {
             UserImpl user = (UserImpl) api.getUserMap().remove(memberId);
             if (user.hasPrivateChannel())
@@ -118,8 +115,8 @@ public class GuildDeleteHandler extends SocketHandler
                 PrivateChannelImpl priv = (PrivateChannelImpl) user.getPrivateChannel();
                 user.setFake(true);
                 priv.setFake(true);
-                api.getFakeUserMap().put(user.getId(), user);
-                api.getFakePrivateChannelMap().put(priv.getId(), priv);
+                api.getFakeUserMap().put(user.getIdLong(), user);
+                api.getFakePrivateChannelMap().put(priv.getIdLong(), priv);
             }
             else if (api.getAccountType() == AccountType.CLIENT)
             {
@@ -131,16 +128,18 @@ public class GuildDeleteHandler extends SocketHandler
                     if (grp.getNonFriendUsers().contains(user))
                     {
                         user.setFake(true);
-                        api.getFakeUserMap().put(user.getId(), user);
+                        api.getFakeUserMap().put(user.getIdLong(), user);
                         break; //Breaks from groups loop, not memberIds loop
                     }
                 }
             }
-        }
 
-        api.getGuildMap().remove(guild.getId());
-        guild.getTextChannels().forEach(chan -> api.getTextChannelMap().remove(chan.getId()));
-        guild.getVoiceChannels().forEach(chan -> api.getVoiceChannelMap().remove(chan.getId()));
+            return true;
+        });
+
+        api.getGuildMap().remove(guild.getIdLong());
+        guild.getTextChannels().forEach(chan -> api.getTextChannelMap().remove(chan.getIdLong()));
+        guild.getVoiceChannels().forEach(chan -> api.getVoiceChannelMap().remove(chan.getIdLong()));
         api.getEventManager().handle(
                 new GuildLeaveEvent(
                         api, responseNumber,

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildMemberAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildMemberAddHandler.java
@@ -32,17 +32,16 @@ public class GuildMemberAddHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        if (GuildLock.get(api).isLocked(content.getString("guild_id")))
-        {
-            return content.getString("guild_id");
-        }
+        final long id = content.getLong("guild_id");
+        if (GuildLock.get(api).isLocked(id))
+            return id;
 
-        GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
+        GuildImpl guild = (GuildImpl) api.getGuildMap().get(id);
         if (guild == null)
         {
-            EventCache.get(api).cache(EventCache.Type.GUILD, content.getString("guild_id"), () ->
+            EventCache.get(api).cache(EventCache.Type.GUILD, id, () ->
             {
                 handle(responseNumber, allContent);
             });
@@ -54,7 +53,7 @@ public class GuildMemberAddHandler extends SocketHandler
                 new GuildMemberJoinEvent(
                         api, responseNumber,
                         guild, member));
-        EventCache.get(api).playbackCache(EventCache.Type.USER, member.getUser().getId());
+        EventCache.get(api).playbackCache(EventCache.Type.USER, member.getUser().getIdLong());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildMemberUpdateHandler.java
@@ -41,18 +41,18 @@ public class GuildMemberUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        if (GuildLock.get(api).isLocked(content.getString("guild_id")))
-        {
-            return content.getString("guild_id");
-        }
+        final long id = content.getLong("guild_id");
+        if (GuildLock.get(api).isLocked(id))
+            return id;
 
         JSONObject userJson = content.getJSONObject("user");
-        GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("guild_id"));
+        final long userId = userJson.getLong("id");
+        GuildImpl guild = (GuildImpl) api.getGuildMap().get(id);
         if (guild == null)
         {
-            EventCache.get(api).cache(EventCache.Type.GUILD, userJson.getString("id"), () ->
+            EventCache.get(api).cache(EventCache.Type.GUILD, userId, () ->
             {
                 handle(responseNumber, allContent);
             });
@@ -60,10 +60,10 @@ public class GuildMemberUpdateHandler extends SocketHandler
             return null;
         }
 
-        MemberImpl member = (MemberImpl) guild.getMembersMap().get(userJson.getString("id"));
+        MemberImpl member = (MemberImpl) guild.getMembersMap().get(userId);
         if (member == null)
         {
-            EventCache.get(api).cache(EventCache.Type.USER, userJson.getString("id"), () ->
+            EventCache.get(api).cache(EventCache.Type.USER, userId, () ->
             {
                 handle(responseNumber, allContent);
             });
@@ -137,14 +137,15 @@ public class GuildMemberUpdateHandler extends SocketHandler
         LinkedList<Role> roles = new LinkedList<>();
         for(int i = 0; i < array.length(); i++)
         {
-            Role r = guild.getRolesMap().get(array.getString(i));
+            final long id = Long.parseLong(array.getString(i));
+            Role r = guild.getRolesMap().get(id);
             if (r != null)
             {
                 roles.add(r);
             }
             else
             {
-                EventCache.get(api).cache(EventCache.Type.ROLE, array.getString(i), () ->
+                EventCache.get(api).cache(EventCache.Type.ROLE, id, () ->
                 {
                     handle(responseNumber, allContent);
                 });

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildMembersChunkHandler.java
@@ -16,20 +16,22 @@
 
 package net.dv8tion.jda.core.handle;
 
+import gnu.trove.map.TLongIntMap;
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongIntHashMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.core.entities.EntityBuilder;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
 public class GuildMembersChunkHandler extends SocketHandler
 {
-    HashMap<String, Integer> expectedGuildMembers = new HashMap<>();
-    HashMap<String, List<JSONArray>> memberChunksCache = new HashMap<>();
-
+    private final TLongIntMap expectedGuildMembers = new TLongIntHashMap();
+    private final TLongObjectMap<List<JSONArray>> memberChunksCache = new TLongObjectHashMap<>();
 
     public GuildMembersChunkHandler(JDAImpl api)
     {
@@ -37,11 +39,11 @@ public class GuildMembersChunkHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.getString("guild_id");
+        final long guildId = content.getLong("guild_id");
         List<JSONArray> memberChunks = memberChunksCache.get(guildId);
-        Integer expectMemberCount = (Integer) expectedGuildMembers.get(guildId);
+        int expectMemberCount = expectedGuildMembers.get(guildId);
 
         JSONArray members = content.getJSONArray("members");
         JDAImpl.LOG.debug("GUILD_MEMBER_CHUNK for: " + guildId + " \tMembers: " + members.length());
@@ -63,24 +65,24 @@ public class GuildMembersChunkHandler extends SocketHandler
         return null;
     }
 
-    public void setExpectedGuildMembers(String guildId, int count)
+    public void setExpectedGuildMembers(long guildId, int count)
     {
-        if (expectedGuildMembers.get(guildId) != null)
+        if (expectedGuildMembers.containsKey(guildId))
             JDAImpl.LOG.warn("Set the count of expected users from GuildMembersChunk even though a value already exists! GuildId: " + guildId);
 
         expectedGuildMembers.put(guildId, count);
 
-        if (memberChunksCache.get(guildId) != null)
+        if (memberChunksCache.containsKey(guildId))
             JDAImpl.LOG.warn("Set the memberChunks for MemberChunking for a guild that was already setup for chunking! GuildId: " + guildId);
 
         memberChunksCache.put(guildId, new LinkedList<>());
     }
 
-    public void modifyExpectedGuildMember(String guildId, int changeAmount)
+    public void modifyExpectedGuildMember(long guildId, int changeAmount)
     {
         try
         {
-            Integer i = (Integer) expectedGuildMembers.get(guildId);
+            Integer i = expectedGuildMembers.get(guildId);
             i += changeAmount;
             expectedGuildMembers.put(guildId, i);
         }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildRoleCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildRoleCreateHandler.java
@@ -32,9 +32,9 @@ public class GuildRoleCreateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.getString("guild_id");
+        final long guildId = content.getLong("guild_id");
         if (GuildLock.get(api).isLocked(guildId))
         {
             return guildId;
@@ -51,12 +51,12 @@ public class GuildRoleCreateHandler extends SocketHandler
             return null;
         }
 
-        Role newRole = EntityBuilder.get(api).createRole(content.getJSONObject("role"), guild.getId());
+        Role newRole = EntityBuilder.get(api).createRole(content.getJSONObject("role"), guild.getIdLong());
         api.getEventManager().handle(
                 new RoleCreateEvent(
                         api, responseNumber,
                         newRole));
-        EventCache.get(api).playbackCache(EventCache.Type.ROLE, newRole.getId());
+        EventCache.get(api).playbackCache(EventCache.Type.ROLE, newRole.getIdLong());
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildRoleUpdateHandler.java
@@ -33,33 +33,27 @@ public class GuildRoleUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.getString("guild_id");
+        final long guildId = content.getLong("guild_id");
         if (GuildLock.get(api).isLocked(guildId))
-        {
             return guildId;
-        }
 
         JSONObject rolejson = content.getJSONObject("role");
         GuildImpl guild = (GuildImpl) api.getGuildMap().get(guildId);
         if (guild == null)
         {
             EventCache.get(api).cache(EventCache.Type.GUILD, guildId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+                    handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a Role Update for a Guild that is not yet cached: " + content);
             return null;
         }
 
-        RoleImpl role = (RoleImpl) guild.getRolesMap().get(rolejson.getString("id"));
+        final long roleId = rolejson.getLong("id");
+        RoleImpl role = (RoleImpl) guild.getRolesMap().get(roleId);
         if (role == null)
         {
-            EventCache.get(api).cache(EventCache.Type.ROLE, rolejson.getString("id"), () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.ROLE, roleId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a Role Update for Role that is not yet cached: " + content);
             return null;
         }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildSyncHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildSyncHandler.java
@@ -30,9 +30,9 @@ public class GuildSyncHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.getString("id");
+        final long guildId = content.getLong("id");
         if (!api.getGuildMap().containsKey(guildId))
         {
             JDAImpl.LOG.fatal("Received a GUILD_SYNC for a Guild that does not yet exist in JDA's guild cache. This is a BAD ERROR FOR CLIENTS!");

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildUpdateHandler.java
@@ -36,15 +36,14 @@ public class GuildUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        if (GuildLock.get(api).isLocked(content.getString("id")))
-        {
-            return content.getString("id");
-        }
+        final long id = content.getLong("id");
+        if (GuildLock.get(api).isLocked(id))
+            return id;
 
-        GuildImpl guild = (GuildImpl) api.getGuildMap().get(content.getString("id"));
-        Member owner = guild.getMembersMap().get(content.getString("owner_id"));
+        GuildImpl guild = (GuildImpl) api.getGuildMap().get(id);
+        Member owner = guild.getMembersMap().get(content.getLong("owner_id"));
         String name = content.getString("name");
         String iconId = !content.isNull("icon") ? content.getString("icon") : null;
         String splashId = !content.isNull("splash") ? content.getString("splash") : null;
@@ -54,7 +53,7 @@ public class GuildUpdateHandler extends SocketHandler
         Guild.MFALevel mfaLevel = Guild.MFALevel.fromKey(content.getInt("mfa_level"));
         Guild.Timeout afkTimeout = Guild.Timeout.fromKey(content.getInt("afk_timeout"));
         VoiceChannel afkChannel = !content.isNull("afk_channel_id")
-                ? guild.getVoiceChannelMap().get(content.getString("afk_channel_id"))
+                ? guild.getVoiceChannelMap().get(content.getLong("afk_channel_id"))
                 : null;
 
         if (!Objects.equals(owner, guild.getOwner()))

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageCreateHandler.java
@@ -28,11 +28,9 @@ import net.dv8tion.jda.core.requests.GuildLock;
 import net.dv8tion.jda.core.requests.WebSocketClient;
 import org.json.JSONObject;
 
-import java.util.regex.Pattern;
-
 public class MessageCreateHandler extends SocketHandler
 {
-    private static final Pattern invitePattern = Pattern.compile("\\bhttps://(?:www\\.)?discord(?:\\.gg|app\\.com/invite)/([a-zA-Z0-9-]+)\\b");
+    //private static final Pattern invitePattern = Pattern.compile("\\bhttps://(?:www\\.)?discord(?:\\.gg|app\\.com/invite)/([a-zA-Z0-9-]+)\\b");
 
     public MessageCreateHandler(JDAImpl api)
     {
@@ -40,7 +38,7 @@ public class MessageCreateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         MessageType type = MessageType.fromId(content.getInt("type"));
 
@@ -54,7 +52,7 @@ public class MessageCreateHandler extends SocketHandler
         return null;
     }
 
-    private String handleDefaultMessage(JSONObject content)
+    private Long handleDefaultMessage(JSONObject content)
     {
         Message message;
         try
@@ -67,19 +65,15 @@ public class MessageCreateHandler extends SocketHandler
             {
                 case EntityBuilder.MISSING_CHANNEL:
                 {
-                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    final long channelId = content.getLong("channel_id");
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("Received a message for a channel that JDA does not currently have cached");
                     return null;
                 }
                 case EntityBuilder.MISSING_USER:
                 {
-                    EventCache.get(api).cache(EventCache.Type.USER, content.getJSONObject("author").getString("id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    final long authorId = content.getJSONObject("author").getLong("id");
+                    EventCache.get(api).cache(EventCache.Type.USER, authorId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("Received a message for a user that JDA does not currently have cached");
                     return null;
                 }
@@ -93,9 +87,9 @@ public class MessageCreateHandler extends SocketHandler
             case TEXT:
             {
                 TextChannel channel = message.getTextChannel();
-                if (GuildLock.get(api).isLocked(channel.getGuild().getId()))
+                if (GuildLock.get(api).isLocked(channel.getGuild().getIdLong()))
                 {
-                    return channel.getGuild().getId();
+                    return channel.getGuild().getIdLong();
                 }
                 api.getEventManager().handle(
                         new GuildMessageReceivedEvent(

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageReactionHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageReactionHandler.java
@@ -40,15 +40,15 @@ public class MessageReactionHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         JSONObject emoji = content.getJSONObject("emoji");
 
-        String userId = content.getString("user_id");
-        String messageId = content.getString("message_id");
-        String channelId = content.getString("channel_id");
+        final long userId    = content.getLong("user_id");
+        final long messageId = content.getLong("message_id");
+        final long channelId = content.getLong("channel_id");
 
-        String emojiId = emoji.isNull("id") ? null : emoji.getString("id");
+        final Long emojiId = emoji.isNull("id") ? null : emoji.getLong("id");
         String emojiName = emoji.isNull("name") ? null : emoji.getString("name");
 
         if (emojiId == null && emojiName == null)
@@ -62,27 +62,27 @@ public class MessageReactionHandler extends SocketHandler
             user = api.getFakeUserMap().get(userId);
         if (user == null)
         {
-            EventCache.get(api).cache(EventCache.Type.USER, userId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.USER, userId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a reaction for a user that JDA does not currently have cached");
             return null;
         }
 
         MessageChannel channel = api.getTextChannelById(channelId);
         if (channel == null)
+        {
             channel = api.getPrivateChannelById(channelId);
+        }
         if (channel == null && api.getAccountType() == AccountType.CLIENT)
+        {
             channel = api.asClient().getGroupById(channelId);
-        if (channel == null)
-            channel = api.getFakePrivateChannelMap().get(channelId);
+        }
         if (channel == null)
         {
-            EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            channel = api.getFakePrivateChannelMap().get(channelId);
+        }
+        if (channel == null)
+        {
+            EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a reaction for a channel that JDA does not currently have cached");
             return null;
         }

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageUpdateHandler.java
@@ -43,7 +43,7 @@ public class MessageUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         if (content.has("author"))
         {
@@ -76,7 +76,7 @@ public class MessageUpdateHandler extends SocketHandler
             return handleMessageEmbed(content);
     }
 
-    private String handleDefaultMessage(JSONObject content)
+    private Long handleDefaultMessage(JSONObject content)
     {
         Message message;
         try
@@ -89,19 +89,15 @@ public class MessageUpdateHandler extends SocketHandler
             {
                 case EntityBuilder.MISSING_CHANNEL:
                 {
-                    EventCache.get(api).cache(EventCache.Type.CHANNEL, content.getString("channel_id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    final long channelId = content.getLong("channel_id");
+                    EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("Received a message update for a channel that JDA does not currently have cached");
                     return null;
                 }
                 case EntityBuilder.MISSING_USER:
                 {
-                    EventCache.get(api).cache(EventCache.Type.USER, content.getJSONObject("author").getString("id"), () ->
-                    {
-                        handle(responseNumber, allContent);
-                    });
+                    final long authorId = content.getJSONObject("author").getLong("id");
+                    EventCache.get(api).cache(EventCache.Type.USER, authorId, () -> handle(responseNumber, allContent));
                     EventCache.LOG.debug("Received a message update for a user that JDA does not currently have cached");
                     return null;
                 }
@@ -115,9 +111,9 @@ public class MessageUpdateHandler extends SocketHandler
             case TEXT:
             {
                 TextChannel channel = message.getTextChannel();
-                if (GuildLock.get(api).isLocked(channel.getGuild().getId()))
+                if (GuildLock.get(api).isLocked(channel.getGuild().getIdLong()))
                 {
-                    return channel.getGuild().getId();
+                    return channel.getGuild().getIdLong();
                 }
                 api.getEventManager().handle(
                         new GuildMessageUpdateEvent(
@@ -154,11 +150,12 @@ public class MessageUpdateHandler extends SocketHandler
         return null;
     }
 
-    private String handleMessageEmbed(JSONObject content)
+    private Long handleMessageEmbed(JSONObject content)
     {
         EntityBuilder builder = EntityBuilder.get(api);
-        String messageId = content.getString("id");
-        String channelId = content.getString("channel_id");
+        final String messageIdString = content.getString("id");
+        final long messageId = Long.parseLong(messageIdString);
+        final long channelId = content.getLong("channel_id");
         LinkedList<MessageEmbed> embeds = new LinkedList<>();
         MessageChannel channel = api.getTextChannelMap().get(channelId);
         if (channel == null)
@@ -186,34 +183,34 @@ public class MessageUpdateHandler extends SocketHandler
         if (channel instanceof TextChannel)
         {
             TextChannel tChannel = (TextChannel) channel;
-            if (GuildLock.get(api).isLocked(tChannel.getGuild().getId()))
+            if (GuildLock.get(api).isLocked(tChannel.getGuild().getIdLong()))
             {
-                return tChannel.getGuild().getId();
+                return tChannel.getGuild().getIdLong();
             }
             api.getEventManager().handle(
                     new GuildMessageEmbedEvent(
                             api, responseNumber,
-                            messageId, tChannel, embeds));
+                            messageIdString, tChannel, embeds));
         }
         else if (channel instanceof PrivateChannel)
         {
             api.getEventManager().handle(
                     new PrivateMessageEmbedEvent(
                             api, responseNumber,
-                            messageId, (PrivateChannel) channel, embeds));
+                            messageIdString, (PrivateChannel) channel, embeds));
         }
         else
         {
             api.getEventManager().handle(
                     new GroupMessageEmbedEvent(
                             api, responseNumber,
-                            messageId, (Group) channel, embeds));
+                            messageIdString, (Group) channel, embeds));
         }
         //Combo event
         api.getEventManager().handle(
                 new MessageEmbedEvent(
                         api, responseNumber,
-                        messageId, channel, embeds));
+                        messageIdString, channel, embeds));
         return null;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/PresenceUpdateHandler.java
@@ -35,16 +35,18 @@ public class PresenceUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         //Do a pre-check to see if this is for a Guild, and if it is, if the guild is currently locked.
-        if (content.has("guild_id") && GuildLock.get(api).isLocked(content.getString("guild_id")))
+        if (content.has("guild_id"))
         {
-            return content.getString("guild_id");
+            final long guildId = content.getLong("guild_id");
+            if (GuildLock.get(api).isLocked(guildId))
+                return guildId;
         }
 
         JSONObject jsonUser = content.getJSONObject("user");
-        String userId = jsonUser.getString("id");
+        final long userId = jsonUser.getLong("id");
         UserImpl user = (UserImpl) api.getUserMap().get(userId);
 
         //If we do know about the user, lets update the user's specific info.
@@ -112,7 +114,7 @@ public class PresenceUpdateHandler extends SocketHandler
             // If we aren't we'll be dealing with the Relation system.
             if (content.has("guild_id"))
             {
-                GuildImpl guild = (GuildImpl) api.getGuildById(content.getString("guild_id"));
+                GuildImpl guild = (GuildImpl) api.getGuildById(content.getLong("guild_id"));
                 MemberImpl member = (MemberImpl) guild.getMember(user);
 
                 //If the Member is null, then User isn't in the Guild.
@@ -177,7 +179,7 @@ public class PresenceUpdateHandler extends SocketHandler
             //If this was for a Guild, cache it in the Guild for later use in GUILD_MEMBER_ADD
             if (content.has("guild_id"))
             {
-                GuildImpl guild = (GuildImpl) api.getGuildById(content.getString("guild_id"));
+                GuildImpl guild = (GuildImpl) api.getGuildById(content.getLong("guild_id"));
                 guild.getCachedPresenceMap().put(userId, content);
             }
             else

--- a/src/main/java/net/dv8tion/jda/core/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ReadyHandler.java
@@ -33,7 +33,7 @@ import org.json.JSONObject;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ReadyHandler extends SocketHandler
+public class ReadyHandler extends SocketHandler //todo longs
 {
     private final Set<String> incompleteGuilds = new HashSet<>();
     private final Set<String> acknowledgedGuilds = new HashSet<>();
@@ -47,7 +47,7 @@ public class ReadyHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         EntityBuilder builder = EntityBuilder.get(api);
 

--- a/src/main/java/net/dv8tion/jda/core/handle/SocketHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/SocketHandler.java
@@ -35,11 +35,9 @@ public abstract class SocketHandler
     {
         this.allContent = o;
         this.responseNumber = responseTotal;
-        String guildId = handleInternally(o.getJSONObject("d"));
+        final Long guildId = handleInternally(o.getJSONObject("d"));
         if (guildId != null)
-        {
             GuildLock.get(api).queue(guildId, o);
-        }
     }
 
     /**
@@ -49,5 +47,5 @@ public abstract class SocketHandler
      * @return
      *      Guild-id if that guild has a lock, or null if successful
      */
-    protected abstract String handleInternally(JSONObject content);
+    protected abstract Long handleInternally(JSONObject content);
 }

--- a/src/main/java/net/dv8tion/jda/core/handle/TypingStartHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/TypingStartHandler.java
@@ -40,9 +40,9 @@ public class TypingStartHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String channelId = content.getString("channel_id");
+        final long channelId = content.getLong("channel_id");
         MessageChannel channel = api.getTextChannelMap().get(channelId);
         if (channel == null)
             channel = api.getPrivateChannelMap().get(channelId);
@@ -57,14 +57,12 @@ public class TypingStartHandler extends SocketHandler
 
         if (channel instanceof TextChannel)
         {
-            String guildId = ((TextChannel) channel).getGuild().getId();
+            final long guildId = ((TextChannel) channel).getGuild().getIdLong();
             if (GuildLock.get(api).isLocked(guildId))
-            {
                 return guildId;
-            }
         }
 
-        String userId = content.getString("user_id");
+        final long userId = content.getLong("user_id");
         User user;
         if (channel instanceof PrivateChannel)
             user = ((PrivateChannel) channel).getUser();

--- a/src/main/java/net/dv8tion/jda/core/handle/UserUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/UserUpdateHandler.java
@@ -32,7 +32,7 @@ public class UserUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
         SelfUserImpl self = (SelfUserImpl) api.getSelfUser();
 

--- a/src/main/java/net/dv8tion/jda/core/handle/VoiceServerUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/VoiceServerUpdateHandler.java
@@ -36,15 +36,13 @@ public class VoiceServerUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.getString("guild_id");
+        final long guildId = content.getLong("guild_id");
         api.getClient().getQueuedAudioConnectionMap().remove(guildId);
 
         if (GuildLock.get(api).isLocked(guildId))
-        {
             return guildId;
-        }
 
         if (content.isNull("endpoint"))
         {
@@ -56,7 +54,7 @@ public class VoiceServerUpdateHandler extends SocketHandler
 
         String endpoint = content.getString("endpoint");
         String token = content.getString("token");
-        Guild guild = api.getGuildMap().get(content.getString("guild_id"));
+        Guild guild = api.getGuildMap().get(guildId);
         if (guild == null)
             throw new IllegalArgumentException("Attempted to start audio connection with Guild that doesn't exist! JSON: " + content);
         String sessionId = guild.getSelfMember().getVoiceState().getSessionId();

--- a/src/main/java/net/dv8tion/jda/core/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/VoiceStateUpdateHandler.java
@@ -47,31 +47,25 @@ public class VoiceStateUpdateHandler extends SocketHandler
     }
 
     @Override
-    protected String handleInternally(JSONObject content)
+    protected Long handleInternally(JSONObject content)
     {
-        String guildId = content.has("guild_id") ? content.getString("guild_id") : null;
+        final Long guildId = content.has("guild_id") ? content.getLong("guild_id") : null;
         if (guildId != null && GuildLock.get(api).isLocked(guildId))
-        {
             return guildId;
-        }
 
         if (guildId != null)
-        {
             handleGuildVoiceState(content);
-        }
         else
-        {
             handleCallVoiceState(content);
-        }
         return null;
     }
 
     private void handleGuildVoiceState(JSONObject content)
     {
-        String userId = content.getString("user_id");
-        String guildId = content.getString("guild_id");
-        String channelId = !content.isNull("channel_id") ? content.getString("channel_id") : null;
-        String sessionId = !content.isNull("session_id") ? content.getString("session_id") : null;
+        final long userId = content.getLong("user_id");
+        final long guildId = content.getLong("guild_id");
+        final Long channelId = !content.isNull("channel_id") ? content.getLong("channel_id") : null;
+        final String sessionId = !content.isNull("session_id") ? content.getString("session_id") : null;
         boolean selfMuted = content.getBoolean("self_mute");
         boolean selfDeafened = content.getBoolean("self_deaf");
         boolean guildMuted = content.getBoolean("mute");
@@ -81,21 +75,15 @@ public class VoiceStateUpdateHandler extends SocketHandler
         Guild guild = api.getGuildById(guildId);
         if (guild == null)
         {
-            EventCache.get(api).cache(EventCache.Type.GUILD, content.getString("guild_id"), () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.GUILD, guildId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received a VOICE_STATE_UPDATE for a Guild that has yet to be cached. JSON: " + content);
             return;
         }
 
-        VoiceChannelImpl channel = (VoiceChannelImpl) guild.getVoiceChannelById(channelId);
+        VoiceChannelImpl channel = channelId != null ? (VoiceChannelImpl) guild.getVoiceChannelById(channelId) : null;
         if (channel == null && channelId != null)
         {
-            EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received VOICE_STATE_UPDATE for a VoiceChannel that has yet to be cached. JSON: " + content);
             return;
         }
@@ -113,10 +101,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
             // in fact the issue was that the VOICE_STATE_UPDATE was sent after they had left, however, by caching
             // it we will preserve the integrity of the cache in the event that it was actually a mis-ordering of
             // GUILD_MEMBER_ADD and VOICE_STATE_UPDATE. I'll take some bad-data events over an invalid cache.
-            EventCache.get(api).cache(EventCache.Type.USER, userId, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            EventCache.get(api).cache(EventCache.Type.USER, userId, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received VOICE_STATE_UPDATE for a Member that has yet to be cached. JSON: " + content);
             return;
         }
@@ -201,8 +186,8 @@ public class VoiceStateUpdateHandler extends SocketHandler
 
     private void handleCallVoiceState(JSONObject content)
     {
-        String userId = content.getString("user_id");
-        String channelId = !content.isNull("channel_id") ? content.getString("channel_id") : null;
+        final long userId = content.getLong("user_id");
+        final Long channelId = !content.isNull("channel_id") ? content.getLong("channel_id") : null;
         String sessionId = !content.isNull("session_id") ? content.getString("session_id") : null;
         boolean selfMuted = content.getBoolean("self_mute");
         boolean selfDeafened = content.getBoolean("self_deaf");
@@ -232,7 +217,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
             }
 
             CallUser cUser = ((JDAClientImpl) api.asClient()).getCallUserMap().get(userId);
-            if (cUser != null && !channelId.equals(cUser.getCall().getCallableChannel().getId()))
+            if (cUser != null && channelId != cUser.getCall().getCallableChannel().getIdLong())
             {
                 WebSocketClient.LOG.fatal("Received a VOICE_STATE_UPDATE for a user joining a call, but the user was already in a different call! Big error! JSON: " + content);
                 ((CallVoiceStateImpl) cUser.getVoiceState()).setInCall(false);

--- a/src/main/java/net/dv8tion/jda/core/managers/AccountManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/AccountManagerUpdatable.java
@@ -259,7 +259,7 @@ public class AccountManagerUpdatable
         return new RestAction<Void>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (!response.isOk())
                 {

--- a/src/main/java/net/dv8tion/jda/core/managers/ChannelManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/ChannelManagerUpdatable.java
@@ -267,7 +267,7 @@ public class ChannelManagerUpdatable
         return new RestAction<Void>(channel.getJDA(), route, frame)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
@@ -163,7 +163,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -248,7 +248,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -299,7 +299,7 @@ public class GuildController
         return new RestAction<Integer>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Integer> request)
             {
                 if (response.isOk())
                     request.onSuccess(response.getObject().getInt("pruned"));
@@ -348,7 +348,7 @@ public class GuildController
         return new RestAction<Integer>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Integer> request)
             {
                 if (response.isOk())
                     request.onSuccess(response.getObject().getInt("pruned"));
@@ -406,7 +406,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -581,7 +581,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -653,7 +653,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -738,7 +738,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -807,7 +807,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -874,7 +874,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -916,7 +916,7 @@ public class GuildController
         return new RestAction<List<User>>(guild.getJDA(), route, null)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<List<User>> request)
             {
                 if (!response.isOk())
                 {
@@ -1205,7 +1205,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -1319,16 +1319,11 @@ public class GuildController
             throw new IllegalArgumentException("Cannot add the PublicRole of a Guild to a Member. All members have this role by default!");
 
         //Make sure that the current managed roles are preserved and no new ones are added.
-        List<Role> currentManaged = roles.stream().filter(r -> r.isManaged()).collect(Collectors.toList());
-        List<Role> newManaged = roles.stream().filter(r -> r.isManaged()).collect(Collectors.toList());
+        List<Role> currentManaged = roles.stream().filter(Role::isManaged).collect(Collectors.toList());
+        List<Role> newManaged = roles.stream().filter(Role::isManaged).collect(Collectors.toList());
         if (currentManaged.size() != 0 || newManaged.size() != 0)
         {
-            for (Iterator<Role> it = currentManaged.iterator(); it.hasNext();)
-            {
-                Role r = it.next();
-                if (newManaged.contains(r))
-                    it.remove();
-            }
+            currentManaged.removeIf(newManaged::contains);
 
             if (currentManaged.size() > 0)
                 throw new IllegalArgumentException("Cannot remove managed roles from a member! Roles: " + currentManaged.toString());
@@ -1344,7 +1339,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -1406,7 +1401,7 @@ public class GuildController
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);
@@ -1682,12 +1677,12 @@ public class GuildController
         return new RestAction<Emote>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Emote> request)
             {
                 if (response.isOk())
                 {
                     JSONObject obj = response.getObject();
-                    String id = obj.getString("id");
+                    final long id = obj.getLong("id");
                     String name = obj.getString("name");
                     EmoteImpl emote = new EmoteImpl(id, guild).setName(name);
                     // managed is false by default, should always be false for emotes created by client accounts.
@@ -1730,7 +1725,7 @@ public class GuildController
      */
     public ChannelOrderAction<TextChannel> modifyTextChannelPositions()
     {
-        return new ChannelOrderAction(guild, ChannelType.TEXT);
+        return new ChannelOrderAction<>(guild, ChannelType.TEXT);
     }
 
     /**
@@ -1753,7 +1748,7 @@ public class GuildController
      */
     public ChannelOrderAction<VoiceChannel> modifyVoiceChannelPositions()
     {
-        return new ChannelOrderAction(guild, ChannelType.VOICE);
+        return new ChannelOrderAction<>(guild, ChannelType.VOICE);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/managers/GuildManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/GuildManagerUpdatable.java
@@ -379,7 +379,7 @@ public class GuildManagerUpdatable
         return new RestAction<Void>(guild.getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/managers/PermOverrideManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/PermOverrideManagerUpdatable.java
@@ -443,7 +443,7 @@ public class PermOverrideManagerUpdatable
         return new RestAction<Void>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/managers/RoleManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/RoleManagerUpdatable.java
@@ -259,7 +259,7 @@ public class RoleManagerUpdatable
         return new RestAction<Void>(getJDA(), route, body)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/managers/WebhookManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/WebhookManagerUpdatable.java
@@ -228,7 +228,7 @@ public class WebhookManagerUpdatable
         return new RestAction<Void>(getJDA(), route, data)
         {
             @Override
-            protected void handleResponse(Response response, Request request)
+            protected void handleResponse(Response response, Request<Void> request)
             {
                 if (response.isOk())
                     request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/managers/impl/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/impl/AudioManagerImpl.java
@@ -120,7 +120,7 @@ public class AudioManagerImpl implements AudioManager
     {
         synchronized (CONNECTION_LOCK)
         {
-            api.getClient().getQueuedAudioConnectionMap().remove(guild.getId());
+            api.getClient().getQueuedAudioConnectionMap().remove(guild.getIdLong());
             this.queuedAudioConnection = null;
             if (audioConnection == null)
                 return;

--- a/src/main/java/net/dv8tion/jda/core/requests/GuildLock.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/GuildLock.java
@@ -15,12 +15,19 @@
  */
 package net.dv8tion.jda.core.requests;
 
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.utils.SimpleLog;
 import org.json.JSONObject;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 public class GuildLock
 {
@@ -37,15 +44,15 @@ public class GuildLock
     }
 
     private final JDA api;
-    private final Map<String, List<JSONObject>> cache = new HashMap<>();
-    private final Set<String> cached = new HashSet<>();
+    private final TLongObjectMap<List<JSONObject>> cache = new TLongObjectHashMap<>();
+    private final TLongSet cached = new TLongHashSet();
 
-    public boolean isLocked(String guildId)
+    public boolean isLocked(long guildId)
     {
         return cached.contains(guildId);
     }
 
-    public void lock(String guildId)
+    public void lock(long guildId)
     {
         if (!isLocked(guildId))
         {
@@ -54,7 +61,7 @@ public class GuildLock
         }
     }
 
-    public void unlock(String guildId)
+    public void unlock(long guildId)
     {
         if (isLocked(guildId))
         {
@@ -69,7 +76,7 @@ public class GuildLock
         }
     }
 
-    public void queue(String guildId, JSONObject event)
+    public void queue(long guildId, JSONObject event)
     {
         if (isLocked(guildId))
         {

--- a/src/main/java/net/dv8tion/jda/core/requests/RateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RateLimiter.java
@@ -19,7 +19,6 @@ package net.dv8tion.jda.core.requests;
 import com.mashape.unirest.http.HttpResponse;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.requests.Route.CompiledRoute;
-import net.dv8tion.jda.core.requests.Route.RateLimit;
 import net.dv8tion.jda.core.requests.ratelimit.IBucket;
 
 import java.util.ArrayList;
@@ -27,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 public abstract class RateLimiter
 {

--- a/src/main/java/net/dv8tion/jda/core/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Requester.java
@@ -30,10 +30,7 @@ import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.requests.Route.CompiledRoute;
 import net.dv8tion.jda.core.requests.ratelimit.BotRateLimiter;
 import net.dv8tion.jda.core.requests.ratelimit.ClientRateLimiter;
-import net.dv8tion.jda.core.requests.ratelimit.IBucket;
 import net.dv8tion.jda.core.utils.SimpleLog;
-
-import java.util.List;
 
 public class Requester
 {
@@ -66,7 +63,7 @@ public class Requester
         return api;
     }
 
-    public void request(Request apiRequest)
+    public <T> void request(Request<T> apiRequest)
     {
         if (rateLimiter.isShutdown)
             throw new IllegalStateException("The Requester has been shutdown! No new requests can be requested!");
@@ -90,7 +87,7 @@ public class Requester
      * the request can be made again. This could either be for the Per-Route ratelimit or the Global ratelimit.
      * Check if globalCooldown is null to determine if it was Per-Route or Global.
      */
-    public Long execute(Request apiRequest)
+    public <T> Long execute(Request<T> apiRequest)
     {
         CompiledRoute route = apiRequest.getRoute();
         Long retryAfter = rateLimiter.getRateLimit(route);

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -253,7 +253,7 @@ public abstract class RestAction<T>
 
     protected void finalizeData() { }
 
-    protected abstract void handleResponse(Response response, Request request);
+    protected abstract void handleResponse(Response response, Request<T> request);
 
     /**
      * Specialized form of {@link net.dv8tion.jda.core.requests.RestAction} that is used to provide information that
@@ -293,6 +293,6 @@ public abstract class RestAction<T>
         }
 
         @Override
-        protected void handleResponse(Response response, Request request) { }
+        protected void handleResponse(Response response, Request<T> request) { }
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
@@ -326,7 +326,7 @@ public class ChannelAction extends RestAction<Channel>
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<Channel> request)
     {
         if (!response.isOk())
         {
@@ -336,8 +336,8 @@ public class ChannelAction extends RestAction<Channel>
 
         EntityBuilder builder = EntityBuilder.get(api);
         Channel channel = voice
-                ? builder.createVoiceChannel(response.getObject(), guild.getId())
-                : builder.createTextChannel(response.getObject(),  guild.getId());
+                ? builder.createVoiceChannel(response.getObject(), guild.getIdLong())
+                : builder.createTextChannel(response.getObject(),  guild.getIdLong());
 
         request.onSuccess(channel);
     }

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelOrderAction.java
@@ -17,7 +17,10 @@
 package net.dv8tion.jda.core.requests.restaction;
 
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.entities.Channel;
+import net.dv8tion.jda.core.entities.ChannelType;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.exceptions.PermissionException;
 import net.dv8tion.jda.core.requests.Route;
 import org.apache.http.util.Args;

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelOrderAction.java
@@ -40,7 +40,7 @@ import java.util.Collection;
  *
  * @since 3.0
  */
-public class ChannelOrderAction<T extends Channel> extends OrderAction<T, ChannelOrderAction>
+public class ChannelOrderAction<T extends Channel> extends OrderAction<T, ChannelOrderAction<T>>
 {
     protected final Guild guild;
     protected final ChannelType type;

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/InviteAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/InviteAction.java
@@ -62,7 +62,7 @@ public class InviteAction extends RestAction<Invite>
     }
 
     @Override
-    protected void handleResponse(final Response response, final Request request)
+    protected void handleResponse(final Response response, final Request<Invite> request)
     {
         if (response.isOk())
             request.onSuccess(EntityBuilder.get(this.api).createInvite(response.getObject()));

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/OrderAction.java
@@ -402,7 +402,7 @@ public abstract class OrderAction<T, M extends OrderAction> extends RestAction<V
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<Void> request)
     {
         if (response.isOk())
             request.onSuccess(null);

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/OrderAction.java
@@ -46,7 +46,7 @@ import java.util.List;
  *
  * @since 3.0
  */
-public abstract class OrderAction<T, M extends OrderAction> extends RestAction<Void>
+public abstract class OrderAction<T, M extends OrderAction<T, M>> extends RestAction<Void>
 {
     protected final JDA api;
     protected final List<T> orderList;

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
@@ -18,7 +18,10 @@ package net.dv8tion.jda.core.requests.restaction;
 
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.entities.Channel;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.PermissionOverride;
+import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.impl.PermissionOverrideImpl;
 import net.dv8tion.jda.core.entities.impl.TextChannelImpl;
 import net.dv8tion.jda.core.entities.impl.VoiceChannelImpl;
@@ -408,7 +411,7 @@ public class PermissionOverrideAction extends RestAction<PermissionOverride>
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<PermissionOverride> request)
     {
         if (!response.isOk())
         {

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/RoleAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/RoleAction.java
@@ -246,10 +246,10 @@ public class RoleAction extends RestAction<Role>
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<Role> request)
     {
         if (response.isOk())
-            request.onSuccess(EntityBuilder.get(api).createRole(response.getObject(), guild.getId()));
+            request.onSuccess(EntityBuilder.get(api).createRole(response.getObject(), guild.getIdLong()));
         else
             request.onFailure(response);
     }

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/WebhookAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/WebhookAction.java
@@ -90,7 +90,7 @@ public class WebhookAction extends RestAction<Webhook>
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<Webhook> request)
     {
         if (!response.isOk())
         {

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/PaginationAction.java
@@ -251,7 +251,7 @@ public abstract class PaginationAction<T, M extends PaginationAction<T, M>> exte
     }
 
     protected abstract void finalizeRoute();
-    protected abstract void handleResponse(Response response, Request request);
+    protected abstract void handleResponse(Response response, Request<List<T>> request);
 
     /**
      * Iterator implementation for a {@link net.dv8tion.jda.core.requests.restaction.pagination.PaginationAction PaginationAction}.

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/ReactionPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/ReactionPaginationAction.java
@@ -94,7 +94,7 @@ public class ReactionPaginationAction extends PaginationAction<User, ReactionPag
     }
 
     @Override
-    protected void handleResponse(Response response, Request request)
+    protected void handleResponse(Response response, Request<List<User>> request)
     {
         if (!response.isOk())
         {

--- a/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
@@ -168,14 +168,14 @@ public class PermissionUtil
 
         if (emote.isFake() || !emote.getGuild().isMember(issuer))
             return false; // cannot use an emote if you're not in its guild
-        Member member = emote.getGuild().getMemberById(issuer.getId());
+        Member member = emote.getGuild().getMemberById(issuer.getIdLong());
         if (!canInteract(member, emote))
             return false;
         switch (channel.getType())
         {
             case TEXT:
                 TextChannel text = (TextChannel) channel;
-                member = text.getGuild().getMemberById(issuer.getId());
+                member = text.getGuild().getMemberById(issuer.getIdLong());
                 return emote.getGuild().equals(text.getGuild()) // within the same guild
                     || (emote.isManaged() && checkPermission(text, member, Permission.MESSAGE_EXT_EMOJI)); // in different guild
             default:
@@ -236,7 +236,7 @@ public class PermissionUtil
         for (Permission perm : permissions)
         {
             if (!guild.getPublicRole().hasPermission(perm)
-                    && !roles.parallelStream().anyMatch(role -> role.hasPermission(perm)))
+                    && roles.parallelStream().noneMatch(role -> role.hasPermission(perm)))
                 return false;
         }
         return true;

--- a/src/main/java/net/dv8tion/jda/core/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/WidgetUtil.java
@@ -19,6 +19,8 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.core.OnlineStatus;
 import net.dv8tion.jda.core.entities.Game;
 import net.dv8tion.jda.core.entities.Guild;
@@ -32,7 +34,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -159,6 +161,34 @@ public class WidgetUtil
      */
     public static Widget getWidget(String guildId) throws RateLimitedException
     {
+        return getWidget(Long.parseLong(guildId));
+    }
+
+    /**
+     * Makes a GET request to get the information for a Guild's widget. This
+     * widget (if available) contains information about the guild, including the
+     * Guild's name, an invite code (if set), a list of voice channels, and a
+     * list of online members (plus the voice states of any members in voice
+     * channels).
+     *
+     * <p>This Widget can be obtained from any valid guild ID that has
+     * it enabled; no accounts need to be on the server to access this information.
+     *
+     * @param  guildId
+     *         The id of the Guild
+     *
+     * @throws net.dv8tion.jda.core.exceptions.RateLimitedException
+     *         If the request was rate limited, <b>respect the timeout</b>!
+     *
+     * @return {@code null} if the provided guild ID is not a valid Discord guild ID
+     *         <br>a Widget object with null fields and isAvailable() returning
+     *         false if the guild ID is valid but the guild in question does not
+     *         have the widget enabled
+     *         <br>a filled-in Widget object if the guild ID is valid and the guild
+     *         in question has the widget enabled.
+     */
+    public static Widget getWidget(long guildId) throws RateLimitedException
+    {
         Args.notNull(guildId, "GuildId");
         try
         {
@@ -219,23 +249,23 @@ public class WidgetUtil
     public static class Widget implements ISnowflake
     {
         private final boolean isAvailable;
-        private final String id;
+        private final long id;
         private final String name;
         private final String invite;
-        private final HashMap<String, VoiceChannel> channels;
-        private final HashMap<String, Member> members;
+        private final TLongObjectMap<VoiceChannel> channels;
+        private final TLongObjectMap<Member> members;
         
         /**
          * Constructs an unavailable Widget
          */
-        private Widget(String guildId)
+        private Widget(long guildId)
         {
             isAvailable = false;
             id = guildId;
             name = null;
             invite = null;
-            channels = null;
-            members = null;
+            channels = new TLongObjectHashMap<>();
+            members = new TLongObjectHashMap<>();
         }
         
         /**
@@ -251,17 +281,17 @@ public class WidgetUtil
                 inviteCode = inviteCode.substring(inviteCode.lastIndexOf("/") + 1);
             
             isAvailable = true;
-            id = json.getString("id");
+            id = json.getLong("id");
             name = json.getString("name");
             invite = inviteCode;
-            channels = new HashMap<>();
-            members = new HashMap<>();
+            channels = MiscUtil.newLongMap();
+            members = MiscUtil.newLongMap();
             
             JSONArray channelsJson = json.getJSONArray("channels");
             for (int i = 0; i < channelsJson.length(); i++)
             {
                 JSONObject channel = channelsJson.getJSONObject(i);
-                channels.put(channel.getString("id"), new VoiceChannel(channel, this));
+                channels.put(channel.getLong("id"), new VoiceChannel(channel, this));
             }
             
             JSONArray membersJson = json.getJSONArray("members");
@@ -271,7 +301,7 @@ public class WidgetUtil
                 Member member = new Member(memberJson, this);
                 if (!memberJson.isNull("channel_id")) // voice state
                 {
-                    VoiceChannel channel = channels.get(memberJson.getString("channel_id"));
+                    VoiceChannel channel = channels.get(memberJson.getLong("channel_id"));
                     member.setVoiceState(new VoiceState(channel, 
                             memberJson.getBoolean("mute"), 
                             memberJson.getBoolean("deaf"), 
@@ -282,7 +312,7 @@ public class WidgetUtil
                             this));
                     channel.addMember(member);
                 }
-                members.put(member.getId(), member);
+                members.put(member.getIdLong(), member);
             }
         }
         
@@ -296,42 +326,57 @@ public class WidgetUtil
         {
             return isAvailable;
         }
-        
+
         @Override
-        public String getId()
+        public long getIdLong()
         {
             return id;
         }
         
         /**
          * Gets the name of the guild
-         * 
+         *
+         * @throws IllegalStateException
+         *         If the widget is not {@link #isAvailable() available}
+         *
          * @return the name of the guild
          */
         public String getName()
         {
+            checkAvailable();
+
             return name;
         }
         
         /**
          * Gets an invite code for the guild, or null if no invite channel is
          * enabled in the widget
-         * 
+         *
+         * @throws IllegalStateException
+         *         If the widget is not {@link #isAvailable() available}
+         *
          * @return an invite code for the guild, if widget invites are enabled
          */
         public String getInviteCode()
         {
+            checkAvailable();
+
             return invite;
         }
         
         /**
          * Gets the list of voice channels in the guild
-         * 
+         *
+         * @throws IllegalStateException
+         *         If the widget is not {@link #isAvailable() available}
+         *
          * @return the list of voice channels in the guild
          */
         public List<VoiceChannel> getVoiceChannels()
         {
-            return new ArrayList<>(channels.values());
+            checkAvailable();
+
+            return Collections.unmodifiableList(new ArrayList<>(channels.valueCollection()));
         }
         
         /**
@@ -340,21 +385,38 @@ public class WidgetUtil
          * @param  id
          *         the ID of the voice channel
          *
+         * @throws IllegalStateException
+         *         If the widget is not {@link #isAvailable() available}
+         *
          * @return possibly-null VoiceChannel with the given ID. 
          */
         public VoiceChannel getVoiceChannelById(String id)
         {
+            checkAvailable();
+
+            return channels.get(Long.parseLong(id));
+        }
+        //todo docs
+        public VoiceChannel getVoiceChannelById(long id)
+        {
+            checkAvailable();
+
             return channels.get(id);
         }
         
         /**
          * Gets a list of online members in the guild
-         * 
+         *
+         * @throws IllegalStateException
+         *         If the widget is not {@link #isAvailable() available}
+         *
          * @return the list of members
          */
         public List<Member> getMembers()
         {
-            return new ArrayList<>(members.values());
+            checkAvailable();
+
+            return Collections.unmodifiableList(new ArrayList<>(members.valueCollection()));
         }
         
         /**
@@ -363,16 +425,29 @@ public class WidgetUtil
          * @param  id
          *         the ID of the member
          *
+         * @throws IllegalStateException
+         *         If the widget is not {@link #isAvailable() available}
+         *
          * @return possibly-null Member with the given ID. 
          */
         public Member getMemberById(String id)
         {
+            checkAvailable();
+
+            return members.get(Long.parseLong(id));
+        }
+
+        //todo docs
+        public Member getMemberById(long id)
+        {
+            checkAvailable();
+
             return members.get(id);
         }
 
         @Override
         public int hashCode() {
-            return id.hashCode();
+            return Long.hashCode(id);
         }
 
         @Override
@@ -380,13 +455,19 @@ public class WidgetUtil
             if (!(obj instanceof Widget))
                 return false;
             Widget oWidget = (Widget) obj;
-            return this == oWidget || this.id.equals(oWidget.getId());
+            return this == oWidget || this.id == oWidget.getIdLong();
         }
         
         @Override
         public String toString()
         {
-            return "W:" + (isAvailable() ? getName() : "") + '(' + getId() + ')';
+            return "W:" + (isAvailable() ? getName() : "") + '(' + id + ')';
+        }
+
+        private void checkAvailable()
+        {
+            if (!isAvailable)
+                throw new IllegalStateException("The widget for this Guild is unavailable!");
         }
         
         
@@ -394,7 +475,7 @@ public class WidgetUtil
         public static class Member implements ISnowflake, IMentionable
         {
             private final boolean bot;
-            private final String id;
+            private final long id;
             private final String username;
             private final String discriminator;
             private final String avatar;
@@ -408,7 +489,7 @@ public class WidgetUtil
             {
                 this.widget = widget;
                 this.bot = !json.isNull("bot") && json.getBoolean("bot");
-                this.id = json.getString("id");
+                this.id = json.getLong("id");
                 this.username = json.getString("username");
                 this.discriminator = json.getString("discriminator");
                 this.avatar = json.isNull("avatar") ? null : json.getString("avatar");
@@ -443,9 +524,9 @@ public class WidgetUtil
             {
                 return username;
             }
-            
+
             @Override
-            public String getId()
+            public long getIdLong()
             {
                 return id;
             }
@@ -487,7 +568,7 @@ public class WidgetUtil
              */
             public String getAvatarUrl()
             {
-                return getAvatarId() == null ? null : "https://cdn.discordapp.com/avatars/" + getId() + "/" + getAvatarId() 
+                return getAvatarId() == null ? null : "https://cdn.discordapp.com/avatars/" + getId() + "/" + getAvatarId()
                         + (getAvatarId().startsWith("a_") ? ".gif" : ".png");
             }
 
@@ -602,22 +683,22 @@ public class WidgetUtil
                 if (!(obj instanceof Member))
                     return false;
                 Member oMember = (Member) obj;
-                return this == oMember || (this.id.equals(oMember.getId()) && this.widget.getId().equals(oMember.getWidget().getId()));
+                return this == oMember || (this.id == oMember.getIdLong() && this.widget.getIdLong() == oMember.getWidget().getIdLong());
             }
             
             @Override
             public String toString()
             {
-                return "W.M:" + getName() + '(' + getId() + ')';
+                return "W.M:" + getName() + '(' + id + ')';
             }
             
         }
         
         
-        public static class VoiceChannel
+        public static class VoiceChannel implements ISnowflake
         {
             private final int position;
-            private final String id;
+            private final long id;
             private final String name;
             private final List<Member> members;
             private final Widget widget;
@@ -626,7 +707,7 @@ public class WidgetUtil
             {
                 this.widget = widget;
                 this.position = json.getInt("position");
-                this.id = json.getString("id");
+                this.id = json.getLong("id");
                 this.name = json.getString("name");
                 this.members = new ArrayList<>();
             }
@@ -645,13 +726,9 @@ public class WidgetUtil
             {
                 return position;
             }
-            
-            /**
-             * Gets the Discord ID of the channel
-             * 
-             * @return id of the channel
-             */
-            public String getId()
+
+            @Override
+            public long getIdLong()
             {
                 return id;
             }
@@ -688,7 +765,7 @@ public class WidgetUtil
 
             @Override
             public int hashCode() {
-                return id.hashCode();
+                return Long.hashCode(id);
             }
 
             @Override
@@ -696,13 +773,13 @@ public class WidgetUtil
                 if (!(obj instanceof VoiceChannel))
                     return false;
                 VoiceChannel oVChannel = (VoiceChannel) obj;
-                return this == oVChannel || this.id.equals(oVChannel.getId());
+                return this == oVChannel || this.id == oVChannel.getIdLong();
             }
             
             @Override
             public String toString()
             {
-                return "W.VC:" + getName() + '(' + getId() + ')';
+                return "W.VC:" + getName() + '(' + id + ')';
             }
         }
         


### PR DESCRIPTION
In this experiment I changed almost all `id` fields to use `long` over `String`.
To increase performance and memory usage we use `trove4j` which provides HashMap implementations that use backing primitive arrays instead of `Long` arrays.

Test:
- [x] Compiles with no errors
- [x] Runs with no JSONExceptions
- [x] Runs with large sharded bots (LewdBot, DabBot, etc.)
- [x] Benchmarking