### PR TITLE
Fallback body parsing for http response

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Channel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Channel.java
@@ -285,6 +285,7 @@ public interface Channel extends ISnowflake
     /**
      * Creates a {@link net.dv8tion.jda.core.entities.PermissionOverride PermissionOverride}
      * for the specified {@link net.dv8tion.jda.core.entities.Member Member} in this Channel.
+     * You can use {@link #putPermissionOverride(Member)} to replace existing overrides.
      *
      * <p>Possible ErrorResponses include:
      * <ul>
@@ -304,11 +305,13 @@ public interface Channel extends ISnowflake
      *         if the specified Member is null or the Member is not from {@link #getGuild()}
      * @throws java.lang.IllegalStateException
      *         If the specified Member already has a PermissionOverride. Use {@link #getPermissionOverride(Member)} to retrieve it.
+     *         You can use {@link #putPermissionOverride(Member)} to replace existing overrides.
      *
      * @return {@link net.dv8tion.jda.core.requests.restaction.PermissionOverrideAction PermissionOverrideAction}
-     *         The newly created PermissionOverride for the specified Role
+     *         Provides the newly created PermissionOverride for the specified Role
      *
      * @see    #createPermissionOverride(Role)
+     * @see    #putPermissionOverride(Member)
      */
     @CheckReturnValue
     PermissionOverrideAction createPermissionOverride(Member member);
@@ -316,6 +319,7 @@ public interface Channel extends ISnowflake
     /**
      * Creates a {@link net.dv8tion.jda.core.entities.PermissionOverride PermissionOverride}
      * for the specified {@link net.dv8tion.jda.core.entities.Role Role} in this Channel.
+     * You can use {@link #putPermissionOverride(Role)} to replace existing overrides.
      *
      * <p>Possible ErrorResponses include:
      * <ul>
@@ -335,14 +339,58 @@ public interface Channel extends ISnowflake
      *         if the specified Role is null or the Role is not from {@link #getGuild()}
      * @throws java.lang.IllegalStateException
      *         If the specified Role already has a PermissionOverride. Use {@link #getPermissionOverride(Role)} to retrieve it.
+     *         You can use {@link #putPermissionOverride(Role)} to replace existing overrides.
      *
      * @return {@link net.dv8tion.jda.core.requests.restaction.PermissionOverrideAction PermissionOverrideAction}
-     *         The newly created PermissionOverride for the specified Role
+     *         Provides the newly created PermissionOverride for the specified Role
      *
      * @see    #createPermissionOverride(Member)
+     * @see    #putPermissionOverride(Role)
      */
     @CheckReturnValue
     PermissionOverrideAction createPermissionOverride(Role role);
+
+    /**
+     * Creates a {@link net.dv8tion.jda.core.entities.PermissionOverride PermissionOverride}
+     * for the specified {@link net.dv8tion.jda.core.entities.Member Member} in this Channel.
+     * <br>If the member already has an existing override it will be replaced.
+     *
+     * @param  member
+     *         The Member to create the override for
+     *
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         if we don't have the permission to {@link net.dv8tion.jda.core.Permission#MANAGE_PERMISSIONS MANAGE_PERMISSIONS}
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided member is null or from a different guild
+     *
+     * @return {@link net.dv8tion.jda.core.requests.restaction.PermissionOverrideAction PermissionOverrideAction}
+     *         Provides the newly created PermissionOverride for the specified Member
+     *
+     * @see    #putPermissionOverride(Role)
+     */
+    @CheckReturnValue
+    PermissionOverrideAction putPermissionOverride(Member member);
+
+    /**
+     * Creates a {@link net.dv8tion.jda.core.entities.PermissionOverride PermissionOverride}
+     * for the specified {@link net.dv8tion.jda.core.entities.Role Role} in this Channel.
+     * <br>If the role already has an existing override it will be replaced.
+     *
+     * @param  role
+     *         The Role to create the override for
+     *
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         if we don't have the permission to {@link net.dv8tion.jda.core.Permission#MANAGE_PERMISSIONS MANAGE_PERMISSIONS}
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided role is null or from a different guild
+     *
+     * @return {@link net.dv8tion.jda.core.requests.restaction.PermissionOverrideAction PermissionOverrideAction}
+     *         Provides the newly created PermissionOverride for the specified Role
+     *
+     * @see    #putPermissionOverride(Member)
+     */
+    @CheckReturnValue
+    PermissionOverrideAction putPermissionOverride(Role role);
 
     /**
      * Creates a new {@link net.dv8tion.jda.core.requests.restaction.InviteAction InviteAction} which can be used to create a

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/AbstractChannelImpl.java
@@ -180,29 +180,43 @@ public abstract class AbstractChannelImpl<T extends AbstractChannelImpl<T>> impl
     @Override
     public PermissionOverrideAction createPermissionOverride(Member member)
     {
+        Checks.notNull(member, "member");
+        if (overrides.containsKey(member.getUser().getIdLong()))
+            throw new IllegalStateException("Provided member already has a PermissionOverride in this channel!");
+
+        return putPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverrideAction createPermissionOverride(Role role)
+    {
+        Checks.notNull(role, "role");
+        if (overrides.containsKey(role.getIdLong()))
+            throw new IllegalStateException("Provided role already has a PermissionOverride in this channel!");
+
+        return putPermissionOverride(role);
+    }
+
+    @Override
+    public PermissionOverrideAction putPermissionOverride(Member member)
+    {
         checkPermission(Permission.MANAGE_PERMISSIONS);
         Checks.notNull(member, "member");
 
         if (!guild.equals(member.getGuild()))
             throw new IllegalArgumentException("Provided member is not from the same guild as this channel!");
-        if (overrides.containsKey(member.getUser().getIdLong()))
-            throw new IllegalStateException("Provided member already has a PermissionOverride in this channel!");
-
         Route.CompiledRoute route = Route.Channels.CREATE_PERM_OVERRIDE.compile(getId(), member.getUser().getId());
         return new PermissionOverrideAction(getJDA(), route, this, member);
     }
 
     @Override
-    public PermissionOverrideAction createPermissionOverride(Role role)
+    public PermissionOverrideAction putPermissionOverride(Role role)
     {
         checkPermission(Permission.MANAGE_PERMISSIONS);
         Checks.notNull(role, "role");
 
         if (!guild.equals(role.getGuild()))
             throw new IllegalArgumentException("Provided role is not from the same guild as this channel!");
-        if (overrides.containsKey(role.getIdLong()))
-            throw new IllegalStateException("Provided role already has a PermissionOverride in this channel!");
-
         Route.CompiledRoute route = Route.Channels.CREATE_PERM_OVERRIDE.compile(getId(), role.getId());
         return new PermissionOverrideAction(getJDA(), route, this, role);
     }

--- a/src/main/java/net/dv8tion/jda/core/events/http/HttpRequestEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/http/HttpRequestEvent.java
@@ -27,7 +27,6 @@ import okhttp3.ResponseBody;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**

--- a/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
@@ -20,6 +20,8 @@ import net.dv8tion.jda.core.requests.ErrorResponse;
 import net.dv8tion.jda.core.requests.Response;
 import org.json.JSONObject;
 
+import java.util.Optional;
+
 /**
  * Indicates an unhandled error that is returned by Discord API Request using {@link net.dv8tion.jda.core.requests.RestAction RestAction}
  * <br>It holds an {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponse}
@@ -107,7 +109,7 @@ public class ErrorResponseException extends RuntimeException
 
     public static ErrorResponseException create(ErrorResponse errorResponse, Response response)
     {
-        JSONObject obj = response.getObject();
+        Optional<JSONObject> optObj = response.optObject();
         String meaning = errorResponse.getMeaning();
         int code = errorResponse.getCode();
         if (response.isError() && response.getException() != null)
@@ -118,8 +120,9 @@ public class ErrorResponseException extends RuntimeException
             code = response.code;
             meaning = response.getException().getClass().getName();
         }
-        else if (obj != null)
+        else if (optObj.isPresent())
         {
+            JSONObject obj = optObj.get();
             if (!obj.isNull("code") || !obj.isNull("message"))
             {
                 if (!obj.isNull("code"))

--- a/src/main/java/net/dv8tion/jda/core/requests/Request.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Request.java
@@ -89,7 +89,7 @@ public class Request<T>
         else
         {
             onFailure(ErrorResponseException.create(
-                    ErrorResponse.fromJSON(response.getObject()), response));
+                    ErrorResponse.fromJSON(response.optObject().orElse(null)), response));
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/core/requests/Response.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Response.java
@@ -32,9 +32,7 @@ public class Response implements Closeable
     public static final int ERROR_CODE = -1;
     public static final String ERROR_MESSAGE = "ERROR";
     public static final IOFunction<BufferedReader, JSONObject> JSON_SERIALIZE_OBJECT = reader -> new JSONObject(new JSONTokener(reader));
-
     public static final IOFunction<BufferedReader, JSONArray> JSON_SERIALIZE_ARRAY = reader -> new JSONArray(new JSONTokener(reader));
-
 
     public final int code;
     public final String message;

--- a/src/main/java/net/dv8tion/jda/core/requests/Response.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Response.java
@@ -31,8 +31,8 @@ public class Response implements Closeable
 {
     public static final int ERROR_CODE = -1;
     public static final String ERROR_MESSAGE = "ERROR";
-    public static final IOFunction<BufferedReader, JSONObject> JSON_SERIALIZE_OBJECT = reader -> new JSONObject(new JSONTokener(reader));
-    public static final IOFunction<BufferedReader, JSONArray> JSON_SERIALIZE_ARRAY = reader -> new JSONArray(new JSONTokener(reader));
+    public static final IOFunction<BufferedReader, JSONObject> JSON_SERIALIZE_OBJECT = (reader) -> new JSONObject(new JSONTokener(reader));
+    public static final IOFunction<BufferedReader, JSONArray> JSON_SERIALIZE_ARRAY = (reader) -> new JSONArray(new JSONTokener(reader));
 
     public final int code;
     public final String message;
@@ -63,9 +63,8 @@ public class Response implements Closeable
         if (response == null)
         {
             this.body = null;
-            return;
         }
-
+        else // weird compatibility issue, thinks some final isn't initialized if we return pre-maturely
         try
         {
             this.body = Requester.getBody(response);

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
@@ -18,7 +18,10 @@ package net.dv8tion.jda.core.requests.restaction;
 
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.entities.Channel;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.PermissionOverride;
+import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.impl.AbstractChannelImpl;
 import net.dv8tion.jda.core.entities.impl.PermissionOverrideImpl;
 import net.dv8tion.jda.core.requests.Request;
@@ -429,10 +432,11 @@ public class PermissionOverrideAction extends AuditableRestAction<PermissionOver
             return;
         }
 
-        JSONObject object = response.getObject();
         boolean isMember = isMember();
         long id = isMember ? member.getUser().getIdLong() : role.getIdLong();
-        PermissionOverrideImpl override = new PermissionOverrideImpl(channel, id, isMember ? member : role).setAllow(allow).setDeny(deny);
+        PermissionOverrideImpl override = new PermissionOverrideImpl(channel, id, isMember ? member : role);
+        override.setAllow(allow);
+        override.setDeny(deny);
 
         ((AbstractChannelImpl<?>) channel).getOverrideMap().put(id, override);
 

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
@@ -434,9 +434,10 @@ public class PermissionOverrideAction extends AuditableRestAction<PermissionOver
 
         boolean isMember = isMember();
         long id = isMember ? member.getUser().getIdLong() : role.getIdLong();
+        JSONObject object = (JSONObject) request.getRawBody();
         PermissionOverrideImpl override = new PermissionOverrideImpl(channel, id, isMember ? member : role);
-        override.setAllow(allow);
-        override.setDeny(deny);
+        override.setAllow(object.getLong("allow"));
+        override.setDeny(object.getLong("deny"));
 
         ((AbstractChannelImpl<?>) channel).getOverrideMap().put(id, override);
 

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/PermissionOverrideAction.java
@@ -76,12 +76,6 @@ public class PermissionOverrideAction extends AuditableRestAction<PermissionOver
         this.role = null;
     }
 
-    @Override
-    public PermissionOverrideAction setCheck(BooleanSupplier checks)
-    {
-        return (PermissionOverrideAction) super.setCheck(checks);
-    }
-
     /**
      * Creates a new PermissionOverrideAction instance
      *
@@ -102,6 +96,11 @@ public class PermissionOverrideAction extends AuditableRestAction<PermissionOver
         this.role = role;
     }
 
+    @Override
+    public PermissionOverrideAction setCheck(BooleanSupplier checks)
+    {
+        return (PermissionOverrideAction) super.setCheck(checks);
+    }
 
     /**
      * The currently set of allowed permission bits.

--- a/src/main/java/net/dv8tion/jda/core/utils/IOFunction.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/IOFunction.java
@@ -1,0 +1,24 @@
+/*
+ *     Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.utils;
+
+import java.io.IOException;
+
+public interface IOFunction<T, R>
+{
+    R apply(T t) throws IOException;
+}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

Allow fallback for error response with non-json content again.
This fixes a small regression from 3.5.1 where the response is not parsed for error responses that aren't json. Additionally this removes an unused JSONObject in PermissionOverrideAction which isn't present for this endpoint and causes issues.
