### PR TITLE
Add Guild#getChannels for convenience

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -733,6 +733,58 @@ public interface Guild extends ISnowflake
     SnowflakeCacheView<VoiceChannel> getVoiceChannelCache();
 
     /**
+     * Populated list of {@link net.dv8tion.jda.core.entities.Channel channels} for this guild.
+     * This includes all types of channels, such as category/voice/text.
+     * <br>This includes hidden channels by default.
+     *
+     * <p>The returned list is ordered in the same fashion as it would be by the official discord client.
+     * <ol>
+     *     <li>TextChannel without parent</li>
+     *     <li>VoiceChannel without parent</li>
+     *     <li>Categories
+     *         <ol>
+     *             <li>TextChannel with category as parent</li>
+     *             <li>VoiceChannel with category as parent</li>
+     *         </ol>
+     *     </li>
+     * </ol>
+     *
+     * @return Immutable list of channels for this guild
+     *
+     * @see    #getChannels(boolean)
+     */
+    default List<Channel> getChannels()
+    {
+        return getChannels(true);
+    }
+
+    /**
+     * Populated list of {@link net.dv8tion.jda.core.entities.Channel channels} for this guild.
+     * This includes all types of channels, such as category/voice/text.
+     *
+     * <p>The returned list is ordered in the same fashion as it would be by the official discord client.
+     * <ol>
+     *     <li>TextChannel without parent</li>
+     *     <li>VoiceChannel without parent</li>
+     *     <li>Categories
+     *         <ol>
+     *             <li>TextChannel with category as parent</li>
+     *             <li>VoiceChannel with category as parent</li>
+     *         </ol>
+     *     </li>
+     * </ol>
+     *
+     *
+     * @param  includeHidden
+     *         Whether to include channels with denied {@link Permission#VIEW_CHANNEL View Channel Permission}
+     *
+     * @return Immutable list of channels for this guild
+     *
+     * @see    #getChannels()
+     */
+    List<Channel> getChannels(boolean includeHidden);
+
+    /**
      * Gets a {@link net.dv8tion.jda.core.entities.Role Role} from this guild that has the same id as the
      * one provided.
      * <br>If there is no {@link net.dv8tion.jda.core.entities.Role Role} with an id that matches the provided

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -342,7 +342,7 @@ public class GuildImpl implements Guild
         {
             List<TextChannel> textChannels = category.getTextChannels().stream().filter(filterHidden).collect(Collectors.toList());
             List<VoiceChannel> voiceChannels = category.getVoiceChannels().stream().filter(filterHidden).collect(Collectors.toList());
-            if (textChannels.isEmpty() && voiceChannels.isEmpty())
+            if (!includeHidden && textChannels.isEmpty() && voiceChannels.isEmpty())
                 continue;
             channels.add(category);
             channels.addAll(textChannels);

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/GuildImpl.java
@@ -340,11 +340,13 @@ public class GuildImpl implements Guild
 
         for (Category category : categories)
         {
-            if (!filterHidden.test(category))
+            List<TextChannel> textChannels = category.getTextChannels().stream().filter(filterHidden).collect(Collectors.toList());
+            List<VoiceChannel> voiceChannels = category.getVoiceChannels().stream().filter(filterHidden).collect(Collectors.toList());
+            if (textChannels.isEmpty() && voiceChannels.isEmpty())
                 continue;
             channels.add(category);
-            category.getTextChannels().stream().filter(filterHidden).forEach(channels::add);
-            category.getVoiceChannels().stream().filter(filterHidden).forEach(channels::add);
+            channels.addAll(textChannels);
+            channels.addAll(voiceChannels);
         }
 
         return Collections.unmodifiableList(channels);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Convenience method to retrieve list of channels in a guild. The returned list is ordered the same way the client orders channels.
