### PR TITLE
Prevent using complete() in callbacks

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/CallbackContext.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/CallbackContext.java
@@ -18,7 +18,7 @@ package net.dv8tion.jda.core.requests;
 
 class CallbackContext implements AutoCloseable
 {
-    private static ThreadLocal<Boolean> callback = ThreadLocal.withInitial(() -> false);
+    private static final ThreadLocal<Boolean> callback = ThreadLocal.withInitial(() -> false);
     private static final CallbackContext instance = new CallbackContext();
 
     static CallbackContext getInstance()

--- a/src/main/java/net/dv8tion/jda/core/requests/CallbackContext.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/CallbackContext.java
@@ -18,7 +18,7 @@ package net.dv8tion.jda.core.requests;
 
 class CallbackContext implements AutoCloseable
 {
-    private static ThreadLocal<Boolean> callback = new ThreadLocal<>();
+    private static ThreadLocal<Boolean> callback = ThreadLocal.withInitial(() -> false);
     private static final CallbackContext instance = new CallbackContext();
 
     static CallbackContext getInstance()
@@ -29,7 +29,7 @@ class CallbackContext implements AutoCloseable
 
     static boolean isCallbackContext()
     {
-        return callback.get() != null && callback.get();
+        return callback.get();
     }
 
     private static void startCallback()

--- a/src/main/java/net/dv8tion/jda/core/requests/CallbackContext.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/CallbackContext.java
@@ -1,0 +1,45 @@
+/*
+ *     Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.requests;
+
+class CallbackContext implements AutoCloseable
+{
+    private static ThreadLocal<Boolean> callback = new ThreadLocal<>();
+    private static final CallbackContext instance = new CallbackContext();
+
+    static CallbackContext getInstance()
+    {
+        startCallback();
+        return instance;
+    }
+
+    static boolean isCallbackContext()
+    {
+        return callback.get() != null && callback.get();
+    }
+
+    private static void startCallback()
+    {
+        callback.set(true);
+    }
+
+    @Override
+    public void close()
+    {
+        callback.set(false);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/requests/Request.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/Request.java
@@ -71,7 +71,8 @@ public class Request<T>
     {
         api.getCallbackPool().execute(() ->
         {
-            try (ThreadLocalReason.Closable __ = ThreadLocalReason.closable(localReason))
+            try (ThreadLocalReason.Closable __ = ThreadLocalReason.closable(localReason);
+                 CallbackContext ___ = CallbackContext.getInstance())
             {
                 onSuccess.accept(successObj);
             }
@@ -101,7 +102,8 @@ public class Request<T>
     {
         api.getCallbackPool().execute(() ->
         {
-            try (ThreadLocalReason.Closable __ = ThreadLocalReason.closable(localReason))
+            try (ThreadLocalReason.Closable __ = ThreadLocalReason.closable(localReason);
+                 CallbackContext ___ = CallbackContext.getInstance())
             {
                 onFailure.accept(failException);
                 if (failException instanceof Error)

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -420,6 +420,8 @@ public abstract class RestAction<T>
      */
     public T complete(boolean shouldQueue) throws RateLimitedException
     {
+        if (CallbackContext.isCallbackContext())
+            throw new IllegalStateException("Preventing use of complete() in callback threads! This operation can be a deadlock cause");
         try
         {
             return submit(shouldQueue).get();

--- a/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/RestAction.java
@@ -387,6 +387,9 @@ public abstract class RestAction<T>
      *
      * <p><b>This might throw {@link java.lang.RuntimeException RuntimeExceptions}</b>
      *
+     * @throws IllegalStateException
+     *         If used within a {@link #queue(Consumer, Consumer) queue(...)} callback
+     *
      * @return The response value
      */
     public T complete()
@@ -412,6 +415,8 @@ public abstract class RestAction<T>
      * @param  shouldQueue
      *         Whether this should automatically handle rate limitations (default true)
      *
+     * @throws IllegalStateException
+     *         If used within a {@link #queue(Consumer, Consumer) queue(...)} callback
      * @throws RateLimitedException
      *         If we were rate limited and the {@code shouldQueue} is false.
      *         Use {@link #complete()} to avoid this Exception.


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

## Description

```java
channel.sendMessage("hello there").queue( msg -> {
    msg.editMessage("general kenobi").queue(); // ok
    msg.delete().complete(); // throws
});
```

This way we prevent any deadlocks from occurring in a fixed-pool causing everything to halt for a shard (or all shards if one shared pool is used)