### PR TITLE
Use proper value for shutdown hooks of managed shards

### DIFF
--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -488,7 +488,7 @@ public class DefaultShardManager implements ShardManager
     protected JDAImpl buildInstance(final int shardId) throws LoginException, RateLimitedException
     {
         final JDAImpl jda = new JDAImpl(AccountType.BOT, this.token, this.httpClientBuilder, this.wsFactory, this.shardedRateLimiter,
-            this.autoReconnect, this.enableVoice, this.enableBulkDeleteSplitting, this.enableBulkDeleteSplitting, retryOnTimeout,
+            this.autoReconnect, this.enableVoice, false, this.enableBulkDeleteSplitting, retryOnTimeout,
             this.corePoolSize, this.maxReconnectDelay);
 
         jda.asBot().setShardManager(this);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Template

### Pull Request

There's a bug here where the DefaultShardManager is erroneously passing the `enableBulkDeleteSplitting` field as a parameter for enabling shutdown hooks. Instead the value should always be false, since the DefaultShardManager manages the shutdown hook itself.