### PR TITLE
Allow null user_id and provide partial Webhooks

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/audit/AuditLogEntry.java
+++ b/src/main/java/net/dv8tion/jda/core/audit/AuditLogEntry.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import net.dv8tion.jda.core.entities.Webhook;
+import net.dv8tion.jda.core.entities.impl.WebhookImpl;
 
 /**
  * Single entry for an {@link net.dv8tion.jda.core.requests.restaction.pagination.AuditLogPaginationAction
@@ -41,20 +43,22 @@ public class AuditLogEntry implements ISnowflake
     protected final long targetId;
     protected final GuildImpl guild;
     protected final UserImpl user;
+    protected final WebhookImpl webhook;
     protected final String reason;
 
     protected final Map<String, AuditLogChange> changes;
     protected final Map<String, Object> options;
     protected final ActionType type;
 
-    public AuditLogEntry(ActionType type, long id, long targetId, GuildImpl guild, UserImpl user, String reason,
-                         Map<String, AuditLogChange> changes, Map<String, Object> options)
+    public AuditLogEntry(ActionType type, long id, long targetId, GuildImpl guild, UserImpl user, WebhookImpl webhook, 
+                        String reason, Map<String, AuditLogChange> changes, Map<String, Object> options)
     {
         this.type = type;
         this.id = id;
         this.targetId = targetId;
         this.guild = guild;
         this.user = user;
+        this.webhook = webhook;
         this.reason = reason;
         this.changes = changes != null && !changes.isEmpty()
                 ? Collections.unmodifiableMap(changes)
@@ -93,6 +97,16 @@ public class AuditLogEntry implements ISnowflake
     {
         return Long.toUnsignedString(targetId);
     }
+    
+    /**
+     * The {@link net.dv8tion.jda.core.entities.Webhook Webhook} that the target id of this audit-log entry refers to
+     * 
+     * @return Possibly-null Webhook instance
+     */
+    public Webhook getWebhook()
+    {
+        return webhook;
+    }
 
     /**
      * The {@link net.dv8tion.jda.core.entities.Guild Guild} this audit-log entry refers to
@@ -108,7 +122,7 @@ public class AuditLogEntry implements ISnowflake
      * The {@link net.dv8tion.jda.core.entities.User User} responsible
      * for this action.
      *
-     * @return The User instance
+     * @return Possibly-null User instance
      */
     public User getUser()
     {

--- a/src/main/java/net/dv8tion/jda/core/audit/AuditLogEntry.java
+++ b/src/main/java/net/dv8tion/jda/core/audit/AuditLogEntry.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Single entry for an {@link net.dv8tion.jda.core.requests.restaction.pagination.AuditLogPaginationAction
@@ -104,6 +105,7 @@ public class AuditLogEntry implements ISnowflake
      * 
      * @return Possibly-null Webhook instance
      */
+    @Nullable
     public Webhook getWebhook()
     {
         return webhook;
@@ -125,6 +127,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-null User instance
      */
+    @Nullable
     public User getUser()
     {
         return user;
@@ -135,6 +138,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-null reason String
      */
+    @Nullable
     public String getReason()
     {
         return reason;
@@ -172,6 +176,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-null value corresponding to the specified key
      */
+    @Nullable
     public AuditLogChange getChangeByKey(final AuditLogKey key)
     {
         return key == null ? null : getChangeByKey(key.getKey());
@@ -186,6 +191,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-null value corresponding to the specified key
      */
+    @Nullable
     public AuditLogChange getChangeByKey(final String key)
     {
         return changes.get(key);
@@ -246,6 +252,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-null value corresponding to the specified key
      */
+    @Nullable
     @SuppressWarnings("unchecked")
     public <T> T getOptionByName(String name)
     {
@@ -267,6 +274,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-null value corresponding to the specified option constant
      */
+    @Nullable
     public <T> T getOption(AuditLogOption option)
     {
         Checks.notNull(option, "Option");

--- a/src/main/java/net/dv8tion/jda/core/audit/AuditLogEntry.java
+++ b/src/main/java/net/dv8tion/jda/core/audit/AuditLogEntry.java
@@ -20,15 +20,16 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.entities.User;
+import net.dv8tion.jda.core.entities.Webhook;
 import net.dv8tion.jda.core.entities.impl.GuildImpl;
 import net.dv8tion.jda.core.entities.impl.UserImpl;
+import net.dv8tion.jda.core.entities.impl.WebhookImpl;
 import net.dv8tion.jda.core.utils.Checks;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import net.dv8tion.jda.core.entities.Webhook;
-import net.dv8tion.jda.core.entities.impl.WebhookImpl;
 
 /**
  * Single entry for an {@link net.dv8tion.jda.core.requests.restaction.pagination.AuditLogPaginationAction

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -485,9 +485,9 @@ public class EntityBuilder
         }
     }
 
-    public User createFakeUser(JSONObject user, boolean modifyCache) { return createUser(user, true, modifyCache); }
-    public User createUser(JSONObject user)     { return createUser(user, false, true); }
-    private User createUser(JSONObject user, boolean fake, boolean modifyCache)
+    public UserImpl createFakeUser(JSONObject user, boolean modifyCache) { return createUser(user, true, modifyCache); }
+    public UserImpl createUser(JSONObject user)     { return createUser(user, false, true); }
+    private UserImpl createUser(JSONObject user, boolean fake, boolean modifyCache)
     {
         final long id = user.getLong("id");
         UserImpl userObj;
@@ -1157,7 +1157,7 @@ public class EntityBuilder
         return permOverride.setAllow(allow).setDeny(deny);
     }
 
-    public Webhook createWebhook(JSONObject object)
+    public WebhookImpl createWebhook(JSONObject object)
     {
         final long id = object.getLong("id");
         final long guildId = object.getLong("guild_id");
@@ -1196,7 +1196,7 @@ public class EntityBuilder
         
         return new WebhookImpl(channel, id)
                 .setToken(token)
-                .setOwner(owner==null ? null : channel.getGuild().getMember(owner))
+                .setOwner(owner == null ? null : channel.getGuild().getMember(owner))
                 .setUser(defaultUser);
     }
 
@@ -1383,8 +1383,8 @@ public class EntityBuilder
         final JSONObject options = entryJson.isNull("options") ? null : entryJson.getJSONObject("options");
         final String reason = entryJson.optString("reason", null);
 
-        final UserImpl user = userJson == null ? null : (UserImpl) createFakeUser(userJson, false);
-        final WebhookImpl webhook = webhookJson == null ? null : (WebhookImpl) createWebhook(webhookJson);
+        final UserImpl user = userJson == null ? null : createFakeUser(userJson, false);
+        final WebhookImpl webhook = webhookJson == null ? null : createWebhook(webhookJson);
         final Set<AuditLogChange> changesList;
         final ActionType type = ActionType.from(typeKey);
 

--- a/src/main/java/net/dv8tion/jda/core/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Webhook.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
  *
  * @since  3.0
  */
-public interface Webhook extends ISnowflake
+public interface Webhook extends ISnowflake, IFakeable
 {
 
     /**
@@ -58,7 +58,7 @@ public interface Webhook extends ISnowflake
     TextChannel getChannel();
 
     /**
-     * The owner of this Webhook. This will be null for partial Webhooks, such as those retrieved from Audit Logs.
+     * The owner of this Webhook. This will be null for fake Webhooks, such as those retrieved from Audit Logs.
      *
      * @return Possibly-null {@link net.dv8tion.jda.core.entities.Member Member} instance
      *         representing the owner of this Webhook.
@@ -99,7 +99,7 @@ public interface Webhook extends ISnowflake
      * <br>This can be used to modify/delete/execute
      * this Webhook.
      * 
-     * <p><b>Note: Webhooks retrieved from Audit Logs do not contain a token</b>
+     * <p><b>Note: Fake Webhooks, such as those retrieved from Audit Logs, do not contain a token</b>
      *
      * @return The execute token for this Webhook
      */
@@ -109,7 +109,7 @@ public interface Webhook extends ISnowflake
     /**
      * The {@code POST} route for this Webhook.
      * <br>This contains the {@link #getToken() token} and {@link #getId() id}
-     * of this Webhook. Webhooks without tokens (such as those retrieved from Audit Logs)
+     * of this Webhook. Fake Webhooks without tokens (such as those retrieved from Audit Logs)
      * will return a URL without a token.
      *
      * <p>The route returned by this method does not need permission checks
@@ -128,6 +128,9 @@ public interface Webhook extends ISnowflake
     /**
      * Deletes this Webhook.
      *
+     * @throws IllegalStateException 
+     *         if the Webhook is fake, such as the Webhooks retrieved from Audit Logs
+     * 
      * @return {@link net.dv8tion.jda.core.requests.restaction.AuditableRestAction AuditableRestAction}
      *         <br>The rest action to delete this Webhook.
      */
@@ -141,6 +144,9 @@ public interface Webhook extends ISnowflake
      * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link net.dv8tion.jda.core.Permission#MANAGE_WEBHOOKS Permission.MANAGE_WEBHOOKS}
      *
+     * @throws IllegalStateException 
+     *         if the Webhook is fake, such as the Webhooks retrieved from Audit Logs
+     * 
      * @return The {@link net.dv8tion.jda.core.managers.WebhookManager WebhookManager} for this Webhook
      */
     WebhookManager getManager();
@@ -167,7 +173,7 @@ public interface Webhook extends ISnowflake
      * <p><b><u>Remember to close the WebhookClient once you don't need it anymore to free resources!</u></b>
      *
      * @throws IllegalStateException 
-     *         if the Webhook does not have a known token, such as the Webhooks retrieved from Audit Logs
+     *         if the Webhook is fake, such as the Webhooks retrieved from Audit Logs
      * 
      * @return The new WebhookClientBuilder
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Webhook.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.core.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.webhook.WebhookClientBuilder;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 
 /**
  * An object representing Webhooks in Discord
@@ -57,11 +58,12 @@ public interface Webhook extends ISnowflake
     TextChannel getChannel();
 
     /**
-     * The owner of this Webhook.
+     * The owner of this Webhook. This will be null for partial Webhooks, such as those retrieved from Audit Logs.
      *
-     * @return A {@link net.dv8tion.jda.core.entities.Member Member} instance
-     *         representing the owner of this Webhook
+     * @return Possibly-null {@link net.dv8tion.jda.core.entities.Member Member} instance
+     *         representing the owner of this Webhook.
      */
+    @Nullable
     Member getOwner();
 
     /**
@@ -96,15 +98,19 @@ public interface Webhook extends ISnowflake
      * The execute token for this Webhook.
      * <br>This can be used to modify/delete/execute
      * this Webhook.
+     * 
+     * <p><b>Note: Webhooks retrieved from Audit Logs do not contain a token</b>
      *
      * @return The execute token for this Webhook
      */
+    @Nullable
     String getToken();
 
     /**
      * The {@code POST} route for this Webhook.
      * <br>This contains the {@link #getToken() token} and {@link #getId() id}
-     * of this Webhook.
+     * of this Webhook. Webhooks without tokens (such as those retrieved from Audit Logs)
+     * will return a URL without a token.
      *
      * <p>The route returned by this method does not need permission checks
      * to be executed.

--- a/src/main/java/net/dv8tion/jda/core/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Webhook.java
@@ -160,6 +160,9 @@ public interface Webhook extends ISnowflake
      *
      * <p><b><u>Remember to close the WebhookClient once you don't need it anymore to free resources!</u></b>
      *
+     * @throws IllegalStateException 
+     *         if the Webhook does not have a known token, such as the Webhooks retrieved from Audit Logs
+     * 
      * @return The new WebhookClientBuilder
      */
     WebhookClientBuilder newClient();

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
@@ -99,7 +99,7 @@ public class WebhookImpl implements Webhook
     @Override
     public String getUrl()
     {
-        return Requester.DISCORD_API_PREFIX + "webhooks/" + getId() + "/" + getToken();
+        return Requester.DISCORD_API_PREFIX + "webhooks/" + getId() + (getToken() == null ? "" : "/" + getToken());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
@@ -105,6 +105,9 @@ public class WebhookImpl implements Webhook
     @Override
     public AuditableRestAction<Void> delete()
     {
+        if (isFake())
+            throw new IllegalStateException("Fake Webhooks (such as those retrieved from Audit Logs) "
+                    + "cannot be used for deletion!");
         Route.CompiledRoute route = Route.Webhooks.DELETE_TOKEN_WEBHOOK.compile(getId(), token);
         return new AuditableRestAction<Void>(getJDA(), route)
         {
@@ -122,6 +125,9 @@ public class WebhookImpl implements Webhook
     @Override
     public WebhookManager getManager()
     {
+        if (isFake())
+            throw new IllegalStateException("Fake Webhooks (such as those retrieved from Audit Logs) "
+                    + "cannot provide a WebhookManager!");
         WebhookManager mng = manager;
         if (mng == null)
         {
@@ -155,8 +161,8 @@ public class WebhookImpl implements Webhook
     @Override
     public WebhookClientBuilder newClient()
     {
-        if (token == null)
-            throw new IllegalStateException("Webhooks without known tokens (such as those retrieved from Audit Logs) "
+        if (isFake())
+            throw new IllegalStateException("Fake Webhooks (such as those retrieved from Audit Logs) "
                     + "cannot be used to create a WebhookClient!");
         return new WebhookClientBuilder(id, token);
     }
@@ -165,6 +171,12 @@ public class WebhookImpl implements Webhook
     public long getIdLong()
     {
         return id;
+    }
+
+    @Override
+    public boolean isFake()
+    {
+        return token == null;
     }
 
     /* -- Impl Setters -- */

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/WebhookImpl.java
@@ -155,6 +155,9 @@ public class WebhookImpl implements Webhook
     @Override
     public WebhookClientBuilder newClient()
     {
+        if (token == null)
+            throw new IllegalStateException("Webhooks without known tokens (such as those retrieved from Audit Logs) "
+                    + "cannot be used to create a WebhookClient!");
         return new WebhookClientBuilder(id, token);
     }
 

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/AuditLogPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/AuditLogPaginationAction.java
@@ -29,13 +29,13 @@ import net.dv8tion.jda.core.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.Route;
+import net.dv8tion.jda.core.utils.Helpers;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
-import net.dv8tion.jda.core.utils.Helpers;
 
 /**
  * {@link net.dv8tion.jda.core.requests.restaction.pagination.PaginationAction PaginationAction}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

This PR fixes an issue where JDA required the user_id field in audit log entries to be non-null, despite Discord allowing null values for items such as webhook self-deletion. This PR also adds a getWebhook() method to AuditLogEntry to get a partial Webhook object that are the target of some Audit Log Entries. This fulfills #662.
