### PR TITLE
Reordered VoiceState changes. Fixes #805

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/core/handle/VoiceStateUpdateHandler.java
@@ -110,6 +110,39 @@ public class VoiceStateUpdateHandler extends SocketHandler
             return;
         vState.setSessionId(sessionId); //Cant really see a reason for an event for this
 
+        boolean wasMute = vState.isMuted();
+        boolean wasDeaf = vState.isDeafened();
+
+        if (selfMuted != vState.isSelfMuted())
+        {
+            vState.setSelfMuted(selfMuted);
+            getJDA().getEventManager().handle(new GuildVoiceSelfMuteEvent(getJDA(), responseNumber, member));
+        }
+        if (selfDeafened != vState.isSelfDeafened())
+        {
+            vState.setSelfDeafened(selfDeafened);
+            getJDA().getEventManager().handle(new GuildVoiceSelfDeafenEvent(getJDA(), responseNumber, member));
+        }
+        if (guildMuted != vState.isGuildMuted())
+        {
+            vState.setGuildMuted(guildMuted);
+            getJDA().getEventManager().handle(new GuildVoiceGuildMuteEvent(getJDA(), responseNumber, member));
+        }
+        if (guildDeafened != vState.isGuildDeafened())
+        {
+            vState.setGuildDeafened(guildDeafened);
+            getJDA().getEventManager().handle(new GuildVoiceGuildDeafenEvent(getJDA(), responseNumber, member));
+        }
+        if (suppressed != vState.isSuppressed())
+        {
+            vState.setSuppressed(suppressed);
+            getJDA().getEventManager().handle(new GuildVoiceSuppressEvent(getJDA(), responseNumber, member));
+        }
+        if (wasMute != vState.isMuted())
+            getJDA().getEventManager().handle(new GuildVoiceMuteEvent(getJDA(), responseNumber, member));
+        if (wasDeaf != vState.isDeafened())
+            getJDA().getEventManager().handle(new GuildVoiceDeafenEvent(getJDA(), responseNumber, member));
+            
         if (!Objects.equals(channel, vState.getChannel()))
         {
             VoiceChannelImpl oldChannel = (VoiceChannelImpl) vState.getChannel();
@@ -162,39 +195,6 @@ public class VoiceStateUpdateHandler extends SocketHandler
                                 member, oldChannel));
             }
         }
-
-        boolean wasMute = vState.isMuted();
-        boolean wasDeaf = vState.isDeafened();
-
-        if (selfMuted != vState.isSelfMuted())
-        {
-            vState.setSelfMuted(selfMuted);
-            getJDA().getEventManager().handle(new GuildVoiceSelfMuteEvent(getJDA(), responseNumber, member));
-        }
-        if (selfDeafened != vState.isSelfDeafened())
-        {
-            vState.setSelfDeafened(selfDeafened);
-            getJDA().getEventManager().handle(new GuildVoiceSelfDeafenEvent(getJDA(), responseNumber, member));
-        }
-        if (guildMuted != vState.isGuildMuted())
-        {
-            vState.setGuildMuted(guildMuted);
-            getJDA().getEventManager().handle(new GuildVoiceGuildMuteEvent(getJDA(), responseNumber, member));
-        }
-        if (guildDeafened != vState.isGuildDeafened())
-        {
-            vState.setGuildDeafened(guildDeafened);
-            getJDA().getEventManager().handle(new GuildVoiceGuildDeafenEvent(getJDA(), responseNumber, member));
-        }
-        if (suppressed != vState.isSuppressed())
-        {
-            vState.setSuppressed(suppressed);
-            getJDA().getEventManager().handle(new GuildVoiceSuppressEvent(getJDA(), responseNumber, member));
-        }
-        if (wasMute != vState.isMuted())
-            getJDA().getEventManager().handle(new GuildVoiceMuteEvent(getJDA(), responseNumber, member));
-        if (wasDeaf != vState.isDeafened())
-            getJDA().getEventManager().handle(new GuildVoiceDeafenEvent(getJDA(), responseNumber, member));
     }
 
     private void handleCallVoiceState(JSONObject content)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #805

## Description
Fixes issue where we were firing VoiceChannel Join/Move/Leave events before updating VoiceState (mute, deaf, guildMute, guildDeaf, etc).
