### PR TITLE
Handle NumberFormatException when parsing channel mentions

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -920,8 +920,8 @@ public class EntityBuilder
             {
                 try
                 {
-                    TextChannel channel = chanMap.get(Long.parseLong(matcher.group(1)));
-                    if(channel != null && !mentionedChannels.contains(channel))
+                    TextChannel channel = chanMap.get(Long.parseUnsignedLong(matcher.group(1)));
+                    if (channel != null && !mentionedChannels.contains(channel))
                     {
                         mentionedChannels.add(channel);
                     }

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -918,10 +918,14 @@ public class EntityBuilder
             Matcher matcher = channelMentionPattern.matcher(content);
             while (matcher.find())
             {
-                TextChannel channel = chanMap.get(Long.parseLong(matcher.group(1)));
-                if(channel != null && !mentionedChannels.contains(channel))
+                try
                 {
-                    mentionedChannels.add(channel);
+                    TextChannel channel = chanMap.get(Long.parseLong(matcher.group(1)));
+                    if(channel != null && !mentionedChannels.contains(channel))
+                    {
+                        mentionedChannels.add(channel);
+                    }
+                } catch (NumberFormatException ignored) {
                 }
             }
             message.setMentionedChannels(mentionedChannels);


### PR DESCRIPTION
These are triggered when a message contains something like <#111111111111111111111111111111111>

```
java.lang.NumberFormatException: For input string: "111111111111111111111111111111111"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Long.parseLong(Long.java:592)
    at java.lang.Long.parseLong(Long.java:631)
    at net.dv8tion.jda.core.entities.EntityBuilder.createMessage(EntityBuilder.java:921)
    at net.dv8tion.jda.core.entities.EntityBuilder.createMessage(EntityBuilder.java:749)
    at net.dv8tion.jda.core.handle.MessageCreateHandler.handleDefaultMessage(MessageCreateHandler.java:61)
    at net.dv8tion.jda.core.handle.MessageCreateHandler.handleInternally(MessageCreateHandler.java:49)
    at net.dv8tion.jda.core.handle.SocketHandler.handle(SocketHandler.java:37)
    at net.dv8tion.jda.core.requests.WebSocketClient.handleEvent(WebSocketClient.java:969)
    at net.dv8tion.jda.core.requests.WebSocketClient.onTextMessage(WebSocketClient.java:661)
    at com.neovisionaries.ws.client.ListenerManager.callOnTextMessage(ListenerManager.java:352)
    at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:260)
    at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:238)
    at com.neovisionaries.ws.client.ReadingThread.handleTextFrame(ReadingThread.java:963)
    at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:746)
    at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108)
    at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64)
    at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45)
```