### PR TITLE
added GuildUpdateExplicitContentLevelEvent to ListenerAdapter

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/core/hooks/ListenerAdapter.java
@@ -212,6 +212,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildUpdateAfkChannel(GuildUpdateAfkChannelEvent event) {}
     public void onGuildUpdateSystemChannel(GuildUpdateSystemChannelEvent event) {}
     public void onGuildUpdateAfkTimeout(GuildUpdateAfkTimeoutEvent event) {}
+    public void onGuildUpdateExplicitContentLevel(GuildUpdateExplicitContentLevelEvent event) {}
     public void onGuildUpdateIcon(GuildUpdateIconEvent event) {}
     public void onGuildUpdateMFALevel(GuildUpdateMFALevelEvent event) {}
     public void onGuildUpdateName(GuildUpdateNameEvent event){}
@@ -522,6 +523,8 @@ public abstract class ListenerAdapter implements EventListener
             onGuildUpdateSystemChannel((GuildUpdateSystemChannelEvent) event);
         else if (event instanceof GuildUpdateAfkTimeoutEvent)
             onGuildUpdateAfkTimeout((GuildUpdateAfkTimeoutEvent) event);
+        else if (event instanceof GuildUpdateExplicitContentLevelEvent)
+            onGuildUpdateExplicitContentLevel((GuildUpdateExplicitContentLevelEvent) event);
         else if (event instanceof GuildUpdateIconEvent)
             onGuildUpdateIcon((GuildUpdateIconEvent) event);
         else if (event instanceof GuildUpdateMFALevelEvent)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Template

### Pull Request

GuildUpdateExplicitContentLevelEvent was missing from the ListenerAdapter and this PR adds it.
