### PR TITLE
Add purgeMessages methods for convenient message deletions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ javadoc {
     options.author()
     options.encoding = 'UTF-8'
     options.addStringOption('-html5')
-    options.addStringOption('tag', 'incubating:any:Incubating')
+    options.addStringOption('tag', 'incubating:any:Incubating:')
 
     //### excludes ###
     //jda internals

--- a/src/main/java/net/dv8tion/jda/client/entities/impl/GroupImpl.java
+++ b/src/main/java/net/dv8tion/jda/client/entities/impl/GroupImpl.java
@@ -23,8 +23,10 @@ import net.dv8tion.jda.client.entities.Group;
 import net.dv8tion.jda.client.entities.Relationship;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.ChannelType;
+import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
+import net.dv8tion.jda.core.requests.RequestFuture;
 import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.core.utils.cache.UpstreamReference;
@@ -138,6 +140,20 @@ public class GroupImpl implements Group
                 friends.add(friend);
         });
         return Collections.unmodifiableList(friends);
+    }
+
+    @Override
+    public List<RequestFuture<Void>> purgeMessages(List<? extends Message> messages)
+    {
+        if (messages == null || messages.isEmpty())
+            return Collections.emptyList();
+        for (Message m : messages)
+        {
+            if (m.getAuthor().equals(getJDA().getSelfUser()))
+                continue;
+            throw new IllegalArgumentException("Cannot delete messages of other users in a group channel");
+        }
+        return Group.super.purgeMessages(messages);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -720,8 +720,8 @@ public interface Message extends ISnowflake, Formattable
      * a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} and the current account has
      * {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in the channel.
      *
-     * <p><u>To delete up 100 messages at once in a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
-     * you should use {@link net.dv8tion.jda.core.entities.TextChannel#deleteMessages(java.util.Collection) TextChannel.deleteMessages(Collection)}</u>
+     * <p><u>To delete many messages at once in a {@link net.dv8tion.jda.core.entities.MessageChannel MessageChannel}
+     * you should use {@link net.dv8tion.jda.core.entities.MessageChannel#purgeMessages(List) MessageChannel.purgeMessages(Collection)} instead.</u>
      *
      * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
@@ -754,6 +754,7 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.core.requests.restaction.AuditableRestAction AuditableRestAction}
      *
      * @see    net.dv8tion.jda.core.entities.TextChannel#deleteMessages(java.util.Collection) TextChannel.deleteMessages(Collection)
+     * @see    net.dv8tion.jda.core.entities.MessageChannel#purgeMessages(java.util.List) MessageChannel.purgeMessages(List)
      */
     @CheckReturnValue
     AuditableRestAction<Void> delete();

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -115,6 +115,11 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param  messages
      *         The message ids to delete
      *
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If one of the provided messages is from another user and cannot be deleted due to permissions
+     * @throws IllegalArgumentException
+     *         If one of the provided messages is from another user and cannot be deleted because this is not in a guild
+     *
      * @return List of futures representing all deletion tasks
      *
      * @see    RequestFuture#allOf(Collection)
@@ -122,10 +127,7 @@ public interface MessageChannel extends ISnowflake, Formattable
     default List<RequestFuture<Void>> purgeMessages(Message... messages)
     {
         Checks.notNull(messages, "Messages");
-        long[] ids = new long[messages.length];
-        for (int i = 0; i < ids.length; i++)
-            ids[i] = messages[i].getIdLong();
-        return purgeMessagesById(ids);
+        return purgeMessages(Arrays.asList(messages));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -82,7 +82,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Convenience method to delete messages in the most efficient way available.
-     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link Message#delete()}
+     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link #deleteMessageById(long)}
      * to delete all messages provided. No checks will be done to prevent failures, use {@link java.util.concurrent.CompletionStage#exceptionally(Function)}
      * to handle failures.
      *
@@ -107,7 +107,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Convenience method to delete messages in the most efficient way available.
-     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link Message#delete()}
+     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link #deleteMessageById(long)}
      * to delete all messages provided. No checks will be done to prevent failures, use {@link java.util.concurrent.CompletionStage#exceptionally(Function)}
      * to handle failures.
      *
@@ -186,7 +186,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Convenience method to delete messages in the most efficient way available.
-     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link deleteMessageById(long)}
+     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link #deleteMessageById(long)}
      * to delete all messages provided. No checks will be done to prevent failures, use {@link java.util.concurrent.CompletionStage#exceptionally(Function)}
      * to handle failures.
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -136,7 +136,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * <p>For possible ErrorResponses see {@link #purgeMessagesById(long...)}.
      *
      * @param  messages
-     *         The message to delete
+     *         The messages to delete
      *
      * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
      *         If one of the provided messages is from another user and cannot be deleted due to permissions
@@ -163,7 +163,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * <p>For possible ErrorResponses see {@link #purgeMessagesById(long...)}.
      *
      * @param  messages
-     *         The message to delete
+     *         The messages to delete
      *
      * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
      *         If one of the provided messages is from another user and cannot be deleted due to permissions

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -97,7 +97,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default List<RequestFuture<Void>> purgeMessagesById(List<String> messageIds)
     {
-        Checks.notNull(messageIds, "Messages IDs");
+        if (messageIds == null || messageIds.isEmpty())
+            return Collections.emptyList();
         long[] ids = new long[messageIds.size()];
         for (int i = 0; i < ids.length; i++)
             ids[i] = MiscUtil.parseSnowflake(messageIds.get(i));
@@ -112,8 +113,30 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * <p>For possible ErrorResponses see {@link #purgeMessagesById(long...)}.
      *
-     * @param  messages
+     * @param  messageIds
      *         The message ids to delete
+     *
+     * @return List of futures representing all deletion tasks
+     *
+     * @see    RequestFuture#allOf(Collection)
+     */
+    default List<RequestFuture<Void>> purgeMessagesById(String... messageIds)
+    {
+        if (messageIds == null || messageIds.length == 0)
+            return Collections.emptyList();
+        return purgeMessagesById(Arrays.asList(messageIds));
+    }
+
+    /**
+     * Convenience method to delete messages in the most efficient way available.
+     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link Message#delete()}
+     * to delete all messages provided. No checks will be done to prevent failures, use {@link java.util.concurrent.CompletionStage#exceptionally(Function)}
+     * to handle failures.
+     *
+     * <p>For possible ErrorResponses see {@link #purgeMessagesById(long...)}.
+     *
+     * @param  messages
+     *         The message to delete
      *
      * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
      *         If one of the provided messages is from another user and cannot be deleted due to permissions
@@ -126,7 +149,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default List<RequestFuture<Void>> purgeMessages(Message... messages)
     {
-        Checks.notNull(messages, "Messages");
+        if (messages == null || messages.length == 0)
+            return Collections.emptyList();
         return purgeMessages(Arrays.asList(messages));
     }
 
@@ -139,7 +163,12 @@ public interface MessageChannel extends ISnowflake, Formattable
      * <p>For possible ErrorResponses see {@link #purgeMessagesById(long...)}.
      *
      * @param  messages
-     *         The message ids to delete
+     *         The message to delete
+     *
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If one of the provided messages is from another user and cannot be deleted due to permissions
+     * @throws IllegalArgumentException
+     *         If one of the provided messages is from another user and cannot be deleted because this is not in a guild
      *
      * @return List of futures representing all deletion tasks
      *
@@ -147,7 +176,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     default List<RequestFuture<Void>> purgeMessages(List<? extends Message> messages)
     {
-        Checks.notNull(messages, "Messages");
+        if (messages == null || messages.isEmpty())
+            return Collections.emptyList();
         long[] ids = new long[messages.size()];
         for (int i = 0; i < ids.length; i++)
             ids[i] = messages.get(i).getIdLong();
@@ -156,7 +186,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Convenience method to delete messages in the most efficient way available.
-     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link Message#delete()}
+     * <br>This combines both {@link TextChannel#deleteMessagesByIds(Collection)} as well as {@link deleteMessageById(long)}
      * to delete all messages provided. No checks will be done to prevent failures, use {@link java.util.concurrent.CompletionStage#exceptionally(Function)}
      * to handle failures.
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -186,7 +186,10 @@ public interface MessageChannel extends ISnowflake, Formattable
         if (messageIds == null || messageIds.length == 0)
             return Collections.emptyList();
         List<RequestFuture<Void>> list = new ArrayList<>(messageIds.length);
+        TreeSet<Long> sortedIds = new TreeSet<>(Comparator.reverseOrder());
         for (long messageId : messageIds)
+            sortedIds.add(messageId);
+        for (long messageId : sortedIds)
             list.add(deleteMessageById(messageId).submit());
         return list;
     }

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -140,6 +140,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      * @return {@link net.dv8tion.jda.core.requests.restaction.AuditableRestAction AuditableRestAction}
      *
      * @see    #deleteMessagesByIds(Collection)
+     * @see    #purgeMessages(List)
      */
     @CheckReturnValue
     RestAction<Void> deleteMessages(Collection<Message> messages);
@@ -188,6 +189,7 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      * @return {@link net.dv8tion.jda.core.requests.restaction.AuditableRestAction AuditableRestAction}
      *
      * @see    #deleteMessages(Collection)
+     * @see    #purgeMessagesById(List)
      */
     @CheckReturnValue
     RestAction<Void> deleteMessagesByIds(Collection<String> messageIds);

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/PrivateChannelImpl.java
@@ -20,14 +20,13 @@ import net.dv8tion.jda.client.entities.Call;
 import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.entities.*;
-import net.dv8tion.jda.core.requests.Request;
-import net.dv8tion.jda.core.requests.Response;
-import net.dv8tion.jda.core.requests.RestAction;
-import net.dv8tion.jda.core.requests.Route;
+import net.dv8tion.jda.core.requests.*;
 import net.dv8tion.jda.core.requests.restaction.MessageAction;
 import net.dv8tion.jda.core.utils.cache.UpstreamReference;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
 
 public class PrivateChannelImpl implements PrivateChannel
 {
@@ -98,6 +97,20 @@ public class PrivateChannelImpl implements PrivateChannel
                     request.onFailure(response);
             }
         };
+    }
+
+    @Override
+    public List<RequestFuture<Void>> purgeMessages(List<? extends Message> messages)
+    {
+        if (messages == null || messages.isEmpty())
+            return Collections.emptyList();
+        for (Message m : messages)
+        {
+            if (m.getAuthor().equals(getJDA().getSelfUser()))
+                continue;
+            throw new IllegalArgumentException("Cannot delete messages of other users in a private channel");
+        }
+        return PrivateChannel.super.purgeMessages(messages);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -171,12 +171,14 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
         if (messages == null || messages.isEmpty())
             return Collections.emptyList();
         boolean hasPerms = getGuild().getSelfMember().hasPermission(this, Permission.MESSAGE_MANAGE);
-        for (Message m : messages)
+        if (!hasPerms)
         {
-            if (m.getAuthor().equals(getJDA().getSelfUser()))
-                continue;
-            if (!hasPerms)
+            for (Message m : messages)
+            {
+                if (m.getAuthor().equals(getJDA().getSelfUser()))
+                    continue;
                 throw new InsufficientPermissionException(Permission.MESSAGE_MANAGE, "Cannot delete messages of other users");
+            }
         }
         return TextChannel.super.purgeMessages(messages);
     }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -17,13 +17,11 @@
 package net.dv8tion.jda.core.entities.impl;
 
 import net.dv8tion.jda.client.exceptions.VerificationLevelException;
+import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException;
-import net.dv8tion.jda.core.requests.Request;
-import net.dv8tion.jda.core.requests.Response;
-import net.dv8tion.jda.core.requests.RestAction;
-import net.dv8tion.jda.core.requests.Route;
+import net.dv8tion.jda.core.requests.*;
 import net.dv8tion.jda.core.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.core.requests.restaction.ChannelAction;
 import net.dv8tion.jda.core.requests.restaction.MessageAction;
@@ -35,10 +33,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implements TextChannel
@@ -126,25 +121,11 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
         if (messageIds.size() < 2 || messageIds.size() > 100)
             throw new IllegalArgumentException("Must provide at least 2 or at most 100 messages to be deleted.");
 
-        long twoWeeksAgo = ((System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000)) - MiscUtil.DISCORD_EPOCH) << MiscUtil.TIMESTAMP_OFFSET;
+        long twoWeeksAgo = MiscUtil.getDiscordTimestamp((System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000)));
         for (String id : messageIds)
-        {
             Checks.check(MiscUtil.parseSnowflake(id) > twoWeeksAgo, "Message Id provided was older than 2 weeks. Id: " + id);
-        }
 
-        JSONObject body = new JSONObject().put("messages", messageIds);
-        Route.CompiledRoute route = Route.Messages.DELETE_MESSAGES.compile(getId());
-        return new RestAction<Void>(getJDA(), route, body)
-        {
-            @Override
-            protected void handleResponse(Response response, Request<Void> request)
-            {
-                if (response.isOk())
-                    request.onSuccess(null);
-                else
-                    request.onFailure(response);
-            }
-        };
+        return deleteMessages0(messageIds);
     }
 
     @Override
@@ -182,6 +163,42 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
             throw new IllegalArgumentException("Provided Member is not from the Guild that this TextChannel is part of.");
 
         return member.hasPermission(this, Permission.MESSAGE_READ, Permission.MESSAGE_WRITE);
+    }
+
+    @Override
+    @SuppressWarnings("ConstantConditions")
+    public List<RequestFuture<Void>> purgeMessagesById(long... messageIds)
+    {
+        if (messageIds == null || messageIds.length == 0)
+            return Collections.emptyList();
+        if (getJDA().getAccountType() != AccountType.BOT
+            || !getGuild().getSelfMember().hasPermission(Permission.MESSAGE_MANAGE))
+            return TextChannel.super.purgeMessagesById(messageIds);
+
+        // remove duplicates and sort messages
+        List<RequestFuture<Void>> list = new LinkedList<>();
+        TreeSet<Long> sortedIds = new TreeSet<>();
+        for (long messageId : messageIds)
+            sortedIds.add(messageId);
+
+        // delete messages too old for bulk delete
+        long twoWeeksAgo = MiscUtil.getDiscordTimestamp(System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000) - 10000);
+        Set<Long> oldMessages = sortedIds.stream().filter(id -> twoWeeksAgo > id).collect(Collectors.toSet());
+        for (long message : oldMessages)
+            list.add(deleteMessageById(message).submit());
+
+        sortedIds.removeAll(oldMessages);
+
+        // delete chunks of 100 messages each
+        List<String> toDelete = new ArrayList<>(100);
+        while (!sortedIds.isEmpty())
+        {
+            toDelete.clear();
+            for (int i = 0; i < 100 && !sortedIds.isEmpty(); i++)
+                toDelete.add(Long.toUnsignedString(sortedIds.pollLast()));
+            list.add(deleteMessages0(toDelete).submit());
+        }
+        return list;
     }
 
     @Override
@@ -496,5 +513,22 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     {
         if (!getGuild().checkVerification())
             throw new VerificationLevelException(getGuild().getVerificationLevel());
+    }
+
+    private RestAction<Void> deleteMessages0(Collection<String> messageIds)
+    {
+        JSONObject body = new JSONObject().put("messages", messageIds);
+        Route.CompiledRoute route = Route.Messages.DELETE_MESSAGES.compile(getId());
+        return new RestAction<Void>(getJDA(), route, body)
+        {
+            @Override
+            protected void handleResponse(Response response, Request<Void> request)
+            {
+                if (response.isOk())
+                    request.onSuccess(null);
+                else
+                    request.onFailure(response);
+            }
+        };
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/TextChannelImpl.java
@@ -166,13 +166,29 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     }
 
     @Override
+    public List<RequestFuture<Void>> purgeMessages(List<? extends Message> messages)
+    {
+        if (messages == null || messages.isEmpty())
+            return Collections.emptyList();
+        boolean hasPerms = getGuild().getSelfMember().hasPermission(this, Permission.MESSAGE_MANAGE);
+        for (Message m : messages)
+        {
+            if (m.getAuthor().equals(getJDA().getSelfUser()))
+                continue;
+            if (!hasPerms)
+                throw new InsufficientPermissionException(Permission.MESSAGE_MANAGE, "Cannot delete messages of other users");
+        }
+        return TextChannel.super.purgeMessages(messages);
+    }
+
+    @Override
     @SuppressWarnings("ConstantConditions")
     public List<RequestFuture<Void>> purgeMessagesById(long... messageIds)
     {
         if (messageIds == null || messageIds.length == 0)
             return Collections.emptyList();
         if (getJDA().getAccountType() != AccountType.BOT
-            || !getGuild().getSelfMember().hasPermission(Permission.MESSAGE_MANAGE))
+            || !getGuild().getSelfMember().hasPermission(this, Permission.MESSAGE_MANAGE))
             return TextChannel.super.purgeMessagesById(messageIds);
 
         // remove duplicates and sort messages

--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -508,7 +508,7 @@ public class Route
     {
         private DeleteMessageRoute()
         {
-            super(DELETE, "channels/{channel_id}/messages/{message_id}", "channel_id");
+            super(DELETE, true, "channels/{channel_id}/messages/{message_id}", "channel_id");
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/core/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Route.java
@@ -208,7 +208,7 @@ public class Route
         public static final Route REMOVE_ALL_REACTIONS =     new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions",                           "channel_id");
         public static final Route GET_REACTION_USERS =       new Route(GET,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}",           "channel_id");
 
-        public static final Route DELETE_MESSAGE =      new Route(DELETE, true, "channels/{channel_id}/messages/{message_id}", "channel_id");
+        public static final Route DELETE_MESSAGE =      new DeleteMessageRoute();
         public static final Route GET_MESSAGE_HISTORY = new Route(GET,    true, "channels/{channel_id}/messages",              "channel_id");
 
         //Bot only
@@ -353,7 +353,7 @@ public class Route
 
         //Compile the route for interfacing with discord.
         String compiledRoute = String.format(compilableRoute, (Object[]) params);
-        String compiledRatelimitRoute = ratelimitRoute;
+        String compiledRatelimitRoute = getRatelimitRoute();
 
         //If this route has major parameters which help to uniquely distinguish it from others of this route type then
         // compile it using the major parameter indexes we discovered in the constructor.
@@ -489,6 +489,32 @@ public class Route
         public final int getResetTime()
         {
             return this.resetTime;
+        }
+    }
+
+    //edit message uses a different rate-limit bucket as delete message and thus we need a special handling
+
+    /*
+    From the docs:
+
+    There is currently a single exception to the above rule regarding different HTTP methods sharing the same rate limit,
+    and that is for the deletion of messages.
+    Deleting messages falls under a separate, higher rate limit so that bots are able
+    to more quickly delete content from channels (which is useful for moderation bots).
+
+    As of 1st of September 2018
+     */
+    private static class DeleteMessageRoute extends Route
+    {
+        private DeleteMessageRoute()
+        {
+            super(DELETE, "channels/{channel_id}/messages/{message_id}", "channel_id");
+        }
+
+        @Override
+        public String getRatelimitRoute()
+        {
+            return "channels/%s/messages/{message_id}/delete"; //the additional "/delete" forces a new bucket
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/PaginationAction.java
@@ -317,6 +317,7 @@ public abstract class PaginationAction<T, M extends PaginationAction<T, M>>
 
     /**
      * Convenience method to retrieve an amount of entities from this pagination action.
+     * <br>This also includes already cached entities similar to {@link #forEachAsync(Procedure)}.
      *
      * @param  amount
      *         The maximum amount to retrieve
@@ -335,6 +336,7 @@ public abstract class PaginationAction<T, M extends PaginationAction<T, M>>
 
     /**
      * Convenience method to retrieve an amount of entities from this pagination action.
+     * <br>Unlike {@link #takeAsync(int)} this does not include already cached entities.
      *
      * @param  amount
      *         The maximum amount to retrieve


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

## Description

This makes deleting messages a lot easier than it was before.

Example:

```java
List<Message> messages = new LinkedList<>();
AtomicInteger count = new AtomicInteger(0);
event.getChannel().getIterableHistory().forEachAsync((msg) -> {
   messages.add(msg);
   return count.incrementAndGet() < 1000;
}).thenRunAsync(() -> {
    for (RequestFuture<Void> future : event.getChannel().purgeMessages(messages))
    {
        future.exceptionally((t) -> {
            t.printStackTrace();
            return null;
        });
    }
});
```
