### PR TITLE
Allow requester to retry once on SocketTimeoutException

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -920,6 +920,15 @@ public interface JDA
     void setAutoReconnect(boolean reconnect);
 
     /**
+     * Whether the Requester should retry when
+     * a {@link java.net.SocketTimeoutException SocketTimeoutException} occurs.
+     *
+     * @param  retryOnTimeout
+     *         True, if the Request should retry once on a socket timeout
+     */
+    void setRequestTimeoutRetry(boolean retryOnTimeout);
+
+    /**
      * USed to determine whether or not autoReconnect is enabled for JDA.
      *
      * @return True if JDA will attempt to automatically reconnect when a connection-error is encountered.

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -64,6 +64,7 @@ public class JDABuilder
     protected boolean enableBulkDeleteSplitting = true;
     protected boolean autoReconnect = true;
     protected boolean idle = false;
+    protected boolean requestTimeoutRetry = true;
 
     /**
      * Creates a completely empty JDABuilder.
@@ -132,6 +133,24 @@ public class JDABuilder
     }
 
     /**
+     * Whether the Requester should retry when
+     * a {@link java.net.SocketTimeoutException SocketTimeoutException} occurs.
+     * <br><b>Default</b>: {@code true}
+     *
+     * <p>This value can be changed at any time with {@link net.dv8tion.jda.core.JDA#setRequestTimeoutRetry(boolean) JDA.setRequestTimeoutRetry(boolean)}!
+     *
+     * @param  retryOnTimeout
+     *         True, if the Request should retry once on a socket timeout
+     *
+     * @return The {@link net.dv8tion.jda.core.JDABuilder JDABuilder} instance. Useful for chaining.
+     */
+    public JDABuilder setRequestTimeoutRetry(boolean retryOnTimeout)
+    {
+        this.requestTimeoutRetry = retryOnTimeout;
+        return this;
+    }
+
+    /**
      * Sets the token that will be used by the {@link net.dv8tion.jda.core.JDA} instance to log in when
      * {@link net.dv8tion.jda.core.JDABuilder#buildAsync() buildAsync()}
      * or {@link net.dv8tion.jda.core.JDABuilder#buildBlocking() buildBlocking()}
@@ -160,7 +179,7 @@ public class JDABuilder
      * @param  token
      *         The token of the account that you would like to login with.
      *
-     * @return Returns the {@link net.dv8tion.jda.core.JDABuilder JDABuilder} instance. Useful for chaining.
+     * @return The {@link net.dv8tion.jda.core.JDABuilder JDABuilder} instance. Useful for chaining.
      */
     public JDABuilder setToken(String token)
     {
@@ -520,9 +539,8 @@ public class JDABuilder
     {
         OkHttpClient.Builder httpClientBuilder = this.httpClientBuilder == null ? new OkHttpClient.Builder() : this.httpClientBuilder;
         WebSocketFactory wsFactory = this.wsFactory == null ? new WebSocketFactory() : this.wsFactory;
-        JDAImpl jda = new JDAImpl(accountType, httpClientBuilder, wsFactory, shardRateLimiter,
-                                  autoReconnect, enableVoice, enableShutdownHook, enableBulkDeleteSplitting,
-                                  corePoolSize, maxReconnectDelay);
+        JDAImpl jda = new JDAImpl(accountType, httpClientBuilder, wsFactory, shardRateLimiter, autoReconnect, enableVoice, enableShutdownHook,
+                enableBulkDeleteSplitting, requestTimeoutRetry, corePoolSize, maxReconnectDelay);
 
         if (eventManager != null)
             jda.setEventManager(eventManager);

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -103,9 +103,8 @@ public class JDAImpl implements JDA
     protected long responseTotal;
     protected long ping = -1;
 
-    public JDAImpl(AccountType accountType, OkHttpClient.Builder httpClientBuilder, WebSocketFactory wsFactory, ShardedRateLimiter rateLimiter,
-                   boolean autoReconnect, boolean audioEnabled, boolean useShutdownHook, boolean bulkDeleteSplittingEnabled,
-                   int corePoolSize, int maxReconnectDelay)
+    public JDAImpl(AccountType accountType, OkHttpClient.Builder httpClientBuilder, WebSocketFactory wsFactory, ShardedRateLimiter rateLimiter,boolean autoReconnect, boolean audioEnabled,
+            boolean useShutdownHook, boolean bulkDeleteSplittingEnabled,boolean retryOnTimeout, int corePoolSize, int maxReconnectDelay)
     {
         this.accountType = accountType;
         this.httpClientBuilder = httpClientBuilder;
@@ -119,6 +118,7 @@ public class JDAImpl implements JDA
 
         this.presence = new PresenceImpl(this);
         this.requester = new Requester(this, rateLimiter);
+        this.requester.setRetryOnTimeout(retryOnTimeout);
 
         this.jdaClient = accountType == AccountType.CLIENT ? new JDAClientImpl(this) : null;
         this.jdaBot = accountType == AccountType.BOT ? new JDABotImpl(this) : null;
@@ -285,6 +285,12 @@ public class JDAImpl implements JDA
         {
             client.setAutoReconnect(autoReconnect);
         }
+    }
+
+    @Override
+    public void setRequestTimeoutRetry(boolean retryOnTimeout)
+    {
+        requester.setRetryOnTimeout(retryOnTimeout);
     }
 
     @Override


### PR DESCRIPTION
Ever since we switched to okhttp we got reports for SocketTimeoutException.
This should retry once on every timeout. 
For users that dislike this it is possible to disable the retry logic using JDABuilder#setRequestTimeoutRetry(boolean) and the respective version in JDA.