### PR TITLE
Replace ScheduledThreadPoolExecutor with ScheduledExecutorService

### DIFF
--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManager.java
@@ -149,9 +149,9 @@ public class DefaultShardManager implements ShardManager
     protected final OkHttpClient httpClient;
 
     /**
-     * The {@link ScheduledThreadPoolExecutor ScheduledThreadPoolExecutor} that will be used by JDAs rate-limit handler.
+     * The {@link ScheduledExecutorService ScheduledExecutorService} that will be used by JDAs rate-limit handler.
      */
-    protected final ThreadPoolProvider<? extends ScheduledThreadPoolExecutor> rateLimitPoolProvider;
+    protected final ThreadPoolProvider<? extends ScheduledExecutorService> rateLimitPoolProvider;
 
     /**
      * The {@link ExecutorService ExecutorService} that will be used by JDAs callback handler.
@@ -297,7 +297,7 @@ public class DefaultShardManager implements ShardManager
                                   final String token, final IEventManager eventManager, final IAudioSendFactory audioSendFactory,
                                   final IntFunction<? extends Game> gameProvider, final IntFunction<OnlineStatus> statusProvider,
                                   final OkHttpClient.Builder httpClientBuilder, final OkHttpClient httpClient,
-                                  final ThreadPoolProvider<? extends ScheduledThreadPoolExecutor> rateLimitPoolProvider,
+                                  final ThreadPoolProvider<? extends ScheduledExecutorService> rateLimitPoolProvider,
                                   final ThreadPoolProvider<? extends ExecutorService> callbackPoolProvider,
                                   final WebSocketFactory wsFactory, final ThreadFactory threadFactory,
                                   final int maxReconnectDelay, final int corePoolSize, final boolean enableVoice,
@@ -626,7 +626,7 @@ public class DefaultShardManager implements ShardManager
         OkHttpClient httpClient = this.httpClient;
         if (httpClient == null)
             httpClient = this.httpClientBuilder.build();
-        ScheduledThreadPoolExecutor rateLimitPool = null;
+        ScheduledExecutorService rateLimitPool = null;
         boolean shutdownRateLimitPool = true;
         if (rateLimitPoolProvider != null)
         {

--- a/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/DefaultShardManagerBuilder.java
@@ -62,7 +62,7 @@ public class DefaultShardManagerBuilder
     protected IntFunction<OnlineStatus> statusProvider = null;
     protected IntFunction<? extends Game> gameProvider = null;
     protected IntFunction<? extends ConcurrentMap<String, String>> contextProvider = null;
-    protected ThreadPoolProvider<? extends ScheduledThreadPoolExecutor> rateLimitPoolProvider = null;
+    protected ThreadPoolProvider<? extends ScheduledExecutorService> rateLimitPoolProvider = null;
     protected ThreadPoolProvider<? extends ExecutorService> callbackPoolProvider = null;
     protected Collection<Integer> shards = null;
     protected IEventManager eventManager = null;
@@ -421,7 +421,7 @@ public class DefaultShardManagerBuilder
      * {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} which is used
      * in various locations throughout the JDA instance created by this ShardManager. (Default: 5)
      * <br>Note: This has no effect if you set a pool using
-     * {@link #setRateLimitPool(ScheduledThreadPoolExecutor)} or {@link #setRateLimitPoolProvider(ThreadPoolProvider)}.
+     * {@link #setRateLimitPool(ScheduledExecutorService)} or {@link #setRateLimitPoolProvider(ThreadPoolProvider)}.
      *
      * @param  size
      *         The core pool size for the global JDA executor
@@ -653,25 +653,25 @@ public class DefaultShardManagerBuilder
     }
 
     /**
-     * Sets the {@link ScheduledThreadPoolExecutor ScheduledThreadPoolExecutor} that should be used in
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} that should be used in
      * the JDA rate-limit handler. Changing this can drastically change the JDA behavior for RestAction execution
      * and should be handled carefully. <b>Only change this pool if you know what you're doing.</b>
      * <br>This will override the rate-limit pool provider set from {@link #setRateLimitPoolProvider(ThreadPoolProvider)}.
      * <br><b>This automatically disables the automatic shutdown of the JDA pools, you can enable
-     * it using {@link #setRateLimitPool(ScheduledThreadPoolExecutor, boolean) setRateLimiPool(executor, true)}</b>
+     * it using {@link #setRateLimitPool(ScheduledExecutorService, boolean) setRateLimiPool(executor, true)}</b>
      *
      * @param  pool
      *         The thread-pool to use for rate-limit handling
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder setRateLimitPool(ScheduledThreadPoolExecutor pool)
+    public DefaultShardManagerBuilder setRateLimitPool(ScheduledExecutorService pool)
     {
         return setRateLimitPool(pool, pool == null);
     }
 
     /**
-     * Sets the {@link ScheduledThreadPoolExecutor ScheduledThreadPoolExecutor} that should be used in
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} that should be used in
      * the JDA rate-limit handler. Changing this can drastically change the JDA behavior for RestAction execution
      * and should be handled carefully. <b>Only change this pool if you know what you're doing.</b>
      * <br>This will override the rate-limit pool provider set from {@link #setRateLimitPoolProvider(ThreadPoolProvider)}.
@@ -683,13 +683,13 @@ public class DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder setRateLimitPool(ScheduledThreadPoolExecutor pool, boolean automaticShutdown)
+    public DefaultShardManagerBuilder setRateLimitPool(ScheduledExecutorService pool, boolean automaticShutdown)
     {
         return setRateLimitPoolProvider(pool == null ? null : new ThreadPoolProviderImpl<>(pool, automaticShutdown));
     }
 
     /**
-     * Sets the {@link ScheduledThreadPoolExecutor ScheduledThreadPoolExecutor} provider that should be used in
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} provider that should be used in
      * the JDA rate-limit handler. Changing this can drastically change the JDA behavior for RestAction execution
      * and should be handled carefully. <b>Only change this pool if you know what you're doing.</b>
      *
@@ -698,7 +698,7 @@ public class DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    public DefaultShardManagerBuilder setRateLimitPoolProvider(ThreadPoolProvider<? extends ScheduledThreadPoolExecutor> provider)
+    public DefaultShardManagerBuilder setRateLimitPoolProvider(ThreadPoolProvider<? extends ScheduledExecutorService> provider)
     {
         this.rateLimitPoolProvider = provider;
         return this;

--- a/src/main/java/net/dv8tion/jda/core/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/JDABuilder.java
@@ -37,7 +37,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Used to create new {@link net.dv8tion.jda.core.JDA} instances. This is also useful for making sure all of
@@ -54,7 +54,7 @@ public class JDABuilder
     protected final List<Object> listeners;
     protected final AccountType accountType;
 
-    protected ScheduledThreadPoolExecutor rateLimitPool = null;
+    protected ScheduledExecutorService rateLimitPool = null;
     protected boolean shutdownRateLimitPool = true;
     protected ExecutorService callbackPool = null;
     protected boolean shutdownCallbackPool = true;
@@ -319,7 +319,7 @@ public class JDABuilder
      * Sets the core pool size for the global JDA
      * {@link java.util.concurrent.ScheduledExecutorService ScheduledExecutorService} which is used
      * in various locations throughout the JDA instance created by this builder. (Default: 5)
-     * <br>Note: This has no effect if you set a pool using {@link #setRateLimitPool(ScheduledThreadPoolExecutor)}.
+     * <br>Note: This has no effect if you set a pool using {@link #setRateLimitPool(ScheduledExecutorService)}.
      *
      * @param  size
      *         The core pool size for the global JDA executor
@@ -337,24 +337,24 @@ public class JDABuilder
     }
 
     /**
-     * Sets the {@link ScheduledThreadPoolExecutor ScheduledThreadPoolExecutor} that should be used in
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} that should be used in
      * the JDA rate-limit handler. Changing this can drastically change the JDA behavior for RestAction execution
      * and should be handled carefully. <b>Only change this pool if you know what you're doing.</b>
      * <br><b>This automatically disables the automatic shutdown of the JDA pools, you can enable
-     * it using {@link #setRateLimitPool(ScheduledThreadPoolExecutor, boolean) setRateLimitPool(executor, true)}</b>
+     * it using {@link #setRateLimitPool(ScheduledExecutorService, boolean) setRateLimitPool(executor, true)}</b>
      *
      * @param  pool
      *         The thread-pool to use for rate-limit handling
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    public JDABuilder setRateLimitPool(ScheduledThreadPoolExecutor pool)
+    public JDABuilder setRateLimitPool(ScheduledExecutorService pool)
     {
         return setRateLimitPool(pool, pool == null);
     }
 
     /**
-     * Sets the {@link ScheduledThreadPoolExecutor ScheduledThreadPoolExecutor} that should be used in
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} that should be used in
      * the JDA rate-limit handler. Changing this can drastically change the JDA behavior for RestAction execution
      * and should be handled carefully. <b>Only change this pool if you know what you're doing.</b>
      *
@@ -365,7 +365,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    public JDABuilder setRateLimitPool(ScheduledThreadPoolExecutor pool, boolean automaticShutdown)
+    public JDABuilder setRateLimitPool(ScheduledExecutorService pool, boolean automaticShutdown)
     {
         this.rateLimitPool = pool;
         this.shutdownRateLimitPool = automaticShutdown;

--- a/src/main/java/net/dv8tion/jda/core/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/core/audio/AudioWebSocket.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -55,7 +55,7 @@ class AudioWebSocket extends WebSocketAdapter
 
     private final AudioConnection audioConnection;
     private final ConnectionListener listener;
-    private final ScheduledThreadPoolExecutor keepAlivePool;
+    private final ScheduledExecutorService keepAlivePool;
     private final Guild guild;
     private final String sessionId;
     private final String token;


### PR DESCRIPTION
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code)
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

Some existing delegators out there, for example Spring's `DelegatingSecurityContextScheduledExecutorService`, only implement the `ScheduledExecutorService` interface, and therefore can't be used for JDA's ratelimit pool.
The only reason JDA requires a `ScheduledThreadPoolExecutor` for the ratelimit pool is due to the optional customizing of the pool's shutdown behavior, therefore I think moving to using the more generic `ScheduledExecutorService` would be reasonable.