### PR TITLE
Added new RestAction operations for planned execution and async Request callback execution

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/core/audio/AudioWebSocket.java
@@ -16,7 +16,10 @@
 
 package net.dv8tion.jda.core.audio;
 
-import com.neovisionaries.ws.client.*;
+import com.neovisionaries.ws.client.WebSocket;
+import com.neovisionaries.ws.client.WebSocketAdapter;
+import com.neovisionaries.ws.client.WebSocketException;
+import com.neovisionaries.ws.client.WebSocketFrame;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.audio.hooks.ConnectionListener;
 import net.dv8tion.jda.core.audio.hooks.ConnectionStatus;
@@ -24,9 +27,9 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.entities.VoiceChannel;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.events.ExceptionEvent;
 import net.dv8tion.jda.core.managers.impl.AudioManagerImpl;
 import net.dv8tion.jda.core.utils.SimpleLog;
-import org.apache.http.HttpHost;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -281,6 +284,7 @@ public class AudioWebSocket extends WebSocketAdapter
     public void handleCallbackError(WebSocket websocket, Throwable cause)
     {
         LOG.log(cause);
+        api.getEventManager().handle(new ExceptionEvent(api, cause, true));
     }
 
     public void close(ConnectionStatus closeStatus)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -488,6 +488,7 @@ public class JDAImpl implements JDA
 
         if (free)
         {
+            Requester.destroy();
             try
             {
                 Unirest.shutdown();

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -687,20 +687,7 @@ public class JDAImpl implements JDA
         {
             final Thread thread = new Thread(r, "JDA-Thread " + getIdentifierString());
             thread.setDaemon(true);
-            thread.setUncaughtExceptionHandler(UncaughtExceptionHandler.INSTANCE);
             return thread;
-        }
-    }
-
-    private static class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler
-    {
-        private static UncaughtExceptionHandler INSTANCE = new UncaughtExceptionHandler();
-
-        @Override
-        public void uncaughtException(Thread t, Throwable e)
-        {
-            LOG.fatal(String.format("Uncaught Exception in JDA Schedule Thread [%s]", t.getName()));
-            LOG.log(e);
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/events/ExceptionEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ExceptionEvent.java
@@ -1,0 +1,59 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.events;
+
+import net.dv8tion.jda.core.JDA;
+
+/**
+ * Fired when JDA does not have a specific handling for a Throwable.
+ * <br>This includes {@link java.lang.Error Errors} and {@link com.neovisionaries.ws.client.WebSocketException WebSocketExceptions}
+ *
+ * <p>It is not recommended to simply use this and print each event as some throwables where already logged
+ * by JDA. See {@link #isLogged()}.
+ */
+public class ExceptionEvent extends Event
+{
+    protected final Throwable throwable;
+    protected final boolean logged;
+
+    public ExceptionEvent(JDA api, Throwable throwable, boolean logged)
+    {
+        super(api, -1);
+        this.throwable = throwable;
+        this.logged = logged;
+    }
+
+    /**
+     * Whether this Throwable was already printed using the JDA logging system
+     *
+     * @return True, if this throwable was already logged
+     */
+    public boolean isLogged()
+    {
+        return logged;
+    }
+
+    /**
+     * The cause Throwable for this event
+     *
+     * @return The cause
+     */
+    public Throwable getCause()
+    {
+        return throwable;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/EventCache.java
@@ -25,7 +25,7 @@ import java.util.List;
 public class EventCache
 {
     public static final SimpleLog LOG = SimpleLog.getLog("EventCache");
-    private static HashMap<JDA, EventCache> caches = new HashMap<>();
+    private static final HashMap<JDA, EventCache> caches = new HashMap<>();
     private HashMap<Type, HashMap<String, List<Runnable>>> eventCache = new HashMap<>();
 
     public static EventCache get(JDA jda)

--- a/src/main/java/net/dv8tion/jda/core/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/core/hooks/ListenerAdapter.java
@@ -94,6 +94,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onDisconnect(DisconnectEvent event) {}
     public void onShutdown(ShutdownEvent event) {}
     public void onStatusChange(StatusChangeEvent event) {}
+    public void onException(ExceptionEvent event) {}
 
     //User Events
     public void onUserNameUpdate(UserNameUpdateEvent event) {}
@@ -299,6 +300,8 @@ public abstract class ListenerAdapter implements EventListener
             onShutdown((ShutdownEvent) event);
         else if (event instanceof StatusChangeEvent)
             onStatusChange((StatusChangeEvent) event);
+        else if (event instanceof ExceptionEvent)
+            onException((ExceptionEvent) event);
 
         //Message Events
         //Guild (TextChannel) Message Events

--- a/src/main/java/net/dv8tion/jda/core/requests/GuildLock.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/GuildLock.java
@@ -24,8 +24,8 @@ import java.util.*;
 
 public class GuildLock
 {
-    public static SimpleLog LOG = SimpleLog.getLog("JDAGuildLock");
-    private static Map<JDA, GuildLock> locks = new HashMap<>();
+    public static final SimpleLog LOG = SimpleLog.getLog("JDAGuildLock");
+    private static final Map<JDA, GuildLock> locks = new HashMap<>();
 
     public static synchronized GuildLock get(JDA jda)
     {

--- a/src/main/java/net/dv8tion/jda/core/requests/Request.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Request.java
@@ -42,15 +42,18 @@ public class Request<T>
 
     public void onSuccess(T successObj)
     {
-        try
+        Requester.THREAD_POOL.execute(() ->
         {
-            onSuccess.accept(successObj);
-        }
-        catch (Throwable t)
-        {
-            RestAction.LOG.fatal("Encountered error while processing success consumer");
-            RestAction.LOG.log(t);
-        }
+            try
+            {
+                onSuccess.accept(successObj);
+            }
+            catch (Throwable t)
+            {
+                RestAction.LOG.fatal("Encountered error while processing success consumer");
+                RestAction.LOG.log(t);
+            }
+        });
     }
 
     public void onFailure(Response response)
@@ -68,15 +71,18 @@ public class Request<T>
 
     public void onFailure(Throwable failException)
     {
-        try
+        Requester.THREAD_POOL.execute(() ->
         {
-            onFailure.accept(failException);
-        }
-        catch (Throwable t)
-        {
-            RestAction.LOG.fatal("Encountered error while processing failure consumer");
-            RestAction.LOG.log(t);
-        }
+            try
+            {
+                onFailure.accept(failException);
+            }
+            catch (Throwable t)
+            {
+                RestAction.LOG.fatal("Encountered error while processing failure consumer");
+                RestAction.LOG.log(t);
+            }
+        });
     }
 
     public RestAction<T> getRestAction()

--- a/src/main/java/net/dv8tion/jda/core/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Requester.java
@@ -32,11 +32,6 @@ import net.dv8tion.jda.core.requests.ratelimit.BotRateLimiter;
 import net.dv8tion.jda.core.requests.ratelimit.ClientRateLimiter;
 import net.dv8tion.jda.core.utils.SimpleLog;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class Requester
 {
     public static final SimpleLog LOG = SimpleLog.getLog("JDARequester");
@@ -45,9 +40,6 @@ public class Requester
 
     private final JDAImpl api;
     private final RateLimiter rateLimiter;
-
-    // use this for callback computation rather than global pool to avoid deadlocks
-    final ExecutorService pool = Executors.newCachedThreadPool(new ResponseHandlerThreadFactory());
 
     public Requester(JDA api)
     {
@@ -174,7 +166,6 @@ public class Requester
 
     public void shutdown()
     {
-        pool.shutdown();
         rateLimiter.shutdown();
     }
 
@@ -220,19 +211,5 @@ public class Requester
         request.header("user-agent", USER_AGENT);
         request.header("Accept-Encoding", "gzip");
         return baseRequest;
-    }
-
-    private static final class ResponseHandlerThreadFactory implements ThreadFactory
-    {
-
-        private final AtomicInteger count = new AtomicInteger(1);
-
-        @Override
-        public Thread newThread(Runnable r)
-        {
-            Thread t = new Thread(r, "ResponseHandlerThread #" + count.getAndIncrement());
-            t.setDaemon(true);
-            return t;
-        }
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -217,243 +217,6 @@ public abstract class RestAction<T>
     }
 
     /**
-     * Schedules a call to {@link #complete()} to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>The returned Future will provide the return type of a {@link #complete()} operation when
-     * received through the <b>blocking</b> call to {@link java.util.concurrent.Future#get()}!
-     *
-     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService}
-     * is used for this operation.
-     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
-     * or you can provide your own Executor using {@link #completeAfter(long, java.util.concurrent.TimeUnit, java.util.concurrent.ScheduledExecutorService)}!
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the
-     *         delayed operation
-     */
-    public ScheduledFuture<T> completeAfter(long delay, TimeUnit unit)
-    {
-        return completeAfter(delay, unit, api.pool);
-    }
-
-    /**
-     * Schedules a call to {@link #complete()} to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>The returned Future will provide the return type of a {@link #complete()} operation when
-     * received through the <b>blocking</b> call to {@link java.util.concurrent.Future#get()}!
-     *
-     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     * @param  executor
-     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
-     *         to schedule this operation
-     *
-     * @throws java.lang.IllegalArgumentException
-     *         If any of the provided arguments is {@code null}
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<T> completeAfter(long delay, TimeUnit unit, ScheduledExecutorService executor)
-    {
-        Args.notNull(executor, "Scheduler");
-        Args.notNull(unit, "TimeUnit");
-        return executor.schedule((Callable<T>) this::complete, delay, unit);
-    }
-
-    /**
-     * Schedules a call to {@link #queue()} to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>This operation gives no access to the response value.
-     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer)} to access
-     * the success consumer for {@link #queue(java.util.function.Consumer)}!
-     *
-     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
-     * or provide your own Executor with {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.concurrent.ScheduledExecutorService)}
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit)
-    {
-        return queueAfter(delay, unit, api.pool);
-    }
-
-    /**
-     * Schedules a call to {@link #queue(java.util.function.Consumer)} to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>This operation gives no access to the failure callback.
-     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.function.Consumer)} to access
-     * the failure consumer for {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}!
-     *
-     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
-     * or provide your own Executor with {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.concurrent.ScheduledExecutorService)}
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     * @param  success
-     *         The success {@link java.util.function.Consumer Consumer} that should be called
-     *         once the {@link #queue(java.util.function.Consumer)} operation completes successfully.
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success)
-    {
-        return queueAfter(delay, unit, success, api.pool);
-    }
-
-    /**
-     * Schedules a call to {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}
-     * to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
-     * or provide your own Executor with
-     * {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.function.Consumer, java.util.concurrent.ScheduledExecutorService)}
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     * @param  success
-     *         The success {@link java.util.function.Consumer Consumer} that should be called
-     *         once the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation completes successfully.
-     * @param  failure
-     *         The failure {@link java.util.function.Consumer Consumer} that should be called
-     *         in case of an error of the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation.
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success, Consumer<Throwable> failure)
-    {
-        return queueAfter(delay, unit, success, failure, api.pool);
-    }
-
-    /**
-     * Schedules a call to {@link #queue()} to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>This operation gives no access to the response value.
-     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer)} to access
-     * the success consumer for {@link #queue(java.util.function.Consumer)}!
-     *
-     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     * @param  executor
-     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
-     *         to schedule this operation
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, ScheduledExecutorService executor)
-    {
-        return queueAfter(delay, unit, null, executor);
-    }
-
-    /**
-     * Schedules a call to {@link #queue(java.util.function.Consumer)} to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>This operation gives no access to the failure callback.
-     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.function.Consumer)} to access
-     * the failure consumer for {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}!
-     *
-     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     * @param  success
-     *         The success {@link java.util.function.Consumer Consumer} that should be called
-     *         once the {@link #queue(java.util.function.Consumer)} operation completes successfully.
-     * @param  executor
-     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
-     *         to schedule this operation
-     *
-     * @throws java.lang.IllegalArgumentException
-     *         If any of the provided arguments is {@code null}
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success, ScheduledExecutorService executor)
-    {
-        return queueAfter(delay, unit, success, null, executor);
-    }
-
-    /**
-     * Schedules a call to {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}
-     * to be executed after the specified {@code delay}.
-     * <br>This is an <b>asynchronous</b> operation that will return a
-     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
-     *
-     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
-     *
-     * @param  delay
-     *         The delay after which this computation should be executed, negative to execute immediately
-     * @param  unit
-     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
-     * @param  success
-     *         The success {@link java.util.function.Consumer Consumer} that should be called
-     *         once the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation completes successfully.
-     * @param  failure
-     *         The failure {@link java.util.function.Consumer Consumer} that should be called
-     *         in case of an error of the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation.
-     * @param  executor
-     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
-     *         to schedule this operation
-     *
-     * @throws java.lang.IllegalArgumentException
-     *         If any of the provided arguments is {@code null}
-     *
-     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
-     *         representing the delayed operation
-     */
-    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success, Consumer<Throwable> failure, ScheduledExecutorService executor)
-    {
-        Args.notNull(executor, "Scheduler");
-        Args.notNull(unit, "TimeUnit");
-        return executor.schedule(() -> queue(success, failure), delay, unit);
-    }
-
-    /**
      * Blocks the current Thread and awaits the completion
      * of an {@link #submit()} request.
      * <br>Used for synchronous logic.
@@ -511,6 +274,258 @@ public abstract class RestAction<T>
             }
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Schedules a call to {@link #complete()} to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>The returned Future will provide the return type of a {@link #complete()} operation when
+     * received through the <b>blocking</b> call to {@link java.util.concurrent.Future#get()}!
+     *
+     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService}
+     * is used for this operation.
+     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
+     * or you can provide your own Executor using {@link #completeAfter(long, java.util.concurrent.TimeUnit, java.util.concurrent.ScheduledExecutorService)}!
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the
+     *         delayed operation
+     */
+    public ScheduledFuture<T> completeAfter(long delay, TimeUnit unit)
+    {
+        return completeAfter(delay, unit, api.pool);
+    }
+
+    /**
+     * Schedules a call to {@link #complete()} to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>The returned Future will provide the return type of a {@link #complete()} operation when
+     * received through the <b>blocking</b> call to {@link java.util.concurrent.Future#get()}!
+     *
+     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     * @param  executor
+     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
+     *         to schedule this operation
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit or ScheduledExecutorService is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<T> completeAfter(long delay, TimeUnit unit, ScheduledExecutorService executor)
+    {
+        Args.notNull(executor, "Scheduler");
+        Args.notNull(unit, "TimeUnit");
+        return executor.schedule((Callable<T>) this::complete, delay, unit);
+    }
+
+    /**
+     * Schedules a call to {@link #queue()} to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>This operation gives no access to the response value.
+     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer)} to access
+     * the success consumer for {@link #queue(java.util.function.Consumer)}!
+     *
+     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
+     * or provide your own Executor with {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.concurrent.ScheduledExecutorService)}
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit)
+    {
+        return queueAfter(delay, unit, api.pool);
+    }
+
+    /**
+     * Schedules a call to {@link #queue(java.util.function.Consumer)} to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>This operation gives no access to the failure callback.
+     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.function.Consumer)} to access
+     * the failure consumer for {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}!
+     *
+     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
+     * or provide your own Executor with {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.concurrent.ScheduledExecutorService)}
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     * @param  success
+     *         The success {@link java.util.function.Consumer Consumer} that should be called
+     *         once the {@link #queue(java.util.function.Consumer)} operation completes successfully.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success)
+    {
+        return queueAfter(delay, unit, success, api.pool);
+    }
+
+    /**
+     * Schedules a call to {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}
+     * to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>The global JDA {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     * <br>You can change the core pool size for this Executor through {@link net.dv8tion.jda.core.JDABuilder#setCorePoolSize(int) JDABuilder.setCorePoolSize(int)}
+     * or provide your own Executor with
+     * {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.function.Consumer, java.util.concurrent.ScheduledExecutorService)}
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     * @param  success
+     *         The success {@link java.util.function.Consumer Consumer} that should be called
+     *         once the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation completes successfully.
+     * @param  failure
+     *         The failure {@link java.util.function.Consumer Consumer} that should be called
+     *         in case of an error of the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success, Consumer<Throwable> failure)
+    {
+        return queueAfter(delay, unit, success, failure, api.pool);
+    }
+
+    /**
+     * Schedules a call to {@link #queue()} to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>This operation gives no access to the response value.
+     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer)} to access
+     * the success consumer for {@link #queue(java.util.function.Consumer)}!
+     *
+     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     * @param  executor
+     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
+     *         to schedule this operation
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit or ScheduledExecutorService is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, ScheduledExecutorService executor)
+    {
+        return queueAfter(delay, unit, null, executor);
+    }
+
+    /**
+     * Schedules a call to {@link #queue(java.util.function.Consumer)} to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>This operation gives no access to the failure callback.
+     * <br>Use {@link #queueAfter(long, java.util.concurrent.TimeUnit, java.util.function.Consumer, java.util.function.Consumer)} to access
+     * the failure consumer for {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}!
+     *
+     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     * @param  success
+     *         The success {@link java.util.function.Consumer Consumer} that should be called
+     *         once the {@link #queue(java.util.function.Consumer)} operation completes successfully.
+     * @param  executor
+     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
+     *         to schedule this operation
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit or ScheduledExecutorService is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success, ScheduledExecutorService executor)
+    {
+        return queueAfter(delay, unit, success, null, executor);
+    }
+
+    /**
+     * Schedules a call to {@link #queue(java.util.function.Consumer, java.util.function.Consumer)}
+     * to be executed after the specified {@code delay}.
+     * <br>This is an <b>asynchronous</b> operation that will return a
+     * {@link java.util.concurrent.ScheduledFuture ScheduledFuture} representing the task.
+     *
+     * <p>The specified {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} is used for this operation.
+     *
+     * @param  delay
+     *         The delay after which this computation should be executed, negative to execute immediately
+     * @param  unit
+     *         The {@link java.util.concurrent.TimeUnit TimeUnit} to convert the specified {@code delay}
+     * @param  success
+     *         The success {@link java.util.function.Consumer Consumer} that should be called
+     *         once the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation completes successfully.
+     * @param  failure
+     *         The failure {@link java.util.function.Consumer Consumer} that should be called
+     *         in case of an error of the {@link #queue(java.util.function.Consumer, java.util.function.Consumer)} operation.
+     * @param  executor
+     *         The Non-null {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} that should be used
+     *         to schedule this operation
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided TimeUnit or ScheduledExecutorService is {@code null}
+     *
+     * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
+     *         representing the delayed operation
+     */
+    public ScheduledFuture<?> queueAfter(long delay, TimeUnit unit, Consumer<T> success, Consumer<Throwable> failure, ScheduledExecutorService executor)
+    {
+        Args.notNull(executor, "Scheduler");
+        Args.notNull(unit, "TimeUnit");
+        return executor.schedule(() -> queue(success, failure), delay, unit);
     }
 
     protected void finalizeData() { }

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -110,7 +110,7 @@ import java.util.function.Consumer;
  *     action.{@link #queue(Consumer) queue(callback)};
  * </code></pre>
  *
- * <h2>Example Complete: (not recommended)</h2>
+ * <h2>Example Complete:</h2>
  * <pre><code>
  *     {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel} channel = event.getChannel();
  *     final long time = System.currentTimeMillis();
@@ -130,6 +130,9 @@ import java.util.function.Consumer;
  * <p><b>Developer Note:</b> It is generally a good practice to use asynchronous logic because blocking threads requires resources
  * which can be avoided by using callbacks over blocking operations:
  * <br>{@link #queue(Consumer)} {@literal >} {@link #complete()}
+ *
+ * <p>There is a dedicated <a href="https://github.com/DV8FromTheWorld/JDA/wiki/7)-Using-RestAction" target="_blank">wiki page</a>
+ * for RestActions that can be useful for learning.
  *
  * @param <T>
  *        The generic response type for this RestAction

--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -761,7 +761,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     @Override
     public void handleCallbackError(WebSocket websocket, Throwable cause)
     {
-//        LOG.log(cause);
+        api.getEventManager().handle(new ExceptionEvent(api, cause, false));
     }
 
     public void setChunkingAndSyncing(boolean active)

--- a/src/main/java/net/dv8tion/jda/core/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/ratelimit/BotRateLimiter.java
@@ -18,6 +18,8 @@ package net.dv8tion.jda.core.requests.ratelimit;
 
 import com.mashape.unirest.http.Headers;
 import com.mashape.unirest.http.HttpResponse;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.events.ExceptionEvent;
 import net.dv8tion.jda.core.requests.RateLimiter;
 import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Requester;
@@ -339,6 +341,11 @@ public class BotRateLimiter extends RateLimiter
             {
                 Requester.LOG.fatal("Requester system encountered an internal error from beyond the synchronized execution blocks. NOT GOOD!");
                 Requester.LOG.log(err);
+                if (err instanceof Error)
+                {
+                    JDAImpl api = requester.getJDA();
+                    api.getEventManager().handle(new ExceptionEvent(api, err, true));
+                }
             }
         }
 

--- a/src/main/java/net/dv8tion/jda/core/requests/ratelimit/ClientRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/ratelimit/ClientRateLimiter.java
@@ -17,6 +17,8 @@
 package net.dv8tion.jda.core.requests.ratelimit;
 
 import com.mashape.unirest.http.HttpResponse;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.events.ExceptionEvent;
 import net.dv8tion.jda.core.requests.RateLimiter;
 import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Requester;
@@ -238,6 +240,11 @@ public class ClientRateLimiter extends RateLimiter
             {
                 Requester.LOG.fatal("Requester system encountered an internal error from beyond the synchronized execution blocks. NOT GOOD!");
                 Requester.LOG.log(err);
+                if (err instanceof Error)
+                {
+                    JDAImpl api = requester.getJDA();
+                    api.getEventManager().handle(new ExceptionEvent(api, err, true));
+                }
             }
         }
 


### PR DESCRIPTION
This experiment will improve the JDA Requester system by adding a new Requester pool that will be used to execute request callbacks in an additional thread to counter possible deadlocks.
In addition I added new RestAction operations and documentation:
- `completeAfter(long, TimeUnit)`
- `submitAfter(long, TimeUnit [, ScheduledExecutorService])`
- `queueAfter(long, TimeUnit [, ScheduledExecutorService])`
- `queueAfter(long, TimeUnit, Consumer<T> [, ScheduledExecutorService])`
- `queueAfter(long, TimeUnit, Consumer<T>, Consumer<Throwable> [, ScheduledExecutorService])`

More information on how these work can be found in the documentation.

> Note: This can still be changed.