### PR TITLE
Allow EmbedBuilder to accept an Object field value

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -716,11 +716,11 @@ public class EmbedBuilder
      *
      * @return the builder after the field has been added
      */
-    public EmbedBuilder addField(String name, String value, boolean inline)
+    public EmbedBuilder addField(String name, Object value, boolean inline)
     {
         if (name == null && value == null)
             return this;
-        this.fields.add(new MessageEmbed.Field(name, value, inline));
+        this.fields.add(new MessageEmbed.Field(name, String.valueOf(value), inline));
         return this;
     }
     


### PR DESCRIPTION
## Pull Request Etiquette

There are several guidelines you should follow in order for your Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

Allow the value type to be an Object because it won't break existing calls to this method and only add an extra method call (toString()) on any strings. An example of where this is useful is a field that displays an int like "Guilds" with value "9001". The developer can easily type: `embedBuilder.addField("Guilds", String.valueOf(getGuildCount()), false);`
But it's a lot cleaner for the developer to just type: `embedBuilder.addField("Guilds", getGuildCount(), false)`