### PR TITLE
Step 0 busywork for category channels implementation

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -452,6 +452,71 @@ public interface JDA
     List<Role> getRolesByName(String name, boolean ignoreCase);
 
     /**
+     * An unmodifiable List of all {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} of all connected
+     * {@link net.dv8tion.jda.core.entities.Guild Guilds}.
+     *
+     * <p><b>Note:</b> If you log into this account on the discord client, it is possible that you will see fewer channels than this
+     * returns. This is because the discord client hides any {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}
+     * that you don't have the {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} permission in.
+     *
+     * @return Possibly-empty list of all known {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels}.
+     */
+    List<CategoryChannel> getCategoryChannels();
+
+    /**
+     * This returns the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} which has the same id as the one provided.
+     * <br>If there is no known {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with an id that matches the provided
+     * one, then this returns {@code null}.
+     *
+     * <p><b>Note:</b> If you log into this account on the discord client, it is possible that you will see fewer channels than this
+     * returns. This is because the discord client hides any {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}
+     * that you don't have the {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} permission in.
+     *
+     * @param  id
+     *         The id of the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}.
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with matching id.
+     */
+    CategoryChannel getCategoryChannelById(String id);
+
+    /**
+     * This returns the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} which has the same id as the one provided.
+     * <br>If there is no known {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with an id that matches the provided
+     * one, then this returns {@code null}.
+     *
+     * <p><b>Note:</b> If you log into this account on the discord client, it is possible that you will see fewer channels than this
+     * returns. This is because the discord client hides any {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}
+     * that you don't have the {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} permission in.
+     *
+     * @param  id
+     *         The id of the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with matching id.
+     */
+    CategoryChannel getCategoryChannelById(long id);
+
+    /**
+     * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} that have the same name as the one provided.
+     * <br>If there are no {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} with the provided name, then this returns an empty list.
+     *
+     * <p><b>Note:</b> If you log into this account on the discord client, it is possible that you will see fewer channels than this
+     * returns. This is because the discord client hides any {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}
+     * that you don't have the {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} permission in.
+     *
+     * @param  name
+     *         The name of the requested {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels}.
+     * @param  ignoreCase
+     *         Whether to ignore case or not when comparing the provided name to each {@link net.dv8tion.jda.core.entities.CategoryChannel#getName()}.
+     *
+     * @return Possibly-empty list of all the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} that all have the
+     *      same name as the provided name.
+     */
+    List<CategoryChannel> getCategoryChannelsByName(String name, boolean ignoreCase);
+
+    /**
      * An unmodifiable List of all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} of all connected
      * {@link net.dv8tion.jda.core.entities.Guild Guilds}.
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/CategoryChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/CategoryChannel.java
@@ -1,0 +1,23 @@
+package net.dv8tion.jda.core.entities;
+
+import net.dv8tion.jda.core.JDA;
+
+import java.util.List;
+
+public interface CategoryChannel extends Channel, Comparable<CategoryChannel>
+{
+    /**
+     * Gets all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} in this {@link net.dv8tion.jda.core.entities.CategoryChannel Category}.
+     * <br>The channels returned will be sorted according to their position.
+     *
+     * @return An immutable List of all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} in this Category.
+     */
+    List<TextChannel> getTextChannels();
+
+    /**
+     * Returns the {@link net.dv8tion.jda.core.JDA JDA} instance of this CategoryChannel
+     *
+     * @return the corresponding JDA instance
+     */
+    JDA getJDA();
+}

--- a/src/main/java/net/dv8tion/jda/core/entities/ChannelType.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ChannelType.java
@@ -37,6 +37,10 @@ public enum ChannelType
      */
     GROUP(3),
     /**
+     * A {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}, Guild-Only.
+     */
+    CATEGORY(4, true),
+    /**
      * Unknown Discord channel type. Should never happen and would only possibly happen if Discord implemented a new
      * channel type and JDA had yet to implement support for it.
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -297,6 +297,59 @@ public interface Guild extends ISnowflake
     List<Member> getMembersWithRoles(Collection<Role> roles);
 
     /**
+     * Gets a {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} from this guild that has the same id as the
+     * one provided. This method is similar to {@link net.dv8tion.jda.core.JDA#getCategoryChannelById(String)}, but it only
+     * checks this specific Guild for a CategoryChannel.
+     * <br>If there is no {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with an id that matches the provided
+     * one, then this returns {@code null}.
+     *
+     * @param  id
+     *         The id of the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}.
+     *
+     * @throws java.lang.NumberFormatException
+     *         If the provided {@code id} cannot be parsed by {@link Long#parseLong(String)}
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with matching id.
+     */
+    CategoryChannel getCategoryChannelById(String id);
+
+    /**
+     * Gets a {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} from this guild that has the same id as the
+     * one provided. This method is similar to {@link net.dv8tion.jda.core.JDA#getCategoryChannelById(long)}, but it only
+     * checks this specific Guild for a CategoryChannel.
+     * <br>If there is no {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with an id that matches the provided
+     * one, then this returns {@code null}.
+     *
+     * @param  id
+     *         The id of the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} with matching id.
+     */
+    CategoryChannel getCategoryChannelById(long id);
+
+    /**
+     * Gets all {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
+     * <br>The channels returned will be sorted according to their position.
+     *
+     * @return An immutable List of all {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} in this Guild.
+     */
+    List<CategoryChannel> getCategoryChannels();
+
+    /**
+     * Gets a list of all {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} in this Guild that have the same
+     * name as the one provided.
+     * <br>If there are no {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels} with the provided name, then this returns an empty list.
+     *
+     * @param  name
+     *         The name used to filter the returned {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannels}.
+     * @param  ignoreCase
+     *         Determines if the comparison ignores case when comparing. True - case insensitive.
+     *
+     * @return Possibly-empty immutable list of all CategoryChannels names that match the provided name.
+     */
+    List<CategoryChannel> getCategoryChannelsByName(String name, boolean ignoreCase);
+    
+    /**
      * Gets a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} from this guild that has the same id as the
      * one provided. This method is similar to {@link net.dv8tion.jda.core.JDA#getTextChannelById(String)}, but it only
      * checks this specific Guild for a TextChannel.

--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -260,6 +260,19 @@ public interface Message extends ISnowflake, Formattable
     TextChannel getTextChannel();
 
     /**
+     * Returns the {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel} that this message was sent in.
+     * <br><b>This is only valid if the Message was actually sent in a TextChannel.</b> This will return {@code null}
+     * if it was not sent from a TextChannel.
+     * <br>You can check the type of channel this message was sent from using {@link #isFromType(ChannelType)} or {@link #getChannelType()}.
+     *
+     * <p>Use {@link #getChannel()} for an ambiguous {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}
+     * if you do not need functionality specific to {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.
+     *
+     * @return The CategoryChannel this message was sent in, or {@code null} if it was not sent from a TextChannel.
+     */
+    CategoryChannel getCategoryChannel();
+
+    /**
      * Returns the {@link net.dv8tion.jda.core.entities.Guild Guild} that this message was sent in.
      * <br>This is just a shortcut to {@link #getTextChannel()}{@link net.dv8tion.jda.core.entities.TextChannel#getGuild() .getGuild()}.
      * <br><b>This is only valid if the Message was actually sent in a TextChannel.</b> This will return {@code null}

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/CategoryChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/CategoryChannelImpl.java
@@ -1,0 +1,77 @@
+package net.dv8tion.jda.core.entities.impl;
+
+import gnu.trove.map.TLongObjectMap;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+import net.dv8tion.jda.core.entities.ChannelType;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.utils.MiscUtil;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class CategoryChannelImpl extends AbstractChannelImpl<CategoryChannelImpl> implements CategoryChannel
+{
+    private final TLongObjectMap<TextChannel> textChannels = MiscUtil.newLongMap();
+
+    public CategoryChannelImpl(long id, GuildImpl guild)
+    {
+        super(id, guild);
+    }
+
+    @Override
+    public int compareTo(CategoryChannel chan)
+    {
+        if (this == chan)
+            return 0;
+
+        if (!this.getGuild().equals(chan.getGuild()))
+            throw new IllegalArgumentException("Cannot compare CategoryChannels that aren't from the same guild!");
+
+        if (this.getPositionRaw() != chan.getPositionRaw())
+            return chan.getPositionRaw() - this.getPositionRaw();
+
+        OffsetDateTime thisTime = this.getCreationTime();
+        OffsetDateTime chanTime = chan.getCreationTime();
+
+        //We compare the provided channel's time to this's time instead of the reverse as one would expect due to how
+        // discord deals with hierarchy. The more recent a channel was created, the lower its hierarchy ranking when
+        // it shares the same position as another channel.
+        return chanTime.compareTo(thisTime);
+    }
+
+    @Override
+    public List<TextChannel> getTextChannels()
+    {
+        ArrayList<TextChannel> channels = new ArrayList<>(textChannels.valueCollection());
+        channels.sort(Comparator.reverseOrder());
+        return Collections.unmodifiableList(channels);
+    }
+
+    @Override
+    public ChannelType getType()
+    {
+        return ChannelType.CATEGORY;
+    }
+
+    @Override
+    public List<Member> getMembers()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int getPosition()
+    {
+        return 0;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "CC:" + getName() + '(' + id + ')';
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -53,6 +53,7 @@ public class GuildImpl implements Guild
 {
     private final long id;
     private final JDAImpl api;
+    private final TLongObjectMap<CategoryChannel> categoryChannels = MiscUtil.newLongMap();
     private final TLongObjectMap<TextChannel> textChannels = MiscUtil.newLongMap();
     private final TLongObjectMap<VoiceChannel> voiceChannels = MiscUtil.newLongMap();
     private final TLongObjectMap<Member> members = MiscUtil.newLongMap();
@@ -281,6 +282,38 @@ public class GuildImpl implements Guild
         return Collections.unmodifiableList(members.valueCollection().stream()
                         .filter(m -> m.getRoles().containsAll(roles))
                         .collect(Collectors.toList()));
+    }
+
+    @Override
+    public CategoryChannel getCategoryChannelById(String id)
+    {
+        return categoryChannels.get(MiscUtil.parseSnowflake(id));
+    }
+
+    @Override
+    public CategoryChannel getCategoryChannelById(long id)
+    {
+        return categoryChannels.get(id);
+    }
+
+    @Override
+    public List<CategoryChannel> getCategoryChannelsByName(String name, boolean ignoreCase)
+    {
+        Checks.notNull(name, "name");
+        return Collections.unmodifiableList(categoryChannels.valueCollection().stream()
+            .filter(tc ->
+                ignoreCase
+                    ? name.equalsIgnoreCase(tc.getName())
+                    : name.equals(tc.getName()))
+            .collect(Collectors.toList()));
+    }
+
+    @Override
+    public List<CategoryChannel> getCategoryChannels()
+    {
+        ArrayList<CategoryChannel> channels = new ArrayList<>(categoryChannels.valueCollection());
+        channels.sort(Comparator.reverseOrder());
+        return Collections.unmodifiableList(channels);
     }
 
     @Override
@@ -795,6 +828,11 @@ public class GuildImpl implements Guild
     }
 
     // -- Map getters --
+
+    public TLongObjectMap<CategoryChannel> getCategoryChannelsMap()
+    {
+        return categoryChannels;
+    }
 
     public TLongObjectMap<TextChannel> getTextChannelsMap()
     {

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -59,6 +59,7 @@ public class JDAImpl implements JDA
 
     protected final TLongObjectMap<User> users = MiscUtil.newLongMap();
     protected final TLongObjectMap<Guild> guilds = MiscUtil.newLongMap();
+    protected final TLongObjectMap<CategoryChannel> categoryChannels = MiscUtil.newLongMap();
     protected final TLongObjectMap<TextChannel> textChannels = MiscUtil.newLongMap();
     protected final TLongObjectMap<VoiceChannel> voiceChannels = MiscUtil.newLongMap();
     protected final TLongObjectMap<PrivateChannel> privateChannels = MiscUtil.newLongMap();
@@ -454,6 +455,35 @@ public class JDAImpl implements JDA
     }
 
     @Override
+    public List<CategoryChannel> getCategoryChannels()
+    {
+        return Collections.unmodifiableList(new ArrayList<>(categoryChannels.valueCollection()));
+    }
+
+    @Override
+    public CategoryChannel getCategoryChannelById(String id)
+    {
+        return categoryChannels.get(MiscUtil.parseSnowflake(id));
+    }
+
+    @Override
+    public CategoryChannel getCategoryChannelById(long id)
+    {
+        return categoryChannels.get(id);
+    }
+
+    @Override
+    public List<CategoryChannel> getCategoryChannelsByName(String name, boolean ignoreCase)
+    {
+        return categoryChannels.valueCollection().stream().filter(tc ->
+            ignoreCase
+                ? name.equalsIgnoreCase(tc.getName())
+                : name.equals(tc.getName()))
+            .collect(Collectors.toList());
+    }
+
+
+    @Override
     public List<TextChannel> getTextChannels()
     {
         return Collections.unmodifiableList(new ArrayList<>(textChannels.valueCollection()));
@@ -742,6 +772,11 @@ public class JDAImpl implements JDA
     public TLongObjectMap<Guild> getGuildMap()
     {
         return guilds;
+    }
+
+    public TLongObjectMap<CategoryChannel> getCategoryChannelMap()
+    {
+        return categoryChannels;
     }
 
     public TLongObjectMap<TextChannel> getTextChannelMap()

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MessageImpl.java
@@ -373,6 +373,13 @@ public class MessageImpl implements Message
         return isFromType(ChannelType.TEXT) ? (TextChannel) channel : null;
     }
 
+    // TODO
+    @Override
+    public CategoryChannel getCategoryChannel()
+    {
+        return null;
+    }
+
     @Override
     public Guild getGuild()
     {

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/CategoryChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/CategoryChannelCreateEvent.java
@@ -1,0 +1,33 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+
+/**
+ * <b><u>CategoryChannelCreateEvent</u></b><br>
+ * Fired if a {@link CategoryChannel CategoryChannel} has been created.<br>
+ * <br>
+ * Use: Detect new CategoryChannel creation.
+ */
+public class CategoryChannelCreateEvent extends GenericCategoryChannelEvent
+{
+    public CategoryChannelCreateEvent(JDA api, long responseNumber, CategoryChannel channel)
+    {
+        super(api, responseNumber, channel);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/CategoryChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/CategoryChannelDeleteEvent.java
@@ -1,0 +1,33 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+
+/**
+ * <b><u>CategoryChannelDeleteEvent</u></b><br>
+ * Fired if a {@link CategoryChannel CategoryChannel} has been deleted.<br>
+ * <br>
+ * Use: Detect when a CategoryChannel has been deleted.
+ */
+public class CategoryChannelDeleteEvent extends GenericCategoryChannelEvent
+{
+    public CategoryChannelDeleteEvent(JDA api, long responseNumber, CategoryChannel channel)
+    {
+        super(api, responseNumber, channel);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/GenericCategoryChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/GenericCategoryChannelEvent.java
@@ -1,0 +1,49 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+import net.dv8tion.jda.core.events.Event;
+
+/**
+ * <b><u>GenericCategoryChannelEvent</u></b><br>
+ * Fired whenever a {@link CategoryChannel CategoryChannel} event is fired.<br>
+ * Every CategoryChannelEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any CategoryChannelEvent. <i>(No real use for JDA user)</i>
+ */
+public abstract class GenericCategoryChannelEvent extends Event
+{
+    private final CategoryChannel channel;
+
+    public GenericCategoryChannelEvent(JDA api, long responseNumber, CategoryChannel channel)
+    {
+        super(api, responseNumber);
+        this.channel = channel;
+    }
+
+    public CategoryChannel getChannel()
+    {
+        return channel;
+    }
+
+    public Guild getGuild()
+    {
+        return channel.getGuild();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/package-info.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/package-info.java
@@ -1,0 +1,25 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Specific events indicating that a {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}
+ * was either {@link net.dv8tion.jda.core.events.channel.category.CategoryChannelCreateEvent created}
+ * or {@link net.dv8tion.jda.core.events.channel.category.CategoryChannelDeleteEvent deleted}
+ *
+ * <p>All events of this package and its subpackages
+ * are extensions of the {@link net.dv8tion.jda.core.events.channel.category.GenericCategoryChannelEvent GenericCategoryChannelEvent}
+ */
+package net.dv8tion.jda.core.events.channel.category;

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/update/CategoryChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/update/CategoryChannelUpdateNameEvent.java
@@ -1,0 +1,40 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category.update;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+
+/**
+ * <b><u>CategoryChannelUpdateNameEvent</u></b><br>
+ * Fired if a {@link CategoryChannel CategoryChannel}'s name changes.<br>
+ * <br>
+ * Use: Detect when a CategoryChannel name changes and get it's previous name.
+ */
+public class CategoryChannelUpdateNameEvent extends GenericCategoryChannelUpdateEvent
+{
+    private final String oldName;
+    public CategoryChannelUpdateNameEvent(JDA api, long responseNumber, CategoryChannel channel, String oldName)
+    {
+        super(api, responseNumber, channel);
+        this.oldName = oldName;
+    }
+
+    public String getOldName()
+    {
+        return oldName;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/update/CategoryChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/update/CategoryChannelUpdatePermissionsEvent.java
@@ -1,0 +1,63 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category.update;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.IPermissionHolder;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * <b><u>CategoryChannelUpdatePermissionsEvent</u></b><br>
+ * Fired if a {@link CategoryChannel CategoryChannel}'s permission overrides change.<br>
+ * <br>
+ * Use: Detect when a CategoryChannel's permission overrides change and get affected {@link Role Roles}/{@link net.dv8tion.jda.core.entities.User Users}.
+ */
+public class CategoryChannelUpdatePermissionsEvent extends GenericCategoryChannelUpdateEvent
+{
+    private final List<IPermissionHolder> changed;
+
+    public CategoryChannelUpdatePermissionsEvent(JDA api, long responseNumber, CategoryChannel channel, List<IPermissionHolder> permHolders)
+    {
+        super(api, responseNumber, channel);
+        this.changed = permHolders;
+    }
+
+    public List<IPermissionHolder> getChangedPermissionHolders()
+    {
+        return changed;
+    }
+
+    public List<Role> getChangedRoles()
+    {
+        return changed.stream()
+                      .filter(it -> it instanceof Role)
+                      .map(Role.class::cast)
+                      .collect(Collectors.toList());
+    }
+
+    public List<Member> getMembersWithPermissionChanges()
+    {
+        return changed.stream()
+                .filter(it -> it instanceof Member)
+                .map(Member.class::cast)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/update/CategoryChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/update/CategoryChannelUpdatePositionEvent.java
@@ -1,0 +1,41 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category.update;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+
+/**
+ * <b><u>CategoryChannelUpdatePositionEvent</u></b><br>
+ * Fired if a {@link CategoryChannel CategoryChannel}'s position changes.<br>
+ * <br>
+ * Use: Detect when a CategoryChannel position changes and get it's previous position.
+ */
+public class CategoryChannelUpdatePositionEvent extends GenericCategoryChannelUpdateEvent
+{
+    private final int oldPosition;
+
+    public CategoryChannelUpdatePositionEvent(JDA api, long responseNumber, CategoryChannel channel, int oldPosition)
+    {
+        super(api, responseNumber, channel);
+        this.oldPosition = oldPosition;
+    }
+
+    public int getOldPosition()
+    {
+        return oldPosition;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/update/GenericCategoryChannelUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/update/GenericCategoryChannelUpdateEvent.java
@@ -1,0 +1,37 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.dv8tion.jda.core.events.channel.category.update;
+
+import net.dv8tion.jda.core.JDA;
+import net.dv8tion.jda.core.entities.CategoryChannel;
+import net.dv8tion.jda.core.events.channel.category.GenericCategoryChannelEvent;
+
+/**
+ * <b><u>GenericCategoryChannelUpdateEvent</u></b><br>
+ * Fired whenever a {@link CategoryChannel CategoryChannel} is updated.<br>
+ * Every CategoryChannelUpdateEvent is an instance of this event and can be casted. (no exceptions)<br>
+ * <br>
+ * Use: Detect any CategoryChannelUpdateEvent. <i>(No real use for JDA user)</i>
+ */
+public abstract class GenericCategoryChannelUpdateEvent extends GenericCategoryChannelEvent
+{
+
+    public GenericCategoryChannelUpdateEvent(JDA api, long responseNumber, CategoryChannel channel)
+    {
+        super(api, responseNumber, channel);
+    }
+
+}

--- a/src/main/java/net/dv8tion/jda/core/events/channel/category/update/package-info.java
+++ b/src/main/java/net/dv8tion/jda/core/events/channel/category/update/package-info.java
@@ -1,0 +1,24 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Events indicating that a {@link net.dv8tion.jda.core.entities.CategoryChannel CategoryChannel}
+ * has been modified.
+ *
+ * <p>This provides both a {@link net.dv8tion.jda.core.events.channel.category.GenericCategoryChannelEvent GenericCategoryChannelUpdateEvent}
+ * and event for specific CategoryChannel settings such as the {@link net.dv8tion.jda.core.events.channel.category.update.CategoryChannelUpdateNameEvent name}.
+ */
+package net.dv8tion.jda.core.events.channel.category.update;

--- a/src/main/java/net/dv8tion/jda/core/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ChannelCreateHandler.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.core.handle;
 import net.dv8tion.jda.client.events.group.GroupJoinEvent;
 import net.dv8tion.jda.core.entities.ChannelType;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.events.channel.category.CategoryChannelCreateEvent;
 import net.dv8tion.jda.core.events.channel.priv.PrivateChannelCreateEvent;
 import net.dv8tion.jda.core.events.channel.text.TextChannelCreateEvent;
 import net.dv8tion.jda.core.events.channel.voice.VoiceChannelCreateEvent;
@@ -76,6 +77,14 @@ public class ChannelCreateHandler extends SocketHandler
                         new GroupJoinEvent(
                                 api, responseNumber,
                                 api.getEntityBuilder().createGroup(content)));
+                break;
+            }
+            case CATEGORY:
+            {
+                api.getEventManager().handle(
+                        new CategoryChannelCreateEvent(
+                                api, responseNumber,
+                                api.getEntityBuilder().createCategoryChannel(content, guildId)));
                 break;
             }
             default:

--- a/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
@@ -20,13 +20,11 @@ import net.dv8tion.jda.client.entities.impl.GroupImpl;
 import net.dv8tion.jda.client.entities.impl.JDAClientImpl;
 import net.dv8tion.jda.client.events.group.GroupLeaveEvent;
 import net.dv8tion.jda.core.audio.hooks.ConnectionStatus;
-import net.dv8tion.jda.core.entities.ChannelType;
-import net.dv8tion.jda.core.entities.PrivateChannel;
-import net.dv8tion.jda.core.entities.TextChannel;
-import net.dv8tion.jda.core.entities.VoiceChannel;
+import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.entities.impl.GuildImpl;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.entities.impl.UserImpl;
+import net.dv8tion.jda.core.events.channel.category.CategoryChannelDeleteEvent;
 import net.dv8tion.jda.core.events.channel.priv.PrivateChannelDeleteEvent;
 import net.dv8tion.jda.core.events.channel.text.TextChannelDeleteEvent;
 import net.dv8tion.jda.core.events.channel.voice.VoiceChannelDeleteEvent;
@@ -156,6 +154,24 @@ public class ChannelDeleteHandler extends SocketHandler
                         new GroupLeaveEvent(
                                 api, responseNumber,
                                 group));
+                break;
+            }
+            case CATEGORY:
+            {
+                GuildImpl guild = (GuildImpl) api.getGuildMap().get(guildId);
+                CategoryChannel channel = api.getCategoryChannelMap().remove(channelId);
+                if (channel == null)
+                {
+                    api.getEventCache().cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
+                    EventCache.LOG.debug("CHANNEL_DELETE attempted to delete a category channel that is not yet cached. JSON: " + content);
+                    return null;
+                }
+
+                guild.getTextChannelsMap().remove(channel.getIdLong());
+                api.getEventManager().handle(
+                        new CategoryChannelDeleteEvent(
+                                api, responseNumber,
+                                channel));
                 break;
             }
             default:

--- a/src/main/java/net/dv8tion/jda/core/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/core/hooks/ListenerAdapter.java
@@ -35,6 +35,11 @@ import net.dv8tion.jda.client.events.message.group.react.GroupMessageReactionRem
 import net.dv8tion.jda.client.events.relationship.*;
 import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.events.*;
+import net.dv8tion.jda.core.events.channel.category.CategoryChannelCreateEvent;
+import net.dv8tion.jda.core.events.channel.category.CategoryChannelDeleteEvent;
+import net.dv8tion.jda.core.events.channel.category.update.CategoryChannelUpdateNameEvent;
+import net.dv8tion.jda.core.events.channel.category.update.CategoryChannelUpdatePermissionsEvent;
+import net.dv8tion.jda.core.events.channel.category.update.CategoryChannelUpdatePositionEvent;
 import net.dv8tion.jda.core.events.channel.priv.PrivateChannelCreateEvent;
 import net.dv8tion.jda.core.events.channel.priv.PrivateChannelDeleteEvent;
 import net.dv8tion.jda.core.events.channel.text.GenericTextChannelEvent;
@@ -159,6 +164,13 @@ public abstract class ListenerAdapter implements EventListener
     public void onMessageReactionRemoveAll(MessageReactionRemoveAllEvent event) {}
 
 //    public void onInviteReceived(InviteReceivedEvent event) {}
+
+    //CategoryChannel Events
+    public void onCategoryChannelDelete(CategoryChannelDeleteEvent event) {}
+    public void onCategoryChannelUpdateName(CategoryChannelUpdateNameEvent event) {}
+    public void onCategoryChannelUpdatePosition(CategoryChannelUpdatePositionEvent event) {}
+    public void onCategoryChannelUpdatePermissions(CategoryChannelUpdatePermissionsEvent event) {}
+    public void onCategoryChannelCreate(CategoryChannelCreateEvent event) {}
 
     //TextChannel Events
     public void onTextChannelDelete(TextChannelDeleteEvent event) {}
@@ -426,6 +438,18 @@ public abstract class ListenerAdapter implements EventListener
             onSelfUpdateName((SelfUpdateNameEvent) event);
         else if (event instanceof SelfUpdateVerifiedEvent)
             onSelfUpdateVerified((SelfUpdateVerifiedEvent) event);
+
+        //CategoryChannel Events
+        else if (event instanceof CategoryChannelCreateEvent)
+            onCategoryChannelCreate((CategoryChannelCreateEvent) event);
+        else if (event instanceof CategoryChannelUpdateNameEvent)
+            onCategoryChannelUpdateName((CategoryChannelUpdateNameEvent) event);
+        else if (event instanceof CategoryChannelUpdatePositionEvent)
+            onCategoryChannelUpdatePosition((CategoryChannelUpdatePositionEvent) event);
+        else if (event instanceof CategoryChannelDeleteEvent)
+            onCategoryChannelDelete((CategoryChannelDeleteEvent) event);
+        else if (event instanceof CategoryChannelUpdatePermissionsEvent)
+            onCategoryChannelUpdatePermissions((CategoryChannelUpdatePermissionsEvent) event);
 
         //TextChannel Events
         else if (event instanceof TextChannelCreateEvent)

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
@@ -371,7 +371,7 @@ public class ChannelAction extends AuditableRestAction<Channel>
             return;
         }
 
-        EntityBuilder builder = api.getEntityBuilder();;
+        EntityBuilder builder = api.getEntityBuilder();
         Channel channel = voice
                 ? builder.createVoiceChannel(response.getObject(), guild.getIdLong())
                 : builder.createTextChannel(response.getObject(),  guild.getIdLong());

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/order/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/order/ChannelOrderAction.java
@@ -63,7 +63,19 @@ public class ChannelOrderAction<T extends Channel> extends OrderAction<T, Channe
         this.guild = guild;
         this.type = type;
 
-        Collection chans = type == ChannelType.TEXT ? guild.getTextChannels() : guild.getVoiceChannels();
+        Collection chans;
+        if (type == ChannelType.TEXT)
+        {
+            chans = guild.getTextChannels();
+        }
+        else if (type == ChannelType.CATEGORY)
+        {
+            chans = guild.getCategoryChannels();
+        }
+        else
+        {
+            chans = guild.getVoiceChannels();
+        }
         this.orderList.addAll(chans);
     }
 


### PR DESCRIPTION
This is a groundwork implementation of category channels. __**It is not feature-complete, however it does currently resolves the warnings.**__
* New interface: `CategoryChannel` and its implementation `CategoryChannelImpl`.
  * `AbstractChannelImpl` were implemented by `CategoryChannelImpl`.
* JDA(Impl) and Guild(Impl) gained a new set of methods for categories (partially tested).
* New events relating to categories (partially tested).
* Updated `EntityBuilder.java` to build categories.

However, there are several problems that should be delegated to staff of JDA.
* Category channels JSON content and creation happens **after** text and voice channels so far from my tests.
* TextChannel and VoiceChannel has a nullable `parent_id` field that points to the category it belongs to.
* CategoryChannel has a `getTextChannel()` method but due to the previous two problems, it currently returns an empty list because I'm not sure what is the best way to add child text and voice channels to it (todo for the staff).
* Message also has a new `getCategoryChannel()` but it currently returns null as a limitation those 3 problems.
* TextChannelUpdatePositionEvent and VoiceChannelUpdatePositionEvent will also have to update to handle moving to categories.

Just wanted to help out <3