### PR TITLE
Implement AudioPacketInterceptor

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/core/audio/AudioConnection.java
@@ -268,13 +268,13 @@ public class AudioConnection
     {
         boolean hasConsumer = packetInterceptor != null || receiveHandler != null;
         
-        if (hasConsumer) {
-            if (udpSocket == null || udpSocket.isClosed())
-                return;
-            
+        if (hasConsumer && udpSocket != null && !udpSocket.isClosed()) 
+        {
             // UDP connection open, and we are expecting packets
             setupReceiveThread();
-        } else {
+        }
+        else
+        {
             // Cleanup existing threads
             if (receiveThread != null) 
             {
@@ -289,7 +289,8 @@ public class AudioConnection
         if (combinedAudioExecutor != null) 
         {
             // If the handler is gone/unable to receive combined audio, cleanup the thread
-            if (receiveHandler == null || !receiveHandler.canReceiveCombined()) {
+            if (receiveHandler == null || !receiveHandler.canReceiveCombined())
+            {
                 combinedAudioExecutor.shutdownNow();
                 combinedAudioExecutor = null;
             }

--- a/src/main/java/net/dv8tion/jda/core/audio/AudioPacketInterceptor.java
+++ b/src/main/java/net/dv8tion/jda/core/audio/AudioPacketInterceptor.java
@@ -1,0 +1,48 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.audio;
+
+import net.dv8tion.jda.core.entities.User;
+
+/**
+ * Semi-internal API, used to intercept decrypted AudioPackets before they get processed by the 
+ * receiver thread of {@link net.dv8tion.jda.core.audio.AudioConnection AudioConnection}.
+ */
+public interface AudioPacketInterceptor 
+{
+    
+     /**
+     * This method is called whenever the {@link net.dv8tion.jda.core.audio.AudioConnection AudioConnection} receive 
+     * thread has successfully decrypted an audio packet, but before it is passed trough the OPUS decoder and the dispatch
+     * mechanism of JDA.
+     * For further documentation on the internals, refer to {@link net.dv8tion.jda.core.audio.AudioPacket AudioPacket}.
+     * <p>
+     * <b>Be vary that JDA does not guarantee the order and timing of incoming packets, implementors are responsible
+     * for reassembling audio streams themselves.</b>
+     * <p>
+     * The method is called from the network receive thread, just like {@link net.dv8tion.jda.core.audio.AudioReceiveHandler#handleUserAudio(UserAudio) AudioReceiveHandler.handleUserAudio}
+     * <p>
+     * Note that by returning true, JDA will discard the packet without further processing.
+     *
+     * @param decryptedPacket Audio packet that has been received, and successfully decrypted
+     * @param user User the packet originated from
+     *
+     * @return If true, the packet is discarded, and won't be decoded or passed to the registered {@link net.dv8tion.jda.core.audio.AudioReceiveHandler AudioReceiveHandler}
+     */
+    boolean handleDecryptedPacket(AudioPacket decryptedPacket, User user);
+    
+}

--- a/src/main/java/net/dv8tion/jda/core/managers/AudioManager.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/AudioManager.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.core.managers;
 
 import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.audio.AudioPacketInterceptor;
 import net.dv8tion.jda.core.audio.AudioReceiveHandler;
 import net.dv8tion.jda.core.audio.AudioSendHandler;
 import net.dv8tion.jda.core.audio.hooks.ConnectionListener;
@@ -199,6 +200,32 @@ public interface AudioManager
      */
     AudioReceiveHandler getReceiveHandler();
 
+    /**
+     * Sets the {@link net.dv8tion.jda.core.audio.AudioPacketInterceptor AudioPacketInterceptor}
+     * that the manager will pass decrypted audio packets before further processing.
+     *
+     * <p>The interceptor provided here will persist between audio connection connect and disconnects.
+     * Furthermore, you don't need to have an audio connection to set an interceptor, but it is highly
+     * recommended to set this before the connection is established. (See note)
+     * When JDA sets up a new audio connection it will use the interceptor provided here.
+     * <br>Setting this to null will remove the interceptor.
+     *
+     * Note that if you wish to entirely suppress creation of OPUS decoders by JDA, you will have to
+     * register your interceptor <b>before</b> the connection is established!
+     *
+     * @param packetInterceptor
+     *        The {@link net.dv8tion.jda.core.audio.AudioPacketInterceptor AudioPacketInterceptor}
+     */
+    void setPacketInterceptor(AudioPacketInterceptor packetInterceptor);
+    
+    /**
+     * The currently set {@link net.dv8tion.jda.core.audio.AudioPacketInterceptor AudioPacketInterceptor}.
+     * If there is no interceptor currently set, this method will return {@code null}.
+     *
+     * @return The currently active {@link net.dv8tion.jda.core.audio.AudioPacketInterceptor AudioPacketInterceptor} or {@code null}.
+     */
+    AudioPacketInterceptor getPacketInterceptor();
+    
     /**
      * Sets the {@link net.dv8tion.jda.core.audio.hooks.ConnectionListener ConnectionListener} for this AudioManager.
      * It will be informed about meta data of any audio connection established through this AudioManager.

--- a/src/main/java/net/dv8tion/jda/core/managers/impl/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/impl/AudioManagerImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.WebSocketCode;
 import net.dv8tion.jda.core.audio.AudioConnection;
+import net.dv8tion.jda.core.audio.AudioPacketInterceptor;
 import net.dv8tion.jda.core.audio.AudioReceiveHandler;
 import net.dv8tion.jda.core.audio.AudioSendHandler;
 import net.dv8tion.jda.core.audio.hooks.ConnectionListener;
@@ -58,6 +59,8 @@ public class AudioManagerImpl implements AudioManager
 
     protected AudioSendHandler sendHandler;
     protected AudioReceiveHandler receiveHandler;
+    protected AudioPacketInterceptor packetInterceptor;
+    
     protected ListenerProxy connectionListener = new ListenerProxy();
     protected long queueTimeout = 100;
     protected boolean shouldReconnect = true;
@@ -223,6 +226,21 @@ public class AudioManagerImpl implements AudioManager
     }
 
     @Override
+    public void setPacketInterceptor(AudioPacketInterceptor packetInterceptor) 
+    {
+        this.packetInterceptor = packetInterceptor;
+        if (audioConnection != null)
+            audioConnection.setPacketInterceptor(packetInterceptor);
+    }
+    
+    @Override
+    public AudioPacketInterceptor getPacketInterceptor() 
+    {
+        return packetInterceptor;
+    }
+    
+    
+    @Override
     public void setConnectionListener(ConnectionListener listener)
     {
         this.connectionListener.setListener(listener);
@@ -304,6 +322,7 @@ public class AudioManagerImpl implements AudioManager
         this.queuedAudioConnection = null;
         audioConnection.setSendingHandler(sendHandler);
         audioConnection.setReceivingHandler(receiveHandler);
+        audioConnection.setPacketInterceptor(packetInterceptor);
         audioConnection.setQueueTimeout(queueTimeout);
     }
 


### PR DESCRIPTION
Implemented a new interface for AudioPacketInterceptor.

This object can be registered just like an AudioReceiveHandler, but it provides a much more low level access to audio packets than the standard handleUserAudio callback.

Also allows discarding AudioPackets, effectively hiding them from the JDA backend.

This PR implements issue #418