### PR TITLE
Fixing Role#getAsMention() for public Role

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/IMentionable.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/IMentionable.java
@@ -52,6 +52,7 @@ public interface IMentionable extends Formattable
 {
     /**
      * Retrieve a Mention for this Entity.
+     * For the public {@link net.dv8tion.jda.core.entities.Role Role} (@everyone), this will return the literal string {@code "@everyone"}.
      *
      * @return A resolvable mention.
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/RoleImpl.java
@@ -274,7 +274,7 @@ public class RoleImpl implements Role
     @Override
     public String getAsMention()
     {
-        return "<@&" + getId() + '>';
+        return isPublicRole() ? "@everyone" : "<@&" + getId() + '>';
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

This PR changes/fixes the behavior of `Role#getAsMention()` when called on the public role (`@everyone`).

Previously, it used the default Role mention pattern (`<@&ID>`) even for the public role. Now it returns the literal String `"@everyone"` in that special case instead.