### PR TITLE
Don't call toString() eagerly on arguments to format()

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
@@ -643,6 +643,6 @@ public class PermissionUtil
     private static void checkGuild(Guild o1, Guild o2, String name)
     {
         Checks.check(o1.equals(o2),
-            "Specified %s is not in the same guild! (%s / %s)", name, o1.toString(), o2.toString());
+            "Specified %s is not in the same guild! (%s / %s)", name, o1, o2);
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

Since the `%s` format specifier already does toString conversion, it's only wasteful to call toString before handing it over to String.format.
Let me know what you think.