### PR TITLE
Made audio manager cache accessible from JDA instances

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -20,8 +20,10 @@ import net.dv8tion.jda.bot.JDABot;
 import net.dv8tion.jda.client.JDAClient;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.hooks.IEventManager;
+import net.dv8tion.jda.core.managers.AudioManager;
 import net.dv8tion.jda.core.managers.Presence;
 import net.dv8tion.jda.core.requests.RestAction;
+import net.dv8tion.jda.core.utils.cache.CacheView;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.core.requests.restaction.AuditableRestAction;
 
@@ -240,6 +242,29 @@ public interface JDA
      * @return List of currently registered Objects acting as EventListeners.
      */
     List<Object> getRegisteredListeners();
+
+    /**
+     * {@link net.dv8tion.jda.core.utils.cache.CacheView CacheView} of
+     * all cached {@link net.dv8tion.jda.core.managers.AudioManager AudioManagers} created for this JDA instance.
+     * <br>AudioManagers are created when first retrieved via {@link net.dv8tion.jda.core.entities.Guild#getAudioManager() Guild.getAudioManager()}.
+     * <u>Using this will perform better than calling {@code Guild.getAudioManager()} iteratively as that would cause many useless audio managers to be created!</u>
+     *
+     * <p>AudioManagers are cross-session persistent!
+     *
+     * @return {@link net.dv8tion.jda.core.utils.cache.CacheView CacheView}
+     */
+    CacheView<AudioManager> getAudioManagerCache();
+
+    /**
+     * Immutable list of all created {@link net.dv8tion.jda.core.managers.AudioManager AudioManagers} for this JDA instance!
+     *
+     * @return Immutable list of all created AudioManager instances
+     */
+    default List<AudioManager> getAudioManagers()
+    {
+        return getAudioManagerCache().asList();
+    }
+
 
     /**
      * {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView} of

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -453,8 +453,8 @@ public class GuildImpl implements Guild
         if (!api.isAudioEnabled())
             throw new IllegalStateException("Audio is disabled. Cannot retrieve an AudioManager while audio is disabled.");
 
-        final TLongObjectMap<AudioManagerImpl> managerMap = api.getAudioManagerMap();
-        AudioManagerImpl mng = managerMap.get(id);
+        final TLongObjectMap<AudioManager> managerMap = api.getAudioManagerMap();
+        AudioManager mng = managerMap.get(id);
         if (mng == null)
         {
             // No previous manager found -> create one

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/JDAImpl.java
@@ -37,7 +37,6 @@ import net.dv8tion.jda.core.hooks.IEventManager;
 import net.dv8tion.jda.core.hooks.InterfacedEventManager;
 import net.dv8tion.jda.core.managers.AudioManager;
 import net.dv8tion.jda.core.managers.Presence;
-import net.dv8tion.jda.core.managers.impl.AudioManagerImpl;
 import net.dv8tion.jda.core.managers.impl.PresenceImpl;
 import net.dv8tion.jda.core.requests.*;
 import net.dv8tion.jda.core.requests.restaction.AuditableRestAction;
@@ -46,6 +45,7 @@ import net.dv8tion.jda.core.utils.MiscUtil;
 import net.dv8tion.jda.core.utils.SimpleLog;
 import net.dv8tion.jda.core.utils.cache.CacheView;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
+import net.dv8tion.jda.core.utils.cache.impl.AbstractCacheView;
 import net.dv8tion.jda.core.utils.cache.impl.SnowflakeCacheViewImpl;
 import okhttp3.OkHttpClient;
 import org.json.JSONObject;
@@ -73,7 +73,7 @@ public class JDAImpl implements JDA
     protected final TLongObjectMap<User> fakeUsers = MiscUtil.newLongMap();
     protected final TLongObjectMap<PrivateChannel> fakePrivateChannels = MiscUtil.newLongMap();
 
-    protected final TLongObjectMap<AudioManagerImpl> audioManagers = MiscUtil.newLongMap();
+    protected final AbstractCacheView<AudioManager> audioManagers = new CacheView.SimpleCacheView<>(m -> m.getGuild().getName());
 
     protected final OkHttpClient.Builder httpClientBuilder;
     protected final WebSocketFactory wsFactory;
@@ -378,6 +378,12 @@ public class JDAImpl implements JDA
     }
 
     @Override
+    public CacheView<AudioManager> getAudioManagerCache()
+    {
+        return audioManagers;
+    }
+
+    @Override
     public SnowflakeCacheView<Guild> getGuildCache()
     {
         return guildCache;
@@ -446,7 +452,7 @@ public class JDAImpl implements JDA
             return;
 
         setStatus(Status.SHUTTING_DOWN);
-        audioManagers.valueCollection().forEach(AudioManager::closeAudioConnection);
+        audioManagers.forEach(AudioManager::closeAudioConnection);
         audioManagers.clear();
 
         if (audioKeepAlivePool != null)
@@ -638,9 +644,9 @@ public class JDAImpl implements JDA
         return fakePrivateChannels;
     }
 
-    public TLongObjectMap<AudioManagerImpl> getAudioManagerMap()
+    public TLongObjectMap<AudioManager> getAudioManagerMap()
     {
-        return audioManagers;
+        return audioManagers.getMap();
     }
 
     public void setSelfUser(SelfUser selfUser)

--- a/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/ChannelDeleteHandler.java
@@ -85,7 +85,7 @@ public class ChannelDeleteHandler extends SocketHandler
                 }
 
                 //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
-                AudioManagerImpl manager = api.getAudioManagerMap().get(guild.getIdLong());
+                AudioManagerImpl manager = (AudioManagerImpl) api.getAudioManagerMap().get(guild.getIdLong());
                 if (manager != null && manager.isConnected()
                         && manager.getConnectedChannel().getIdLong() == channel.getIdLong())
                 {

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildDeleteHandler.java
@@ -33,6 +33,7 @@ import net.dv8tion.jda.core.entities.impl.PrivateChannelImpl;
 import net.dv8tion.jda.core.entities.impl.UserImpl;
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.core.events.guild.GuildUnavailableEvent;
+import net.dv8tion.jda.core.managers.AudioManager;
 import net.dv8tion.jda.core.managers.impl.AudioManagerImpl;
 import org.json.JSONObject;
 
@@ -76,10 +77,10 @@ public class GuildDeleteHandler extends SocketHandler
         }
 
         api.getClient().removeAudioConnection(id);
-        final TLongObjectMap<AudioManagerImpl> audioManagerMap = api.getAudioManagerMap();
+        final TLongObjectMap<AudioManager> audioManagerMap = api.getAudioManagerMap();
         synchronized (audioManagerMap)
         {
-            final AudioManagerImpl manager = audioManagerMap.get(id);
+            final AudioManagerImpl manager = (AudioManagerImpl) audioManagerMap.get(id);
             if (manager != null) // close existing audio connection if needed
                 manager.closeAudioConnection(ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD);
             // remove manager from central map to avoid old guild references

--- a/src/main/java/net/dv8tion/jda/core/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/VoiceStateUpdateHandler.java
@@ -133,7 +133,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
             }
             else
             {
-                AudioManagerImpl mng = api.getAudioManagerMap().get(guildId);
+                AudioManagerImpl mng = (AudioManagerImpl) api.getAudioManagerMap().get(guildId);
 
                 //If the currently connected account is the one that is being moved
                 if (guild.getSelfMember().equals(member) && mng != null)

--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -831,17 +831,17 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected void updateAudioManagerReferences()
     {
-        final TLongObjectMap<AudioManagerImpl> managerMap = api.getAudioManagerMap();
+        final TLongObjectMap<AudioManager> managerMap = api.getAudioManagerMap();
         if (managerMap.size() > 0)
             LOG.trace("Updating AudioManager references");
 
         synchronized (managerMap)
         {
-            for (TLongObjectIterator<AudioManagerImpl> it = managerMap.iterator(); it.hasNext(); )
+            for (TLongObjectIterator<AudioManager> it = managerMap.iterator(); it.hasNext(); )
             {
                 it.advance();
                 final long guildId = it.key();
-                final AudioManagerImpl mng = it.value();
+                final AudioManagerImpl mng = (AudioManagerImpl) it.value();
                 ConnectionListener listener = mng.getConnectionListener();
 
                 GuildImpl guild = (GuildImpl) api.getGuildById(guildId);

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
@@ -18,11 +18,13 @@ package net.dv8tion.jda.core.utils.cache;
 
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.utils.Checks;
+import net.dv8tion.jda.core.utils.cache.impl.AbstractCacheView;
 import net.dv8tion.jda.core.utils.cache.impl.UnifiedCacheViewImpl;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -258,5 +260,20 @@ public interface CacheView<T> extends Iterable<T>
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl.UnifiedMemberCacheViewImpl(generator);
+    }
+
+    /**
+     * Basic implementation of {@link net.dv8tion.jda.core.utils.cache.CacheView CacheView} interface.
+     * <br>Using {@link gnu.trove.map.TLongObjectMap TLongObjectMap} to cache entities!
+     *
+     * @param <T>
+     *        The type this should cache
+     */
+    class SimpleCacheView<T> extends AbstractCacheView<T>
+    {
+        public SimpleCacheView(Function<T, String> nameMapper)
+        {
+            super(nameMapper);
+        }
     }
 }


### PR DESCRIPTION
This will allow for better performance on checking how many active audio connections are present in a JDA instance:
```java
JDA api; // = ....
MessageChannel channel; // = ....
CacheView<AudioManager> cache = api.getAudioManagerCache();
channel.sendMessageFormat("Currently connected to **%d** channels!", cache.stream().filter(m -> m.isConnected()).count()).queue();
```