### PR TITLE
WebhookManagerUpdatable Guild check fix

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/managers/WebhookManagerUpdatable.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/WebhookManagerUpdatable.java
@@ -283,7 +283,7 @@ public class WebhookManagerUpdatable
             public void checkValue(TextChannel value)
             {
                 Checks.notNull(value, "channel");
-                Checks.check(value.equals(getChannel()), "Channel is not from the same Guild!");
+                Checks.check(value.getGuild().equals(getGuild()), "Channel is not from the same Guild!");
             }
         };
     }


### PR DESCRIPTION
Looks like bug in WebhookManagerUpdatable, which trying to compare channels instead of their guilds