### PR TITLE
Added TextChannel#clearReactionsById

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -689,8 +689,6 @@ public interface Message extends ISnowflake, Formattable
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
      *         and the currently logged in account does not have
      *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in the channel.
-     * @throws java.lang.IllegalArgumentException
-     *         If the provided unicode emoji is null or empty.
      *
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -689,7 +689,9 @@ public interface Message extends ISnowflake, Formattable
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
      *         and the currently logged in account does not have
      *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in the channel.
-     *
+     * @throws java.lang.IllegalStateException
+     *         If this message was <b>not</b> sent in a
+     *         {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
     RestAction<Void> clearReactions();

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -193,9 +193,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
 
     /**
      * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
-     *
      * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
-     *
      *
      * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
@@ -217,7 +215,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *         If the currently logged in account does not have
      *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
      * @throws java.lang.IllegalArgumentException
-     *         If the provided unicode emoji is null or empty.
+     *         If the provided {@code id} is {@code null} or empty.
      *
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -225,9 +223,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
 
     /**
      * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
-     *
      * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
-     *
      *
      * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
@@ -248,8 +244,6 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      * @throws net.dv8tion.jda.core.exceptions.PermissionException
      *         If the currently logged in account does not have
      *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
-     * @throws java.lang.IllegalArgumentException
-     *         If the provided unicode emoji is null or empty.
      *
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -192,6 +192,72 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
     RestAction<Void> deleteWebhookById(String id);
 
     /**
+     * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
+     *
+     * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
+     *
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The clear-reactions request was attempted after the account lost access to the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *         due to {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} being revoked, or the
+     *         account lost access to the {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The clear-reactions request was attempted after the account lost {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
+     *         in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} when adding the reaction.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *         The clear-reactions request was attempted after the Message had been deleted.</li>
+     * </ul>
+     *
+     * @throws net.dv8tion.jda.core.exceptions.PermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided unicode emoji is null or empty.
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     */
+    RestAction<Void> clearReactionsByMessageId(String messageId);
+
+    /**
+     * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
+     *
+     * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
+     *
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The clear-reactions request was attempted after the account lost access to the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *         due to {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} being revoked, or the
+     *         account lost access to the {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The clear-reactions request was attempted after the account lost {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
+     *         in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} when adding the reaction.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *         The clear-reactions request was attempted after the Message had been deleted.</li>
+     * </ul>
+     *
+     * @throws net.dv8tion.jda.core.exceptions.PermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided unicode emoji is null or empty.
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     */
+    default RestAction<Void> clearReactionsByMessageId(long messageId) {
+        return clearReactionsByMessageId(Long.toUnsignedString(messageId));
+    }
+
+    /**
      * Whether we can send messages in this channel.
      * <br>This is an overload of {@link #canTalk(Member)} with the SelfMember.
      * <br>Checks for both {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} and

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -221,7 +221,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    RestAction<Void> clearReactionsByMessageId(String messageId);
+    RestAction<Void> clearReactionsById(String messageId);
 
     /**
      * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
@@ -253,8 +253,8 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    default RestAction<Void> clearReactionsByMessageId(long messageId) {
-        return clearReactionsByMessageId(Long.toUnsignedString(messageId));
+    default RestAction<Void> clearReactionsById(long messageId) {
+        return clearReactionsById(Long.toUnsignedString(messageId));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -142,7 +142,8 @@ public class MessageImpl implements Message
     public RestAction<Void> clearReactions()
     {
         checkPermission(Permission.MESSAGE_MANAGE);
-        return new RestAction<Void>(getJDA(), Route.Messages.REMOVE_ALL_REACTIONS.compile(getChannel().getId(), getId()), null)
+        Route.CompiledRoute route = Route.Messages.REMOVE_ALL_REACTIONS.compile(getChannel().getId(), getId());
+        return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
             protected void handleResponse(Response response, Request<Void> request)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -141,10 +141,9 @@ public class MessageImpl implements Message
     @Override
     public RestAction<Void> clearReactions()
     {
-        if (!isFromType(ChannelType.TEXT)) {
+        if (!isFromType(ChannelType.TEXT))
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
-        }
-        return ((TextChannel) channel).clearReactionsById(getId());
+        return getTextChannel().clearReactionsById(getId());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -141,19 +141,10 @@ public class MessageImpl implements Message
     @Override
     public RestAction<Void> clearReactions()
     {
-        checkPermission(Permission.MESSAGE_MANAGE);
-        Route.CompiledRoute route = Route.Messages.REMOVE_ALL_REACTIONS.compile(getChannel().getId(), getId());
-        return new RestAction<Void>(getJDA(), route, null)
-        {
-            @Override
-            protected void handleResponse(Response response, Request<Void> request)
-            {
-                if (response.isOk())
-                    request.onSuccess(null);
-                else
-                    request.onFailure(response);
-            }
-        };
+        if (!isFromType(ChannelType.TEXT)) {
+            throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
+        }
+        return ((TextChannel) channel).clearReactionsById(getId());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -386,7 +386,7 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
-    public RestAction<Void> clearReactionsByMessageId(String messageId)
+    public RestAction<Void> clearReactionsById(String messageId)
     {
         checkPermission(Permission.MESSAGE_MANAGE);
         return new RestAction<Void>(getJDA(), Route.Messages.REMOVE_ALL_REACTIONS.compile(getId(), messageId), null)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -388,8 +388,11 @@ public class TextChannelImpl implements TextChannel
     @Override
     public RestAction<Void> clearReactionsById(String messageId)
     {
+        Args.notEmpty(messageId, "Message ID");
+
         checkPermission(Permission.MESSAGE_MANAGE);
-        return new RestAction<Void>(getJDA(), Route.Messages.REMOVE_ALL_REACTIONS.compile(getId(), messageId), null)
+        Route.CompiledRoute route = Route.Messages.REMOVE_ALL_REACTIONS.compile(getId(), messageId);
+        return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
             protected void handleResponse(Response response, Request<Void> request)

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -386,6 +386,23 @@ public class TextChannelImpl implements TextChannel
     }
 
     @Override
+    public RestAction<Void> clearReactionsByMessageId(String messageId)
+    {
+        checkPermission(Permission.MESSAGE_MANAGE);
+        return new RestAction<Void>(getJDA(), Route.Messages.REMOVE_ALL_REACTIONS.compile(getId(), messageId), null)
+        {
+            @Override
+            protected void handleResponse(Response response, Request<Void> request)
+            {
+                if (response.isOk())
+                    request.onSuccess(null);
+                else
+                    request.onFailure(response);
+            }
+        };
+    }
+
+    @Override
     public PermissionOverride getPermissionOverride(Member member)
     {
         return memberOverrides.get(member);


### PR DESCRIPTION
also added TextChannel#clearReactionsById(long messageId) as a default method
copied over the docs and changed relevant parts

also removed a `@throws IllegalArgumentException` from Message#clearReactions since it doesn't take any arguments