### PR TITLE
Upgrade efficiency of ShardManager#getGuildById

### DIFF
--- a/src/main/java/net/dv8tion/jda/bot/entities/impl/ShardManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/bot/entities/impl/ShardManagerImpl.java
@@ -144,13 +144,15 @@ public class ShardManagerImpl implements ShardManager
     @Override
     public Guild getGuildById(final long id)
     {
-        return this.findSnowflakeInCombinedCollection(jda -> jda.getGuildMap().valueCollection(), id);
+        int shardId = MiscUtil.getShardForGuild(id, shardsTotal);
+        JDA jda = this.getShard(shardId);
+        return jda != null ? jda.getGuildById(id) : null;
     }
 
     @Override
     public Guild getGuildById(final String id)
     {
-        return this.findSnowflakeInCombinedCollection(jda -> jda.getGuildMap().valueCollection(), id);
+        return this.getGuildById(MiscUtil.parseSnowflake(id));
     }
 
     @Override


### PR DESCRIPTION
While looking at the additions, I realized that the ShardManager#getGuildById method can be more efficient.
Rather than finding the snowflake in a combined collection, you could calculate the shard id of the Guild, get the shard and obtain the guild from there instead. This upgrades the method from O(n) to O(1).