### PR TITLE
Replaced Semaphore with (superior) ReentrantLock

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -53,7 +53,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterOutputStream;
@@ -87,7 +87,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     //GuildId, <TimeOfNextAttempt, ConnectionStage, AudioConnection>
     protected final TLongObjectMap<ConnectionRequest> queuedAudioConnections = MiscUtil.newLongMap();
-    protected final Semaphore audioQueueLock = new Semaphore(1, true);
+    protected final ReentrantLock audioQueueLock = new ReentrantLock();
 
     protected final LinkedList<String> chunkSyncQueue = new LinkedList<>();
     protected final LinkedList<String> ratelimitQueue = new LinkedList<>();
@@ -266,7 +266,6 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 MDC.setContextMap(api.getContextMap());
             boolean needRatelimit;
             boolean attemptedToSend;
-            boolean queueLocked = false;
             while (!Thread.currentThread().isInterrupted())
             {
                 try
@@ -279,17 +278,16 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                     }
                     attemptedToSend = false;
                     needRatelimit = false;
-                    audioQueueLock.acquire();
-                    queueLocked = true;
+                    audioQueueLock.lockInterruptibly();
 
                     ConnectionRequest audioRequest = getNextAudioConnectRequest();
-
                     String chunkOrSyncRequest = chunkSyncQueue.peekFirst();
+
+                    //if lock isn't needed we already unlock here
+                    if (audioRequest == null || chunkOrSyncRequest != null)
+                        maybeUnlock();
                     if (chunkOrSyncRequest != null)
                     {
-                        audioQueueLock.release();
-                        queueLocked = false;
-
                         needRatelimit = !send(chunkOrSyncRequest, false);
                         if (!needRatelimit)
                             chunkSyncQueue.removeFirst();
@@ -305,8 +303,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                             // race condition on guild delete, avoid NPE on DISCONNECT requests
                             queuedAudioConnections.remove(audioRequest.getGuildIdLong());
 
-                            audioQueueLock.release();
-                            queueLocked = false;
+                            maybeUnlock();
                             continue;
                         }
                         ConnectionStage stage = audioRequest.getStage();
@@ -335,15 +332,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                             final GuildVoiceState voiceState = guild.getSelfMember().getVoiceState();
                             updateAudioConnection0(guild.getIdLong(), voiceState.getChannel());
                         }
-                        audioQueueLock.release();
-                        queueLocked = false;
+                        maybeUnlock();
                         attemptedToSend = true;
                     }
                     else
                     {
-                        audioQueueLock.release();
-                        queueLocked = false;
-
                         String message = ratelimitQueue.peekFirst();
                         if (message != null)
                         {
@@ -364,9 +357,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 }
                 finally
                 {
-                    // on any exception that might cause this semaphore to not release
-                    if (queueLocked)
-                        audioQueueLock.release();
+                    // on any exception that might cause this lock to not release
+                    maybeUnlock();
                 }
             }
         });
@@ -1146,11 +1138,17 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         chunkingAndSyncing = active;
     }
 
+    private void maybeUnlock()
+    {
+        if (audioQueueLock.isHeldByCurrentThread())
+            audioQueueLock.unlock();
+    }
+
     public void queueAudioReconnect(VoiceChannel channel)
     {
         try
         {
-            audioQueueLock.acquire();
+            audioQueueLock.lockInterruptibly();
             final long guildId = channel.getGuild().getIdLong();
             ConnectionRequest request = queuedAudioConnections.get(guildId);
 
@@ -1174,7 +1172,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         finally
         {
-            audioQueueLock.release();
+            maybeUnlock();
         }
     }
 
@@ -1182,7 +1180,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     {
         try
         {
-            audioQueueLock.acquire();
+            audioQueueLock.lockInterruptibly();
             final long guildId = channel.getGuild().getIdLong();
             ConnectionRequest request = queuedAudioConnections.get(guildId);
 
@@ -1207,7 +1205,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         finally
         {
-            audioQueueLock.release();
+            maybeUnlock();
         }
     }
 
@@ -1215,7 +1213,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     {
         try
         {
-            audioQueueLock.acquire();
+            audioQueueLock.lockInterruptibly();
             final long guildId = guild.getIdLong();
             ConnectionRequest request = queuedAudioConnections.get(guildId);
 
@@ -1237,7 +1235,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         finally
         {
-            audioQueueLock.release();
+            maybeUnlock();
         }
     }
 
@@ -1248,7 +1246,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         //TODO: users may still queue new requests via the old AudioManager, how could we prevent this?
         try
         {
-            audioQueueLock.acquire();
+            audioQueueLock.lockInterruptibly();
             return queuedAudioConnections.remove(guildId);
         }
         catch (InterruptedException e)
@@ -1257,7 +1255,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         finally
         {
-            audioQueueLock.release();
+            maybeUnlock();
         }
         return null;
     }
@@ -1266,7 +1264,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     {
         try
         {
-            audioQueueLock.acquire();
+            audioQueueLock.lockInterruptibly();
             return updateAudioConnection0(guildId, connectedChannel);
         }
         catch (InterruptedException e)
@@ -1275,7 +1273,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         finally
         {
-            audioQueueLock.release();
+            maybeUnlock();
         }
         return null;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

I feel like this lock fits better than a semaphore.
