### PR TITLE
Fix IllegalArgumentException on TextChannel#canTalk()

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -178,7 +178,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     @Override
     public boolean canTalk(Member member)
     {
-        if (!guild.equals(member.getGuild()))
+        if (!getGuild().equals(member.getGuild()))
             throw new IllegalArgumentException("Provided Member is not from the Guild that this TextChannel is part of.");
 
         return member.hasPermission(this, Permission.MESSAGE_READ, Permission.MESSAGE_WRITE);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

Since the `guild` field is now an `UpstreamReference`, directly comparing it to a Guild object results in an error:
```java
java.lang.IllegalArgumentException: Provided Member is not from the Guild that this TextChannel is part of.
	at net.dv8tion.jda.core.entities.impl.TextChannelImpl.canTalk(TextChannelImpl.java:182)
	at net.dv8tion.jda.core.entities.impl.TextChannelImpl.canTalk(TextChannelImpl.java:175)
```