### PR TITLE
Use exception name as response message on requester exceptions

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
@@ -110,7 +110,15 @@ public class ErrorResponseException extends RuntimeException
         JSONObject obj = response.getObject();
         String meaning = errorResponse.getMeaning();
         int code = errorResponse.getCode();
-        if (obj != null)
+        if (response.isError() && response.getException() != null)
+        {
+            // this generally means that an exception occurred trying to
+            //make an http request. e.g.:
+            //SocketTimeoutException/ UnknownHostException
+            code = response.code;
+            meaning = response.getException().getClass().getName();
+        }
+        else if (obj != null)
         {
             if (!obj.isNull("code") || !obj.isNull("message"))
             {

--- a/src/main/java/net/dv8tion/jda/core/requests/Response.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Response.java
@@ -133,6 +133,11 @@ public class Response implements Closeable
         return cfRays;
     }
 
+    public Exception getException()
+    {
+        return exception;
+    }
+
     public boolean isError()
     {
         return this.code == Response.ERROR_CODE;


### PR DESCRIPTION
New format would look like `[ErrorResponseException] -1: java.net.SocketTimeoutException`