### PR TITLE
Added WebhookClientBuilder(String) constructor

### DIFF
--- a/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
+++ b/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Builder that creates a new {@link net.dv8tion.jda.webhook.WebhookClient WebhookClient} instance
@@ -32,6 +34,7 @@ import java.util.concurrent.ThreadFactory;
 public class WebhookClientBuilder
 {
     public static final OkHttpClient.Builder DEFAULT_HTTP_BUILDER = new OkHttpClient.Builder();
+    private static final Pattern WEBHOOK_PATTERN = Pattern.compile("webhooks\\/(\\d+)\\/([\\w-]+)");
 
     protected final long id;
     protected final String token;
@@ -59,6 +62,29 @@ public class WebhookClientBuilder
         Checks.noWhitespace(token, "Token");
         this.id = id;
         this.token = token;
+    }
+
+    /**
+     * Creates a new WebhookClientBuilder with the provided webhook URL
+     *
+     * @param  url
+     *         The URL of the webhook. May be directly copied from Discord's UI
+     *         <br>Example: {@code https://discordapp.com/api/webhooks/123456789012345678/my-webhook-token}
+     *         <br>This constructor also parses URLs pointing to subdomains of {@code discordapp.com}
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided token is {@code null}
+     *         or is incorrectly formatted
+     */
+    public WebhookClientBuilder(@Nonnull String url)
+    {
+        Matcher matcher = WEBHOOK_PATTERN.matcher(url);
+        if(!matcher.find()) {
+            throw new IllegalArgumentException("Failed to parse webhook URL");
+        }
+
+        this.id = Long.parseLong(matcher.group(1));
+        this.token = matcher.group(2);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
+++ b/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
@@ -80,7 +80,8 @@ public class WebhookClientBuilder
     public WebhookClientBuilder(@Nonnull String url)
     {
         Matcher matcher = WEBHOOK_PATTERN.matcher(url);
-        if (!matcher.matches()) {
+        if (!matcher.matches())
+        {
             throw new IllegalArgumentException("Failed to parse webhook URL");
         }
 

--- a/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
+++ b/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 public class WebhookClientBuilder
 {
     public static final OkHttpClient.Builder DEFAULT_HTTP_BUILDER = new OkHttpClient.Builder();
-    private static final Pattern WEBHOOK_PATTERN = Pattern.compile("(?:https?://)?(?:\\w+.)?discordapp\\.com/api(?:/\\d+)?/webhooks/(\\d+)/([\\w-]+)(?:/(?:\\w+)?)?");
+    private static final Pattern WEBHOOK_PATTERN = Pattern.compile("(?:https?://)?(?:\\w+\\.)?discordapp\\.com/api(?:/v\\d+)?/webhooks/(\\d+)/([\\w-]+)(?:/(?:\\w+)?)?");
 
     protected final long id;
     protected final String token;
@@ -80,10 +80,8 @@ public class WebhookClientBuilder
     public WebhookClientBuilder(@Nonnull String url)
     {
         Matcher matcher = WEBHOOK_PATTERN.matcher(url);
-        if(!matcher.find()) {
+        if (!matcher.matches()) {
             throw new IllegalArgumentException("Failed to parse webhook URL");
-        } else if (!matcher.matches()) {
-            throw new IllegalArgumentException("Failed to match the entire string as a webhook URL");
         }
 
         this.id = MiscUtil.parseSnowflake(matcher.group(1));

--- a/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
+++ b/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.webhook;
 
 import net.dv8tion.jda.core.entities.Webhook;
 import net.dv8tion.jda.core.utils.Checks;
+import net.dv8tion.jda.core.utils.MiscUtil;
 import okhttp3.OkHttpClient;
 
 import javax.annotation.Nonnull;
@@ -34,7 +35,7 @@ import java.util.regex.Pattern;
 public class WebhookClientBuilder
 {
     public static final OkHttpClient.Builder DEFAULT_HTTP_BUILDER = new OkHttpClient.Builder();
-    private static final Pattern WEBHOOK_PATTERN = Pattern.compile("webhooks\\/(\\d+)\\/([\\w-]+)");
+    private static final Pattern WEBHOOK_PATTERN = Pattern.compile("(?:https?://)?(?:\\w+.)?discordapp\\.com/api(?:/\\d+)?/webhooks/(\\d+)/([\\w-]+)(?:/(?:\\w+)?)?");
 
     protected final long id;
     protected final String token;
@@ -81,9 +82,11 @@ public class WebhookClientBuilder
         Matcher matcher = WEBHOOK_PATTERN.matcher(url);
         if(!matcher.find()) {
             throw new IllegalArgumentException("Failed to parse webhook URL");
+        } else if (!matcher.matches()) {
+            throw new IllegalArgumentException("Failed to match the entire string as a webhook URL");
         }
 
-        this.id = Long.parseLong(matcher.group(1));
+        this.id = MiscUtil.parseSnowflake(matcher.group(1));
         this.token = matcher.group(2);
     }
 

--- a/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
+++ b/src/main/java/net/dv8tion/jda/webhook/WebhookClientBuilder.java
@@ -73,7 +73,7 @@ public class WebhookClientBuilder
      *         <br>This constructor also parses URLs pointing to subdomains of {@code discordapp.com}
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the provided token is {@code null}
+     *         If the provided URL is {@code null}
      *         or is incorrectly formatted
      */
     public WebhookClientBuilder(@Nonnull String url)


### PR DESCRIPTION
This adds a constructor to `WebhookClientBuilder` which takes the URL for the webhook (as opposed to the id and token separately.)

Tested for the following URLs:
```
https://discordapp.com/api/webhooks/370264727500095498/token
http://discordapp.com/api/webhooks/370264727500095498/token
https://discordapp.com/api/6/webhooks/370264727500095498/token
https://canary.discordapp.com/api/webhooks/370264727500095498/token
https://discordapp.com/api/webhooks/370264727500095498/token/slack
```