### PR TITLE
Fixed an error in parseSnowflake and improved ErrorResponseException message

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/Permission.java
+++ b/src/main/java/net/dv8tion/jda/core/Permission.java
@@ -33,6 +33,7 @@ public enum Permission
     MANAGE_CHANNEL(4, true, true, "Manage Channels"),
     MANAGE_SERVER(5, true, false, "Manage Server"),
     MESSAGE_ADD_REACTION(6, true, true, "Add Reactions"),
+    VIEW_AUDIT_LOGS(7, true, false, "View Audit Logs"),
 
     MESSAGE_READ(10, true, true, "Read Messages"),
     MESSAGE_WRITE(11, true, true, "Send Messages"),

--- a/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
@@ -112,10 +112,20 @@ public class ErrorResponseException extends RuntimeException
         int code = errorResponse.getCode();
         if (obj != null)
         {
-            if (!obj.isNull("code"))
-                code = obj.getInt("code");
-            if (!obj.isNull("message"))
-                meaning = obj.getString("message");
+            if (!obj.isNull("code") || !obj.isNull("message"))
+            {
+                if (!obj.isNull("code"))
+                    code = obj.getInt("code");
+                if (!obj.isNull("message"))
+                    meaning = obj.getString("message");
+            }
+            else
+            {
+                // This means that neither code or message is provided
+                //In that case we simply put the raw response in place!
+                code = response.code;
+                meaning = response.responseText;
+            }
         }
 
         return new ErrorResponseException(errorResponse, response, code, meaning);

--- a/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
@@ -132,9 +132,9 @@ public class MiscUtil
         Args.notEmpty(input, "ID");
         try
         {
-            if (input.startsWith("-")) // if negative -> parse unsigned
+            if (!input.startsWith("-")) // if not negative -> parse unsigned
                 return Long.parseUnsignedLong(input);
-            else // if not negative -> parse normal
+            else // if negative -> parse normal
                 return Long.parseLong(input);
         }
         catch (NumberFormatException ex)


### PR DESCRIPTION
Flipped the if/else in `parseSnowflake` to fix an IllegalStateException trying to use `parseUnsignedLong` on a string starting with `-`