### PR TITLE
Add support to retrieve emotes via RestAction access

### DIFF
--- a/src/main/java/net/dv8tion/jda/client/managers/EmoteManager.java
+++ b/src/main/java/net/dv8tion/jda/client/managers/EmoteManager.java
@@ -74,12 +74,18 @@ public class EmoteManager extends ManagerBase
      */
     public EmoteManager(EmoteImpl emote)
     {
-        super(emote.getJDA(), Route.Emotes.MODIFY_EMOTE.compile(emote.getGuild().getId(), emote.getId()));
-        if (emote.isFake())
-            throw new IllegalStateException("Cannot modify a fake emote");
+        super(emote.getJDA(), Route.Emotes.MODIFY_EMOTE.compile(notNullGuild(emote).getId(), emote.getId()));
         this.emote = emote;
         if (isPermissionChecksEnabled())
             checkPermissions();
+    }
+
+    private static Guild notNullGuild(EmoteImpl emote)
+    {
+        Guild g = emote.getGuild();
+        if (g == null)
+            throw new IllegalStateException("Cannot modify a fake emote");
+        return g;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Emote.java
@@ -32,6 +32,14 @@ import java.util.List;
  *
  * <p><b>This does not represent unicode emojis like they are used in the official client! (:smiley: is not a custom emoji)</b>
  *
+ * <h2>Fake Emote</h2>
+ * When an emote is declared as fake it cannot be updated by JDA. That means it will not be accessible
+ * through cache such as {@link Guild#getEmoteCache()} and similar.
+ * <br>Fake emotes may or may not have an attached {@link Guild Guild} and thus might not be manageable though
+ * {@link #getManager()} or {@link #delete()}. They also might lack attached roles for {@link #getRoles()}.
+ *
+ * @see    net.dv8tion.jda.core.entities.ListedEmote ListedEmote
+ *
  * @since  2.2
  */
 public interface Emote extends ISnowflake, IMentionable, IFakeable
@@ -50,11 +58,23 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
      * <br><a href="https://discordapp.com/developers/docs/resources/guild#emoji-object" target="_blank">Learn More</a>
      *
      * @throws IllegalStateException
-     *         If this Emote is fake ({@link #isFake()})
+     *         If this Emote does not have attached roles according to {@link #hasRoles()}
      *
      * @return An immutable list of the roles this emote is active for (all roles if empty)
+     *
+     * @see    #hasRoles()
      */
     List<Role> getRoles();
+
+    /**
+     * Whether this Emote has attached roles. This might not be the case when the emote
+     * is retrieved through special cases like audit-logs.
+     *
+     * <p>If this is not true then {@link #getRoles()} will throw {@link IllegalStateException}.
+     *
+     * @return True, if this emote has roles attached
+     */
+    boolean hasRoles();
 
     /**
      * The name of this emote
@@ -152,7 +172,7 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
     @Override
     default String getAsMention()
     {
-        return (isAnimated() ? "<a:" : "<:") + getName() + ":" + getIdLong() + ">";
+        return (isAnimated() ? "<a:" : "<:") + getName() + ":" + getId() + ">";
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Emote.java
@@ -27,13 +27,15 @@ import java.util.List;
 /**
  * Represents a Custom Emote. (Custom Emoji in official Discord API terminology)
  *
+ * <p>You can retrieve the creator of an emote by using {@link Guild#retrieveEmote(Emote)} followed
+ * by using {@link ListedEmote#getUser()}.
+ *
  * <p><b>This does not represent unicode emojis like they are used in the official client! (:smiley: is not a custom emoji)</b>
  *
  * @since  2.2
  */
 public interface Emote extends ISnowflake, IMentionable, IFakeable
 {
-
     /**
      * The {@link net.dv8tion.jda.core.entities.Guild Guild} this emote is attached to.
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -699,6 +699,25 @@ public class EntityBuilder
             largeImageKey, largeImageText, smallImageKey, smallImageText);
     }
 
+    public EmoteImpl createEmote(GuildImpl guildObj, JSONObject json, boolean fake)
+    {
+        JSONArray emoteRoles = json.isNull("roles") ? new JSONArray() : json.getJSONArray("roles");
+        final long emoteId = json.getLong("id");
+        final User user = json.isNull("user") ? null : createFakeUser(json.getJSONObject("user"), false);
+        EmoteImpl emoteObj = (EmoteImpl) guildObj.getEmoteById(emoteId);
+        if (emoteObj == null)
+            emoteObj = new EmoteImpl(emoteId, guildObj, fake);
+        Set<Role> roleSet = emoteObj.getRoleSet();
+
+        for (int j = 0; j < emoteRoles.length(); j++)
+            roleSet.add(guildObj.getRoleById(emoteRoles.getString(j)));
+        return emoteObj
+                .setUser(user)
+                .setName(json.optString("name"))
+                .setAnimated(json.optBoolean("animated"))
+                .setManaged(Helpers.optBoolean(json, "managed"));
+    }
+
     public Category createCategory(JSONObject json, long guildId)
     {
         return createCategory(json, guildId, true);

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -709,10 +709,12 @@ public class EntityBuilder
             emoteObj = new EmoteImpl(emoteId, guildObj, fake);
         Set<Role> roleSet = emoteObj.getRoleSet();
 
+        roleSet.clear();
         for (int j = 0; j < emoteRoles.length(); j++)
             roleSet.add(guildObj.getRoleById(emoteRoles.getString(j)));
+        if (user != null)
+            emoteObj.setUser(user);
         return emoteObj
-                .setUser(user)
                 .setName(json.optString("name"))
                 .setAnimated(json.optBoolean("animated"))
                 .setManaged(Helpers.optBoolean(json, "managed"));

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -860,6 +860,38 @@ public interface Guild extends ISnowflake
     SnowflakeCacheView<Emote> getEmoteCache();
 
     /**
+     * Retrieves a list of emotes together with their respective creators.
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: List of {@link net.dv8tion.jda.core.entities.ListedEmote ListedEmote}
+     */
+    RestAction<List<ListedEmote>> retrieveEmotes();
+
+    /**
+     * Retrieves a listed emote together with its respective creators.
+     *
+     * @param  id
+     *         The emote id
+     * @throws IllegalArgumentException
+     *         If the provided id is not a valid snowflake
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.ListedEmote ListedEmote}
+     */
+    RestAction<ListedEmote> retrieveEmoteById(String id);
+
+    /**
+     * Retrieves a listed emote together with its respective creators.
+     *
+     * @param  id
+     *         The emote id
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.core.entities.ListedEmote ListedEmote}
+     */
+    default RestAction<ListedEmote> retrieveEmoteById(long id)
+    {
+        return retrieveEmoteById(Long.toUnsignedString(id));
+    }
+
+    /**
      * Gets an unmodifiable list of the currently banned {@link net.dv8tion.jda.core.entities.User Users}.
      * <br>If you wish to ban or unban a user, please {@link GuildController#ban(User, int) GuildController.ban(User, int)} or
      * {@link GuildController#unban(User) GuildController.ban(User)}.

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -946,10 +946,11 @@ public interface Guild extends ISnowflake
     default RestAction<ListedEmote> retrieveEmote(Emote emote)
     {
         Checks.notNull(emote, "Emote");
-        Checks.check(emote.getGuild().equals(this), "Emote must be from the same Guild!");
+        if (emote.getGuild() != null)
+            Checks.check(emote.getGuild().equals(this), "Emote must be from the same Guild!");
         if (emote instanceof ListedEmote && !emote.isFake())
         {
-            ListedEmote listedEmote = ((ListedEmote) emote);
+            ListedEmote listedEmote = (ListedEmote) emote;
             if (listedEmote.hasUser() || !getSelfMember().hasPermission(Permission.MANAGE_EMOTES))
                 return new RestAction.EmptyRestAction<>(getJDA(), listedEmote);
         }

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -862,12 +862,18 @@ public interface Guild extends ISnowflake
     /**
      * Retrieves a list of emotes together with their respective creators.
      *
+     * <p>Note that {@link ListedEmote#getUser()} is only available if the currently
+     * logged in account has {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
+     *
      * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: List of {@link net.dv8tion.jda.core.entities.ListedEmote ListedEmote}
      */
     RestAction<List<ListedEmote>> retrieveEmotes();
 
     /**
      * Retrieves a listed emote together with its respective creators.
+     *
+     * <p>Note that {@link ListedEmote#getUser()} is only available if the currently
+     * logged in account has {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
      *
      * @param  id
      *         The emote id
@@ -880,6 +886,9 @@ public interface Guild extends ISnowflake
 
     /**
      * Retrieves a listed emote together with its respective creators.
+     *
+     * <p>Note that {@link ListedEmote#getUser()} is only available if the currently
+     * logged in account has {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
      *
      * @param  id
      *         The emote id

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -870,6 +870,8 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
+    @Nonnull
+    @CheckReturnValue
     RestAction<List<ListedEmote>> retrieveEmotes();
 
     /**
@@ -896,7 +898,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
-    RestAction<ListedEmote> retrieveEmoteById(String id);
+    @Nonnull
+    @CheckReturnValue
+    RestAction<ListedEmote> retrieveEmoteById(@Nonnull String id);
 
     /**
      * Retrieves a listed emote together with its respective creator.
@@ -918,6 +922,8 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
+    @Nonnull
+    @CheckReturnValue
     default RestAction<ListedEmote> retrieveEmoteById(long id)
     {
         return retrieveEmoteById(Long.toUnsignedString(id));
@@ -943,7 +949,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
-    default RestAction<ListedEmote> retrieveEmote(Emote emote)
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<ListedEmote> retrieveEmote(@Nonnull Emote emote)
     {
         Checks.notNull(emote, "Emote");
         if (emote.getGuild() != null)

--- a/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.entities;
+
+/**
+ * Represents an emote retrieved from {@link Guild#retrieveEmotes()} or {@link Guild#retrieveEmoteById(long)}
+ */
+public interface ListedEmote extends Emote
+{
+    /**
+     * The user who created this Emote
+     *
+     * @return The user who created this Emote
+     */
+    User getUser();
+}

--- a/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
@@ -43,7 +43,7 @@ public interface ListedEmote extends Emote
      *
      * <p>This is only available for manually retrieved emotes from {@link Guild#retrieveEmotes()}
      * and {@link Guild#retrieveEmoteById(long)}.
-     *      * Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
+     * Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
      *
      * @return True, if this emote has an owner
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
@@ -24,7 +24,28 @@ public interface ListedEmote extends Emote
     /**
      * The user who created this Emote
      *
+     * <p>This is only available for manually retrieved emotes from {@link Guild#retrieveEmotes()}
+     * and {@link Guild#retrieveEmoteById(long)}.
+     * Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
+     *
+     * @throws IllegalStateException
+     *         If this emote does not have user information
+     *
      * @return The user who created this Emote
+     *
+     * @see    #hasUser()
      */
     User getUser();
+
+    /**
+     * Whether this Emote has information about the creator.
+     * <br>If this is false, {@link #getUser()} throws an {@link IllegalStateException}.
+     *
+     * <p>This is only available for manually retrieved emotes from {@link Guild#retrieveEmotes()}
+     * and {@link Guild#retrieveEmoteById(long)}.
+     *      * Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
+     *
+     * @return True, if this emote has an owner
+     */
+    boolean hasUser();
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
@@ -18,6 +18,8 @@ package net.dv8tion.jda.core.entities;
 
 /**
  * Represents an emote retrieved from {@link Guild#retrieveEmotes()} or {@link Guild#retrieveEmoteById(long)}
+ *
+ * @since 3.8.0
  */
 public interface ListedEmote extends Emote
 {
@@ -26,7 +28,7 @@ public interface ListedEmote extends Emote
      *
      * <p>This is only available for manually retrieved emotes from {@link Guild#retrieveEmotes()}
      * and {@link Guild#retrieveEmoteById(long)}.
-     * Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
+     * <br>Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
      *
      * @throws IllegalStateException
      *         If this emote does not have user information
@@ -43,7 +45,7 @@ public interface ListedEmote extends Emote
      *
      * <p>This is only available for manually retrieved emotes from {@link Guild#retrieveEmotes()}
      * and {@link Guild#retrieveEmoteById(long)}.
-     * Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
+     * <br>Requires {@link net.dv8tion.jda.core.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}.
      *
      * @return True, if this emote has an owner
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ListedEmote.java
@@ -19,6 +19,8 @@ package net.dv8tion.jda.core.entities;
 /**
  * Represents an emote retrieved from {@link Guild#retrieveEmotes()} or {@link Guild#retrieveEmoteById(long)}
  *
+ * @see   net.dv8tion.jda.core.entities.Emote Emote
+ *
  * @since 3.8.0
  */
 public interface ListedEmote extends Emote

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
@@ -65,7 +65,7 @@ public class EmoteImpl implements ListedEmote
         this.guild = guild;
         this.api = guild.getJDA();
         this.roles = Collections.synchronizedSet(new HashSet<>());
-        this.fake = false;
+        this.fake = fake;
     }
 
     public EmoteImpl(long id, JDAImpl api)
@@ -124,7 +124,15 @@ public class EmoteImpl implements ListedEmote
     @Override
     public User getUser()
     {
+        if (!hasUser())
+            throw new IllegalStateException("This emote does not have a user");
         return user;
+    }
+
+    @Override
+    public boolean hasUser()
+    {
+        return user != null;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
@@ -19,9 +19,10 @@ package net.dv8tion.jda.core.entities.impl;
 import net.dv8tion.jda.client.managers.EmoteManager;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.ListedEmote;
 import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
@@ -37,12 +38,13 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @since  2.2
  */
-public class EmoteImpl implements Emote
+public class EmoteImpl implements ListedEmote
 {
     private final long id;
     private final GuildImpl guild;
     private final JDAImpl api;
     private final Set<Role> roles;
+    private final boolean fake;
 
     private final ReentrantLock mngLock = new ReentrantLock();
     private volatile EmoteManager manager = null;
@@ -50,13 +52,20 @@ public class EmoteImpl implements Emote
     private boolean managed = false;
     private boolean animated = false;
     private String name;
+    private User user;
 
     public EmoteImpl(long id, GuildImpl guild)
+    {
+        this(id, guild, false);
+    }
+
+    public EmoteImpl(long id, GuildImpl guild, boolean fake)
     {
         this.id = id;
         this.guild = guild;
         this.api = guild.getJDA();
         this.roles = Collections.synchronizedSet(new HashSet<>());
+        this.fake = false;
     }
 
     public EmoteImpl(long id, JDAImpl api)
@@ -65,6 +74,7 @@ public class EmoteImpl implements Emote
         this.api = api;
         this.guild = null;
         this.roles = null;
+        this.fake = true;
     }
 
     @Override
@@ -96,7 +106,7 @@ public class EmoteImpl implements Emote
     @Override
     public boolean isFake()
     {
-        return guild == null;
+        return fake;
     }
 
     @Override
@@ -109,6 +119,12 @@ public class EmoteImpl implements Emote
     public JDA getJDA()
     {
         return api;
+    }
+
+    @Override
+    public User getUser()
+    {
+        return user;
     }
 
     @Override
@@ -174,6 +190,12 @@ public class EmoteImpl implements Emote
     public EmoteImpl setManaged(boolean val)
     {
         this.managed = val;
+        return this;
+    }
+
+    public EmoteImpl setUser(User user)
+    {
+        this.user = user;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
@@ -86,9 +86,15 @@ public class EmoteImpl implements ListedEmote
     @Override
     public List<Role> getRoles()
     {
-        if (isFake())
+        if (!hasRoles())
             throw new IllegalStateException("Unable to return roles because this emote is fake. (We do not know the origin Guild of this emote)");
         return Collections.unmodifiableList(new LinkedList<>(roles));
+    }
+
+    @Override
+    public boolean hasRoles()
+    {
+        return roles != null;
     }
 
     @Override
@@ -160,7 +166,7 @@ public class EmoteImpl implements ListedEmote
     @Override
     public AuditableRestAction<Void> delete()
     {
-        if (isFake())
+        if (getGuild() == null)
             throw new IllegalStateException("The emote you are trying to delete is not an actual emote we have access to (it is fake)!");
         if (managed)
             throw new UnsupportedOperationException("You cannot delete a managed emote!");
@@ -243,7 +249,7 @@ public class EmoteImpl implements ListedEmote
     public EmoteImpl clone()
     {
         if (isFake()) return null;
-        EmoteImpl copy = new EmoteImpl(id, guild).setManaged(managed).setAnimated(animated).setName(name);
+        EmoteImpl copy = new EmoteImpl(id, guild).setUser(user).setManaged(managed).setAnimated(animated).setName(name);
         copy.roles.addAll(roles);
         return copy;
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -327,6 +327,56 @@ public class GuildImpl implements Guild
         return emoteCache;
     }
 
+    @Override
+    public RestAction<List<ListedEmote>> retrieveEmotes()
+    {
+        Route.CompiledRoute route = Route.Emotes.GET_EMOTES.compile(getId());
+        return new RestAction<List<ListedEmote>>(api, route) {
+            @Override
+            protected void handleResponse(Response response, Request<List<ListedEmote>> request)
+            {
+                if (!response.isOk())
+                {
+                    request.onFailure(response);
+                    return;
+                }
+
+                EntityBuilder builder = GuildImpl.this.getJDA().getEntityBuilder();
+                JSONArray emotes = response.getArray();
+                List<ListedEmote> list = new ArrayList<>(emotes.length());
+                for (int i = 0; i < emotes.length(); i++)
+                {
+                    JSONObject emote = emotes.getJSONObject(i);
+                    list.add(builder.createEmote(GuildImpl.this, emote, true));
+                }
+
+                request.onSuccess(Collections.unmodifiableList(list));
+            }
+        };
+    }
+
+    @Override
+    public RestAction<ListedEmote> retrieveEmoteById(String id)
+    {
+        Checks.isSnowflake(id, "Emote ID");
+        Route.CompiledRoute route = Route.Emotes.GET_EMOTE.compile(getId(), id);
+        return new RestAction<ListedEmote>(api, route) {
+            @Override
+            protected void handleResponse(Response response, Request<ListedEmote> request)
+            {
+                if (!response.isOk())
+                {
+                    request.onFailure(response);
+                    return;
+                }
+
+                EntityBuilder builder = GuildImpl.this.getJDA().getEntityBuilder();
+                EmoteImpl emote = builder.createEmote(GuildImpl.this, response.getObject(), true);
+                request.onSuccess(emote);
+            }
+        };
+    }
+
     @Nonnull
     @Override
     public RestAction<List<Ban>> getBanList()

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -331,7 +331,8 @@ public class GuildImpl implements Guild
     public RestAction<List<ListedEmote>> retrieveEmotes()
     {
         Route.CompiledRoute route = Route.Emotes.GET_EMOTES.compile(getId());
-        return new RestAction<List<ListedEmote>>(api, route) {
+        return new RestAction<List<ListedEmote>>(api, route)
+        {
             @Override
             protected void handleResponse(Response response, Request<List<ListedEmote>> request)
             {
@@ -359,8 +360,16 @@ public class GuildImpl implements Guild
     public RestAction<ListedEmote> retrieveEmoteById(String id)
     {
         Checks.isSnowflake(id, "Emote ID");
+        Emote emote = getEmoteById(id);
+        if (emote != null && !emote.isFake())
+        {
+            ListedEmote listedEmote = (ListedEmote) emote;
+            if (listedEmote.hasUser() || !getSelfMember().hasPermission(Permission.MANAGE_EMOTES))
+                return new RestAction.EmptyRestAction<>(getJDA(), listedEmote);
+        }
         Route.CompiledRoute route = Route.Emotes.GET_EMOTE.compile(getId(), id);
-        return new RestAction<ListedEmote>(api, route) {
+        return new RestAction<ListedEmote>(api, route)
+        {
             @Override
             protected void handleResponse(Response response, Request<ListedEmote> request)
             {

--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -138,9 +138,12 @@ public class Route
     public static class Emotes
     {
         // These are all client endpoints and thus don't need defined major parameters
-        public static final Route MODIFY_EMOTE = new Route(PATCH,  "guilds/{guild_id}/emojis/{emote_id}");
-        public static final Route DELETE_EMOTE = new Route(DELETE, "guilds/{guild_id}/emojis/{emote_id}");
-        public static final Route CREATE_EMOTE = new Route(POST,   "guilds/{guild_id}/emojis");
+        public static final Route MODIFY_EMOTE = new Route(PATCH,  "guilds/{guild_id}/emojis/{emote_id}", "guild_id");
+        public static final Route DELETE_EMOTE = new Route(DELETE, "guilds/{guild_id}/emojis/{emote_id}", "guild_id");
+        public static final Route CREATE_EMOTE = new Route(POST,   "guilds/{guild_id}/emojis",            "guild_id");
+
+        public static final Route GET_EMOTES   = new Route(GET,    "guilds/{guild_id}/emojis",            "guild_id");
+        public static final Route GET_EMOTE    = new Route(GET,    "guilds/{guild_id}/emojis/{emoji_id}", "guild_id");
     }
 
     public static class Webhooks


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

## Description

Discord actually also lists the emote creator this way and its required
when disabling emote cache manually (see experimental/guild-setup)
