### PR TITLE
Update of audit log reasons / allow utf-8

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -695,7 +695,7 @@ public interface Message extends ISnowflake, Formattable
      *         {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    AuditableRestAction<Void> clearReactions();
+    RestAction<Void> clearReactions();
 
     /**
      * This specifies the {@link net.dv8tion.jda.core.entities.MessageType MessageType} of this Message.

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -109,7 +109,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @see    #deleteMessagesByIds(Collection)
      */
-    AuditableRestAction<Void> deleteMessages(Collection<Message> messages);
+    RestAction<Void> deleteMessages(Collection<Message> messages);
 
     /**
      * Bulk deletes a list of messages.
@@ -156,7 +156,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @see    #deleteMessages(Collection)
      */
-    AuditableRestAction<Void> deleteMessagesByIds(Collection<String> messageIds);
+    RestAction<Void> deleteMessagesByIds(Collection<String> messageIds);
 
     /**
      * Deletes a {@link net.dv8tion.jda.core.entities.Webhook Webhook} attached to this channel
@@ -223,7 +223,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @return {@link net.dv8tion.jda.core.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    AuditableRestAction<Void> clearReactionsById(String messageId);
+    RestAction<Void> clearReactionsById(String messageId);
 
     /**
      * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
@@ -254,7 +254,8 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *
      * @return {@link net.dv8tion.jda.core.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    default AuditableRestAction<Void> clearReactionsById(long messageId) {
+    default RestAction<Void> clearReactionsById(long messageId)
+    {
         return clearReactionsById(Long.toUnsignedString(messageId));
     }
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -137,7 +137,7 @@ public class MessageImpl implements Message
     }
 
     @Override
-    public AuditableRestAction<Void> clearReactions()
+    public RestAction<Void> clearReactions()
     {
         if (!isFromType(ChannelType.TEXT))
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -94,7 +94,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     }
 
     @Override
-    public AuditableRestAction<Void> deleteMessages(Collection<Message> messages)
+    public RestAction<Void> deleteMessages(Collection<Message> messages)
     {
         Args.notEmpty(messages, "Messages collection");
 
@@ -104,7 +104,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     }
 
     @Override
-    public AuditableRestAction<Void> deleteMessagesByIds(Collection<String> messageIds)
+    public RestAction<Void> deleteMessagesByIds(Collection<String> messageIds)
     {
         checkPermission(Permission.MESSAGE_MANAGE, "Must have MESSAGE_MANAGE in order to bulk delete messages in this channel regardless of author.");
         if (messageIds.size() < 2 || messageIds.size() > 100)
@@ -119,7 +119,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
 
         JSONObject body = new JSONObject().put("messages", messageIds);
         Route.CompiledRoute route = Route.Messages.DELETE_MESSAGES.compile(getId());
-        return new AuditableRestAction<Void>(getJDA(), route, body)
+        return new RestAction<Void>(getJDA(), route, body)
         {
             @Override
             protected void handleResponse(Response response, Request<Void> request)
@@ -342,13 +342,13 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     }
 
     @Override
-    public AuditableRestAction<Void> clearReactionsById(String messageId)
+    public RestAction<Void> clearReactionsById(String messageId)
     {
         Args.notEmpty(messageId, "Message ID");
 
         checkPermission(Permission.MESSAGE_MANAGE);
         Route.CompiledRoute route = Route.Messages.REMOVE_ALL_REACTIONS.compile(getId(), messageId);
-        return new AuditableRestAction<Void>(getJDA(), route, null)
+        return new RestAction<Void>(getJDA(), route, null)
         {
             @Override
             protected void handleResponse(Response response, Request<Void> request)

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -27,7 +27,6 @@ import net.dv8tion.jda.core.utils.SimpleLog;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.http.util.Args;
 
-import java.nio.charset.Charset;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
 
@@ -628,12 +627,6 @@ public abstract class RestAction<T>
     protected CaseInsensitiveMap<String, String> finalizeHeaders()
     {
         return null;
-    }
-
-    protected static String encodeHeaderValue(String reason)
-    {
-        byte[] bytes = reason.getBytes();
-        return new String(bytes, Charset.forName("iso-8859-1"));
     }
 
     protected abstract void handleResponse(Response response, Request<T> request);

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/AuditableRestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/AuditableRestAction.java
@@ -65,11 +65,18 @@ public abstract class AuditableRestAction<T> extends RestAction<T>
     @Override
     protected CaseInsensitiveMap<String, String> finalizeHeaders()
     {
-        if (reason == null)
+        if (reason == null || reason.isEmpty())
             return null;
         CaseInsensitiveMap<String, String> map = new CaseInsensitiveMap<>();
-        map.put("X-Audit-Log-Reason", MiscUtil.encodeUTF8(reason));
+        String encodedReason = uriEncode(reason);
+        map.put("X-Audit-Log-Reason", encodedReason);
         return map;
+    }
+
+    private String uriEncode(String input)
+    {
+        String formEncode = MiscUtil.encodeUTF8(input);
+        return formEncode.replace('+', ' ');
     }
 
     public static class EmptyRestAction<T> extends AuditableRestAction<T>

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/AuditableRestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/AuditableRestAction.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.requests.Route;
+import net.dv8tion.jda.core.utils.MiscUtil;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 import java.util.concurrent.Future;
@@ -67,7 +68,7 @@ public abstract class AuditableRestAction<T> extends RestAction<T>
         if (reason == null)
             return null;
         CaseInsensitiveMap<String, String> map = new CaseInsensitiveMap<>();
-        map.put("X-Audit-Log-Reason", encodeHeaderValue(reason));
+        map.put("X-Audit-Log-Reason", MiscUtil.encodeUTF8(reason));
         return map;
     }
 


### PR DESCRIPTION
Note that I made TextChannel#deleteMessages only return RestAction according to hammerandchisel/discord-api-docs#265
And I did the same for TextChannel#clearReactionsById due to there not being an action type I suspect there not to be one in the near future