### PR TITLE
Renamed formatting send/edit message methods to avoid conflicting calls.

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -412,7 +412,7 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message Message}
      *     <br>The {@link net.dv8tion.jda.core.entities.Message Message} with the updated content
      */
-    RestAction<Message> editMessage(String format, Object... args);
+    RestAction<Message> editMessageFormat(String format, Object... args);
 
     /**
      * Edits this Message's content to the provided {@link net.dv8tion.jda.core.entities.Message Message}.

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -221,7 +221,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message Message}
      *         <br>The newly created Message after it has been sent to Discord.
      */
-    default RestAction<Message> sendMessage(String format, Object... args)
+    default RestAction<Message> sendMessageFormat(String format, Object... args)
     {
         Args.notEmpty(format, "Format");
         return sendMessage(new MessageBuilder().appendFormat(format, args).build());
@@ -1863,7 +1863,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message}
      *         <br>The modified Message
      */
-    default RestAction<Message> editMessageById(String messageId, String format, Object... args)
+    default RestAction<Message> editMessageFormatById(String messageId, String format, Object... args)
     {
         Args.notBlank(format, "Format String");
         return editMessageById(messageId, new MessageBuilder().appendFormat(format, args).build());
@@ -1914,7 +1914,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.Message}
      *         <br>The modified Message
      */
-    default RestAction<Message> editMessageById(long messageId, String format, Object... args)
+    default RestAction<Message> editMessageFormatById(long messageId, String format, Object... args)
     {
         Args.notBlank(format, "Format String");
         return editMessageById(messageId, new MessageBuilder().appendFormat(format, args).build());

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -22,10 +22,7 @@ import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.exceptions.PermissionException;
-import net.dv8tion.jda.core.requests.Request;
-import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
-import net.dv8tion.jda.core.requests.Route;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.util.Args;
 import org.json.JSONObject;
@@ -446,7 +443,7 @@ public class MessageImpl implements Message
     }
 
     @Override
-    public RestAction<Message> editMessage(String format, Object... args)
+    public RestAction<Message> editMessageFormat(String format, Object... args)
     {
         Args.notBlank(format, "Format String");
         return editMessage(new MessageBuilder().appendFormat(format, args).build());


### PR DESCRIPTION
Before users that did `sendMessage("Hello")` would essentially use the format method which was unintentional

Note: This will cause issues for people that were using the format methods but those cannot be avoided.