### PR TITLE
Fixing parameter pass-through of Presence#setGame and Presence#setIdle

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/managers/impl/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/impl/PresenceImpl.java
@@ -92,13 +92,13 @@ public class PresenceImpl implements Presence
     @Override
     public void setGame(Game game)
     {
-        setPresence(status, idle);
+        setPresence(status, game);
     }
 
     @Override
     public void setIdle(boolean idle)
     {
-        setPresence(status, game);
+        setPresence(status, idle);
     }
 
     @Override


### PR DESCRIPTION
Fixes wrong parameters of Presence#setGame and Presence#setIdle to the 2-arg methods. 
Fixes setting game and idle via Presence

Fixes #482 