### PR TITLE
First pass on new event docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/DisconnectEvent.java
@@ -26,10 +26,10 @@ import java.util.List;
  * Indicates that JDA has been disconnected from the remote server.
  * <br>When this event is fired JDA will try to reconnect if possible
  * unless {@link net.dv8tion.jda.core.JDABuilder#setAutoReconnect(boolean) JDABuilder.setAutoReconnect(Boolean)}
- * has been provided {@code false}!
+ * has been provided {@code false} or the disconnect was too fatal.
  *
  * <p>When reconnecting was successful either a {@link net.dv8tion.jda.core.events.ReconnectedEvent ReconnectEvent}
- * or a {@link net.dv8tion.jda.core.events.ResumedEvent ResumedEvent} is fired
+ * or a {@link net.dv8tion.jda.core.events.ResumedEvent ResumedEvent} is fired.
  */
 public class DisconnectEvent extends Event
 {
@@ -38,10 +38,12 @@ public class DisconnectEvent extends Event
     protected final boolean closedByServer;
     protected final OffsetDateTime disconnectTime;
 
-    public DisconnectEvent(JDA api, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer,
-                           OffsetDateTime disconnectTime)
+    public DisconnectEvent(
+        JDA api,
+        WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame,
+        boolean closedByServer, OffsetDateTime disconnectTime)
     {
-        super(api, -1);
+        super(api);
         this.serverCloseFrame = serverCloseFrame;
         this.clientCloseFrame = clientCloseFrame;
         this.closedByServer = closedByServer;
@@ -76,21 +78,41 @@ public class DisconnectEvent extends Event
         return api.getCloudflareRays();
     }
 
+    /**
+     * The close frame discord sent to us
+     *
+     * @return The {@link com.neovisionaries.ws.client.WebSocketFrame WebSocketFrame} discord sent as closing handshake
+     */
     public WebSocketFrame getServiceCloseFrame()
     {
         return serverCloseFrame;
     }
 
+    /**
+     * The close frame we sent to discord
+     *
+     * @return The {@link com.neovisionaries.ws.client.WebSocketFrame WebSocketFrame} we sent as closing handshake
+     */
     public WebSocketFrame getClientCloseFrame()
     {
         return clientCloseFrame;
     }
 
+    /**
+     * Whether the connection was closed by discord
+     *
+     * @return True, if discord closed our connection
+     */
     public boolean isClosedByServer()
     {
         return closedByServer;
     }
 
+    /**
+     * Time at which we noticed the disconnection
+     *
+     * @return Time of closure
+     */
     public OffsetDateTime getDisconnectTime()
     {
         return disconnectTime;

--- a/src/main/java/net/dv8tion/jda/core/events/Event.java
+++ b/src/main/java/net/dv8tion/jda/core/events/Event.java
@@ -18,32 +18,47 @@ package net.dv8tion.jda.core.events;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>Event</u></b><br>
- * Fired for every event.<br>
- * All events JDA fires are based on an instance of this class.<br>
- * <br>
- * Use: Used in {@link net.dv8tion.jda.core.hooks.EventListener EventListener} implementations to distinguish what event is being fired.<br><br>
- * Example implementation: {@link net.dv8tion.jda.core.hooks.ListenerAdapter ListenerAdapter}
+ * Top-level event type
+ * <br>All events JDA fires are derived from this class.
+ *
+ * <p>Can be used to check if an Object is a JDA event in {@link net.dv8tion.jda.core.hooks.EventListener EventListener} implementations to distinguish what event is being fired.
+ * <br>Adapter implementation: {@link net.dv8tion.jda.core.hooks.ListenerAdapter ListenerAdapter}
  */
 public abstract class Event
 {
     protected final JDA api;
     protected final long responseNumber;
 
+    /**
+     * Creates a new Event from the given JDA instance
+     *
+     * @param api
+     *        Current JDA instance
+     * @param responseNumber
+     *        The sequence number for this event
+     *
+     * @see   #Event(net.dv8tion.jda.core.JDA)
+     */
     public Event(JDA api, long responseNumber)
     {
         this.api = api;
         this.responseNumber = responseNumber;
     }
 
+    /**
+     * Creates a new Event from the given JDA instance
+     * <br>Uses the current {@link net.dv8tion.jda.core.JDA#getResponseTotal()} as sequence
+     *
+     * @param api
+     *        Current JDA instance
+     */
     public Event(JDA api)
     {
-        this.api = api;
-        this.responseNumber = api.getResponseTotal();
+        this(api, api.getResponseTotal());
     }
 
     /**
-     * Returns the JDA instance corresponding to this Event
+     * The current JDA instance corresponding to this Event
      *
      * @return The corresponding JDA instance
      */
@@ -52,6 +67,12 @@ public abstract class Event
         return api;
     }
 
+    /**
+     * The current sequence for this event.
+     * <br>This can be used to keep events in order when making sequencing system.
+     *
+     * @return The current sequence number for this event
+     */
     public long getResponseNumber()
     {
         return responseNumber;

--- a/src/main/java/net/dv8tion/jda/core/events/ExceptionEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ExceptionEvent.java
@@ -19,8 +19,9 @@ package net.dv8tion.jda.core.events;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * Fired when JDA does not have a specific handling for a Throwable.
- * <br>This includes {@link java.lang.Error Errors} and {@link com.neovisionaries.ws.client.WebSocketException WebSocketExceptions}
+ * Indicates that JDA encountered a Throwable that could not be forwarded to another end-user frontend.
+ * <br>For instance this is fired for events in internal WebSocket handling or audio threads.
+ * This includes {@link java.lang.Error Errors} and {@link com.neovisionaries.ws.client.WebSocketException WebSocketExceptions}
  *
  * <p>It is not recommended to simply use this and print each event as some throwables where already logged
  * by JDA. See {@link #isLogged()}.
@@ -32,7 +33,7 @@ public class ExceptionEvent extends Event
 
     public ExceptionEvent(JDA api, Throwable throwable, boolean logged)
     {
-        super(api, -1);
+        super(api);
         this.throwable = throwable;
         this.logged = logged;
     }

--- a/src/main/java/net/dv8tion/jda/core/events/ReadyEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ReadyEvent.java
@@ -18,11 +18,11 @@ package net.dv8tion.jda.core.events;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>ReadyEvent</u></b><br>
- * Fired if our connection finished loading the ready event.<br>
- * Before this event was fired all entity related functions (like JDA#getUserById(String)) were not guaranteed to work as expected.<br>
- * <br>
- * Use: JDA finished populating internal objects and is now ready to be used. When this is fired all entities are cached and accessible.
+ * Indicates that JDA finished loading all entities.
+ * <br>Before this event was fired all entity related functions were not guaranteed to work as expected.
+ *
+ * <p>Can be used to indicate when JDA finished populating internal objects and is ready to be used.
+ * When this is fired all entities are cached and accessible.
  */
 public class ReadyEvent extends Event
 {

--- a/src/main/java/net/dv8tion/jda/core/events/ReconnectedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ReconnectedEvent.java
@@ -18,11 +18,11 @@ package net.dv8tion.jda.core.events;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>ReconnectedEvent</u></b><br>
- * Fired if JDA successfully re-established it's connection to the WebSocket.<br>
- * All Objects have been replaced when this is fired and events were likely missed in the downtime.<br>
- * <br>
- * Use: This marks the continuation of event flow stopped by the {@link net.dv8tion.jda.core.events.DisconnectEvent DisconnectEvent}. User should replace any cached Objects (like User/Guild objects).
+ * Indicates if JDA successfully re-established its connection to the gateway.
+ * <br>All Objects have been replaced when this is fired and events were likely missed in the downtime.
+ *
+ * <p>Can be used to mark the continuation of event flow which was stopped by the {@link net.dv8tion.jda.core.events.DisconnectEvent DisconnectEvent}.
+ * User should replace any cached Objects (like User/Guild objects).
  */
 public class ReconnectedEvent extends Event
 {

--- a/src/main/java/net/dv8tion/jda/core/events/ResumedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ResumedEvent.java
@@ -18,11 +18,10 @@ package net.dv8tion.jda.core.events;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>ResumedEvent</u></b><br>
- * Fired if JDA successfully re-established it's connection to the WebSocket.<br>
- * All Objects are still in place and events are replayed.<br>
- * <br>
- * Use: This marks the continuation of event flow stopped by the {@link net.dv8tion.jda.core.events.DisconnectEvent DisconnectEvent}.
+ * Indicates that JDA successfully resumed its connection to the gateway.
+ * <br>All Objects are still in place and events are replayed.
+ *
+ * <p>Can be used to marks the continuation of event flow stopped by the {@link net.dv8tion.jda.core.events.DisconnectEvent DisconnectEvent}.
  */
 public class ResumedEvent extends Event
 {

--- a/src/main/java/net/dv8tion/jda/core/events/ShutdownEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ShutdownEvent.java
@@ -21,8 +21,7 @@ import net.dv8tion.jda.core.requests.CloseCode;
 import java.time.OffsetDateTime;
 
 /**
- * Indicates that JDA has fully disconnected from Discord
- * and will not attempt to reconnect again.
+ * Indicates that JDA has fully disconnected from Discord and will not attempt to reconnect again.
  * <br>At this stage all internal cache is invalid!
  */
 public class ShutdownEvent extends Event
@@ -32,7 +31,7 @@ public class ShutdownEvent extends Event
 
     public ShutdownEvent(JDA api, OffsetDateTime shutdownTime, int code)
     {
-        super(api, -1);
+        super(api);
         this.shutdownTime = shutdownTime;
         this.code = code;
     }

--- a/src/main/java/net/dv8tion/jda/core/events/StatusChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/StatusChangeEvent.java
@@ -18,10 +18,9 @@ package net.dv8tion.jda.core.events;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>StatusChangedEvent</u></b><br>
- * Fired if our {@link net.dv8tion.jda.core.JDA.Status Status} changed. (Example: SHUTTING_DOWN -&gt; SHUTDOWN)<br>
- * <br>
- * Use: Detect internal status changes. Possibly to log or forward on user's end.
+ * Indicates that our {@link net.dv8tion.jda.core.JDA.Status Status} changed. (Example: SHUTTING_DOWN -&gt; SHUTDOWN)
+ *
+ * <br>Can be used to detect internal status changes. Possibly to log or forward on user's end.
  */
 public class StatusChangeEvent extends Event
 {
@@ -30,16 +29,26 @@ public class StatusChangeEvent extends Event
 
     public StatusChangeEvent(JDA api, JDA.Status newStatus, JDA.Status oldStatus)
     {
-        super(api, -1);
+        super(api);
         this.newStatus = newStatus;
         this.oldStatus = oldStatus;
     }
 
+    /**
+     * The status that we changed to
+     *
+     * @return The new status
+     */
     public JDA.Status getStatus()
     {
         return newStatus;
     }
 
+    /**
+     * The previous status
+     *
+     * @return The previous status
+     */
     public JDA.Status getOldStatus()
     {
         return oldStatus;

--- a/src/main/java/net/dv8tion/jda/core/events/emote/EmoteAddedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/emote/EmoteAddedEvent.java
@@ -19,6 +19,9 @@ package net.dv8tion.jda.core.events.emote;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Emote;
 
+/**
+ * Indicates that a new {@link net.dv8tion.jda.core.entities.Emote Emote} was added to a {@link net.dv8tion.jda.core.entities.Guild Guild}.
+ */
 public class EmoteAddedEvent extends GenericEmoteEvent
 {
     public EmoteAddedEvent(JDA api, long responseNumber, Emote emote)

--- a/src/main/java/net/dv8tion/jda/core/events/emote/EmoteRemovedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/emote/EmoteRemovedEvent.java
@@ -19,6 +19,9 @@ package net.dv8tion.jda.core.events.emote;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Emote;
 
+/**
+ * Indicates that an {@link net.dv8tion.jda.core.entities.Emote Emote} was removed from a Guild.
+ */
 public class EmoteRemovedEvent extends GenericEmoteEvent
 {
     public EmoteRemovedEvent(JDA api, long responseNumber, Emote emote)

--- a/src/main/java/net/dv8tion/jda/core/events/emote/GenericEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/emote/GenericEmoteEvent.java
@@ -21,9 +21,11 @@ import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.events.Event;
 
-public class GenericEmoteEvent extends Event
+/**
+ * Indicates that an {@link net.dv8tion.jda.core.entities.Emote Emote} was created/removed/updated.
+ */
+public abstract class GenericEmoteEvent extends Event
 {
-
     protected final Emote emote;
 
     public GenericEmoteEvent(JDA api, long responseNumber, Emote emote)
@@ -32,16 +34,31 @@ public class GenericEmoteEvent extends Event
         this.emote = emote;
     }
 
+    /**
+     * The {@link net.dv8tion.jda.core.entities.Guild Guild} where the emote came from
+     *
+     * @return The origin Guild
+     */
     public Guild getGuild()
     {
         return emote.getGuild();
     }
 
+    /**
+     * The responsible {@link net.dv8tion.jda.core.entities.Emote Emote} for this event
+     *
+     * @return The emote
+     */
     public Emote getEmote()
     {
         return emote;
     }
 
+    /**
+     * Whether this emote is managed by an integration
+     *
+     * @return True, if this emote is managed by an integration
+     */
     public boolean isManaged()
     {
         return emote.isManaged();

--- a/src/main/java/net/dv8tion/jda/core/events/emote/update/EmoteUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/emote/update/EmoteUpdateNameEvent.java
@@ -19,6 +19,11 @@ package net.dv8tion.jda.core.events.emote.update;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Emote;
 
+/**
+ * Indicates that the name of an {@link net.dv8tion.jda.core.entities.Emote Emote} changed.
+ *
+ * <p>Can be used to retrieve the old name
+ */
 public class EmoteUpdateNameEvent extends GenericEmoteUpdateEvent
 {
     protected final String oldName;
@@ -29,11 +34,21 @@ public class EmoteUpdateNameEvent extends GenericEmoteUpdateEvent
         this.oldName = oldName;
     }
 
+    /**
+     * The old name
+     *
+     * @return The old name
+     */
     public String getOldName()
     {
         return oldName;
     }
 
+    /**
+     * The new name
+     *
+     * @return The new name
+     */
     public String getNewName()
     {
         return emote.getName();

--- a/src/main/java/net/dv8tion/jda/core/events/emote/update/EmoteUpdateRolesEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/emote/update/EmoteUpdateRolesEvent.java
@@ -25,6 +25,11 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+/**
+ * Indicates that the role whitelist for an {@link net.dv8tion.jda.core.entities.Emote Emote} changed.
+ *
+ * <p>Can be used to retrieve the old role whitelist
+ */
 public class EmoteUpdateRolesEvent extends GenericEmoteUpdateEvent
 {
     protected final List<Role> oldRoles;
@@ -35,11 +40,21 @@ public class EmoteUpdateRolesEvent extends GenericEmoteUpdateEvent
         this.oldRoles = Collections.unmodifiableList(new LinkedList<>(oldRoles));
     }
 
+    /**
+     * The old role whitelist
+     *
+     * @return The old role whitelist
+     */
     public List<Role> getOldRoles()
     {
         return oldRoles;
     }
 
+    /**
+     * The new role whitelist
+     *
+     * @return The new role whitelist
+     */
     public List<Role> getNewRoles()
     {
         return emote.getRoles();

--- a/src/main/java/net/dv8tion/jda/core/events/emote/update/GenericEmoteUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/emote/update/GenericEmoteUpdateEvent.java
@@ -20,6 +20,9 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.events.emote.GenericEmoteEvent;
 
+/**
+ * Indicates that an {@link net.dv8tion.jda.core.entities.Emote Emote} was updated.
+ */
 public class GenericEmoteUpdateEvent extends GenericEmoteEvent
 {
     public GenericEmoteUpdateEvent(JDA api, long responseNumber, Emote emote)

--- a/src/main/java/net/dv8tion/jda/core/events/http/HttpRequestEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/http/HttpRequestEvent.java
@@ -27,11 +27,10 @@ import okhttp3.ResponseBody;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
- * Fired when a Rest request has been executed.
+ * Indicates that a {@link net.dv8tion.jda.core.requests.RestAction RestAction} has been executed.
  * 
  * <p>Depending on the request and its result not all values have to be populated.
  */

--- a/src/main/java/net/dv8tion/jda/core/events/role/GenericRoleEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/GenericRoleEvent.java
@@ -21,6 +21,12 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.events.Event;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} was created/deleted/changed.
+ * <br>Every RoleEvent is derived from this event and can be casted.
+ *
+ * <p>Can be used to detect any RoleEvent.
+ */
 public abstract class GenericRoleEvent extends Event
 {
     protected final Role role;
@@ -31,11 +37,21 @@ public abstract class GenericRoleEvent extends Event
         this.role = role;
     }
 
+    /**
+     * The role for this event
+     *
+     * @return The role for this event
+     */
     public Role getRole()
     {
         return role;
     }
 
+    /**
+     * The guild of the role
+     *
+     * @return The guild of the role
+     */
     public Guild getGuild()
     {
         return role.getGuild();

--- a/src/main/java/net/dv8tion/jda/core/events/role/RoleCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/RoleCreateEvent.java
@@ -20,10 +20,9 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 
 /**
- * <b><u>RoleCreateEvent</u></b><br>
- * Fired if a {@link net.dv8tion.jda.core.entities.Role Role} is created.<br>
- * <br>
- * Use: Retrieve created Role and it's Guild.
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} was created.
+ *
+ * <p>Can be used to retrieve the created Role and its Guild.
  */
 public class RoleCreateEvent extends GenericRoleEvent
 {

--- a/src/main/java/net/dv8tion/jda/core/events/role/RoleDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/RoleDeleteEvent.java
@@ -20,10 +20,9 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 
 /**
- * <b><u>RoleDeleteEvent</u></b><br>
- * Fired if a {@link net.dv8tion.jda.core.entities.Role Role} is deleted.<br>
- * <br>
- * Use: Retrieve deleted Role and it's Guild.
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} was deleted.
+ *
+ * <p>Can be used to retrieve the deleted Role and its Guild.
  */
 public class RoleDeleteEvent extends GenericRoleEvent
 {

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/GenericRoleUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/GenericRoleUpdateEvent.java
@@ -20,6 +20,12 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.events.role.GenericRoleEvent;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} was updated.
+ * <br>Every RoleUpdateEvent is derived from this event and can be casted.
+ *
+ * <p>Can be used to detect any RoleUpdateEvent.
+ */
 public abstract class GenericRoleUpdateEvent extends GenericRoleEvent
 {
     public GenericRoleUpdateEvent(JDA api, long responseNumber, Role role)

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateColorEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateColorEvent.java
@@ -21,6 +21,11 @@ import net.dv8tion.jda.core.entities.Role;
 
 import java.awt.Color;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} updated its color.
+ *
+ * <p>Can be used to retrieve the old color.
+ */
 public class RoleUpdateColorEvent extends GenericRoleUpdateEvent
 {
     private final Color oldColor;
@@ -31,6 +36,11 @@ public class RoleUpdateColorEvent extends GenericRoleUpdateEvent
         this.oldColor = oldColor;
     }
 
+    /**
+     * The old color
+     *
+     * @return The old color
+     */
     public Color getOldColor()
     {
         return oldColor;

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateHoistedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateHoistedEvent.java
@@ -19,6 +19,11 @@ package net.dv8tion.jda.core.events.role.update;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} updated its hoist state.
+ *
+ * <p>Can be used to retrieve the hoist state.
+ */
 public class RoleUpdateHoistedEvent extends GenericRoleUpdateEvent
 {
     private final boolean wasHoisted;
@@ -29,6 +34,11 @@ public class RoleUpdateHoistedEvent extends GenericRoleUpdateEvent
         this.wasHoisted = wasHoisted;
     }
 
+    /**
+     * Whether the role was hoisted
+     *
+     * @return True, if the role was hoisted before this update
+     */
     public boolean wasHoisted()
     {
         return wasHoisted;

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateMentionableEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateMentionableEvent.java
@@ -19,6 +19,11 @@ package net.dv8tion.jda.core.events.role.update;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} updated its mentionable state.
+ *
+ * <p>Can be used to retrieve the old mentionable state.
+ */
 public class RoleUpdateMentionableEvent extends GenericRoleUpdateEvent
 {
     private final boolean wasMentionable;
@@ -29,6 +34,11 @@ public class RoleUpdateMentionableEvent extends GenericRoleUpdateEvent
         this.wasMentionable = wasMentionable;
     }
 
+    /**
+     * Whether the role was mentionable
+     *
+     * @return True, if this role was mentionable before this update
+     */
     public boolean wasMentionable()
     {
         return wasMentionable;

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdateNameEvent.java
@@ -19,6 +19,11 @@ package net.dv8tion.jda.core.events.role.update;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} updated its name.
+ *
+ * <p>Can be used to retrieve the old name.
+ */
 public class RoleUpdateNameEvent extends GenericRoleUpdateEvent
 {
     private final String oldName;
@@ -29,6 +34,11 @@ public class RoleUpdateNameEvent extends GenericRoleUpdateEvent
         this.oldName = oldName;
     }
 
+    /**
+     * The old name
+     *
+     * @return The old name
+     */
     public String getOldName()
     {
         return oldName;

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdatePermissionsEvent.java
@@ -23,6 +23,11 @@ import net.dv8tion.jda.core.entities.Role;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} updated its permissions.
+ *
+ * <p>Can be used to retrieve the old permissions.
+ */
 public class RoleUpdatePermissionsEvent extends GenericRoleUpdateEvent
 {
     private final long oldPermissionsRaw;
@@ -33,12 +38,22 @@ public class RoleUpdatePermissionsEvent extends GenericRoleUpdateEvent
         this.oldPermissionsRaw = oldPermissionsRaw;
     }
 
+    /**
+     * The old permissions
+     *
+     * @return The old permissions
+     */
     public List<Permission> getOldPermissions()
     {
         return Collections.unmodifiableList(
                 Permission.getPermissions(oldPermissionsRaw));
     }
 
+    /**
+     * The old permissions
+     *
+     * @return The old permissions
+     */
     public long getOldPermissionsRaw()
     {
         return oldPermissionsRaw;

--- a/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/role/update/RoleUpdatePositionEvent.java
@@ -19,6 +19,11 @@ package net.dv8tion.jda.core.events.role.update;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Role;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.Role Role} updated its position.
+ *
+ * <p>Can be used to retrieve the old position.
+ */
 public class RoleUpdatePositionEvent extends GenericRoleUpdateEvent
 {
     private final int oldPosition;
@@ -31,11 +36,21 @@ public class RoleUpdatePositionEvent extends GenericRoleUpdateEvent
         this.oldPositionRaw = oldPositionRaw;
     }
 
+    /**
+     * The old position
+     *
+     * @return The old position
+     */
     public int getOldPosition()
     {
         return oldPosition;
     }
 
+    /**
+     * The old position
+     *
+     * @return The old position
+     */
     public int getOldPositionRaw()
     {
         return oldPositionRaw;

--- a/src/main/java/net/dv8tion/jda/core/events/self/GenericSelfUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/GenericSelfUpdateEvent.java
@@ -20,6 +20,12 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.SelfUser;
 import net.dv8tion.jda.core.events.Event;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.core.entities.SelfUser SelfUser} changed or started an activity.
+ * <br>Every SelfUserEvent is derived from this event and can be casted.
+ *
+ * <p>Can be used to detect any SelfUserEvent.
+ */
 public abstract class GenericSelfUpdateEvent extends Event
 {
     public GenericSelfUpdateEvent(JDA api, long responseNumber)
@@ -27,6 +33,11 @@ public abstract class GenericSelfUpdateEvent extends Event
         super(api, responseNumber);
     }
 
+    /**
+     * The {@link net.dv8tion.jda.core.entities.SelfUser SelfUser}
+     *
+     * @return The {@link net.dv8tion.jda.core.entities.SelfUser SelfUser}
+     */
     public SelfUser getSelfUser()
     {
         return api.getSelfUser();

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateAvatarEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateAvatarEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.core.events.self;
 
 import net.dv8tion.jda.core.JDA;
 
+/**
+ * Indicates that the avatar of the current user changed.
+ *
+ * <p>Can be used to retrieve the old avatar.
+ */
 public class SelfUpdateAvatarEvent extends GenericSelfUpdateEvent
 {
     private final String oldAvatarId;
@@ -28,13 +33,23 @@ public class SelfUpdateAvatarEvent extends GenericSelfUpdateEvent
         this.oldAvatarId = oldAvatarId;
     }
 
+    /**
+     * The old avatar id
+     *
+     * @return The old avatar id
+     */
     public String getOldAvatarId()
     {
         return oldAvatarId;
     }
 
+    /**
+     * The old avatar url
+     *
+     * @return  The old avatar url
+     */
     public String getOldAvatarUrl()
     {
-        return oldAvatarId == null ? null : "https://cdn.discordapp.com/avatars/" + getSelfUser().getId() + "/" + oldAvatarId + ".jpg";
+        return oldAvatarId == null ? null : "https://cdn.discordapp.com/avatars/" + getSelfUser().getId() + "/" + oldAvatarId + (oldAvatarId.startsWith("a_") ? ".gif" : ".png");
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateEmailEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateEmailEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.core.events.self;
 
 import net.dv8tion.jda.core.JDA;
 
+/**
+ * Indicates that the email of the current user changed. (client-only)
+ *
+ * <p>Can be used to retrieve the old email.
+ */
 public class SelfUpdateEmailEvent extends GenericSelfUpdateEvent
 {
     private final String oldEmail;
@@ -28,6 +33,11 @@ public class SelfUpdateEmailEvent extends GenericSelfUpdateEvent
         this.oldEmail = oldEmail;
     }
 
+    /**
+     * The old email
+     *
+     * @return The old email
+     */
     public String getOldEmail()
     {
         return oldEmail;

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateMFAEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateMFAEvent.java
@@ -18,6 +18,12 @@ package net.dv8tion.jda.core.events.self;
 
 import net.dv8tion.jda.core.JDA;
 
+/**
+ * Indicates that the mfa level of the current user changed.
+ * <br>This is relevant for elevated permissions (guild moderating/managing).
+ *
+ * <p>Can be used to retrieve the old mfa level.
+ */
 public class SelfUpdateMFAEvent extends GenericSelfUpdateEvent
 {
     private final boolean wasMfaEnabled;
@@ -28,6 +34,11 @@ public class SelfUpdateMFAEvent extends GenericSelfUpdateEvent
         this.wasMfaEnabled = wasMfaEnabled;
     }
 
+    /**
+     * Whether MFA was previously enabled or not
+     *
+     * @return True, if the account had MFA enabled prior to this event
+     */
     public boolean wasMfaEnabled()
     {
         return wasMfaEnabled;

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateMobileEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateMobileEvent.java
@@ -19,8 +19,9 @@ package net.dv8tion.jda.core.events.self;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>SelfUpdateMobileEvent</u></b><br>
- * Fired if you login to your discord account with a mobile device for the first time.<br>
+ * Indicates that you login to your discord account with a mobile device for the first time. (client-only)
+ *
+ * <p>Can be used to detect that your account was used with a mobile device.
  */
 public class SelfUpdateMobileEvent extends GenericSelfUpdateEvent
 {
@@ -33,7 +34,7 @@ public class SelfUpdateMobileEvent extends GenericSelfUpdateEvent
     }
 
     /**
-     * Returns the old mobile status. <i>Should</i> always be {@code false}.
+     * The old mobile status. <i>Should</i> always be {@code false}.
      *
      * @return The mobile status.
      */

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateNameEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.core.events.self;
 
 import net.dv8tion.jda.core.JDA;
 
+/**
+ * Indicates that the name/discriminator of the current user changed.
+ *
+ * <p>Can be used to retrieve the old name/discriminator.
+ */
 public class SelfUpdateNameEvent extends GenericSelfUpdateEvent
 {
     private final String oldName;
@@ -30,11 +35,21 @@ public class SelfUpdateNameEvent extends GenericSelfUpdateEvent
         this.oldDiscriminator = oldDiscriminator;
     }
 
+    /**
+     * The old name
+     *
+     * @return The old name
+     */
     public String getOldName()
     {
         return oldName;
     }
 
+    /**
+     * The old discriminator
+     *
+     * @return The old discriminator
+     */
     public String getOldDiscriminator()
     {
         return oldDiscriminator;

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateNitroEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateNitroEvent.java
@@ -19,8 +19,9 @@ package net.dv8tion.jda.core.events.self;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>SelfUpdateNitroEvent</u></b><br>
- * Fired if you subscribe to nitro or your active nitro subscription runs out.<br>
+ * Indicates that the current user subscribed to nitro or the active nitro subscription ran out. (client-only)
+ *
+ * <p>Can be used to track the state of the nitro subscription.
  */
 public class SelfUpdateNitroEvent extends GenericSelfUpdateEvent
 {
@@ -33,9 +34,9 @@ public class SelfUpdateNitroEvent extends GenericSelfUpdateEvent
     }
 
     /**
-     * Returns whether or not a nitro subscription used to be active before.
+     * Whether or not a nitro subscription used to be active before.
      *
-     * @return The the old nitro subscription status.
+     * @return The old nitro subscription status.
      */
     public boolean wasNitro()
     {

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdatePhoneNumberEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdatePhoneNumberEvent.java
@@ -19,8 +19,9 @@ package net.dv8tion.jda.core.events.self;
 import net.dv8tion.jda.core.JDA;
 
 /**
- * <b><u>SelfUpdatePhoneNumberEvent</u></b><br>
- * Fired if you change the phone number associated with your account.<br>
+ * Indicates that the phone number associated with your account changed. (client-only)
+ *
+ * <p>Can be used to retrieve the old phone number.
  */
 public class SelfUpdatePhoneNumberEvent extends GenericSelfUpdateEvent
 {
@@ -33,7 +34,7 @@ public class SelfUpdatePhoneNumberEvent extends GenericSelfUpdateEvent
     }
 
     /**
-     * Returns the old phone number or {@code null} if no phone number was previously set.
+     * The old phone number or {@code null} if no phone number was previously set.
      *
      * @return The old phone number or {@code null}.
      */

--- a/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateVerifiedEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/self/SelfUpdateVerifiedEvent.java
@@ -18,6 +18,11 @@ package net.dv8tion.jda.core.events.self;
 
 import net.dv8tion.jda.core.JDA;
 
+/**
+ * Indicates that the verification state of the current user changed. (client-only)
+ *
+ * <p>Can be used to retrieve the old verification state.
+ */
 public class SelfUpdateVerifiedEvent extends GenericSelfUpdateEvent
 {
     private final boolean wasVerified;
@@ -28,6 +33,11 @@ public class SelfUpdateVerifiedEvent extends GenericSelfUpdateEvent
         this.wasVerified = wasVerified;
     }
 
+    /**
+     * Whether the account was verified
+     *
+     * @return True, if this account was previously verified
+     */
     public boolean wasVerified()
     {
         return wasVerified;

--- a/src/main/java/net/dv8tion/jda/core/events/user/GenericUserEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/GenericUserEvent.java
@@ -20,11 +20,10 @@ import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.Event;
 
 /**
- * <b><u>GenericUserEvent</u></b><br>
- * Fired whenever a {@link net.dv8tion.jda.core.entities.User User} changes their presence. (like avatar/game)<br>
- * Every UserEvent is an instance of this event and can be casted. (no exceptions)<br>
- * <br>
- * Use: Detect any UserEvent. <i>(No real use for the JDA user)</i>
+ * Indicates that a {@link net.dv8tion.jda.core.entities.User User} changed or started an activity.
+ * <br>Every UserEvent is derived from this event and can be casted.
+ *
+ * <p>Can be used to detect any UserEvent.
  */
 public abstract class GenericUserEvent extends Event
 {
@@ -36,6 +35,11 @@ public abstract class GenericUserEvent extends Event
         this.user = user;
     }
 
+    /**
+     * The related user instance
+     *
+     * @return The user instance related to this event
+     */
     public User getUser()
     {
         return user;

--- a/src/main/java/net/dv8tion/jda/core/events/user/GenericUserPresenceEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/GenericUserPresenceEvent.java
@@ -22,6 +22,13 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.User;
 
+/**
+ * Indicates that the presence of a {@link net.dv8tion.jda.core.entities.User User} has changed.
+ * <br>Users don't have presences directly, this is fired when either a {@link net.dv8tion.jda.core.entities.Member Member} from a {@link net.dv8tion.jda.core.entities.Guild Guild}
+ * or one of the client's {@link net.dv8tion.jda.client.entities.Friend Friends} changes their presence.
+ *
+ * <p>Can be used to track the presence updates of members/friends.
+ */
 public abstract class GenericUserPresenceEvent extends GenericUserEvent
 {
     protected final Guild guild;
@@ -32,21 +39,41 @@ public abstract class GenericUserPresenceEvent extends GenericUserEvent
         this.guild = guild;
     }
 
+    /**
+     * Possibly-null guild in which the presence has changed.
+     *
+     * @return The guild, or null if this is related to a {@link net.dv8tion.jda.client.entities.Friend Friend}
+     */
     public Guild getGuild()
     {
         return guild;
     }
 
+    /**
+     * Possibly-null member who changed their presence.
+     *
+     * @return The member, or null if this is related to a {@link net.dv8tion.jda.client.entities.Friend Friend}
+     */
     public Member getMember()
     {
-        return isRelationshipUpdate() ? null : getGuild().getMember(getUser());
+        return !isRelationshipUpdate() ? getGuild().getMember(getUser()) : null;
     }
 
+    /**
+     * Possibly-null friend who changed their presence.
+     *
+     * @return The friend, or null if this is related to a {@link net.dv8tion.jda.core.entities.Member Member}
+     */
     public Friend getFriend()
     {
         return isRelationshipUpdate() ? getJDA().asClient().getFriend(getUser()) : null;
     }
 
+    /**
+     * Whether this is a change for a friend presence.
+     *
+     * @return True, if this was the presence update for a {@link net.dv8tion.jda.client.entities.Friend Friend}
+     */
     public boolean isRelationshipUpdate()
     {
         return getGuild() == null;

--- a/src/main/java/net/dv8tion/jda/core/events/user/UserAvatarUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/UserAvatarUpdateEvent.java
@@ -19,10 +19,9 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.User;
 
 /**
- * <b><u>UserAvatarUpdateEvent</u></b><br>
- * Fired if the Avatar of a {@link net.dv8tion.jda.core.entities.User User} changes.<br>
- * <br>
- * Use: Retrieve the User who's Avatar changed and their previous Avatar ID/URL.
+ * Indicates that the Avatar of a {@link net.dv8tion.jda.core.entities.User User} changed.
+ *
+ * <p>Can be used to retrieve the User who changed their avatar and their previous Avatar ID/URL.
  */
 public class UserAvatarUpdateEvent extends GenericUserEvent
 {
@@ -34,13 +33,23 @@ public class UserAvatarUpdateEvent extends GenericUserEvent
         this.previousAvatarId = previousAvatarId;
     }
 
+    /**
+     * The previous avatar id
+     *
+     * @return The previous avatar id
+     */
     public String getPreviousAvatarId()
     {
         return previousAvatarId;
     }
 
+    /**
+     * The previous avatar url
+     *
+     * @return The previous avatar url
+     */
     public String getPreviousAvatarUrl()
     {
-        return previousAvatarId == null ? null : "https://cdn.discordapp.com/avatars/" + getUser().getId() + "/" + previousAvatarId + ".jpg";
+        return previousAvatarId == null ? null : "https://cdn.discordapp.com/avatars/" + getUser().getId() + "/" + previousAvatarId + (previousAvatarId.startsWith("a_") ? ".gif" : ".png");
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/events/user/UserGameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/UserGameUpdateEvent.java
@@ -15,18 +15,16 @@
  */
 package net.dv8tion.jda.core.events.user;
 
-import net.dv8tion.jda.client.entities.Friend;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Game;
 import net.dv8tion.jda.core.entities.Guild;
-import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.User;
 
 /**
- * <b><u>UserGameUpdateEvent</u></b><br>
- * Fired if the {@link net.dv8tion.jda.core.entities.Game Game} of a {@link net.dv8tion.jda.core.entities.User User} changes.<br>
- * <br>
- * Use: Retrieve the User who's Game changed and their previous Game.
+ * Indicates that the {@link net.dv8tion.jda.core.entities.Game Game} of a {@link net.dv8tion.jda.core.entities.User User} changes.
+ * <br>As with any presence updates this either happened for a {@link net.dv8tion.jda.core.entities.Member Member} in a Guild or a {@link net.dv8tion.jda.client.entities.Friend Friend}!
+ *
+ * <p>Can be used to retrieve the User who changed their Game and their previous Game.
  */
 public class UserGameUpdateEvent extends GenericUserPresenceEvent
 {
@@ -38,11 +36,21 @@ public class UserGameUpdateEvent extends GenericUserPresenceEvent
         this.previousGame = previousGame;
     }
 
+    /**
+     * The previous {@link net.dv8tion.jda.core.entities.Game Game}
+     *
+     * @return The previous {@link net.dv8tion.jda.core.entities.Game Game}
+     */
     public Game getPreviousGame()
     {
         return previousGame;
     }
 
+    /**
+     * The current {@link net.dv8tion.jda.core.entities.Game Game}
+     *
+     * @return The current {@link net.dv8tion.jda.core.entities.Game Game}
+     */
     public Game getCurrentGame()
     {
         return isRelationshipUpdate() ? getFriend().getGame() : getMember().getGame();

--- a/src/main/java/net/dv8tion/jda/core/events/user/UserNameUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/UserNameUpdateEvent.java
@@ -19,10 +19,9 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.User;
 
 /**
- * <b><u>UserNameUpdateEvent</u></b><br>
- * Fired if the username of a {@link net.dv8tion.jda.core.entities.User User} changes. (Not Nickname)<br>
- * <br>
- * Use: Retrieve the User who's username changed and their previous username.
+ * Indicates that the username/discriminator of a {@link net.dv8tion.jda.core.entities.User User} changed. (Not Nickname)
+ *
+ * <p>Can be used to retrieve the User who changed their username/discriminator and their previous username/discriminator.
  */
 public class UserNameUpdateEvent extends GenericUserEvent
 {
@@ -36,11 +35,21 @@ public class UserNameUpdateEvent extends GenericUserEvent
         this.oldDiscriminator = oldDiscriminator;
     }
 
+    /**
+     * The old username
+     *
+     * @return The old username
+     */
     public String getOldName()
     {
         return oldName;
     }
 
+    /**
+     * The old discriminator
+     *
+     * @return The old discriminator
+     */
     public String getOldDiscriminator()
     {
         return oldDiscriminator;

--- a/src/main/java/net/dv8tion/jda/core/events/user/UserOnlineStatusUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/UserOnlineStatusUpdateEvent.java
@@ -21,10 +21,10 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.User;
 
 /**
- * <b><u>UserOnlineStatusUpdateEvent</u></b><br>
- * Fired if the {@link OnlineStatus OnlineStatus} of a {@link net.dv8tion.jda.core.entities.User User} changes.<br>
- * <br>
- * Use: Retrieve the User who's status changed and their previous status.
+ * Indicates that the {@link OnlineStatus OnlineStatus} of a {@link net.dv8tion.jda.core.entities.User User} changed.
+ * <br>As with any presence updates this either happened for a {@link net.dv8tion.jda.core.entities.Member Member} in a Guild or a {@link net.dv8tion.jda.client.entities.Friend Friend}!
+ *
+ * <p>Can be used to retrieve the User who changed their status and their previous status.
  */
 public class UserOnlineStatusUpdateEvent extends GenericUserPresenceEvent
 {
@@ -36,11 +36,21 @@ public class UserOnlineStatusUpdateEvent extends GenericUserPresenceEvent
         this.previousOnlineStatus = previousOnlineStatus;
     }
 
+    /**
+     * The previous status
+     *
+     * @return The previous status
+     */
     public OnlineStatus getPreviousOnlineStatus()
     {
         return previousOnlineStatus;
     }
 
+    /**
+     * The current status
+     *
+     * @return The current status
+     */
     public OnlineStatus getCurrentOnlineStatus()
     {
         return isRelationshipUpdate() ? getFriend().getOnlineStatus() : getMember().getOnlineStatus();

--- a/src/main/java/net/dv8tion/jda/core/events/user/UserTypingEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/user/UserTypingEvent.java
@@ -15,16 +15,16 @@
  */
 package net.dv8tion.jda.core.events.user;
 
+import net.dv8tion.jda.client.entities.Group;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.*;
 
 import java.time.OffsetDateTime;
 
 /**
- * <b><u>UserTypingUpdateEvent</u></b><br>
- * Fired if a {@link net.dv8tion.jda.core.entities.User User} starts typing. (Similar to the typing indicator in the Discord client)<br>
- * <br>
- * Use: Retrieve the User who started typing and when and in which MessageChannel they started typing.
+ * Indicates that a {@link net.dv8tion.jda.core.entities.User User} started typing. (Similar to the typing indicator in the Discord client)
+ *
+ * <p>Can be used to retrieve the User who started typing and when and in which MessageChannel they started typing.
  */
 public class UserTypingEvent extends GenericUserEvent
 {
@@ -38,38 +38,114 @@ public class UserTypingEvent extends GenericUserEvent
         this.timestamp = timestamp;
     }
 
+    /**
+     * The time when the user started typing
+     *
+     * @return The time when the typing started
+     */
     public OffsetDateTime getTimestamp()
     {
         return timestamp;
     }
 
+    /**
+     * The channel where the typing was started
+     *
+     * @return The channel
+     */
     public MessageChannel getChannel()
     {
         return channel;
     }
 
+    /**
+     * Whether this was in a private channel
+     *
+     * @return True, if this was in a private channel
+     *
+     * @deprecated
+     *         Use {@link #isFromType(net.dv8tion.jda.core.entities.ChannelType)} instead
+     */
+    @Deprecated
     public boolean isPrivate()
     {
-        return channel instanceof PrivateChannel;
+        return isFromType(ChannelType.PRIVATE);
     }
 
+    /**
+     * Whether the user started typing in a channel of the specified type.
+     *
+     * @param  type
+     *         {@link net.dv8tion.jda.core.entities.ChannelType ChannelType}
+     *
+     * @return True, if the user started typing in a channel of the specified type
+     */
+    public boolean isFromType(ChannelType type)
+    {
+        return channel.getType() == type;
+    }
+
+    /**
+     * The {@link net.dv8tion.jda.core.entities.ChannelType ChannelType}
+     *
+     * @return The {@link net.dv8tion.jda.core.entities.ChannelType ChannelType}
+     */
+    public ChannelType getType()
+    {
+        return channel.getType();
+    }
+
+    /**
+     * {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel} in which this users started typing,
+     * or {@code null} if this was not in a PrivateChannel.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannel}
+     */
     public PrivateChannel getPrivateChannel()
     {
-        return isPrivate() ? (PrivateChannel) channel : null;
+        return isFromType(ChannelType.PRIVATE) ? (PrivateChannel) channel : null;
     }
 
+    /**
+     * {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} in which this users started typing,
+     * or {@code null} if this was not in a TextChannel.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     */
     public TextChannel getTextChannel()
     {
-        return !isPrivate() ? (TextChannel) channel : null;
+        return isFromType(ChannelType.TEXT) ? (TextChannel) channel : null;
     }
 
+    /**
+     * {@link net.dv8tion.jda.client.entities.Group Group} in which this users started typing,
+     * or {@code null} if this was not in a Group.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.client.entities.Group Group}
+     */
+    public Group getGroup()
+    {
+        return isFromType(ChannelType.GROUP) ? (Group) channel : null;
+    }
+
+    /**
+     * {@link net.dv8tion.jda.core.entities.Guild Guild} in which this users started typing,
+     * or {@code null} if this was not in a Guild.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.Guild Guild}
+     */
     public Guild getGuild()
     {
-        return !isPrivate() ? getTextChannel().getGuild() : null;
+        return isFromType(ChannelType.TEXT) ? getTextChannel().getGuild() : null;
     }
 
+    /**
+     * {@link net.dv8tion.jda.core.entities.Member Member} instance for the User, or null if this was not in a Guild.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.Member Member}
+     */
     public Member getMember()
     {
-        return !isPrivate() ? getGuild().getMember(getUser()) : null;
+        return isFromType(ChannelType.TEXT) ? getGuild().getMember(getUser()) : null;
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

This updates some of the ancient event docs and adds new ones were missing.

- [x] Core events
- [x] User events
- [x] SelfUser events
- [x] Role events
- [x] HTTP events
- [ ] Guild events
- [ ] Channel events
- [ ] Message events

The client events are not included in this update.

This is inspired by the recent pull requests that wanted to fix a single typo in the docs, if you find more then make a pull requests to this branch instead.

## New Formats

### Generic Event

```java
/**
 * Indicates that a <ENTITY-REF> changed.
 * <br>Every <ENTITY-NAME>Event is derived from this event and can be casted.
 *
 * <p>Can be used to detect any <ENTITY-NAME>Event.
 */
public abstract class <ENTITY-NAME>Event extends Event {
...
```

### Specific Event

```java
/**
 * Indicates that <MEANING>.
 *  [DETAILS]
 *
 * [<p>Can be used to <USAGE>.]
 */
public class <ENTITY-NAME>[Update]Event extends [Generic<ENTITY>[Update]]Event {
....
```

`<...>` - replace with appropriate context
`[...]` - optional details/note/description