### PR TITLE
Add sharded listener provider

### DIFF
--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -40,7 +40,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.IntFunction;
 
 /**
@@ -107,7 +106,7 @@ public class DefaultShardManager implements ShardManager
     /**
      * The sharded event listener providers for new and restarted JDA instances.
      */
-    protected final List<Function<Integer, Object>> shardedListenerProviders;
+    protected final List<IntFunction<Object>> shardedListenerProviders;
 
     /**
      * The maximum amount of time that JDA will back off to wait when attempting to reconnect the MainWebsocket.
@@ -266,7 +265,7 @@ public class DefaultShardManager implements ShardManager
      */
     protected DefaultShardManager(final int shardsTotal, final Collection<Integer> shardIds,
                                   final SessionController controller, final List<Object> listeners,
-                                  final List<Function<Integer, Object>> shardedListenerProviders,
+                                  final List<IntFunction<Object>> shardedListenerProviders,
                                   final String token, final IEventManager eventManager, final IAudioSendFactory audioSendFactory,
                                   final IntFunction<Game> gameProvider, final IntFunction<OnlineStatus> statusProvider,
                                   final OkHttpClient.Builder httpClientBuilder, final WebSocketFactory wsFactory,
@@ -338,7 +337,7 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void addShardedEventListeners(Function<Integer, Object> shardedEventListenerProvider) {
+    public void addShardedEventListeners(IntFunction<Object> shardedEventListenerProvider) {
         ShardManager.super.addShardedEventListeners(shardedEventListenerProvider);
         this.shardedListenerProviders.add(shardedEventListenerProvider);
     }

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -104,9 +104,9 @@ public class DefaultShardManager implements ShardManager
     protected final List<Object> listeners;
 
     /**
-     * The sharded event listener providers for new and restarted JDA instances.
+     * The event listener providers for new and restarted JDA instances.
      */
-    protected final List<IntFunction<Object>> shardedListenerProviders;
+    protected final List<IntFunction<Object>> listenerProviders;
 
     /**
      * The maximum amount of time that JDA will back off to wait when attempting to reconnect the MainWebsocket.
@@ -218,8 +218,8 @@ public class DefaultShardManager implements ShardManager
      *         The {@link net.dv8tion.jda.core.utils.SessionController SessionController}
      * @param  listeners
      *         The event listeners for new JDA instances.
-     * @param  shardedListenerProviders
-     *         Providers of sharded event listeners for JDA instances. Each will have the shard id applied to them upon
+     * @param  listenerProviders
+     *         Providers of event listeners for JDA instances. Each will have the shard id applied to them upon
      *         shard creation (including shard restarts) and must return an event listener
      * @param  token
      *         The token
@@ -265,7 +265,7 @@ public class DefaultShardManager implements ShardManager
      */
     protected DefaultShardManager(final int shardsTotal, final Collection<Integer> shardIds,
                                   final SessionController controller, final List<Object> listeners,
-                                  final List<IntFunction<Object>> shardedListenerProviders,
+                                  final List<IntFunction<Object>> listenerProviders,
                                   final String token, final IEventManager eventManager, final IAudioSendFactory audioSendFactory,
                                   final IntFunction<Game> gameProvider, final IntFunction<OnlineStatus> statusProvider,
                                   final OkHttpClient.Builder httpClientBuilder, final WebSocketFactory wsFactory,
@@ -278,7 +278,7 @@ public class DefaultShardManager implements ShardManager
     {
         this.shardsTotal = shardsTotal;
         this.listeners = listeners;
-        this.shardedListenerProviders = shardedListenerProviders;
+        this.listenerProviders = listenerProviders;
         this.token = token;
         this.eventManager = eventManager;
         this.audioSendFactory = audioSendFactory;
@@ -337,9 +337,9 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void addShardedEventListeners(IntFunction<Object> shardedEventListenerProvider) {
-        ShardManager.super.addShardedEventListeners(shardedEventListenerProvider);
-        this.shardedListenerProviders.add(shardedEventListenerProvider);
+    public void addEventListeners(IntFunction<Object> eventListenerProvider) {
+        ShardManager.super.addEventListeners(eventListenerProvider);
+        this.listenerProviders.add(eventListenerProvider);
     }
 
     @Override
@@ -579,7 +579,7 @@ public class DefaultShardManager implements ShardManager
             jda.setAudioSendFactory(this.audioSendFactory);
 
         this.listeners.forEach(jda::addEventListener);
-        this.shardedListenerProviders.forEach(provider -> jda.addEventListener(provider.apply(shardId)));
+        this.listenerProviders.forEach(provider -> jda.addEventListener(provider.apply(shardId)));
         jda.setStatus(JDA.Status.INITIALIZED); //This is already set by JDA internally, but this is to make sure the listeners catch it.
 
         // Set the presence information before connecting to have the correct information ready when sending IDENTIFY

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -337,13 +337,15 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void addEventListeners(IntFunction<Object> eventListenerProvider) {
+    public void addEventListeners(IntFunction<Object> eventListenerProvider)
+    {
         ShardManager.super.addEventListeners(eventListenerProvider);
         this.listenerProviders.add(eventListenerProvider);
     }
 
     @Override
-    public void removeEventListenerProvider(IntFunction<Object> eventListenerProvider) {
+    public void removeEventListenerProvider(IntFunction<Object> eventListenerProvider)
+    {
         this.listenerProviders.remove(eventListenerProvider);
     }
 

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -343,6 +343,11 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
+    public void removeEventListenersProvider(IntFunction<Object> eventListenerProvider) {
+        this.listenerProviders.remove(eventListenerProvider);
+    }
+
+    @Override
     public int getShardsQueued()
     {
         return this.queue.size();

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -343,7 +343,7 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void removeEventListenersProvider(IntFunction<Object> eventListenerProvider) {
+    public void removeEventListenerProvider(IntFunction<Object> eventListenerProvider) {
         this.listenerProviders.remove(eventListenerProvider);
     }
 

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 public class DefaultShardManagerBuilder
 {
     protected final List<Object> listeners = new ArrayList<>();
-    protected final List<IntFunction<Object>> shardedListenerProviders = new ArrayList<>();
+    protected final List<IntFunction<Object>> listenerProviders = new ArrayList<>();
     protected SessionController sessionController = null;
     protected IntFunction<ConcurrentMap<String, String>> contextProvider = null;
     protected boolean enableContext = true;
@@ -223,7 +223,7 @@ public class DefaultShardManagerBuilder
     }
 
     /**
-     * Adds the provided listener provider to the list of listener providers that will be used to create sharded listeners.
+     * Adds the provided listener provider to the list of listener providers that will be used to create listeners.
      * On shard creation (including shard restarts) the provider will have the shard id applied and must return a listener,
      * which will be used, along all other listeners, to populate the listeners of the JDA object of that shard.
      *
@@ -234,18 +234,18 @@ public class DefaultShardManagerBuilder
      * <p><b>Note:</b> When using the {@link net.dv8tion.jda.core.hooks.InterfacedEventManager InterfacedEventListener} (default),
      * given listener(s) <b>must</b> be instance of {@link net.dv8tion.jda.core.hooks.EventListener EventListener}!
      *
-     * @param  shardedListenerProvider
-     *         The listener provider to add to the list of sharded listener providers.
+     * @param  listenerProvider
+     *         The listener provider to add to the list of listener providers.
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder addShardedEventListenerProvider(final IntFunction<Object> shardedListenerProvider)
+    public DefaultShardManagerBuilder addEventListenerProvider(final IntFunction<Object> listenerProvider)
     {
-        return this.addShardedEventListenerProviders(Collections.singleton(shardedListenerProvider));
+        return this.addEventListenerProviders(Collections.singleton(listenerProvider));
     }
 
     /**
-     * Adds the provided listener providers to the list of listener providers that will be used to create sharded listeners.
+     * Adds the provided listener providers to the list of listener providers that will be used to create listeners.
      * On shard creation (including shard restarts) each provider will have the shard id applied and must return a listener,
      * which will be used, along all other listeners, to populate the listeners of the JDA object of that shard.
      *
@@ -256,45 +256,45 @@ public class DefaultShardManagerBuilder
      * <p><b>Note:</b> When using the {@link net.dv8tion.jda.core.hooks.InterfacedEventManager InterfacedEventListener} (default),
      * given listener(s) <b>must</b> be instance of {@link net.dv8tion.jda.core.hooks.EventListener EventListener}!
      *
-     * @param  shardedListenerProviders
-     *         The listener provider to add to the list of sharded listener providers.
+     * @param  listenerProviders
+     *         The listener provider to add to the list of listener providers.
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder addShardedEventListenerProviders(final Collection<IntFunction<Object>> shardedListenerProviders)
+    public DefaultShardManagerBuilder addEventListenerProviders(final Collection<IntFunction<Object>> listenerProviders)
     {
-        Checks.noneNull(shardedListenerProviders, "sharded listener providers");
+        Checks.noneNull(listenerProviders, "listener providers");
 
-        this.shardedListenerProviders.addAll(shardedListenerProviders);
+        this.listenerProviders.addAll(listenerProviders);
         return this;
     }
 
     /**
-     * Removes the provided listener provider from the list of sharded listener providers.
+     * Removes the provided listener provider from the list of listener providers.
      *
-     * @param  shardedListenerProvider
-     *         The listener provider to remove from the list of sharded listener providers.
+     * @param  listenerProvider
+     *         The listener provider to remove from the list of listener providers.
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder removeShardedEventListenerProvider(final IntFunction<Object> shardedListenerProvider)
+    public DefaultShardManagerBuilder removeEventListenerProvider(final IntFunction<Object> listenerProvider)
     {
-        return this.removeEventListeners(Collections.singleton(shardedListenerProvider));
+        return this.removeEventListeners(Collections.singleton(listenerProvider));
     }
 
     /**
-     * Removes all provided listener providers from the list of sharded listener providers.
+     * Removes all provided listener providers from the list of listener providers.
      *
-     * @param  shardedListenerProviders
-     *         The listener provider(s) to remove from the list of sharded listener providers.
+     * @param  listenerProviders
+     *         The listener provider(s) to remove from the list of listener providers.
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder removeShardedEventListenerProviders(final Collection<IntFunction<Object>> shardedListenerProviders)
+    public DefaultShardManagerBuilder removeEventListenerProviders(final Collection<IntFunction<Object>> listenerProviders)
     {
-        Checks.noneNull(shardedListenerProviders, "sharded listener providers");
+        Checks.noneNull(listenerProviders, "listener providers");
 
-        this.shardedListenerProviders.removeAll(shardedListenerProviders);
+        this.listenerProviders.removeAll(listenerProviders);
         return this;
     }
 
@@ -839,7 +839,7 @@ public class DefaultShardManagerBuilder
     {
         final DefaultShardManager manager = new DefaultShardManager(
             this.shardsTotal, this.shards, this.sessionController,
-            this.listeners, this.shardedListenerProviders, this.token, this.eventManager,
+            this.listeners, this.listenerProviders, this.token, this.eventManager,
             this.audioSendFactory, this.gameProvider, this.statusProvider,
             this.httpClientBuilder, this.wsFactory, this.threadFactory, this.shardedRateLimiter,
             this.maxReconnectDelay, this.corePoolSize, this.enableVoice, this.enableShutdownHook, this.enableBulkDeleteSplitting,

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
@@ -279,7 +279,7 @@ public class DefaultShardManagerBuilder
      */
     public DefaultShardManagerBuilder removeEventListenerProvider(final IntFunction<Object> listenerProvider)
     {
-        return this.removeEventListeners(Collections.singleton(listenerProvider));
+        return this.removeEventListenerProviders(Collections.singleton(listenerProvider));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
@@ -25,7 +25,6 @@ import net.dv8tion.jda.core.utils.Checks;
 import net.dv8tion.jda.core.utils.SessionController;
 import okhttp3.OkHttpClient;
 
-import javax.annotation.Nonnull;
 import javax.security.auth.login.LoginException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadFactory;
-import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
@@ -50,7 +48,7 @@ import java.util.stream.Collectors;
 public class DefaultShardManagerBuilder
 {
     protected final List<Object> listeners = new ArrayList<>();
-    protected final List<Function<Integer, Object>> shardedListenerProviders = new ArrayList<>();
+    protected final List<IntFunction<Object>> shardedListenerProviders = new ArrayList<>();
     protected SessionController sessionController = null;
     protected IntFunction<ConcurrentMap<String, String>> contextProvider = null;
     protected boolean enableContext = true;
@@ -241,7 +239,7 @@ public class DefaultShardManagerBuilder
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder addShardedEventListenerProvider(final Function<Integer, Object> shardedListenerProvider)
+    public DefaultShardManagerBuilder addShardedEventListenerProvider(final IntFunction<Object> shardedListenerProvider)
     {
         return this.addShardedEventListenerProviders(Collections.singleton(shardedListenerProvider));
     }
@@ -263,7 +261,7 @@ public class DefaultShardManagerBuilder
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder addShardedEventListenerProviders(final Collection<Function<Integer, Object>> shardedListenerProviders)
+    public DefaultShardManagerBuilder addShardedEventListenerProviders(final Collection<IntFunction<Object>> shardedListenerProviders)
     {
         Checks.noneNull(shardedListenerProviders, "sharded listener providers");
 
@@ -279,7 +277,7 @@ public class DefaultShardManagerBuilder
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder removeShardedEventListenerProvider(final Function<Integer, Object> shardedListenerProvider)
+    public DefaultShardManagerBuilder removeShardedEventListenerProvider(final IntFunction<Object> shardedListenerProvider)
     {
         return this.removeEventListeners(Collections.singleton(shardedListenerProvider));
     }
@@ -292,7 +290,7 @@ public class DefaultShardManagerBuilder
      *
      * @return The {@link net.dv8tion.jda.bot.sharding.DefaultShardManagerBuilder DefaultShardManagerBuilder} instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder removeShardedEventListenerProviders(final Collection<Function<Integer, Object>> shardedListenerProviders)
+    public DefaultShardManagerBuilder removeShardedEventListenerProviders(final Collection<IntFunction<Object>> shardedListenerProviders)
     {
         Checks.noneNull(shardedListenerProviders, "sharded listener providers");
 

--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -125,13 +125,18 @@ public interface ShardManager
      * Remove a listener provider. This will stop further created / restarted shards from getting a listener added by
      * that provider.
      *
+     * Default is a no-op for backwards compatibility, see implementations like
+     * {@link DefaultShardManager#removeEventListenerProvider(IntFunction)} for actual code
+     *
      * @param  eventListenerProvider
      *         The provider of listeners that shall be removed.
      *
      * @throws java.lang.IllegalArgumentException
      *         If the provided listener provider is {@code null}.
      */
-    void removeEventListenerProvider(IntFunction<Object> eventListenerProvider);
+    default void removeEventListenerProvider(IntFunction<Object> eventListenerProvider)
+    {
+    }
 
     /**
      * Returns the amount of shards queued for (re)connecting.

--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -83,20 +83,20 @@ public interface ShardManager
      * <p>Note: when using the {@link net.dv8tion.jda.core.hooks.InterfacedEventManager InterfacedEventListener} (default),
      * given listener <b>must</b> be instance of {@link net.dv8tion.jda.core.hooks.EventListener EventListener}!
      *
-     * @param  shardedEventListenerProvider
+     * @param  eventListenerProvider
      *         The provider of listener(s) which will react to events.
      *
      * @throws java.lang.IllegalArgumentException
      *         If the provided listener provider {@code null}.
      */
-    default void addShardedEventListeners(final IntFunction<Object> shardedEventListenerProvider)
+    default void addEventListeners(final IntFunction<Object> eventListenerProvider)
     {
-        Checks.notNull(shardedEventListenerProvider, "sharded event listener provider");
+        Checks.notNull(eventListenerProvider, "event listener provider");
         this.getShardCache().forEach(jda ->
         {
-            Object shardedListener = shardedEventListenerProvider.apply(jda.getShardInfo().getShardId());
-            Checks.notNull(shardedListener, "sharded listener");
-            jda.addEventListener(shardedListener);
+            Object listener = eventListenerProvider.apply(jda.getShardInfo().getShardId());
+            Checks.notNull(listener, "listener");
+            jda.addEventListener(listener);
         });
     }
 

--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -77,6 +77,30 @@ public interface ShardManager
     }
 
     /**
+     * Adds listeners provided by the listener provider to each shard to the event-listeners that will be used to handle events.
+     * The listener provider gets a shard id applied and is expected to return a listener.
+     *
+     * <p>Note: when using the {@link net.dv8tion.jda.core.hooks.InterfacedEventManager InterfacedEventListener} (default),
+     * given listener <b>must</b> be instance of {@link net.dv8tion.jda.core.hooks.EventListener EventListener}!
+     *
+     * @param  shardedEventListenerProvider
+     *         The provider of listener(s) which will react to events.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided listener provider {@code null}.
+     */
+    default void addShardedEventListeners(final Function<Integer, Object> shardedEventListenerProvider)
+    {
+        Checks.notNull(shardedEventListenerProvider, "sharded event listener provider");
+        this.getShardCache().forEach(jda ->
+        {
+            Object shardedListener = shardedEventListenerProvider.apply(jda.getShardInfo().getShardId());
+            Checks.notNull(shardedListener, "sharded listener");
+            jda.addEventListener(shardedListener);
+        });
+    }
+
+    /**
      * Returns the amount of shards queued for (re)connecting.
      *
      * @return The amount of shards queued for (re)connecting.

--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -89,7 +89,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If the provided listener provider {@code null}.
      */
-    default void addShardedEventListeners(final Function<Integer, Object> shardedEventListenerProvider)
+    default void addShardedEventListeners(final IntFunction<Object> shardedEventListenerProvider)
     {
         Checks.notNull(shardedEventListenerProvider, "sharded event listener provider");
         this.getShardCache().forEach(jda ->

--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -106,18 +106,18 @@ public interface ShardManager
      * The provider takes shard ids, and returns a collection of listeners that shall be removed from the respective
      * shards.
      *
-     * @param eventListenersProvider
+     * @param eventListenerProvider
      *        gets shard ids applied and is expected to return a collection of listeners that shall be removed from
      *        the respective shards
      *
      * @throws java.lang.IllegalArgumentException
      *         If the provided event listeners provider is {@code null}.
      */
-    default void removeEventListeners(final IntFunction<Collection<Object>> eventListenersProvider)
+    default void removeEventListeners(final IntFunction<Collection<Object>> eventListenerProvider)
     {
-        Checks.notNull(eventListenersProvider, "event listeners provider");
+        Checks.notNull(eventListenerProvider, "event listener provider");
         this.getShardCache().forEach(jda ->
-            jda.removeEventListener(eventListenersProvider.apply(jda.getShardInfo().getShardId()))
+            jda.removeEventListener(eventListenerProvider.apply(jda.getShardInfo().getShardId()))
         );
     }
 
@@ -131,7 +131,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If the provided listener provider is {@code null}.
      */
-    void removeEventListenersProvider(IntFunction<Object> eventListenerProvider);
+    void removeEventListenerProvider(IntFunction<Object> eventListenerProvider);
 
     /**
      * Returns the amount of shards queued for (re)connecting.

--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -18,7 +18,6 @@ package net.dv8tion.jda.bot.sharding;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
 import net.dv8tion.jda.bot.entities.ApplicationInfo;
@@ -96,8 +95,7 @@ public interface ShardManager
         this.getShardCache().forEach(jda ->
         {
             Object listener = eventListenerProvider.apply(jda.getShardInfo().getShardId());
-            Checks.notNull(listener, "listener");
-            jda.addEventListener(listener);
+            if (listener != null) jda.addEventListener(listener);
         });
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing] a long time ago lol.

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

This PR adds a feature to the DefaultShardManager.
This will allow the ShardManager and ShardManagerBuilder to be provided with a function which provides listeners based on shard id.
This is helpful when the user wishes for an approach where each shard gets it's own listener object of a certain kind, instead of having a single central listener object of a certain kind for all shards.

### ToDos
- [x] Figure out removal of listener provider _including_ any potentially created listeners with it from built shard manager.

Input is welcome on how to write a convenience method on how to handle removing existing listeners created by a provider when the provider is removed from a shard manager.
  