### PR TITLE
Do not retain the audio managers after shutdown

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -583,6 +583,7 @@ public class JDAImpl implements JDA
 
         setStatus(Status.SHUTTING_DOWN);
         audioManagers.valueCollection().forEach(AudioManager::closeAudioConnection);
+        audioManagers.clear();
 
         if (audioKeepAlivePool != null)
             audioKeepAlivePool.shutdownNow();


### PR DESCRIPTION
_DIsclaimer_ not yet tested.

Is there a reason we don't `clear()` this one, but other maps are cleared? (e.g. `opusDecoders`)