### PR TITLE
Allow plugging in custom ratelimiter pools

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/ratelimit/BotRateLimiter.java
@@ -35,15 +35,16 @@ import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class BotRateLimiter extends RateLimiter
 {
     protected volatile Long timeOffset = null;
 
-    public BotRateLimiter(Requester requester, int poolSize)
+    public BotRateLimiter(Requester requester, ScheduledThreadPoolExecutor pool, boolean managePoolLifecycle)
     {
-        super(requester, poolSize);
+        super(requester, pool, managePoolLifecycle);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/requests/ratelimit/ClientRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/ratelimit/ClientRateLimiter.java
@@ -32,15 +32,16 @@ import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ClientRateLimiter extends RateLimiter
 {
     volatile Long globalCooldown = null;
 
-    public ClientRateLimiter(Requester requester, int poolSize)
+    public ClientRateLimiter(Requester requester, ScheduledThreadPoolExecutor pool, boolean managePoolLifecycle)
     {
-        super(requester, poolSize);
+        super(requester, pool, managePoolLifecycle);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

The current implementation of the ratelimiter creates 5 threads per shard to execute RestActions.
This results in enormous amount of threads for big bots, for example, FredBoat has almost 4k ratelimiter threads sitting around. There must be a less resource intensive way to output a maximum of 50 requests / second. Okhttp provides async callbacks, but that just shifts the problem, as they use an internal threadpool themselves. A super clean solution would be using an NIO based http client, but implementing that would be a lot of work given how JDA integrates with many okhttp classes.
So instead, this PR implements an unperfect, but rather cheap solution of the problem by allowing bot owners to plug in their own thread pools for the ratelimiters.