### PR TITLE
Replace Emote#hasRoles to avoid ambiguity

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Emote.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.core.entities;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.client.managers.EmoteManager;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.requests.restaction.AuditableRestAction;
@@ -58,11 +60,11 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
      * <br><a href="https://discordapp.com/developers/docs/resources/guild#emoji-object" target="_blank">Learn More</a>
      *
      * @throws IllegalStateException
-     *         If this Emote does not have attached roles according to {@link #hasRoles()}
+     *         If this Emote does not have attached roles according to {@link #canProvideRoles()}
      *
      * @return An immutable list of the roles this emote is active for (all roles if empty)
      *
-     * @see    #hasRoles()
+     * @see    #canProvideRoles()
      */
     List<Role> getRoles();
 
@@ -73,8 +75,26 @@ public interface Emote extends ISnowflake, IMentionable, IFakeable
      * <p>If this is not true then {@link #getRoles()} will throw {@link IllegalStateException}.
      *
      * @return True, if this emote has roles attached
+     *
+     * @deprecated This will be replaced by {@link #canProvideRoles()}
      */
-    boolean hasRoles();
+    @Deprecated
+    @DeprecatedSince("3.8.0")
+    @ReplaceWith("canProvideRoles()")
+    default boolean hasRoles()
+    {
+        return canProvideRoles();
+    }
+
+    /**
+     * Whether this Emote has an attached roles list. This might not be the case when the emote
+     * is retrieved through special cases like audit-logs.
+     *
+     * <p>If this is not true then {@link #getRoles()} will throw {@link IllegalStateException}.
+     *
+     * @return True, if this emote has an attached roles list
+     */
+    boolean canProvideRoles();
 
     /**
      * The name of this emote

--- a/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/EntityBuilder.java
@@ -533,7 +533,11 @@ public class EntityBuilder
 
         roleSet.clear();
         for (int j = 0; j < emoteRoles.length(); j++)
-            roleSet.add(guildObj.getRoleById(emoteRoles.getString(j)));
+        {
+            Role role = guildObj.getRoleById(emoteRoles.getString(j));
+            if (role != null)
+                roleSet.add(role);
+        }
         if (user != null)
             emoteObj.setUser(user);
         return emoteObj

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/EmoteImpl.java
@@ -18,9 +18,7 @@ package net.dv8tion.jda.core.entities.impl;
 
 import net.dv8tion.jda.client.managers.EmoteManager;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.ListedEmote;
-import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.exceptions.InsufficientPermissionException;
@@ -87,13 +85,13 @@ public class EmoteImpl implements ListedEmote
     @Override
     public List<Role> getRoles()
     {
-        if (!hasRoles())
+        if (!canProvideRoles())
             throw new IllegalStateException("Unable to return roles because this emote is fake. (We do not know the origin Guild of this emote)");
         return Collections.unmodifiableList(new LinkedList<>(roles));
     }
 
     @Override
-    public boolean hasRoles()
+    public boolean canProvideRoles()
     {
         return roles != null;
     }

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildEmojisUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildEmojisUpdateHandler.java
@@ -89,8 +89,11 @@ public class GuildEmojisUpdateHandler extends SocketHandler
             for (int j = 0; j < roles.length(); j++)
             {
                 Role role = guild.getRoleById(roles.getString(j));
-                newRoles.add(role);
-                oldRoles.remove(role);
+                if (role != null)
+                {
+                    newRoles.add(role);
+                    oldRoles.remove(role);
+                }
             }
 
             //cleanup old cached roles that were not found in the JSONArray

--- a/src/main/java/net/dv8tion/jda/core/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/GuildRoleDeleteHandler.java
@@ -15,8 +15,10 @@
  */
 package net.dv8tion.jda.core.handle;
 
+import net.dv8tion.jda.core.entities.Emote;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.entities.impl.EmoteImpl;
 import net.dv8tion.jda.core.entities.impl.GuildImpl;
 import net.dv8tion.jda.core.entities.impl.JDAImpl;
 import net.dv8tion.jda.core.entities.impl.MemberImpl;
@@ -55,12 +57,20 @@ public class GuildRoleDeleteHandler extends SocketHandler
             return null;
         }
 
-        //Now that the role is removed from the Guild, remove it from all users.
+        //Now that the role is removed from the Guild, remove it from all users and emotes.
         for (Member m : guild.getMembersMap().valueCollection())
         {
             MemberImpl member = (MemberImpl) m;
             member.getRoleSet().remove(removedRole);
         }
+
+        for (Emote emote : guild.getEmoteCache())
+        {
+            EmoteImpl impl = (EmoteImpl) emote;
+            if (impl.canProvideRoles())
+                impl.getRoleSet().remove(removedRole);
+        }
+
         getJDA().getEventManager().handle(
             new RoleDeleteEvent(
                 getJDA(), responseNumber,

--- a/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
@@ -160,7 +160,7 @@ public class PermissionUtil
             }
         }
 
-        return emote.hasRoles() && (emote.getRoles().isEmpty() // Emote restricted to roles -> check if the issuer has them
+        return emote.canProvideRoles() && (emote.getRoles().isEmpty() // Emote restricted to roles -> check if the issuer has them
             || CollectionUtils.containsAny(issuer.getRoles(), emote.getRoles()));
     }
 


### PR DESCRIPTION
Although I am not a fan of having a release that adds a deprecated
method, this is probably for the better

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

Now it should be abundantly clear that this has nothing to do with the size of the list.
