### PR TITLE
Fixed Emote#canInteract logic for bot accounts

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Emote.java
@@ -182,6 +182,7 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
 
     /**
      * Whether the specified Member can interact with this Emote within the provided MessageChannel
+     * <br>Same logic as {@link #canInteract(User, MessageChannel, boolean) canInteract(issuer, channel, true)}!
      *
      * @param  issuer
      *         The User to test
@@ -196,5 +197,26 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
     default boolean canInteract(User issuer, MessageChannel channel)
     {
         return PermissionUtil.canInteract(issuer, this, channel);
+    }
+
+    /**
+     * Whether the specified Member can interact with this Emote within the provided MessageChannel
+     * <br>Special override to exclude elevated bot permissions in case of (for instance) reacting to messages.
+     *
+     * @param  issuer
+     *         The User to test
+     * @param  channel
+     *         The MessageChannel to test
+     * @param  botOverride
+     *         Whether bots can use non-managed emotes in other guilds
+     *
+     * @return True, if the provided Member can use this Emote
+     *
+     * @see    net.dv8tion.jda.core.utils.PermissionUtil#canInteract(Member, Emote)
+     * @see    net.dv8tion.jda.core.utils.PermissionUtil#canInteract(User, Emote, MessageChannel, boolean)
+     */
+    default boolean canInteract(User issuer, MessageChannel channel, boolean botOverride)
+    {
+        return PermissionUtil.canInteract(issuer, this, channel, botOverride);
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -22,10 +22,7 @@ import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.exceptions.PermissionException;
-import net.dv8tion.jda.core.requests.Request;
-import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
-import net.dv8tion.jda.core.requests.Route;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.util.Args;
 import org.json.JSONObject;
@@ -129,7 +126,7 @@ public class MessageImpl implements Message
         Args.notEmpty(unicode, "Provided Unicode");
 
         MessageReaction reaction = reactions.parallelStream()
-                .filter(r -> r.getEmote().getName().equals(unicode))
+                .filter(r -> Objects.equals(r.getEmote().getName(), unicode))
                 .findFirst().orElse(null);
 
         if (reaction != null && reaction.isSelf())


### PR DESCRIPTION
Bots are now able to use non-managed emotes outside of the emote's guild