### PR TITLE
Change jcenter link for okhttp3 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,9 +320,9 @@ version was by looking at the [release page](https://github.com/DV8FromTheWorld/
 This project requires **Java 8**.<br>
 All dependencies are managed automatically by Gradle.
  * NV Websocket Client
-   * Version: **2.2**
+   * Version: **2.4**
    * [Github](https://github.com/TakahikoKawasaki/nv-websocket-client)
-   * [JCenter Repository](https://bintray.com/bintray/jcenter/com.neovisionaries%3Anv-websocket-client/view)
+   * [JCenter Repository](https://bintray.com/bintray/jcenter/com.neovisionaries%3Anv-websocket-client/2.4)
  * OkHttp
    * Version: **3.8.1**
    * [Github](https://github.com/square/okhttp)

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ All dependencies are managed automatically by Gradle.
  * OkHttp
    * Version: **3.8.1**
    * [Github](https://github.com/square/okhttp)
-   * [JCenter Repository](https://bintray.com/bintray/jcenter/com.squareup.okhttp:okhttp)
+   * [JCenter Repository](https://bintray.com/bintray/jcenter/com.squareup.okhttp3:okhttp)
  * Apache Commons Collections4
    * Version: **4.1**
    * [Website](https://commons.apache.org/proper/commons-collections/)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

The jcenter link to the dependency was wrong, as it is for okhttp (2) and JDA uses okhttp 3.8.1 which is okhttp3.