### PR TITLE
Adding ShardedRateLimiter to keep track of global REST rate limit

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -29,10 +29,7 @@ import net.dv8tion.jda.core.utils.Checks;
 import okhttp3.OkHttpClient;
 
 import javax.security.auth.login.LoginException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 /**
  * Used to create new {@link net.dv8tion.jda.core.JDA} instances. This is also useful for making sure all of
@@ -138,7 +135,8 @@ public class JDABuilder
      * or {@link net.dv8tion.jda.core.JDABuilder#buildBlocking() buildBlocking()}
      * is called.
      *
-     * <p><u><b>This will reset the prior provided {@link #setShardedRateLimiter(ShardedRateLimiter)} setting!</b></u>
+     * <p><u><b>This will reset the prior provided {@link #setShardedRateLimiter(ShardedRateLimiter)} setting
+     * if this token is different to the previously set token!</b></u>
      *
      * <p>For {@link net.dv8tion.jda.core.AccountType#BOT} accounts:
      * <ol>
@@ -164,12 +162,12 @@ public class JDABuilder
      */
     public JDABuilder setToken(String token)
     {
-        this.token = token;
         //Share ratelimit for the same token
         // when this builder is used to build different accounts this makes sure we don't use the
         // same ratelimiter on them as it would be inaccurate
-        if (accountType == AccountType.BOT)
+        if (accountType == AccountType.BOT && !Objects.equals(token, this.token))
             shardRateLimiter = new ShardedRateLimiter();
+        this.token = token;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -105,12 +105,14 @@ public class JDABuilder
      * Sets the {@link net.dv8tion.jda.core.ShardedRateLimiter ShardedRateLimiter} that will be used to keep
      * track of rate limits across sessions.
      * <br>When one shard hits the global rate limit all others will be informed by this value wrapper.
+     * This does nothing for {@link net.dv8tion.jda.core.AccountType#CLIENT AccountType.CLIENT}!
      *
      * <p>It is recommended to use the same ShardedRateLimiter for all shards and not one each. This is
      * similar to {@link net.dv8tion.jda.core.requests.SessionReconnectQueue SessionReconnectQueue}!
      *
      * <p><b>This value is set when invoking {@link #setToken(String)} and cannot be unset using {@code null}. The re-use of this builder
      * to build each shard is sufficient and setting it is not required.</b>
+     * <br>Providing {@code null} is equivalent to doing {@code setShardedRateLimiter(new ShardedRateLimiter())}.
      *
      * <p>When you construct multiple JDABuilder instances to build shards it is recommended to use the same ShardedRateLimiter on
      * all of them. But it is to be <u>avoided</u> to use the same ShardedRateLimiter for different accounts/tokens!
@@ -138,7 +140,7 @@ public class JDABuilder
      * <p><u><b>This will reset the prior provided {@link #setShardedRateLimiter(ShardedRateLimiter)} setting
      * if this token is different to the previously set token!</b></u>
      *
-     * <p>For {@link net.dv8tion.jda.core.AccountType#BOT} accounts:
+     * <h2>For {@link net.dv8tion.jda.core.AccountType#BOT}</h2>
      * <ol>
      *     <li>Go to your <a href="https://discordapp.com/developers/applications/me">Discord Applications</a></li>
      *     <li>Create or select an already existing application</li>
@@ -146,7 +148,7 @@ public class JDABuilder
      *     <li>Click the <i>click to reveal</i> link beside the <b>Token</b> label to show your Bot's {@code token}</li>
      * </ol>
      *
-     * <p>For {@link net.dv8tion.jda.core.AccountType#CLIENT} accounts:
+     * <h2>For {@link net.dv8tion.jda.core.AccountType#CLIENT}</h2>
      * <br>Using either the Discord desktop app or the Browser Webapp
      * <ol>
      *     <li>Press {@code Ctrl-Shift-i} which will bring up the developer tools.</li>

--- a/src/main/java/net/dv8tion/jda/core/ShardedRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/ShardedRateLimiter.java
@@ -1,0 +1,34 @@
+/*
+ *     Copyright 2015-2017 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ShardedRateLimiter
+{
+    protected final AtomicLong globalRatelimit = new AtomicLong(Long.MIN_VALUE);
+
+    public void setGlobalRatelimit(long value)
+    {
+        globalRatelimit.set(value);
+    }
+
+    public long getGlobalRatelimit()
+    {
+        return globalRatelimit.get();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/entities/Category.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Category.java
@@ -2,6 +2,7 @@ package net.dv8tion.jda.core.entities;
 
 import net.dv8tion.jda.core.requests.restaction.ChannelAction;
 
+import javax.annotation.CheckReturnValue;
 import java.util.List;
 
 /**
@@ -66,6 +67,7 @@ public interface Category extends Channel, Comparable<Category>
      * @return A specific {@link net.dv8tion.jda.core.requests.restaction.ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new TextChannel before creating it
      */
+    @CheckReturnValue
     ChannelAction createTextChannel(String name);
 
     /**
@@ -98,5 +100,6 @@ public interface Category extends Channel, Comparable<Category>
      * @return A specific {@link net.dv8tion.jda.core.requests.restaction.ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new VoiceChannel before creating it
      */
+    @CheckReturnValue
     ChannelAction createVoiceChannel(String name);
 }

--- a/src/main/java/net/dv8tion/jda/core/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Requester.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.core.requests;
 import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.JDAInfo;
+import net.dv8tion.jda.core.ShardedRateLimiter;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.requests.ratelimit.BotRateLimiter;
 import net.dv8tion.jda.core.requests.ratelimit.ClientRateLimiter;
@@ -46,19 +47,19 @@ public class Requester
 
     private final OkHttpClient httpClient;
 
-    public Requester(JDA api)
+    public Requester(JDA api, ShardedRateLimiter shardedRateLimiter)
     {
-        this(api, api.getAccountType());
+        this(api, api.getAccountType(), shardedRateLimiter);
     }
 
-    public Requester(JDA api, AccountType accountType)
+    public Requester(JDA api, AccountType accountType, ShardedRateLimiter shardedRateLimiter)
     {
         if (accountType == null)
             throw new NullPointerException("Provided accountType was null!");
 
         this.api = (JDAImpl) api;
         if (accountType == AccountType.BOT)
-            rateLimiter = new BotRateLimiter(this, 5);
+            rateLimiter = new BotRateLimiter(this, 5, shardedRateLimiter);
         else
             rateLimiter = new ClientRateLimiter(this, 5);
         

--- a/src/main/java/net/dv8tion/jda/core/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/ratelimit/BotRateLimiter.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.core.requests.ratelimit;
 
+import net.dv8tion.jda.core.ShardedRateLimiter;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.events.ExceptionEvent;
 import net.dv8tion.jda.core.requests.RateLimiter;
@@ -37,16 +38,16 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class BotRateLimiter extends RateLimiter
 {
-    volatile Long timeOffset = null;
-    volatile AtomicLong globalCooldown = new AtomicLong(Long.MIN_VALUE);
+    protected final ShardedRateLimiter shardRateLimit;
+    protected volatile Long timeOffset = null;
 
-    public BotRateLimiter(Requester requester, int poolSize)
+    public BotRateLimiter(Requester requester, int poolSize, ShardedRateLimiter globalRatelimit)
     {
         super(requester, poolSize);
+        this.shardRateLimit = globalRatelimit == null ? new ShardedRateLimiter() : globalRatelimit;
     }
 
     @Override
@@ -104,7 +105,7 @@ public class BotRateLimiter extends RateLimiter
                 else
                 {
                     //If it is global, lock down the threads.
-                    globalCooldown.set(getNow() + retryAfter);
+                    shardRateLimit.setGlobalRatelimit(getNow() + retryAfter);
                 }
 
                 return retryAfter;
@@ -251,17 +252,19 @@ public class BotRateLimiter extends RateLimiter
 
         Long getRateLimit()
         {
-            long gCooldown = globalCooldown.get();
-            if (gCooldown != Long.MIN_VALUE) //Are we on global cooldown?
+            long gCooldown = shardRateLimit.getGlobalRatelimit();
+            if (gCooldown > 0) //Are we on global cooldown?
             {
                 long now = getNow();
                 if (now > gCooldown)   //Verify that we should still be on cooldown.
                 {
-                    globalCooldown.set(Long.MIN_VALUE);  //If we are done cooling down, reset the globalCooldown and continue.
+                    //If we are done cooling down, reset the globalCooldown and continue.
+                    shardRateLimit.setGlobalRatelimit(Long.MIN_VALUE);
                 }
                 else
                 {
-                    return gCooldown - now;    //If we should still be on cooldown, return when we can go again.
+                    //If we should still be on cooldown, return when we can go again.
+                    return gCooldown - now;
                 }
             }
             if (this.routeUsageRemaining <= 0)


### PR DESCRIPTION
This change will not require users to add a ShardedRateLimiter to their JDABuilder if they have already been using the same builder for all shards.