### PR TITLE
Reorder stripping of mentions

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/MessageBuilder.java
@@ -372,7 +372,9 @@ public class MessageBuilder implements Appendable
      */
     public MessageBuilder stripMentions(JDA jda)
     {
-        return this.stripMentions(jda, (Guild) null, MentionType.EVERYONE, MentionType.HERE, MentionType.CHANNEL, MentionType.ROLE, MentionType.USER);
+        // Note: Users can rename to "everyone" or "here", so those
+        // should be stripped after the USER mention is stripped.
+        return this.stripMentions(jda, (Guild) null, MentionType.CHANNEL, MentionType.ROLE, MentionType.USER, MentionType.EVERYONE, MentionType.HERE);
     }
 
     /**
@@ -389,7 +391,9 @@ public class MessageBuilder implements Appendable
      */
     public MessageBuilder stripMentions(Guild guild)
     {
-        return this.stripMentions(guild.getJDA(), guild, MentionType.EVERYONE, MentionType.HERE, MentionType.CHANNEL, MentionType.ROLE, MentionType.USER);
+        // Note: Users can rename to "everyone" or "here", so those
+        // should be stripped after the USER mention is stripped.
+        return this.stripMentions(guild.getJDA(), guild, MentionType.CHANNEL, MentionType.ROLE, MentionType.USER, MentionType.EVERYONE, MentionType.HERE);
     }
 
     /**


### PR DESCRIPTION
You can `/nick everyone`, and the default `stripMentions` will "strip" a mention of yourself to become an unfiltered `@everyone`.

This PR is to fix that. I've locally tested that it works, and written a note to future editors of those functions so that people think twice before rewriting it.