### PR TITLE
Hotfix deadlock in audio connections

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/core/audio/AudioWebSocket.java
@@ -58,7 +58,6 @@ public class AudioWebSocket extends WebSocketAdapter
     private final String token;
     private boolean connected = false;
     private boolean ready = false;
-    private boolean shutdown = false;
     private boolean reconnecting = false;
     private Future<?> keepAliveHandle;
     private String wssEndpoint;
@@ -68,6 +67,8 @@ public class AudioWebSocket extends WebSocketAdapter
     private byte[] secretKey;
     private DatagramSocket udpSocket;
     private InetSocketAddress address;
+
+    private volatile boolean shutdown = false;
 
     public WebSocket socket;
 
@@ -385,37 +386,49 @@ public class AudioWebSocket extends WebSocketAdapter
         }
     }
 
-    public synchronized void reconnect(ConnectionStatus closeStatus)
+    private void locked(Runnable runnable)
+    {
+        AudioManagerImpl manager = (AudioManagerImpl) guild.getAudioManager();
+        synchronized (manager.CONNECTION_LOCK)
+        {
+            runnable.run();
+        }
+    }
+
+    public void reconnect(ConnectionStatus closeStatus)
     {
         if (shutdown)
             return;
-        connected = false;
-        ready = false;
-        reconnecting = true;
-        changeStatus(closeStatus);
-        startConnection();
+        locked(() ->
+        {
+            connected = false;
+            ready = false;
+            reconnecting = true;
+            changeStatus(closeStatus);
+            startConnection();
+        });
     }
 
-    public synchronized void close(ConnectionStatus closeStatus)
+    public void close(final ConnectionStatus closeStatus)
     {
         //Makes sure we don't run this method again after the socket.close(1000) call fires onDisconnect
         if (shutdown)
             return;
-        connected = false;
-        ready = false;
-        shutdown = true;
-        stopKeepAlive();
-
-        if (udpSocket != null)
-            udpSocket.close();
-        if (socket != null && socket.isOpen())
-            socket.sendClose(1000);
-
-        VoiceChannel disconnectedChannel;
         AudioManagerImpl manager = (AudioManagerImpl) guild.getAudioManager();
-
-        synchronized (manager.CONNECTION_LOCK)
+        locked(() ->
         {
+            ConnectionStatus status = closeStatus;
+            connected = false;
+            ready = false;
+            shutdown = true;
+            stopKeepAlive();
+
+            if (udpSocket != null)
+                udpSocket.close();
+            if (socket != null && socket.isOpen())
+                socket.sendClose(1000);
+
+            VoiceChannel disconnectedChannel;
             if (audioConnection != null)
                 audioConnection.shutdown();
 
@@ -425,37 +438,37 @@ public class AudioWebSocket extends WebSocketAdapter
                 disconnectedChannel = manager.getQueuedAudioConnection();
 
             manager.setAudioConnection(null);
-        }
 
-        //Verify that it is actually a lost of connection and not due the connected channel being deleted.
-        if (closeStatus == ConnectionStatus.ERROR_LOST_CONNECTION)
-        {
-            //Get guild from JDA, don't use [guild] field to make sure that we don't have
-            // a problem of an out of date guild stored in [guild] during a possible mWS invalidate.
-            Guild connGuild = api.getGuildById(guild.getIdLong());
-            if (connGuild != null)
+            //Verify that it is actually a lost of connection and not due the connected channel being deleted.
+            if (status == ConnectionStatus.ERROR_LOST_CONNECTION)
             {
-                if (connGuild.getVoiceChannelById(audioConnection.getChannel().getIdLong()) == null)
-                    closeStatus = ConnectionStatus.DISCONNECTED_CHANNEL_DELETED;
+                //Get guild from JDA, don't use [guild] field to make sure that we don't have
+                // a problem of an out of date guild stored in [guild] during a possible mWS invalidate.
+                Guild connGuild = api.getGuildById(guild.getIdLong());
+                if (connGuild != null)
+                {
+                    if (connGuild.getVoiceChannelById(audioConnection.getChannel().getIdLong()) == null)
+                        status = ConnectionStatus.DISCONNECTED_CHANNEL_DELETED;
+                }
             }
-        }
 
-        changeStatus(closeStatus);
+            changeStatus(status);
 
-        //decide if we reconnect.
-        if (shouldReconnect
-                && closeStatus != ConnectionStatus.NOT_CONNECTED    //indicated that the connection was purposely closed. don't reconnect.
-                && closeStatus != ConnectionStatus.DISCONNECTED_CHANNEL_DELETED
-                && closeStatus != ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD
-                && closeStatus != ConnectionStatus.AUDIO_REGION_CHANGE) //Already handled.
-        {
-            manager.setQueuedAudioConnection(disconnectedChannel);
-            api.getClient().queueAudioReconnect(disconnectedChannel);
-        }
-        else if (closeStatus != ConnectionStatus.AUDIO_REGION_CHANGE)
-        {
-            api.getClient().queueAudioDisconnect(guild);
-        }
+            //decide if we reconnect.
+            if (shouldReconnect
+                && status != ConnectionStatus.NOT_CONNECTED    //indicated that the connection was purposely closed. don't reconnect.
+                && status != ConnectionStatus.DISCONNECTED_CHANNEL_DELETED
+                && status != ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD
+                && status != ConnectionStatus.AUDIO_REGION_CHANGE) //Already handled.
+            {
+                manager.setQueuedAudioConnection(disconnectedChannel);
+                api.getClient().queueAudioReconnect(disconnectedChannel);
+            }
+            else if (status != ConnectionStatus.AUDIO_REGION_CHANGE)
+            {
+                api.getClient().queueAudioDisconnect(guild);
+            }
+        });
     }
 
     public DatagramSocket getUdpSocket()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

This is a rare race-condition that could cause deadlocks.

1. AudioConnection ReadyThread calls AudioWebSocket#close
2. AudioManager#closeAudioConnection calls AudioConnection#close
3. AudioWebSocket waits to acquire AudioManager.CONNECTION_LOCK (held by AudioManager)
4. AudioManager waits to acquire AudioWebSocket method lock (held by AudioConnection ReadyThread)
5. Deadlock due to 2 locks waiting to acquire each other

By removing the AudioWebSocket method lock this should resolve itself.

```
"Thread-22390":
  waiting to lock monitor 0x00007f0b789c0fb8 (object 0x00000007599e8478, a net.dv8tion.jda.core.audio.AudioWebSocket),
  which is held by "JDA [4 / 33] AudioConnection Guild: 357081445178802177 Ready Thread"
"JDA [4 / 33] AudioConnection Guild: 357081445178802177 Ready Thread":
  waiting to lock monitor 0x00007f0bc40b3018 (object 0x00000006699579f8, a java.lang.Object),
  which is held by "Thread-22390"

"Thread-22390":
    at net.dv8tion.jda.core.audio.AudioWebSocket.close(AudioWebSocket.java:400)
    - waiting to lock <0x00000007599e8478> (a net.dv8tion.jda.core.audio.AudioWebSocket)
    at net.dv8tion.jda.core.audio.AudioConnection.close(AudioConnection.java:230)
    at net.dv8tion.jda.core.managers.impl.AudioManagerImpl.closeAudioConnection(AudioManagerImpl.java:139)
    - locked <0x00000006699579f8> (a java.lang.Object)
    at net.dv8tion.jda.core.managers.impl.AudioManagerImpl.closeAudioConnection(AudioManagerImpl.java:130)
    at xyz.astolfo.music.impl.SessionImpl$disconnect$1.run(SessionImpl.kt:79)
    at java.lang.Thread.run(Thread.java:748)
"JDA [4 / 33] AudioConnection Guild: 357081445178802177 Ready Thread":
    at net.dv8tion.jda.core.audio.AudioWebSocket.close(AudioWebSocket.java:415)
    - waiting to lock <0x00000006699579f8> (a java.lang.Object)
    - locked <0x00000007599e8478> (a net.dv8tion.jda.core.audio.AudioWebSocket)
    at net.dv8tion.jda.core.audio.AudioConnection.lambda$ready$0(AudioConnection.java:135)
    at net.dv8tion.jda.core.audio.AudioConnection$$Lambda$168/402978473.run(Unknown Source)
    at java.lang.Thread.run(Thread.java:748)
```
