### PR TITLE
Added isWebhookMessage() and docs to (Guild)MessageReceivedEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/message/MessageReceivedEvent.java
@@ -21,11 +21,11 @@ import net.dv8tion.jda.core.entities.*;
 
 /**
  * <b><u>MessageReceivedEvent</u></b><br>
- * Fired if a Message is sent in a {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}.
- * <br>This includes both {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
- * and {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}!
+ * Fired if a Message is received in a {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}.
+ * <br>This includes {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
+ * {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} and {@link net.dv8tion.jda.client.entities.Group Group}!
  * <p>
- * Use: This event indicates that a Message is sent in either a private or guild channel. Providing a MessageChannel and Message.
+ * Use: This event indicates that a Message is received in either a guild, private channel or group. Providing a MessageChannel and Message.
  */
 public class MessageReceivedEvent extends GenericMessageEvent
 {
@@ -39,7 +39,6 @@ public class MessageReceivedEvent extends GenericMessageEvent
 
     /**
      * Returns the received {@link net.dv8tion.jda.core.entities.Message Message} object.
-     * <br>The Message will be of type {@link net.dv8tion.jda.core.entities.impl.ReceivedMessage ReceivedMessage}.
      *
      * @return The received {@link net.dv8tion.jda.core.entities.Message Message} object.
      */
@@ -49,8 +48,8 @@ public class MessageReceivedEvent extends GenericMessageEvent
     }
 
     /**
-     * Returns the Author of the Message sent as {@link net.dv8tion.jda.core.entities.User User} object.
-     * <br>This will be never-null but might be a fake user if Message was sent via Webhook
+     * Returns the Author of the Message received as {@link net.dv8tion.jda.core.entities.User User} object.
+     * <br>This will be never-null but might be a fake user if Message was sent via Webhook (Guild only).
      *
      * @return The Author of the Message.
      *
@@ -63,8 +62,10 @@ public class MessageReceivedEvent extends GenericMessageEvent
     }
 
     /**
-     * Returns the Author of the Message sent as {@link net.dv8tion.jda.core.entities.Member Member} object.
-     * <br>This will be {@code null} in case of Message being sent in a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}
+     * Returns the Author of the Message received as {@link net.dv8tion.jda.core.entities.Member Member} object.
+     * <br>This will be {@code null} in case of Message being received in
+     * a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel},
+     * a {@link net.dv8tion.jda.client.entities.Group Group}
      * or {@link #isWebhookMessage() isWebhookMessage()} returning {@code true}.
      *
      * @return The Author of the Message as null-able Member object.
@@ -77,11 +78,11 @@ public class MessageReceivedEvent extends GenericMessageEvent
     }
 
     /**
-     * Returns the {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} the Message was sent in.
-     * <br>If this Message was not sent in a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel},
+     * Returns the {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} the Message was received in.
+     * <br>If this Message was not received in a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel},
      * this will return {@code null}.
      *
-     * @return The PrivateChannel the Message was sent in or null if not from a PrivateChannel
+     * @return The PrivateChannel the Message was received in or null if not from a PrivateChannel
      *
      * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
      */
@@ -91,11 +92,11 @@ public class MessageReceivedEvent extends GenericMessageEvent
     }
 
     /**
-     * Returns the {@link net.dv8tion.jda.client.entities.Group Group} the Message was sent in.
-     * <br>If this Message was not sent in a {@link net.dv8tion.jda.client.entities.Group Group},
+     * Returns the {@link net.dv8tion.jda.client.entities.Group Group} the Message was received in.
+     * <br>If this Message was not received in a {@link net.dv8tion.jda.client.entities.Group Group},
      * this will return {@code null}.
      *
-     * @return The Group the Message was sent in or null if not from a Group
+     * @return The Group the Message was received in or null if not from a Group
      *
      * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
      */
@@ -105,11 +106,11 @@ public class MessageReceivedEvent extends GenericMessageEvent
     }
 
     /**
-     * Returns the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} the Message was sent in.
-     * <br>If this Message was not sent in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
+     * Returns the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} the Message was received in.
+     * <br>If this Message was not received in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
      * this will return {@code null}.
      *
-     * @return The TextChannel the Message was sent in or null if not from a TextChannel
+     * @return The TextChannel the Message was received in or null if not from a TextChannel
      *
      * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
      */
@@ -119,11 +120,11 @@ public class MessageReceivedEvent extends GenericMessageEvent
     }
 
     /**
-     * Returns the {@link net.dv8tion.jda.core.entities.Guild Guild} the Message was sent in.
-     * <br>If this Message was not sent in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
+     * Returns the {@link net.dv8tion.jda.core.entities.Guild Guild} the Message was received in.
+     * <br>If this Message was not received in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
      * this will return {@code null}.
      *
-     * @return The Guild the Message was sent in or null if not from a TextChannel
+     * @return The Guild the Message was received in or null if not from a TextChannel
      *
      * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
      */

--- a/src/main/java/net/dv8tion/jda/core/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/message/MessageReceivedEvent.java
@@ -21,8 +21,10 @@ import net.dv8tion.jda.core.entities.*;
 
 /**
  * <b><u>MessageReceivedEvent</u></b><br>
- * Fired if a Message is sent in a {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}.<br>
- * <br>
+ * Fired if a Message is sent in a {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}.
+ * <br>This includes both {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+ * and {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}!
+ * <p>
  * Use: This event indicates that a Message is sent in either a private or guild channel. Providing a MessageChannel and Message.
  */
 public class MessageReceivedEvent extends GenericMessageEvent
@@ -35,38 +37,109 @@ public class MessageReceivedEvent extends GenericMessageEvent
         this.message = message;
     }
 
+    /**
+     * Returns the received {@link net.dv8tion.jda.core.entities.Message Message} object.
+     * <br>The Message will be of type {@link net.dv8tion.jda.core.entities.impl.ReceivedMessage ReceivedMessage}.
+     *
+     * @return The received {@link net.dv8tion.jda.core.entities.Message Message} object.
+     */
     public Message getMessage()
     {
         return message;
     }
 
+    /**
+     * Returns the Author of the Message sent as {@link net.dv8tion.jda.core.entities.User User} object.
+     * <br>This will be never-null but might be a fake user if Message was sent via Webhook
+     *
+     * @return The Author of the Message.
+     *
+     * @see #isWebhookMessage()
+     * @see net.dv8tion.jda.core.entities.User#isFake()
+     */
     public User getAuthor()
     {
         return message.getAuthor();
     }
 
+    /**
+     * Returns the Author of the Message sent as {@link net.dv8tion.jda.core.entities.Member Member} object.
+     * <br>This will be {@code null} in case of Message being sent in a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}
+     * or {@link #isWebhookMessage() isWebhookMessage()} returning {@code true}.
+     *
+     * @return The Author of the Message as null-able Member object.
+     *
+     * @see #isWebhookMessage()
+     */
     public Member getMember()
     {
-        return isFromType(ChannelType.TEXT) ? getGuild().getMember(getAuthor()) : null;
+        return isFromType(ChannelType.TEXT) && !isWebhookMessage() ? getGuild().getMember(getAuthor()) : null;
     }
 
+    /**
+     * Returns the {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} the Message was sent in.
+     * <br>If this Message was not sent in a {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel},
+     * this will return {@code null}.
+     *
+     * @return The PrivateChannel the Message was sent in or null if not from a PrivateChannel
+     *
+     * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
+     */
     public PrivateChannel getPrivateChannel()
     {
         return message.getPrivateChannel();
     }
 
+    /**
+     * Returns the {@link net.dv8tion.jda.client.entities.Group Group} the Message was sent in.
+     * <br>If this Message was not sent in a {@link net.dv8tion.jda.client.entities.Group Group},
+     * this will return {@code null}.
+     *
+     * @return The Group the Message was sent in or null if not from a Group
+     *
+     * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
+     */
     public Group getGroup()
     {
         return message.getGroup();
     }
 
+    /**
+     * Returns the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} the Message was sent in.
+     * <br>If this Message was not sent in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
+     * this will return {@code null}.
+     *
+     * @return The TextChannel the Message was sent in or null if not from a TextChannel
+     *
+     * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
+     */
     public TextChannel getTextChannel()
     {
         return message.getTextChannel();
     }
 
+    /**
+     * Returns the {@link net.dv8tion.jda.core.entities.Guild Guild} the Message was sent in.
+     * <br>If this Message was not sent in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel},
+     * this will return {@code null}.
+     *
+     * @return The Guild the Message was sent in or null if not from a TextChannel
+     *
+     * @see net.dv8tion.jda.core.events.message.GenericMessageEvent#isFromType(ChannelType)
+     */
     public Guild getGuild()
     {
         return message.getGuild();
+    }
+
+    /**
+     * Returns whether or not the Message received was sent via a Webhook.
+     * <br>This is a shortcut for {@code getMessage().isWebhookMessage()}.
+     *
+     * @return Whether or not the Message was sent via Webhook
+     */
+    public boolean isWebhookMessage()
+    {
+        return getMessage().isWebhookMessage();
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/message/guild/GuildMessageReceivedEvent.java
@@ -22,8 +22,8 @@ import net.dv8tion.jda.core.entities.User;
 
 /**
  * <b><u>GuildMessageReceivedEvent</u></b><br>
- * Fired if a Message is sent in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.<br>
- * <br>
+ * Fired if a Message is received in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}.
+ * <p>
  * Use: Retrieve affected TextChannel and Message.
  */
 public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
@@ -38,7 +38,6 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
 
     /**
      * Returns the received {@link net.dv8tion.jda.core.entities.Message Message} object.
-     * <br>The Message will be of type {@link net.dv8tion.jda.core.entities.impl.ReceivedMessage ReceivedMessage}.
      *
      * @return The received {@link net.dv8tion.jda.core.entities.Message Message} object.
      */
@@ -48,10 +47,10 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
     }
 
     /**
-     * Returns the Author of the message sent as {@link net.dv8tion.jda.core.entities.User User} object.
-     * <br>This will be never-null but might be a fake user if message was sent via Webhook
+     * Returns the Author of the Message received as {@link net.dv8tion.jda.core.entities.User User} object.
+     * <br>This will be never-null but might be a fake User if Message was sent via Webhook
      *
-     * @return The Author of the message.
+     * @return The Author of the Message.
      *
      * @see #isWebhookMessage()
      * @see net.dv8tion.jda.core.entities.User#isFake()
@@ -62,10 +61,10 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
     }
 
     /**
-     * Returns the Author of the message sent as {@link net.dv8tion.jda.core.entities.Member Member} object.
+     * Returns the Author of the Message received as {@link net.dv8tion.jda.core.entities.Member Member} object.
      * <br>This will be {@code null} in case of {@link #isWebhookMessage() isWebhookMessage()} returning {@code true}.
      *
-     * @return The Author of the message as Member object.
+     * @return The Author of the Message as Member object.
      *
      * @see #isWebhookMessage()
      */

--- a/src/main/java/net/dv8tion/jda/core/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/message/guild/GuildMessageReceivedEvent.java
@@ -36,18 +36,52 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
         this.message = message;
     }
 
+    /**
+     * Returns the received {@link net.dv8tion.jda.core.entities.Message Message} object.
+     * <br>The Message will be of type {@link net.dv8tion.jda.core.entities.impl.ReceivedMessage ReceivedMessage}.
+     *
+     * @return The received {@link net.dv8tion.jda.core.entities.Message Message} object.
+     */
     public Message getMessage()
     {
         return message;
     }
 
+    /**
+     * Returns the Author of the message sent as {@link net.dv8tion.jda.core.entities.User User} object.
+     * <br>This will be never-null but might be a fake user if message was sent via Webhook
+     *
+     * @return The Author of the message.
+     *
+     * @see #isWebhookMessage()
+     * @see net.dv8tion.jda.core.entities.User#isFake()
+     */
     public User getAuthor()
     {
         return message.getAuthor();
     }
 
+    /**
+     * Returns the Author of the message sent as {@link net.dv8tion.jda.core.entities.Member Member} object.
+     * <br>This will be {@code null} in case of {@link #isWebhookMessage() isWebhookMessage()} returning {@code true}.
+     *
+     * @return The Author of the message as Member object.
+     *
+     * @see #isWebhookMessage()
+     */
     public Member getMember()
     {
-        return getGuild().getMember(getAuthor());
+        return isWebhookMessage() ? null : getGuild().getMember(getAuthor());
+    }
+
+    /**
+     * Returns whether or not the Message received was sent via a Webhook.
+     * <br>This is a shortcut for {@code getMessage().isWebhookMessage()}.
+     *
+     * @return Whether or not the Message was sent via Webhook
+     */
+    public boolean isWebhookMessage()
+    {
+        return getMessage().isWebhookMessage();
     }
 }


### PR DESCRIPTION
Need opinion on Docs:
- Should I keep the `@see` stuff?
- Should I say "received Message" or "sent Message" throughout the docs?
- Should I link other classes more frequently? (currently only when needed and not in return statement)
- Should I horizontally align the `@return` and `@see` statements?