### PR TITLE
Consider Snowflake IDs as unsigned

### DIFF
--- a/src/main/java/net/dv8tion/jda/bot/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/bot/entities/ApplicationInfo.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.entities.User;
+import net.dv8tion.jda.core.utils.MiscUtil;
 
 import java.util.Collection;
 
@@ -108,12 +109,15 @@ public interface ApplicationInfo extends ISnowflake
      * @param  permissions
      *         Possibly empty {@link java.util.Collection Collection} of {@link net.dv8tion.jda.core.Permission Permissions}
      *         that should be requested via invite.
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
      * 
      * @return The link used to invite the bot
      */
     default String getInviteUrl(String guildId, Collection<Permission> permissions)
     {
-        return getInviteUrl(Long.parseLong(guildId), permissions);
+        return getInviteUrl(MiscUtil.parseSnowflake(guildId), permissions);
     }
 
     /**
@@ -145,12 +149,15 @@ public interface ApplicationInfo extends ISnowflake
      * @param  permissions 
      *         Possibly empty array of {@link net.dv8tion.jda.core.Permission Permissions} 
      *         that should be requested via invite.
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
      * 
      * @return The link used to invite the bot
      */
     default String getInviteUrl(String guildId, Permission... permissions)
     {
-        return getInviteUrl(Long.parseLong(guildId), permissions);
+        return getInviteUrl(MiscUtil.parseSnowflake(guildId), permissions);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/AuthorizedApplicationImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/AuthorizedApplicationImpl.java
@@ -77,7 +77,7 @@ public class AuthorizedApplicationImpl implements AuthorizedApplication
     @Override
     public String getAuthId()
     {
-        return String.valueOf(this.authId);
+        return Long.toUnsignedString(this.authId);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/CallImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/CallImpl.java
@@ -79,7 +79,7 @@ public class CallImpl implements Call
     @Override
     public String getMessageId()
     {
-        return String.valueOf(messageId);
+        return Long.toUnsignedString(messageId);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
@@ -83,7 +83,7 @@ public class JDAClientImpl implements JDAClient
     @Override
     public Group getGroupById(String id)
     {
-        return groups.get(Long.parseLong(id));
+        return groups.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/JDAClientImpl.java
@@ -144,7 +144,7 @@ public class JDAClientImpl implements JDAClient
     @Override
     public Relationship getRelationshipById(String id)
     {
-        return relationships.get(Long.parseLong(id));
+        return relationships.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/client/handle/CallCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/CallCreateHandler.java
@@ -73,7 +73,7 @@ public class CallCreateHandler extends SocketHandler
 
                 for (int i = 0; i < ringing.length(); i++)
                 {
-                    final long current = Long.parseLong(ringing.getString(i));
+                    final long current = ringing.getLong(i);
                     if (current == userId)
                     {
                         callUser.setRinging(true);

--- a/src/main/java/net/dv8tion/jda/client/handle/CallUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/CallUpdateHandler.java
@@ -121,7 +121,7 @@ public class CallUpdateHandler extends SocketHandler
     {
         List<Long> longs = new ArrayList<>();
         for (int i = 0; i < array.length(); i++)
-            longs.add(Long.parseLong(array.getString(i)));
+            longs.add(array.getLong(i));
 
         return longs;
     }

--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -215,6 +215,9 @@ public interface JDA
      * @param  id
      *         The id of the requested {@link net.dv8tion.jda.core.entities.User User}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.User User} with matching id.
      */
     User getUserById(String id);
@@ -316,6 +319,9 @@ public interface JDA
      * @param  id
      *         The id of the {@link net.dv8tion.jda.core.entities.Guild Guild}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Guild Guild} with matching id.
      */
     Guild getGuildById(String id);
@@ -358,8 +364,12 @@ public interface JDA
      * Retrieves the {@link net.dv8tion.jda.core.entities.Role Role} associated to the provided id.
      * <br>This iterates over all {@link net.dv8tion.jda.core.entities.Guild Guilds} and check whether
      * a Role from that Guild is assigned to the specified ID and will return the first that can be found.
+     *
      * @param  id
      *         The id of the searched Role
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
      *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Role Role} for the specified ID
      */
@@ -418,6 +428,9 @@ public interface JDA
      * @param  id
      *         The id of the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} with matching id.
      */
     TextChannel getTextChannelById(String id);
@@ -475,6 +488,9 @@ public interface JDA
      *
      * @param  id The id of the {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel} with matching id.
      */
     VoiceChannel getVoiceChannelById(String id);
@@ -519,6 +535,9 @@ public interface JDA
      * @param  id
      *         The id of the {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} with matching id.
      */
     PrivateChannel getPrivateChannelById(String id);
@@ -551,6 +570,9 @@ public interface JDA
      *
      * @param  id
      *         The id of the requested {@link net.dv8tion.jda.core.entities.Emote}.
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
      *
      * @return An {@link net.dv8tion.jda.core.entities.Emote Emote} represented by this id or null if none is found in our cache.
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -508,7 +508,7 @@ public class EntityBuilder
         JSONArray rolesJson = memberJson.getJSONArray("roles");
         for (int k = 0; k < rolesJson.length(); k++)
         {
-            final long roleId = Long.parseLong(rolesJson.getString(k));
+            final long roleId = rolesJson.getLong(k);
             Role r = guild.getRolesMap().get(roleId);
             if (r == null)
             {

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -178,6 +178,9 @@ public interface Guild extends ISnowflake
      * @param  userId
      *         The Discord id of the User for which a Member object is requested.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Member Member} with the related {@code userId}.
      */
     Member getMemberById(String userId);
@@ -288,6 +291,9 @@ public interface Guild extends ISnowflake
      * @param  id
      *         The id of the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} with matching id.
      */
     TextChannel getTextChannelById(String id);
@@ -338,6 +344,9 @@ public interface Guild extends ISnowflake
      * @param  id
      *         The id of the {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel} with matching id.
      */
     VoiceChannel getVoiceChannelById(String id);
@@ -387,6 +396,9 @@ public interface Guild extends ISnowflake
      * @param  id
      *         The id of the {@link net.dv8tion.jda.core.entities.Role Role}.
      *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Role Role} with matching id.
      */
     Role getRoleById(String id);
@@ -434,6 +446,9 @@ public interface Guild extends ISnowflake
      *
      * @param  id
      *         the emote id
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
      *
      * @return An Emote matching the specified Id.
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
@@ -34,7 +34,7 @@ public interface ISnowflake
      */
     default String getId()
     {
-        return String.valueOf(getIdLong());
+        return Long.toUnsignedString(getIdLong());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -81,7 +81,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default String getLatestMessageId()
     {
-        return String.valueOf(getLatestMessageIdLong());
+        return Long.toUnsignedString(getLatestMessageIdLong());
     }
 
     /**
@@ -700,8 +700,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     default RestAction<Message> getMessageById(long messageId)
     {
-        Args.notNegative(messageId, "Message ID");
-        return getMessageById(String.valueOf(messageId));
+        return getMessageById(Long.toUnsignedString(messageId));
     }
 
     /**
@@ -799,8 +798,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Void> deleteMessageById(long messageId)
     {
-        Args.positive(messageId, "Message ID");
-        return deleteMessageById(String.valueOf(messageId));
+        return deleteMessageById(Long.toUnsignedString(messageId));
     }
 
     /**
@@ -1031,8 +1029,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<MessageHistory> getHistoryAround(long messageId, int limit)
     {
-        Args.positive(messageId, "Message ID");
-        return getHistoryAround(String.valueOf(messageId), limit);
+        return getHistoryAround(Long.toUnsignedString(messageId), limit);
     }
 
     /**
@@ -1223,8 +1220,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Void> addReactionById(long messageId, String unicode)
     {
-        Args.notNegative(messageId, "Message ID");
-        return addReactionById(String.valueOf(messageId), unicode);
+        return addReactionById(Long.toUnsignedString(messageId), unicode);
     }
 
     /**
@@ -1356,8 +1352,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Void> addReactionById(long messageId, Emote emote)
     {
-        Args.positive(messageId, "Message ID");
-        return addReactionById(String.valueOf(messageId), emote);
+        return addReactionById(Long.toUnsignedString(messageId), emote);
     }
 
     /**
@@ -1456,8 +1451,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Void> pinMessageById(long messageId)
     {
-        Args.positive(messageId, "Message ID");
-        return pinMessageById(String.valueOf(messageId));
+        return pinMessageById(Long.toUnsignedString(messageId));
     }
 
     /**
@@ -1556,8 +1550,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Void> unpinMessageById(long messageId)
     {
-        Args.positive(messageId, "Message Id");
-        return unpinMessageById(String.valueOf(messageId));
+        return unpinMessageById(Long.toUnsignedString(messageId));
     }
 
     /**
@@ -1885,8 +1878,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Message> editMessageById(long messageId, Message newContent)
     {
-        Args.positive(messageId, "Message ID");
-        return editMessageById(String.valueOf(messageId), newContent);
+        return editMessageById(Long.toUnsignedString(messageId), newContent);
     }
 
     /**
@@ -1984,8 +1976,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default RestAction<Message> editMessageById(long messageId, MessageEmbed newEmbed)
     {
-        Args.positive(messageId, "Message ID");
-        return editMessageById(String.valueOf(messageId), newEmbed);
+        return editMessageById(Long.toUnsignedString(messageId), newEmbed);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
@@ -23,8 +23,8 @@ import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.requests.Route;
+import net.dv8tion.jda.core.utils.MiscUtil;
 import org.apache.commons.collections4.map.ListOrderedMap;
-import org.apache.http.util.Args;
 import org.json.JSONArray;
 
 import java.util.*;
@@ -287,9 +287,7 @@ public class MessageHistory
      */
     public Message getMessageById(String id)
     {
-        Args.notEmpty(id, "Provided message id");
-
-        return getMessageById(Long.parseLong(id));
+        return getMessageById(MiscUtil.parseSnowflake(id));
     }
 
     public Message getMessageById(long id)

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
@@ -282,6 +282,8 @@ public class MessageHistory
      *
      * @throws java.lang.IllegalArgumentException
      *         If the provided {@code id} is null or empty.
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
      *
      * @return Possibly-null Message with the same {@code id} as the one provided.
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageReaction.java
@@ -200,7 +200,7 @@ public class MessageReaction
      */
     public String getMessageId()
     {
-        return String.valueOf(messageId);
+        return Long.toUnsignedString(messageId);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -121,6 +121,8 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @throws java.lang.IllegalArgumentException
      *         If the size of the list less than 2 or more than 100 messages.
+     * @throws java.lang.NumberFormatException
+     *         If any of the provided ids cannot be parsed by {@link Long#parseLong(String)}
      * @throws net.dv8tion.jda.core.exceptions.PermissionException
      *         If this account does not have MANAGE_MESSAGES
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -126,7 +126,7 @@ public class GuildImpl implements Guild
         if (!getSelfMember().hasPermission(Permission.MANAGE_WEBHOOKS))
             throw new PermissionException(Permission.MANAGE_WEBHOOKS);
 
-        Route.CompiledRoute route = Route.Guilds.GET_WEBHOOKS.compile(String.valueOf(id));
+        Route.CompiledRoute route = Route.Guilds.GET_WEBHOOKS.compile(getId());
 
         return new RestAction<List<Webhook>>(api, route, null)
         {
@@ -199,7 +199,7 @@ public class GuildImpl implements Guild
     @Override
     public Member getMemberById(String userId)
     {
-        return members.get(Long.parseLong(userId));
+        return members.get(MiscUtil.parseSnowflake(userId));
     }
 
     @Override
@@ -276,7 +276,7 @@ public class GuildImpl implements Guild
     @Override
     public TextChannel getTextChannelById(String id)
     {
-        return textChannels.get(Long.parseLong(id));
+        return textChannels.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -308,7 +308,7 @@ public class GuildImpl implements Guild
     @Override
     public VoiceChannel getVoiceChannelById(String id)
     {
-        return voiceChannels.get(Long.parseLong(id));
+        return voiceChannels.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -340,7 +340,7 @@ public class GuildImpl implements Guild
     @Override
     public Role getRoleById(String id)
     {
-        return roles.get(Long.parseLong(id));
+        return roles.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -372,7 +372,7 @@ public class GuildImpl implements Guild
     @Override
     public Emote getEmoteById(String id)
     {
-        return emotes.get(Long.parseLong(id));
+        return emotes.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -315,7 +315,7 @@ public class JDAImpl implements JDA
     @Override
     public User getUserById(String id)
     {
-        return users.get(Long.parseLong(id));
+        return users.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -392,7 +392,7 @@ public class JDAImpl implements JDA
     @Override
     public Guild getGuildById(String id)
     {
-        return guilds.get(Long.parseLong(id));
+        return guilds.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -422,7 +422,7 @@ public class JDAImpl implements JDA
     @Override
     public Role getRoleById(String id)
     {
-        return getRoleById(Long.parseLong(id));
+        return getRoleById(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -454,7 +454,7 @@ public class JDAImpl implements JDA
     @Override
     public TextChannel getTextChannelById(String id)
     {
-        return textChannels.get(Long.parseLong(id));
+        return textChannels.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -482,7 +482,7 @@ public class JDAImpl implements JDA
     @Override
     public VoiceChannel getVoiceChannelById(String id)
     {
-        return voiceChannels.get(Long.parseLong(id));
+        return voiceChannels.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -510,7 +510,7 @@ public class JDAImpl implements JDA
     @Override
     public PrivateChannel getPrivateChannelById(String id)
     {
-        return privateChannels.get(Long.parseLong(id));
+        return privateChannels.get(MiscUtil.parseSnowflake(id));
     }
 
     @Override
@@ -538,7 +538,7 @@ public class JDAImpl implements JDA
     @Override
     public Emote getEmoteById(String id)
     {
-        return getEmoteById(Long.parseLong(id));
+        return getEmoteById(MiscUtil.parseSnowflake(id));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -96,7 +96,7 @@ public class TextChannelImpl implements TextChannel
         for (String id : messageIds)
         {
             Args.notEmpty(id, "Message id in messageIds");
-            Args.check(Long.parseLong(id) > twoWeeksAgo, "Message Id provided was older than 2 weeks. Id: " + id);
+            Args.check(MiscUtil.parseSnowflake(id) > twoWeeksAgo, "Message Id provided was older than 2 weeks. Id: " + id);
         }
 
         JSONObject body = new JSONObject().put("messages", messageIds);

--- a/src/main/java/net/dv8tion/jda/core/events/guild/UnavailableGuildJoinedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/guild/UnavailableGuildJoinedEvent.java
@@ -37,7 +37,7 @@ public class UnavailableGuildJoinedEvent extends Event
 
     public String getGuildId()
     {
-        return String.valueOf(guildId);
+        return Long.toUnsignedString(guildId);
     }
 
     public long getGuildIdLong()

--- a/src/main/java/net/dv8tion/jda/core/events/message/MessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/message/MessageDeleteEvent.java
@@ -40,7 +40,7 @@ public class MessageDeleteEvent extends Event
 
     public String getMessageId()
     {
-        return String.valueOf(messageId);
+        return Long.toUnsignedString(messageId);
     }
 
     public long getMessageIdLong()

--- a/src/main/java/net/dv8tion/jda/core/events/message/MessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/message/MessageEmbedEvent.java
@@ -45,7 +45,7 @@ public class MessageEmbedEvent extends Event
 
     public String getMessageId()
     {
-        return String.valueOf(messageId);
+        return Long.toUnsignedString(messageId);
     }
 
     public long getMessageIdLong()

--- a/src/main/java/net/dv8tion/jda/core/handle/MessageBulkDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/MessageBulkDeleteHandler.java
@@ -43,7 +43,7 @@ public class MessageBulkDeleteHandler extends SocketHandler
             {
                 handler.handle(responseNumber, new JSONObject()
                     .put("d", new JSONObject()
-                        .put("channel_id", String.valueOf(channelId))
+                        .put("channel_id", Long.toUnsignedString(channelId))
                         .put("id", id)));
             });
         }

--- a/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
@@ -127,6 +127,20 @@ public class MiscUtil
         }
     }
 
+    public static long parseSnowflake(String input)
+    {
+        Args.notEmpty(input, "ID");
+        try
+        {
+            return Long.parseLong(input.trim());
+        }
+        catch (NumberFormatException ex)
+        {
+            throw new NumberFormatException(
+                String.format("The specified ID is not a valid snowflake (%s). Expecting a valid long value!", input));
+        }
+    }
+
     /**
      * Can be used to append a String to a formatter.
      *

--- a/src/main/java/net/dv8tion/jda/core/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/WidgetUtil.java
@@ -151,6 +151,8 @@ public class WidgetUtil
      *
      * @throws net.dv8tion.jda.core.exceptions.RateLimitedException
      *         If the request was rate limited, <b>respect the timeout</b>!
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code guildId} cannot be parsed by {@link Long#parseLong(String)}
      *
      * @return {@code null} if the provided guild ID is not a valid Discord guild ID
      *         <br>a Widget object with null fields and isAvailable() returning
@@ -161,7 +163,7 @@ public class WidgetUtil
      */
     public static Widget getWidget(String guildId) throws RateLimitedException
     {
-        return getWidget(Long.parseLong(guildId));
+        return getWidget(MiscUtil.parseSnowflake(guildId));
     }
 
     /**
@@ -387,6 +389,8 @@ public class WidgetUtil
          *
          * @throws IllegalStateException
          *         If the widget is not {@link #isAvailable() available}
+         * @throws NumberFormatException
+         *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
          *
          * @return possibly-null VoiceChannel with the given ID. 
          */
@@ -394,7 +398,7 @@ public class WidgetUtil
         {
             checkAvailable();
 
-            return channels.get(Long.parseLong(id));
+            return channels.get(MiscUtil.parseSnowflake(id));
         }
 
         /**
@@ -436,6 +440,8 @@ public class WidgetUtil
          * @param  id
          *         the ID of the member
          *
+         * @throws NumberFormatException
+         *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
          * @throws IllegalStateException
          *         If the widget is not {@link #isAvailable() available}
          *
@@ -445,7 +451,7 @@ public class WidgetUtil
         {
             checkAvailable();
 
-            return members.get(Long.parseLong(id));
+            return members.get(MiscUtil.parseSnowflake(id));
         }
 
         /**


### PR DESCRIPTION
- Use `Long.toUnsignedString` to ensure we only return Strings without a leading `'-' `
- Add `MiscUtil.parseSnwoflake` to have a custom `NumberFormatException` to specify we are talking about a snowflake value

Should we add documentation for this exception, too?