### PR TITLE
Fixed handling of GuildMemberRemove and added cleanup to event cache

### DIFF
--- a/src/main/java/net/dv8tion/jda/client/handle/RelationshipRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/client/handle/RelationshipRemoveHandler.java
@@ -92,6 +92,7 @@ public class RelationshipRemoveHandler extends SocketHandler
                         }
                     }
                 }
+                api.getEventCache().clear(EventCache.Type.USER, userId);
             }
         }
         else
@@ -138,6 +139,7 @@ public class RelationshipRemoveHandler extends SocketHandler
                 WebSocketClient.LOG.warn("Received a RELATIONSHIP_REMOVE with an unknown RelationshipType! JSON: " + content);
                 return null;
         }
+        api.getEventCache().clear(EventCache.Type.RELATIONSHIP, userId);
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -587,8 +587,7 @@ public class JDAImpl implements JDA
         if (audioKeepAlivePool != null)
             audioKeepAlivePool.shutdownNow();
 
-        getClient().setAutoReconnect(false);
-        getClient().close();
+        getClient().shutdown();
 
         final long time = 5L;
         final TimeUnit unit = TimeUnit.SECONDS;

--- a/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
@@ -161,6 +161,7 @@ public class ChannelDeleteHandler extends SocketHandler
             default:
                 throw new IllegalArgumentException("CHANNEL_DELETE provided an unknown channel type. JSON: " + content);
         }
+        api.getEventCache().clear(EventCache.Type.CHANNEL, channelId);
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/EventCache.java
@@ -86,7 +86,8 @@ public class EventCache
     {
         try
         {
-            eventCache.get(type).remove(id);
+            List<Runnable> events = eventCache.get(type).remove(id);
+            LOG.debug("Clearing cache for type " + type + " with ID " + id + " (Size: " + events.size() + ')');
         }
         catch (NullPointerException ignored) {}
     }

--- a/src/main/java/net/dv8tion/jda/core/handle/EventCache.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/EventCache.java
@@ -82,6 +82,15 @@ public class EventCache
         eventCache.clear();
     }
 
+    public void clear(Type type, long id)
+    {
+        try
+        {
+            eventCache.get(type).remove(id);
+        }
+        catch (NullPointerException ignored) {}
+    }
+
     public enum Type
     {
         USER, GUILD, CHANNEL, ROLE, RELATIONSHIP, CALL

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildBanHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildBanHandler.java
@@ -43,10 +43,7 @@ public class GuildBanHandler extends SocketHandler
         GuildImpl guild = (GuildImpl) api.getGuildMap().get(id);
         if (guild == null)
         {
-            api.getEventCache().cache(EventCache.Type.GUILD, id, () ->
-            {
-                handle(responseNumber, allContent);
-            });
+            api.getEventCache().cache(EventCache.Type.GUILD, id, () -> handle(responseNumber, allContent));
             EventCache.LOG.debug("Received Guild Member " + (banned ? "Ban" : "Unban") + " event for a Guild not yet cached.");
             return null;
         }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildDeleteHandler.java
@@ -137,17 +137,18 @@ public class GuildDeleteHandler extends SocketHandler
                     }
                 }
             }
-
+            api.getEventCache().clear(EventCache.Type.USER, memberId);
             return true;
         });
 
-        api.getGuildMap().remove(guild.getIdLong());
+        api.getGuildMap().remove(id);
         guild.getTextChannels().forEach(chan -> api.getTextChannelMap().remove(chan.getIdLong()));
         guild.getVoiceChannels().forEach(chan -> api.getVoiceChannelMap().remove(chan.getIdLong()));
         api.getEventManager().handle(
                 new GuildLeaveEvent(
                         api, responseNumber,
                         guild));
+        api.getEventCache().clear(EventCache.Type.GUILD, id);
         return null;
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildMemberRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildMemberRemoveHandler.java
@@ -47,6 +47,11 @@ public class GuildMemberRemoveHandler extends SocketHandler
         }
 
         final long userId = content.getJSONObject("user").getLong("id");
+        if (userId == api.getSelfUser().getIdLong())
+        {
+            //We probably just left the guild and this event is trying to remove us from the guild, therefore ignore
+            return null;
+        }
         MemberImpl member = (MemberImpl) guild.getMembersMap().remove(userId);
 
         if (member == null)
@@ -57,7 +62,6 @@ public class GuildMemberRemoveHandler extends SocketHandler
 
         if (member.getVoiceState().inVoiceChannel())//If this user was in a VoiceChannel, fire VoiceLeaveEvent.
         {
-
             GuildVoiceStateImpl vState = (GuildVoiceStateImpl) member.getVoiceState();
             VoiceChannel channel = vState.getChannel();
             vState.setConnectedChannel(null);
@@ -98,6 +102,7 @@ public class GuildMemberRemoveHandler extends SocketHandler
                     }
                 }
             }
+            api.getEventCache().clear(EventCache.Type.USER, userId);
         }
         api.getEventManager().handle(
                 new GuildMemberLeaveEvent(

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildRoleDeleteHandler.java
@@ -65,6 +65,7 @@ public class GuildRoleDeleteHandler extends SocketHandler
                 new RoleDeleteEvent(
                         api, responseNumber,
                         removedRole));
+        api.getEventCache().clear(EventCache.Type.ROLE, roleId);
         return null;
     }
 }


### PR DESCRIPTION
- Clear event cache for removed entities
- Do not remove self from members to ensure safety of permission checks