### PR TITLE
Updated getAsMention() for members.

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MemberImpl.java
@@ -244,6 +244,6 @@ public class MemberImpl implements Member
     @Override
     public String getAsMention()
     {
-        return user.getAsMention();
+        return nickname == null ? user.getAsMention() : "<@!" + user.getIdLong() + '>';
     }
 }


### PR DESCRIPTION
If the member has a nickname the raw id should be <@!{id}>, since this is what will be returned by the raw content of a message.