### PR TITLE
Allow SessionReconnectQueue extensions to call reconnect

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/SessionReconnectQueue.java
@@ -54,6 +54,12 @@ public class SessionReconnectQueue
         }
     }
 
+    //allows any custom extensions of this class to call reconnects on the WebSocketClient
+    protected static void reconnect(WebSocketClient client, boolean shouldHandleIdentify)
+    {
+        client.reconnect(true, shouldHandleIdentify);
+    }
+
     protected final class ReconnectThread extends Thread
     {
         protected ReconnectThread()
@@ -71,7 +77,7 @@ public class SessionReconnectQueue
                 try
                 {
                     final WebSocketClient client = reconnectQueue.poll();
-                    client.reconnect(true, isFirst);
+                    SessionReconnectQueue.reconnect(client, isFirst);
                     isFirst = false;
 
                     if (!reconnectQueue.isEmpty())


### PR DESCRIPTION
When implementing a custom ReconnectQueue there the issue that there is no way to call the reconnect method of a WebSocketClient because it is `protected`, so here's a method to do so from the `SessionReconnectQueue` class.
There's probably a less ugly way to achieve this like making WebSocketClient#reconnect public or something. I'm just not sure about how JDA wants to handle their method access levels, this is the less intrusive one.