### PR TITLE
Release for JDA 3.2 / finalization

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -733,11 +733,11 @@ public interface JDA
     boolean isBulkDeleteSplittingEnabled();
 
     /**
-     * Shuts down this {@link JDA} instance, closing all its connections.
+     * Shuts down this JDA instance, closing all its connections.
      * After this command is issued the JDA Instance can not be used anymore.
-     * Already enqueued {@link net.dv8tion.jda.core.requests.RestAction RestActions} are still be executed.
+     * Already enqueued {@link net.dv8tion.jda.core.requests.RestAction RestActions} are still going to be executed.
      *
-     * If you want this instance to shutdown without executing  
+     * <p>If you want this instance to shutdown without executing, use {@link #shutdownNow() shutdownNow()}
      *
      * @see #shutdownNow()
      */
@@ -760,7 +760,7 @@ public interface JDA
     }
 
     /**
-     * Shuts down this {@link JDA} instance instantly.
+     * Shuts down this JDA instance instantly.
      * This will also cancel all queued {@link net.dv8tion.jda.core.requests.RestAction RestActions}.
      *
      * @see #shutdown()

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.core.JDA.Status;
 import net.dv8tion.jda.core.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.core.entities.Game;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.exceptions.AccountTypeException;
 import net.dv8tion.jda.core.exceptions.RateLimitedException;
 import net.dv8tion.jda.core.hooks.IEventManager;
 import net.dv8tion.jda.core.managers.impl.PresenceImpl;
@@ -114,7 +115,7 @@ public class JDABuilder
      * <p>Default: <b>0 - Infinite-Timeout (maybe?)</b>
      *
      * @deprecated
-     *         Use the more powerfull {@link #setWebsocketFactory(WebSocketFactory)} instead
+     *         Use the more powerful {@link #setWebsocketFactory(WebSocketFactory)} instead
      *
      * @param  websocketTimeout
      *         Non-negative int representing Websocket timeout in milliseconds.
@@ -448,23 +449,29 @@ public class JDABuilder
      * <br>The shardId that receives all stuff related to given bot is calculated as follows: shardId == (guildId {@literal >>} 22) % shardTotal;
      * <br><b>PMs are only sent to shard 0.</b>
      *
-     * <p>Please note, that a shard will not even know about guilds not assigned to.
+     * <p>Please note, that a shard will not even know about guilds which are not assigned to it.
      *
      * @param  shardId
      *         The id of this shard (starting at 0).
      * @param  shardTotal
      *         The number of overall shards.
      *
-     * @return Returns the {@link net.dv8tion.jda.core.JDABuilder JDABuilder} instance. Useful for chaining.
+     * @throws net.dv8tion.jda.core.exceptions.AccountTypeException
+     *         If this is used on a JDABuilder for {@link net.dv8tion.jda.core.AccountType#CLIENT AccountType.CLIENT}
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided shard configuration is invalid
+     *         ({@code 0 <= shardId < shardTotal} with {@code shardTotal > 0})
+     *
+     * @return The {@link net.dv8tion.jda.core.JDABuilder JDABuilder} instance. Useful for chaining.
      *
      * @see    net.dv8tion.jda.core.JDA#getShardInfo() JDA.getShardInfo()
      */
     public JDABuilder useSharding(int shardId, int shardTotal)
     {
-        if (shardId < 0 || shardTotal < 2 || shardId >= shardTotal)
-        {
-            throw new RuntimeException("This configuration of shardId and shardTotal is not allowed! 0 <= shardId < shardTotal with shardTotal > 1");
-        }
+        if (accountType != AccountType.BOT)
+            throw new AccountTypeException(AccountType.BOT);
+        if (shardId < 0 || shardTotal < 1 || shardId >= shardTotal)
+            throw new RuntimeException("This configuration of shardId and shardTotal is not allowed! 0 <= shardId < shardTotal with shardTotal > 0");
         shardInfo = new JDA.ShardInfo(shardId, shardTotal);
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -449,7 +449,9 @@ public class JDABuilder
      * <br>The shardId that receives all stuff related to given bot is calculated as follows: shardId == (guildId {@literal >>} 22) % shardTotal;
      * <br><b>PMs are only sent to shard 0.</b>
      *
-     * <p>Please note, that a shard will not even know about guilds which are not assigned to it.
+     * <p>Please note, that a shard will not know about guilds which are not assigned to it.
+     *
+     * <p><b>It is not possible to use sharding with an account for {@link net.dv8tion.jda.core.AccountType#CLIENT AccountType.CLIENT}!</b>
      *
      * @param  shardId
      *         The id of this shard (starting at 0).

--- a/src/main/java/net/dv8tion/jda/core/entities/IFakeable.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/IFakeable.java
@@ -24,8 +24,8 @@ package net.dv8tion.jda.core.entities;
  * <br>A fake user can occur when sharding. Discord only sends private messages to Shard 0. If a User which is connected
  * to Guilds on shard 1 sends a private message to the logged in account, it is received on Shard 0. However, if Shard 0
  * does not know about the User due to not having a Guild connection with them, it will use the information provided in
- * the MESSAGE_CREATE event to create a temporary fake user. In this case, the {@link net.dv8tion.jda.core.entities.User#getPrivateChannel()}
- * is also fake!
+ * the MESSAGE_CREATE event to create a temporary fake user.
+ * In this case, the associated {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} is also fake!
  *
  * <p>Another example would be a fake {@link net.dv8tion.jda.core.entities.Emote Emote}. If a user sends a message containing
  * an Emote from a {@link net.dv8tion.jda.core.entities.Guild Guild} that the currently logged in account is not a part of,

--- a/src/main/java/net/dv8tion/jda/core/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/User.java
@@ -146,25 +146,6 @@ public interface User extends ISnowflake, IMentionable, IFakeable
     List<Guild> getMutualGuilds();
 
     /**
-     * Gets the {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} of this
-     * {@link net.dv8tion.jda.core.entities.User User} for use in sending direct messages.
-     *
-     * @throws java.lang.IllegalStateException
-     *         If JDA does not have a private channel cached for this user. Use {@link #hasPrivateChannel()} to check
-     *         and {@link #openPrivateChannel()} to open a channel.
-     *
-     * @return Never-null {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} that is associated with this {@link net.dv8tion.jda.core.entities.User User}.
-     *
-     * @deprecated
-     *         This method will be removed in version <b>3.2</b> due to improper usage by most new users.
-     *         <br>Please use {@link #openPrivateChannel()} instead and use the response PrivateChannel.
-     *         More information can be found in the wiki:
-     *         <a target="_blank" href="https://github.com/DV8FromTheWorld/JDA/wiki/7%29-Using-RestAction">Using RestAction</a>
-     */
-    @Deprecated
-    PrivateChannel getPrivateChannel();
-
-    /**
      * Returns whether or not the given user is a Bot-Account (special badge in client, some different behaviour)
      *
      * @return If the User's Account is marked as Bot

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -569,7 +569,9 @@ public class MessageImpl implements Message
     @Override
     public String toString()
     {
-        return String.format("M:%#s:%.20s(%s)", author, this, getId());
+        return author != null
+            ? String.format("M:%#s:%.20s(%s)", author, this, getId())
+            : String.format("M:%.20s", this); // this message was made using MessageBuilder
     }
 
     public JSONObject toJSONObject()

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/UserImpl.java
@@ -135,7 +135,6 @@ public class UserImpl implements User
         return getJDA().getMutualGuilds(this);
     }
 
-    @Override
     public PrivateChannel getPrivateChannel()
     {
         if (!hasPrivateChannel())

--- a/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
@@ -316,42 +316,6 @@ public class GuildController
     }
 
     /**
-     * The method calculates the amount of Members that would be pruned if {@link #prune(int)} was executed.
-     * Prunability is determined by a Member being offline for at least <i>days</i> days.
-     *
-     * <p>Possible {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} caused by
-     * the returned {@link net.dv8tion.jda.core.requests.RestAction RestAction} include the following:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
-     *     <br>The prune count cannot be fetched due to a permission discrepancy</li>
-     *
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
-     *     <br>We were removed from the Guild before finishing the task</li>
-     * </ul>
-     *
-     * @param  days
-     *         Minimum number of days since a member has been offline to get affected.
-     *
-     * @throws net.dv8tion.jda.core.exceptions.PermissionException
-     *         If the account doesn't have {@link net.dv8tion.jda.core.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
-     * @throws net.dv8tion.jda.core.exceptions.GuildUnavailableException
-     *         If the guild is temporarily not {@link net.dv8tion.jda.core.entities.Guild#isAvailable() available}
-     * @throws IllegalArgumentException
-     *         If the provided days are less than {@code 1}
-     *
-     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: Integer
-     *         <br>The amount of Members that would be affected.
-     *
-     * @deprecated
-     *         Use {@link net.dv8tion.jda.core.entities.Guild#getPrunableMemberCount(int) Guild.getPrunableMemberCount(int)} instead
-     */
-    @Deprecated
-    public RestAction<Integer> getPrunableMemberCount(int days)
-    {
-        return getGuild().getPrunableMemberCount(days);
-    }
-
-    /**
      * Kicks a {@link net.dv8tion.jda.core.entities.Member Member} from the {@link net.dv8tion.jda.core.entities.Guild Guild}.
      *
      * <p><b>Note:</b> {@link net.dv8tion.jda.core.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.core.entities.User User}
@@ -1123,38 +1087,6 @@ public class GuildController
                     request.onFailure(response);
             }
         };
-    }
-
-    /**
-     * Gets an unmodifiable list of the currently banned {@link net.dv8tion.jda.core.entities.User Users}.
-     * <br>If you wish to ban or unban a user, please {@link #ban(net.dv8tion.jda.core.entities.User, int)} or
-     * {@link #unban(net.dv8tion.jda.core.entities.User)}.
-     *
-     * <p>Possible {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} caused by
-     * the returned {@link net.dv8tion.jda.core.requests.RestAction RestAction} include the following:
-     * <ul>
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
-     *     <br>The ban list cannot be fetched due to a permission discrepancy</li>
-     *
-     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
-     *     <br>We were removed from the Guild before finishing the task</li>
-     * </ul>
-     *
-     * @throws net.dv8tion.jda.core.exceptions.PermissionException
-     *         If the logged in account does not have the {@link net.dv8tion.jda.core.Permission#BAN_MEMBERS} permission.
-     * @throws net.dv8tion.jda.core.exceptions.GuildUnavailableException
-     *         If the guild is temporarily not {@link net.dv8tion.jda.core.entities.Guild#isAvailable() available}
-     *
-     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@literal List<}{@link net.dv8tion.jda.core.entities.User User}{@literal >}
-     *         <br>An unmodifiable list of all users currently banned from this Guild
-     *
-     * @deprecated
-     *         Use {@link net.dv8tion.jda.core.entities.Guild#getBans() Guild.getBans()} instead
-     */
-    @Deprecated
-    public RestAction<List<User>> getBans()
-    {
-        return getGuild().getBans();
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
@@ -180,12 +180,14 @@ public class MiscUtil
     }
 
     /**
-     *  Returns a new request body that transmits the provided {@link java.io.InputStream InputStream}.
+     * Creates a new request body that transmits the provided {@link java.io.InputStream InputStream}.
      *  
-     *  @param contentType
+     * @param  contentType
      *         The {@link okhttp3.MediaType MediaType} of the data
-     *  @param stream
+     * @param  stream
      *         The {@link java.io.InputStream InputStream} to be transmitted
+     *
+     * @return RequestBody capable of transmitting the provided InputStream of data
      */
     public static RequestBody createRequestBody(final MediaType contentType, final InputStream stream)
     {

--- a/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
@@ -19,7 +19,6 @@ import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.entities.impl.AbstractChannelImpl;
 import net.dv8tion.jda.core.entities.impl.GuildImpl;
-import net.dv8tion.jda.core.entities.impl.PermissionOverrideImpl;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
@@ -208,30 +207,6 @@ public class PermissionUtil
         return canInteract(issuer, emote, channel, true);
     }
 
-    @Deprecated
-    public static PermissionOverride getFullPermOverride()
-    {
-        PermissionOverrideImpl override = new PermissionOverrideImpl(null, 0, null);
-        long allow = 0, deny = 0;
-        for (Permission permission : Permission.values())
-        {
-            if(permission != Permission.UNKNOWN)
-            {
-                allow = allow | (1 << permission.getOffset());
-            }
-        }
-        return override.setAllow(allow).setDeny(deny);
-    }
-
-    /**
-     * @deprecated Use {@link #checkPermission(net.dv8tion.jda.core.entities.Member, net.dv8tion.jda.core.Permission...)} instead
-     */
-    @Deprecated
-    public static boolean checkPermission(Guild guild, Member member, Permission... permissions)
-    {
-        return checkPermission(member, permissions);
-    }
-
     /**
      * Checks to see if the {@link net.dv8tion.jda.core.entities.Member Member} has the specified {@link net.dv8tion.jda.core.Permission Permissions}
      * in the specified {@link net.dv8tion.jda.core.entities.Guild Guild}. This method properly deals with Owner status.
@@ -303,15 +278,6 @@ public class PermissionUtil
         long effectivePerms = getEffectivePermission(channel, member);
         return isApplied(effectivePerms, Permission.ADMINISTRATOR.getRawValue())
                 || isApplied(effectivePerms, Permission.getRaw(permissions));
-    }
-
-    /**
-     * @deprecated Use {@link #getEffectivePermission(net.dv8tion.jda.core.entities.Member)} instead
-     */
-    @Deprecated
-    public static long getEffectivePermission(Guild guild, Member member)
-    {
-        return getEffectivePermission(member);
     }
 
     /**


### PR DESCRIPTION
Cleanup for some documentation and removal of deprecated methods.
JDABuilder will no longer throw an exception for `useSharding(0, 1)` as it is a valid configuration. (tested)
The exceptions thrown by JDABuilder are now documented and no longer simple RuntimeExceptions!

- [x] Compiles
- [x] No javadoc errors
- [ ] Version bump (will be final release commit)