### PR TITLE
Update documentation of JDABuilder and add new constructor overloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ _Please see the [Discord docs](https://discordapp.com/developers/docs/reference)
 
 ## UserBots and SelfBots
 
-Discord is currently not too fond of people creating and using automated client accounts (AccountType.CLIENT).
+Discord is currently prohibiting creation and usage of automated client accounts (AccountType.CLIENT).
 We however still have support to login with these accounts due to legacy support. That does not mean it is allowed or
 welcome to use.
+Note that JDA is not a good tool to build a custom discord client as it loads all servers/guilds on startup unlike
+a client which does this via lazy loading instead.
 If you need a bot, use a bot account from the [Application Dashboard](https://discordapp.com/developers/applications).
 
 [Read More](https://support.discordapp.com/hc/en-us/articles/115002192352-Automated-user-accounts-self-bots-)
 
 ## Creating the JDA Object
 
-Creating the JDA Object is done via the JDABuilder class by providing an AccountType (Bot/Client).
-After setting the token and other options via setters,
+Creating the JDA Object is done via the JDABuilder class. After setting the token and other options via setters,
 the JDA Object is then created by calling the `build()` method. When `build()` returns,
 JDA might not have finished starting up. However, you can use `awaitReady()`
 on the JDA object to ensure that the entire cache is loaded before proceeding.
@@ -55,7 +56,9 @@ Note that this method is blocking and will cause the thread to sleep until start
 JDA jda = new JDABuilder("token").build();
 ```
 
-**Note**: It is important to set the correct AccountType because Bot-accounts require a token prefix to login.
+**Note**: By default this will use the `AccountType.BOT` as that is the recommended type of account.
+You can change this to use `AccountType.CLIENT` however that is risking account termination.
+Use `new JDABuilder(AccountType)` to change to a different account type.
 
 #### Examples:
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 [license]: https://img.shields.io/badge/License-Apache%202.0-lightgrey.svg
 [jenkins]: https://img.shields.io/badge/Download-Jenkins-brightgreen.svg
 [FAQ]: https://img.shields.io/badge/Wiki-FAQ-blue.svg
+[Troubleshooting]: https://img.shields.io/badge/Wiki-Troubleshooting-red.svg
 [ ![version][] ][download]
 [ ![jenkins][] ](http://home.dv8tion.net:8080/job/JDA/lastSuccessfulBuild/)
 [ ![license][] ](https://github.com/DV8FromTheWorld/JDA/tree/master/LICENSE)
 [ ![Discord](https://discordapp.com/api/guilds/125227483518861312/widget.png) ][discord-invite]
 [ ![FAQ] ](https://github.com/DV8FromTheWorld/JDA/wiki/10\)-FAQ)
+[ ![Troubleshooting] ](https://github.com/DV8FromTheWorld/JDA/wiki/19\)-Troubleshooting)
 
 <img align="right" src="https://i.imgur.com/OG7Tne8.png" height="200" width="200">
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note that this method is blocking and will cause the thread to sleep until start
 **Example**:
 
 ```java
-JDA jda = new JDABuilder(AccountType.BOT).setToken("token").build();
+JDA jda = new JDABuilder("token").build();
 ```
 
 **Note**: It is important to set the correct AccountType because Bot-accounts require a token prefix to login.
@@ -66,8 +66,7 @@ public class ReadyListener implements EventListener
             throws LoginException, InterruptedException
     {
         // Note: It is important to register your ReadyListener before building
-        JDA jda = new JDABuilder(AccountType.BOT)
-            .setToken("token")
+        JDA jda = new JDABuilder("token")
             .addEventListener(new ReadyListener())
             .build();
 
@@ -92,7 +91,7 @@ public class MessageListener extends ListenerAdapter
     public static void main(String[] args)
             throws LoginException
     {
-        JDA jda = new JDABuilder(AccountType.BOT).setToken("token").build();
+        JDA jda = new JDABuilder("token").build();
         jda.addEventListener(new MessageListener());
     }
 
@@ -149,7 +148,7 @@ Since version **3.4.0** JDA provides a `ShardManager` which automates this build
 ```java
 public static void main(String[] args) throws Exception
 {
-    JDABuilder shardBuilder = new JDABuilder(AccountType.BOT).setToken(args[0]);
+    JDABuilder shardBuilder = new JDABuilder(args[0]);
     //register your listeners here using shardBuilder.addEventListener(...)
     shardBuilder.addEventListener(new MessageListener());
     for (int i = 0; i < 10; i++)

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ javadoc {
     options.author()
     options.encoding = 'UTF-8'
     options.addStringOption('-html5')
-    options.addStringOption('tag', 'incubating:any:Incubating:')
+    options.addStringOption('tag', 'incubating:a:Incubating:')
 
     //### excludes ###
     //jda internals

--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -15,7 +15,6 @@
  */
 
 import net.dv8tion.jda.client.entities.Group;
-import net.dv8tion.jda.core.AccountType;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.JDABuilder;
 import net.dv8tion.jda.core.Permission;
@@ -40,8 +39,7 @@ public class MessageListenerExample extends ListenerAdapter
         // we would use AccountType.CLIENT
         try
         {
-            JDA jda = new JDABuilder(AccountType.BOT)
-                    .setToken("Your-Token-Goes-Here")                // The token of the account that is logging in.
+            JDA jda = new JDABuilder("Your-Token-Goes-Here")         // The token of the account that is logging in.
                     .addEventListener(new MessageListenerExample())  // An instance of a class that will handle events.
                     .build();
             jda.awaitReady(); // Blocking guarantees that JDA will be completely loaded.

--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -251,7 +251,7 @@ public class MessageListenerExample extends ListenerAdapter
         else if (msg.equals("!block"))
         {
             //This is an example of how to use the complete() method on RestAction. The complete method acts similarly to how
-            // JDABuilder's buildBlocking works, it waits until the request has been sent before continuing execution.
+            // JDABuilder's awaitReady() works, it waits until the request has been sent before continuing execution.
             //Most developers probably wont need this and can just use queue. If you use complete, JDA will still handle ratelimit
             // control, however if shouldQueue is false it won't queue the Request to be sent after the ratelimit retry after time is past. It
             // will instead fire a RateLimitException!

--- a/src/main/java/net/dv8tion/jda/annotations/Incubating.java
+++ b/src/main/java/net/dv8tion/jda/annotations/Incubating.java
@@ -26,7 +26,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
 public @interface Incubating
 {
 }

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -97,6 +97,11 @@ public class JDABuilder
 
     /**
      * Creates a JDABuilder with the predefined token.
+     *
+     * @param token
+     *        The bot token to use
+     *
+     * @see   #setToken(String)
      */
     public JDABuilder(String token)
     {

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.core;
 
 import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.core.JDA.Status;
 import net.dv8tion.jda.core.audio.factory.IAudioSendFactory;
@@ -51,6 +52,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 public class JDABuilder
 {
     protected final List<Object> listeners;
+    protected final AccountType accountType;
 
     protected ScheduledThreadPoolExecutor rateLimitPool = null;
     protected boolean shutdownRateLimitPool = true;
@@ -62,7 +64,6 @@ public class JDABuilder
     protected OkHttpClient.Builder httpClientBuilder = null;
     protected OkHttpClient httpClient = null;
     protected WebSocketFactory wsFactory = null;
-    protected AccountType accountType;
     protected String token = null;
     protected IEventManager eventManager = null;
     protected IAudioSendFactory audioSendFactory = null;
@@ -82,6 +83,29 @@ public class JDABuilder
 
     /**
      * Creates a completely empty JDABuilder.
+     *
+     * <br>If you use this, you need to set the token using
+     * {@link net.dv8tion.jda.core.JDABuilder#setToken(String) setToken(String)}
+     * before calling {@link net.dv8tion.jda.core.JDABuilder#build() build()}
+     *
+     * @see #JDABuilder(String)
+     */
+    public JDABuilder()
+    {
+        this(AccountType.BOT);
+    }
+
+    /**
+     * Creates a JDABuilder with the predefined token.
+     */
+    public JDABuilder(String token)
+    {
+        this();
+        setToken(token);
+    }
+
+    /**
+     * Creates a completely empty JDABuilder.
      * <br>If you use this, you need to set the token using
      * {@link net.dv8tion.jda.core.JDABuilder#setToken(String) setToken(String)}
      * before calling {@link net.dv8tion.jda.core.JDABuilder#build() build()}
@@ -91,7 +115,10 @@ public class JDABuilder
      *
      * @throws IllegalArgumentException
      *         If the given AccountType is {@code null}
+     *
+     * @incubating Due to policy changes for the discord API this method may not be provided in a future version
      */
+    @Incubating
     public JDABuilder(AccountType accountType)
     {
         Checks.notNull(accountType, "accountType");
@@ -225,15 +252,6 @@ public class JDABuilder
      *     <li>Create or select an already existing application</li>
      *     <li>Verify that it has already been turned into a Bot. If you see the "Create a Bot User" button, click it.</li>
      *     <li>Click the <i>click to reveal</i> link beside the <b>Token</b> label to show your Bot's {@code token}</li>
-     * </ol>
-     *
-     * <h2>For {@link net.dv8tion.jda.core.AccountType#CLIENT}</h2>
-     * <br>Using either the Discord desktop app or the Browser Webapp
-     * <ol>
-     *     <li>Press {@code Ctrl-Shift-i} which will bring up the developer tools.</li>
-     *     <li>Go to the {@code Application} tab</li>
-     *     <li>Under {@code Storage}, select {@code Local Storage}, and then {@code discordapp.com}</li>
-     *     <li>Find the {@code token} row and copy the value that is in quotes.</li>
      * </ol>
      *
      * @param  token


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

There are several guidelines you should follow in order for your
  Pull Request to be merged.

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

> It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.

## Description

The documentation for retrieving a token on `AccountType.CLIENT` is no longer accurate and will not work. Since discord only officially allows `AccountType.BOT` and we recommend not using anything else I've added new default overloads to the constructor and marked the old version as incubating in the case discord actually comes along and asks us to remove it.
