### PR TITLE
Fix WS Sending race condition.

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -218,6 +218,13 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 {
                     try
                     {
+                        //Make sure that we don't send any packets while attempting to connect.
+                        if (!connected || initiating)
+                        {
+                            Thread.sleep(1000);
+                            continue;
+                        }
+
                         attemptedToSend = false;
                         needRatelimit = false;
 


### PR DESCRIPTION
Fixed bug where packets sent by the WS ratelimit system were sent before IDENTIFY due to racecondition.