### PR TITLE
Store color with raw RGB value

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -401,6 +401,8 @@ public class EmbedBuilder
      *         or {@code null} to use no color
      *
      * @return the builder after the color has been set
+     *
+     * @see    #setColor(int)
      */
     public EmbedBuilder setColor(Color color)
     {
@@ -408,6 +410,18 @@ public class EmbedBuilder
         return this;
     }
 
+    /**
+     * Sets the raw RGB color value for the embed.
+     *
+     * <a href="http://i.imgur.com/2YnxnRM.png" target="_blank">Example</a>
+     *
+     * @param  color
+     *         The raw rgb value, or {@link Role#DEFAULT_COLOR_RAW} to use no color
+     *
+     * @return the builder after the color has been set
+     *
+     * @see    #setColor(java.awt.Color)
+     */
     public EmbedBuilder setColor(int color)
     {
         this.color = color;

--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.core;
 import net.dv8tion.jda.core.entities.EmbedType;
 import net.dv8tion.jda.core.entities.EntityBuilder;
 import net.dv8tion.jda.core.entities.MessageEmbed;
+import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.utils.Checks;
 import net.dv8tion.jda.core.utils.Helpers;
 
@@ -43,9 +44,9 @@ public class EmbedBuilder
 
     private final List<MessageEmbed.Field> fields = new LinkedList<>();
     private final StringBuilder description = new StringBuilder();
+    private int color = Role.DEFAULT_COLOR_RAW;
     private String url, title;
     private OffsetDateTime timestamp;
-    private Color color;
     private MessageEmbed.Thumbnail thumbnail;
     private MessageEmbed.AuthorInfo author;
     private MessageEmbed.Footer footer;
@@ -88,7 +89,7 @@ public class EmbedBuilder
             this.url = embed.getUrl();
             this.title = embed.getTitle();
             this.timestamp = embed.getTimestamp();
-            this.color = embed.getColor();
+            this.color = embed.getColorRaw();
             this.thumbnail = embed.getThumbnail();
             this.author = embed.getAuthor();
             this.footer = embed.getFooter();
@@ -132,7 +133,7 @@ public class EmbedBuilder
         url = null;
         title = null;
         timestamp = null;
-        color = null;
+        color = Role.DEFAULT_COLOR_RAW;
         thumbnail = null;
         author = null;
         footer = null;
@@ -402,6 +403,12 @@ public class EmbedBuilder
      * @return the builder after the color has been set
      */
     public EmbedBuilder setColor(Color color)
+    {
+        this.color = color == null ? Role.DEFAULT_COLOR_RAW : color.getRGB();
+        return this;
+    }
+
+    public EmbedBuilder setColor(int color)
     {
         this.color = color;
         return this;

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -42,7 +42,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 
-import java.awt.Color;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -830,12 +829,13 @@ public class EntityBuilder
             role = new RoleImpl(id, guild);
             guild.getRolesMap().put(id, role);
         }
+        final int color = roleJson.getInt("color");
         return role.setName(roleJson.getString("name"))
                 .setRawPosition(roleJson.getInt("position"))
                 .setRawPermissions(roleJson.getLong("permissions"))
                 .setManaged(roleJson.getBoolean("managed"))
                 .setHoisted(roleJson.getBoolean("hoist"))
-                .setColor(roleJson.getInt("color") != 0 ? new Color(roleJson.getInt("color")) : null)
+                .setColor(color == 0 ? Role.DEFAULT_COLOR_RAW : color)
                 .setMentionable(roleJson.has("mentionable") && roleJson.getBoolean("mentionable"));
     }
 
@@ -985,7 +985,7 @@ public class EntityBuilder
         final String title = content.optString("title", null);
         final String description = content.optString("description", null);
         final OffsetDateTime timestamp = content.isNull("timestamp") ? null : OffsetDateTime.parse(content.getString("timestamp"));
-        final Color color = content.isNull("color") ? null : new Color(content.getInt("color"));
+        final int color = content.isNull("color") ? Role.DEFAULT_COLOR_RAW : content.getInt("color");
 
         final Thumbnail thumbnail;
         if (content.isNull("thumbnail"))
@@ -1079,7 +1079,7 @@ public class EntityBuilder
     }
 
     public static MessageEmbed createMessageEmbed(String url, String title, String description, EmbedType type, OffsetDateTime timestamp,
-                                           Color color, Thumbnail thumbnail, Provider siteProvider, AuthorInfo author,
+                                           int color, Thumbnail thumbnail, Provider siteProvider, AuthorInfo author,
                                            VideoInfo videoInfo, Footer footer, ImageInfo image, List<Field> fields)
     {
         return new MessageEmbed(url, title, description, type, timestamp,

--- a/src/main/java/net/dv8tion/jda/core/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Member.java
@@ -126,8 +126,19 @@ public interface Member extends IMentionable, IPermissionHolder
      * <br>If all roles have default color, this returns null.
      *
      * @return The display Color for this Member.
+     *
+     * @see    #getColorRaw()
      */
     Color getColor();
+
+    /**
+     * The raw RGB value for the color of this member.
+     * <br>Defaulting to {@link net.dv8tion.jda.core.entities.Role#DEFAULT_COLOR_RAW Role.DEFAULT_COLOR_RAW}
+     * if this member uses the default color (special property, it changes depending on theme used in the client)
+     *
+     * @return The raw RGB value or the role default
+     */
+    int getColorRaw();
 
     /**
      * The Permissions this Member holds in the specified {@link net.dv8tion.jda.core.entities.Channel Channel}.

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageEmbed.java
@@ -98,7 +98,7 @@ public class MessageEmbed
     protected final String description;
     protected final EmbedType type;
     protected final OffsetDateTime timestamp;
-    protected final Color color;
+    protected final int color;
     protected final Thumbnail thumbnail;
     protected final Provider siteProvider;
     protected final AuthorInfo author;
@@ -112,7 +112,7 @@ public class MessageEmbed
 
     protected MessageEmbed(
         String url, String title, String description, EmbedType type, OffsetDateTime timestamp,
-        Color color, Thumbnail thumbnail, Provider siteProvider, AuthorInfo author,
+        int color, Thumbnail thumbnail, Provider siteProvider, AuthorInfo author,
         VideoInfo videoInfo, Footer footer, ImageInfo image, List<Field> fields)
     {
         this.url = url;
@@ -270,6 +270,17 @@ public class MessageEmbed
      */
     public Color getColor()
     {
+        return color != Role.DEFAULT_COLOR_RAW ? new Color(color) : null;
+    }
+
+    /**
+     * The raw RGB color value for this embed
+     * <br>Defaults to {@link Role#DEFAULT_COLOR_RAW} if no color is set
+     *
+     * @return The raw RGB color value or default
+     */
+    public int getColorRaw()
+    {
         return color;
     }
     
@@ -415,8 +426,8 @@ public class MessageEmbed
                 obj.put("description", description);
             if (timestamp != null)
                 obj.put("timestamp", timestamp.format(DateTimeFormatter.ISO_INSTANT));
-            if (color != null)
-                obj.put("color", color.getRGB() & 0xFFFFFF);
+            if (color != Role.DEFAULT_COLOR_RAW)
+                obj.put("color", color & 0xFFFFFF);
             if (thumbnail != null)
                 obj.put("thumbnail", new JSONObject().put("url", thumbnail.getUrl()));
             if (siteProvider != null)

--- a/src/main/java/net/dv8tion/jda/core/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Role.java
@@ -29,6 +29,9 @@ import java.awt.Color;
  */
 public interface Role extends ISnowflake, IMentionable, IPermissionHolder, Comparable<Role>
 {
+    /** Used to keep consistency between color values used in the API */
+    int DEFAULT_COLOR_RAW = 0x1FFFFFFF; // java.awt.Color fills the MSB with FF, we just use 1F to provide better consistency
+
     /**
      * The hierarchical position of this {@link net.dv8tion.jda.core.entities.Role Role}
      * in the {@link net.dv8tion.jda.core.entities.Guild Guild} hierarchy. (higher value means higher role).
@@ -91,8 +94,18 @@ public interface Role extends ISnowflake, IMentionable, IPermissionHolder, Compa
      * The color this {@link net.dv8tion.jda.core.entities.Role Role} is displayed in.
      *
      * @return Color value of Role-color
+     *
+     * @see    #getColorRaw()
      */
     Color getColor();
+
+    /**
+     * The raw color RGB value used for this role
+     * <br>Defaults to {@link #DEFAULT_COLOR_RAW} if this role has no set color
+     *
+     * @return The raw RGB color value or default
+     */
+    int getColorRaw();
 
     /**
      * Whether this role is the @everyone role for its {@link net.dv8tion.jda.core.entities.Guild Guild},

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/MemberImpl.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.OnlineStatus;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.*;
-import net.dv8tion.jda.core.utils.PermissionUtil;
 import net.dv8tion.jda.core.utils.Checks;
+import net.dv8tion.jda.core.utils.PermissionUtil;
 
 import javax.annotation.Nullable;
 import java.awt.Color;
@@ -113,12 +113,20 @@ public class MemberImpl implements Member
     @Override
     public Color getColor()
     {
+        final int raw = getColorRaw();
+        return raw != Role.DEFAULT_COLOR_RAW ? new Color(raw) : null;
+    }
+
+    @Override
+    public int getColorRaw()
+    {
         for (Role r : getRoles())
         {
-            if (r.getColor() != null)
-                return r.getColor();
+            final int colorRaw = r.getColorRaw();
+            if (colorRaw != Role.DEFAULT_COLOR_RAW)
+                return colorRaw;
         }
-        return null;
+        return Role.DEFAULT_COLOR_RAW;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/RoleImpl.java
@@ -30,8 +30,8 @@ import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.Route;
 import net.dv8tion.jda.core.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.core.requests.restaction.RoleAction;
-import net.dv8tion.jda.core.utils.PermissionUtil;
 import net.dv8tion.jda.core.utils.Checks;
+import net.dv8tion.jda.core.utils.PermissionUtil;
 
 import java.awt.Color;
 import java.time.OffsetDateTime;
@@ -49,11 +49,11 @@ public class RoleImpl implements Role
     private volatile RoleManagerUpdatable managerUpdatable;
 
     private String name;
-    private Color color;
     private boolean managed;
     private boolean hoisted;
     private boolean mentionable;
     private long rawPermissions;
+    private int color;
     private int rawPosition;
 
     public RoleImpl(long id, Guild guild)
@@ -124,6 +124,12 @@ public class RoleImpl implements Role
 
     @Override
     public Color getColor()
+    {
+        return color != Role.DEFAULT_COLOR_RAW ? new Color(color) : null;
+    }
+
+    @Override
+    public int getColorRaw()
     {
         return color;
     }
@@ -324,7 +330,7 @@ public class RoleImpl implements Role
         return this;
     }
 
-    public RoleImpl setColor(Color color)
+    public RoleImpl setColor(int color)
     {
         this.color = color;
         return this;

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateColorEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateColorEvent.java
@@ -23,15 +23,20 @@ import java.awt.Color;
 
 public class RoleUpdateColorEvent extends GenericRoleUpdateEvent
 {
-    private final Color oldColor;
+    private final int oldColor;
 
-    public RoleUpdateColorEvent(JDA api, long responseNumber, Role role, Color oldColor)
+    public RoleUpdateColorEvent(JDA api, long responseNumber, Role role, int oldColor)
     {
         super(api, responseNumber, role);
         this.oldColor = oldColor;
     }
 
     public Color getOldColor()
+    {
+        return oldColor != 0 ? new Color(oldColor) : null;
+    }
+
+    public int getOldColorRaw()
     {
         return oldColor;
     }

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateColorEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateColorEvent.java
@@ -33,7 +33,7 @@ public class RoleUpdateColorEvent extends GenericRoleUpdateEvent
 
     public Color getOldColor()
     {
-        return oldColor != 0 ? new Color(oldColor) : null;
+        return oldColor != Role.DEFAULT_COLOR_RAW ? new Color(oldColor) : null;
     }
 
     public int getOldColorRaw()

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildRoleUpdateHandler.java
@@ -15,13 +15,13 @@
  */
 package net.dv8tion.jda.core.handle;
 
+import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.impl.GuildImpl;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.entities.impl.RoleImpl;
 import net.dv8tion.jda.core.events.role.update.*;
 import org.json.JSONObject;
 
-import java.awt.Color;
 import java.util.Objects;
 
 public class GuildRoleUpdateHandler extends SocketHandler
@@ -58,7 +58,9 @@ public class GuildRoleUpdateHandler extends SocketHandler
         }
 
         String name = rolejson.getString("name");
-        Color color = rolejson.getInt("color") != 0 ? new Color(rolejson.getInt("color")) : null;
+        int color = rolejson.getInt("color");
+        if (color == 0)
+            color = Role.DEFAULT_COLOR_RAW;
         int position = rolejson.getInt("position");
         long permissions = rolejson.getLong("permissions");
         boolean hoisted = rolejson.getBoolean("hoist");
@@ -73,9 +75,9 @@ public class GuildRoleUpdateHandler extends SocketHandler
                             api, responseNumber,
                             role, oldName));
         }
-        if (!Objects.equals(color, role.getColor()))
+        if (color != role.getColorRaw())
         {
-            Color oldColor = role.getColor();
+            int oldColor = role.getColorRaw();
             role.setColor(color);
             api.getEventManager().handle(
                     new RoleUpdateColorEvent(

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/GuildAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/GuildAction.java
@@ -482,6 +482,24 @@ public class GuildAction extends RestAction<Void>
         }
 
         /**
+         * Sets the color for this Role
+         *
+         * @param  color
+         *         The color for this Role, or {@code null} to unset
+         *
+         * @throws java.lang.IllegalStateException
+         *         If this is the public role
+         *
+         * @return The current RoleData instance for chaining convenience
+         */
+        public RoleData setColor(Integer color)
+        {
+            checkPublic("color");
+            this.color = color;
+            return this;
+        }
+
+        /**
          * Sets the position for this Role
          *
          * @param  position


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

This replaces all use of `java.awt.Color` with raw int primitives.
You may still use the old front-facing api for the color class, we just extended it to also allow access to the raw value. The new default is defined as constant in `Role.DEFAULT_COLOR_RAW` to keep consistency between role colors and embed colors.

The default is specified as `0x1FFFFFFF` due to the `Color(int)` constructors behaviour.
If we used `-1` then `new Color(0xFFFFFF)` would yield `-1` as well which breaks compatibility.
