### PR TITLE
Adding SessionReconnectQueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ has the ID 0. The **shardTotal** is the total amount of shards (not 0-based) whi
 When using sharding it is also recommended to use a `SessionReconnectQueue` instance for all shards. This allows JDA to properly
 handle reconnecting multiple shards without violating Discord limitations (not using this might cause an IP ban on bad days).
 
+**Logins between shards _must_ happen with a minimum of _5 SECONDS_ of backoff time. JDA will inform you if the backoff is too short
+with a log message:**
+
+```
+Encountered IDENTIFY (OP 2) Rate Limit! Waiting 5 seconds before trying again!
+```
+> Note: Failing to backoff properly will cause JDA to wait 5 seconds after failing to connect. Respect the 5 second login rate limit!
+
 #### Example Sharding
 
 ```java

--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ public class MessageListener extends ListenerAdapter
 > **Note**: In these examples we override methods from the inheriting class `ListenerAdapter`.<br>
 > The usage of the `@Override` annotation is recommended to validate methods.
 
+### Sharding a Bot
+
+Discord allows Bot-accounts to share load across sessions by limiting them to a fraction of the total connected Guilds/Servers of the bot.
+<br>This can be done using **sharding** which will limit JDA to only a certain amount of Guilds/Servers including events and entities.
+Sharding will limit the amount of Guilds/Channels/Users visible to the JDA session so it is recommended to have some kind of elevated management to
+access information of other shards.
+
+To use sharding in JDA you will need to use `JDABuilder.useSharding(int shardId, int shardTotal)`. The **shardId** is 0-based which means the first shard
+has the ID 0. The **shardTotal** is the total amount of shards (not 0-based) which can be seen similar to the length of an array, the last shard has the ID of 
+`shardTotal - 1`.
+
+When using sharding it is also recommended to use a `SessionReconnectQueue` instance for all shards. This allows JDA to properly
+handle reconnecting multiple shards without violating Discord limitations (not using this might cause an IP ban on bad days).
+
+#### Example Sharding
+
+```java
+public static void main(String[] args) throws Exception
+{
+    JDABuilder shardBuilder = new JDABuilder(AccountType.BOT).setToken(args[0]).setReconnectQueue(new SessionReconnectQueue());
+    //register your listeners here using shardBuilder.addEventListener(...)
+    for (int i = 0; i < 10; i++)
+    {
+        new JDABuilder(AccountType.BOT)
+            .useSharding(i, 10)
+            .buildAsync();
+        Thread.sleep(5000); //sleep 5 seconds between each login
+    }
+}
+```
+
 ## More Examples
 We provide a small set of Examples in the [Example Directory](https://github.com/DV8FromTheWorld/JDA/tree/master/src/examples/java).
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ public static void main(String[] args) throws Exception
     //register your listeners here using shardBuilder.addEventListener(...)
     for (int i = 0; i < 10; i++)
     {
-        new JDABuilder(AccountType.BOT)
-            .useSharding(i, 10)
-            .buildAsync();
+        shardBuilder.useSharding(i, 10)
+                    .buildAsync();
         Thread.sleep(5000); //sleep 5 seconds between each login
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -24,13 +24,15 @@ import net.dv8tion.jda.core.exceptions.AccountTypeException;
 import net.dv8tion.jda.core.exceptions.RateLimitedException;
 import net.dv8tion.jda.core.hooks.IEventManager;
 import net.dv8tion.jda.core.managers.impl.PresenceImpl;
-import net.dv8tion.jda.core.requests.WebSocketClient;
-import okhttp3.OkHttpClient;
+import net.dv8tion.jda.core.requests.SessionReconnectQueue;
 import net.dv8tion.jda.core.utils.Checks;
+import okhttp3.OkHttpClient;
 
 import javax.security.auth.login.LoginException;
-import java.util.*;
-import java.util.concurrent.BlockingQueue;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Used to create new {@link net.dv8tion.jda.core.JDA} instances. This is also useful for making sure all of
@@ -47,7 +49,7 @@ public class JDABuilder
 {
     protected final List<Object> listeners;
 
-    protected BlockingQueue<WebSocketClient> reconnectQueue = null;
+    protected SessionReconnectQueue reconnectQueue = null;
     protected OkHttpClient.Builder httpClientBuilder = null;
     protected WebSocketFactory wsFactory = null;
     protected AccountType accountType;
@@ -137,7 +139,7 @@ public class JDABuilder
      *
      * @return The {@link net.dv8tion.jda.core.JDABuilder JDABuilder} instance. Useful for chaining.
      */
-    public JDABuilder setReconnectQueue(BlockingQueue<WebSocketClient> queue)
+    public JDABuilder setReconnectQueue(SessionReconnectQueue queue)
     {
         this.reconnectQueue = queue;
         return this;

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -116,7 +116,7 @@ public class JDAImpl implements JDA
         this.jdaBot = accountType == AccountType.BOT ? new JDABotImpl(this) : null;
     }
 
-    public void login(String token, ShardInfo shardInfo, Queue<WebSocketClient> reconnectQueue) throws LoginException, RateLimitedException
+    public void login(String token, ShardInfo shardInfo, SessionReconnectQueue reconnectQueue) throws LoginException, RateLimitedException
     {
         setStatus(Status.LOGGING_IN);
         if (token == null || token.isEmpty())

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -116,7 +116,7 @@ public class JDAImpl implements JDA
         this.jdaBot = accountType == AccountType.BOT ? new JDABotImpl(this) : null;
     }
 
-    public void login(String token, ShardInfo shardInfo) throws LoginException, RateLimitedException
+    public void login(String token, ShardInfo shardInfo, Queue<WebSocketClient> reconnectQueue) throws LoginException, RateLimitedException
     {
         setStatus(Status.LOGGING_IN);
         if (token == null || token.isEmpty())
@@ -127,7 +127,7 @@ public class JDAImpl implements JDA
         this.shardInfo = shardInfo;
         LOG.info("Login Successful!");
 
-        client = new WebSocketClient(this);
+        client = new WebSocketClient(this, reconnectQueue);
 
         if (shutdownHook != null)
         {

--- a/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
@@ -54,7 +54,7 @@ public class SessionReconnectQueue
             while (!reconnectQueue.isEmpty())
             {
                 final WebSocketClient client = reconnectQueue.poll();
-                client.init();
+                client.sendIdentify();
                 try
                 {
                     if (!reconnectQueue.isEmpty())

--- a/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
@@ -16,20 +16,20 @@
 
 package net.dv8tion.jda.core.requests;
 
-import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
 
-class SessionReconnectQueue
+public class SessionReconnectQueue
 {
-    private final Object lock = new Object();
-    private final Queue<WebSocketClient> reconnectQueue;
-    private volatile Thread reconnectThread;
+    protected final Object lock = new Object();
+    protected final BlockingQueue<WebSocketClient> reconnectQueue;
+    protected volatile Thread reconnectThread;
 
-    SessionReconnectQueue(final Queue<WebSocketClient> reconnectQueue)
+    public SessionReconnectQueue(final BlockingQueue<WebSocketClient> reconnectQueue)
     {
         this.reconnectQueue = reconnectQueue;
     }
 
-    void appendSession(final WebSocketClient client)
+    protected void appendSession(final WebSocketClient client)
     {
         reconnectQueue.add(client);
         synchronized (lock)
@@ -40,9 +40,9 @@ class SessionReconnectQueue
         }
     }
 
-    final class ReconnectThread extends Thread
+    protected final class ReconnectThread extends Thread
     {
-        ReconnectThread()
+        protected ReconnectThread()
         {
             super("JDA-ReconnectThread");
             start();

--- a/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
@@ -40,11 +40,15 @@ public class SessionReconnectQueue
     protected void appendSession(final WebSocketClient client)
     {
         reconnectQueue.add(client);
+        runWorker();
+    }
+
+    protected void runWorker()
+    {
         synchronized (lock)
         {
-            if (reconnectThread != null)
-                return;
-            reconnectThread = new ReconnectThread();
+            if (reconnectThread == null)
+                reconnectThread = new ReconnectThread();
         }
     }
 
@@ -79,6 +83,8 @@ public class SessionReconnectQueue
             synchronized (lock)
             {
                 reconnectThread = null;
+                if (!reconnectQueue.isEmpty())
+                    runWorker(); // eliminate highly unlikely race condition
             }
         }
     }

--- a/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
@@ -1,0 +1,75 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.requests;
+
+import java.util.Queue;
+
+class SessionReconnectQueue
+{
+    private final Object lock = new Object();
+    private final Queue<WebSocketClient> reconnectQueue;
+    private volatile Thread reconnectThread;
+
+    SessionReconnectQueue(final Queue<WebSocketClient> reconnectQueue)
+    {
+        this.reconnectQueue = reconnectQueue;
+    }
+
+    void appendSession(final WebSocketClient client)
+    {
+        reconnectQueue.add(client);
+        synchronized (lock)
+        {
+            if (reconnectThread != null)
+                return;
+            reconnectThread = new ReconnectThread();
+        }
+    }
+
+    final class ReconnectThread extends Thread
+    {
+        ReconnectThread()
+        {
+            super("JDA-ReconnectThread");
+            start();
+        }
+
+        @Override
+        public final void run()
+        {
+            while (!reconnectQueue.isEmpty())
+            {
+                final WebSocketClient client = reconnectQueue.poll();
+                client.init();
+                try
+                {
+                    if (!reconnectQueue.isEmpty())
+                        Thread.sleep(WebSocketClient.IDENTIFY_DELAY);
+                }
+                catch (InterruptedException ex)
+                {
+                    throw new AssertionError(ex);
+                }
+            }
+            synchronized (lock)
+            {
+                reconnectThread = null;
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -94,12 +94,12 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected boolean processingReady = true;
     protected boolean handleIdentifyRateLimit = false;
 
-    public WebSocketClient(JDAImpl api, Queue<WebSocketClient> reconnectQueue)
+    public WebSocketClient(JDAImpl api, SessionReconnectQueue reconnectQueue)
     {
         this.api = api;
         this.shardInfo = api.getShardInfo();
         this.shouldReconnect = api.isAutoReconnect();
-        this.reconnectQueue = reconnectQueue != null ? new SessionReconnectQueue(reconnectQueue) : null;
+        this.reconnectQueue = reconnectQueue;
         setupHandlers();
         setupSendingThread();
         connect();

--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -333,6 +333,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         socket.sendClose(code);
     }
 
+    public void close(int code, String reason)
+    {
+        socket.sendClose(code, reason);
+    }
+
     /*
         ### Start Internal methods ###
      */
@@ -572,7 +577,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 else if (!handleIdentifyRateLimit) // this can also mean we got rate limited in IDENTIFY (no need to invalidate then)
                     invalidate();
 
-                close(closeCode);
+                close(closeCode, "INVALIDATE_SESSION");
                 break;
             case WebSocketCode.HELLO:
                 LOG.debug("Got HELLO packet (OP 10). Initializing keep-alive.");

--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -134,14 +134,6 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         return connected;
     }
 
-    public void init()
-    {
-        if (sessionId == null)
-            sendIdentify();
-        else
-            sendResume();
-    }
-
     public void ready()
     {
         if (initiating)
@@ -424,10 +416,17 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         reconnectTimeoutS = 2;
         messagesSent = 0;
         ratelimitResetTime = System.currentTimeMillis() + 60000;
-        if (!firstInit && reconnectQueue != null)
-            reconnectQueue.appendSession(this);
+        if (sessionId == null)
+        {
+            if (!firstInit && reconnectQueue != null)
+                reconnectQueue.appendSession(this);
+            else
+                sendIdentify();
+        }
         else
-            init();
+        {
+            sendResume();
+        }
     }
 
     @Override


### PR DESCRIPTION
This can be used to stop sessions from reconnecting simultaneously.
It will prevent them from sending IDENTIFY payloads on reconnect until they come up in the queue.