### PR TITLE
Add shorthand removeReaction methods and improve the reaction docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -956,6 +956,237 @@ public interface Message extends ISnowflake, Formattable
     RestAction<Void> addReaction(String unicode);
 
     /**
+     * Attempts to remove a reaction from this Message using an {@link net.dv8tion.jda.core.entities.Emote Emote}.
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p>This operation attempts to remove only the reaction added by the current account, it does not affect
+     * the reactions added by other users.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p><b><u>Unicode emojis are not included as {@link net.dv8tion.jda.core.entities.Emote Emote}!</u></b>
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_EMOJI}
+     *     <br>The provided unicode character does not refer to a known emoji unicode character.
+     *     <br>Proper unicode characters for emojis can be found at
+     *         <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">http://unicode.org/emoji/charts/full-emoji-list.html</a></li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  emote
+     *         The {@link net.dv8tion.jda.core.entities.Emote Emote} to to remove from this Message.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is not a Received Message from {@link net.dv8tion.jda.core.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *         and the logged in account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} is null.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} is fake {@link net.dv8tion.jda.core.entities.Emote#isFake() Emote.isFake()}.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} cannot be used in the current channel.
+     *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *         </ul>
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     */
+    @CheckReturnValue
+    RestAction<Void> removeReaction(Emote emote);
+
+    /**
+     * Attempts to remove a reaction from this Message using a UTF8 emoji.
+     * <br>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p>This operation attempts to remove only the reaction added by the current account, it does not affect
+     * the reactions added by other users.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p><b><u>Unicode emojis are not included as {@link net.dv8tion.jda.core.entities.Emote Emote}!</u></b>
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_EMOJI}
+     *     <br>The provided unicode character does not refer to a known emoji unicode character.
+     *     <br>Proper unicode characters for emojis can be found at
+     *         <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">http://unicode.org/emoji/charts/full-emoji-list.html</a></li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  unicode
+     *         The UTF8 emoji to add as a reaction to this Message.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is not a Received Message from {@link net.dv8tion.jda.core.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *         and the logged in account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided unicode emoji is null or empty.
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     */
+    @CheckReturnValue
+    RestAction<Void> removeReaction(String unicode);
+
+    /**
+     * Attempts to remove a reaction from this Message using an {@link net.dv8tion.jda.core.entities.Emote Emote}.
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p><b><u>Unicode emojis are not included as {@link net.dv8tion.jda.core.entities.Emote Emote}!</u></b>
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_EMOJI}
+     *     <br>The provided unicode character does not refer to a known emoji unicode character.
+     *     <br>Proper unicode characters for emojis can be found at
+     *         <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">http://unicode.org/emoji/charts/full-emoji-list.html</a></li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  emote
+     *         The {@link net.dv8tion.jda.core.entities.Emote Emote} to remove from this Message
+     * @param  user
+     *         The target {@link net.dv8tion.jda.core.entities.User User} of which to remove from
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is not a Received Message from {@link net.dv8tion.jda.core.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *         and the logged in account does not have
+     *         <ul>
+     *             <li>{@link net.dv8tion.jda.core.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION}</li>
+     *             <li>{@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *         </ul>
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} is null.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} is fake {@link net.dv8tion.jda.core.entities.Emote#isFake() Emote.isFake()}.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} cannot be used in the current channel.
+     *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     */
+    @CheckReturnValue
+    RestAction<Void> removeReaction(Emote emote, User user);
+
+    /**
+     * Attempts to remove a reaction from this Message using an {@link net.dv8tion.jda.core.entities.Emote Emote}.
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p><b><u>Unicode emojis are not included as {@link net.dv8tion.jda.core.entities.Emote Emote}!</u></b>
+     *
+     * <p>The following {@link net.dv8tion.jda.core.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.core.entities.Guild Guild} or {@link net.dv8tion.jda.client.entities.Group Group}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_EMOJI}
+     *     <br>The provided unicode character does not refer to a known emoji unicode character.
+     *     <br>Proper unicode characters for emojis can be found at
+     *         <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">http://unicode.org/emoji/charts/full-emoji-list.html</a></li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  unicode
+     *         The unicode characters of the emoji
+     * @param  user
+     *         The target {@link net.dv8tion.jda.core.entities.User User} of which to remove from
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is not a Received Message from {@link net.dv8tion.jda.core.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
+     *         and the logged in account does not have
+     *         <ul>
+     *             <li>{@link net.dv8tion.jda.core.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION}</li>
+     *             <li>{@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *         </ul>
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} is null.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} is fake {@link net.dv8tion.jda.core.entities.Emote#isFake() Emote.isFake()}.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.core.entities.Emote Emote} cannot be used in the current channel.
+     *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.core.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.core.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
+     *
+     * @return {@link net.dv8tion.jda.core.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     */
+    @CheckReturnValue
+    RestAction<Void> removeReaction(String unicode, User user);
+
+    /**
      * Removes all reactions from this Message.
      * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
      *

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageChannel.java
@@ -1848,11 +1848,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      * Attempts to react to a message represented by the specified {@code messageId}
      * in this MessageChannel.
      *
-     * <p>The unicode provided has to be a unicode representation of the emoji
-     * that is supposed to be represented by the Reaction.
-     * <br>To retrieve the characters needed you can use an api or
-     * the official discord client by escaping the emoji (\:emoji-name:)
-     * and copying the resulting emoji from the sent message.
+     * <p>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     * You can also retrieve the characters needed by escaping the emoji (\:emoji-name:)
+     * in the official Discord client and copying the resulting emoji from the sent message.
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
@@ -1931,11 +1930,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      * Attempts to react to a message represented by the specified {@code messageId}
      * in this MessageChannel.
      *
-     * <p>The unicode provided has to be a unicode representation of the emoji
-     * that is supposed to be represented by the Reaction.
-     * <br>To retrieve the characters needed you can use an api or
-     * the official discord client by escaping the emoji (\:emoji-name:)
-     * and copying the resulting emoji from the sent message.
+     * <p>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     * You can also retrieve the characters needed by escaping the emoji (\:emoji-name:)
+     * in the official Discord client and copying the resulting emoji from the sent message.
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
@@ -2133,14 +2131,13 @@ public interface MessageChannel extends ISnowflake, Formattable
     }
 
     /**
-     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * Attempts to remove the UTF8 emoji reaction from a message represented by the specified {@code messageId}
      * in this MessageChannel.
      *
-     * <p>The unicode provided has to be a unicode representation of the emoji
-     * that is supposed to be represented by the Reaction.
-     * <br>To retrieve the characters needed you can use an api or
-     * the official discord client by escaping the emoji (\:emoji-name:)
-     * and copying the resulting emoji from the sent message.
+     * <p>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     * You can also retrieve the characters needed by escaping the emoji (\:emoji-name:)
+     * in the official Discord client and copying the resulting emoji from the sent message.
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
@@ -2208,14 +2205,13 @@ public interface MessageChannel extends ISnowflake, Formattable
     }
 
     /**
-     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * Attempts to remove the UTF8 emoji reaction from a message represented by the specified {@code messageId}
      * in this MessageChannel.
      *
-     * <p>The unicode provided has to be a unicode representation of the emoji
-     * that is supposed to be represented by the Reaction.
-     * <br>To retrieve the characters needed you can use an api or
-     * the official discord client by escaping the emoji (\:emoji-name:)
-     * and copying the resulting emoji from the sent message.
+     * <p>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     * You can also retrieve the characters needed by escaping the emoji (\:emoji-name:)
+     * in the official Discord client and copying the resulting emoji from the sent message.
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>

--- a/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/TextChannel.java
@@ -44,11 +44,11 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      * @return Possibly-null String containing the topic of this TextChannel.
      */
     String getTopic();
-    
+
     /**
     * Whether or not this channel is considered as "NSFW" (Not-Safe-For-Work)
     * <br>This will check whether the name of this TextChannel begins with {@code nsfw-} or is equal to {@code nsfw}!
-    * 
+    *
     * @return True, If this TextChannel is considered NSFW by the official Discord Client
     */
     boolean isNSFW();
@@ -314,14 +314,13 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
     }
 
     /**
-     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * Attempts to remove a UTF8 emoji reaction from a message represented by the specified {@code messageId}
      * in this MessageChannel.
      *
-     * <p>The unicode provided has to be a unicode representation of the emoji
-     * that is supposed to be represented by the Reaction.
-     * <br>To retrieve the characters needed you can use an api or
-     * the official discord client by escaping the emoji (\:emoji-name:)
-     * and copying the resulting emoji from the sent message.
+     * <p>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     * You can also retrieve the characters needed by escaping the emoji (\:emoji-name:)
+     * in the official Discord client and copying the resulting emoji from the sent message.
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
@@ -376,14 +375,13 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
     RestAction<Void> removeReactionById(String messageId, String unicode, User user);
 
     /**
-     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * Attempts to remove a UTF8 emoji reaction from a message represented by the specified {@code messageId}
      * in this MessageChannel.
      *
-     * <p>The unicode provided has to be a unicode representation of the emoji
-     * that is supposed to be represented by the Reaction.
-     * <br>To retrieve the characters needed you can use an api or
-     * the official discord client by escaping the emoji (\:emoji-name:)
-     * and copying the resulting emoji from the sent message.
+     * <p>A reference of UTF8 emojis can be found here:
+     * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
+     * You can also retrieve the characters needed by escaping the emoji (\:emoji-name:)
+     * in the official Discord client and copying the resulting emoji from the sent message.
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
@@ -456,7 +454,6 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      *         was revoked in the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel}
      *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.core.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
      *
-     *
      *     <li>{@link net.dv8tion.jda.core.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
      *     <br>The request was attempted after the account lost
      *         {@link net.dv8tion.jda.core.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION} in the
@@ -478,9 +475,9 @@ public interface TextChannel extends Channel, MessageChannel, Comparable<TextCha
      * @param  messageId
      *         The messageId to remove the reaction from
      * @param  emote
-     *         The emote to remove
+     *         The {@link net.dv8tion.jda.core.entities.Emote Emote} to remove
      * @param  user
-     *         The target user of which to remove from
+     *         The target {@link net.dv8tion.jda.core.entities.User User} of which to remove from
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/AbstractMessage.java
@@ -382,6 +382,32 @@ public abstract class AbstractMessage implements Message
     }
 
     @Override
+    public RestAction<Void> removeReaction(Emote emote)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(String unicode)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(Emote emote, User user) {
+        unsupported();
+        return null;
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(String unicode, User user) {
+        unsupported();
+        return null;
+    }
+
+    @Override
     public RestAction<Void> clearReactions()
     {
         unsupported();

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
@@ -150,6 +150,66 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
+    public RestAction<Void> removeReaction(Emote emote)
+    {
+        Checks.notNull(emote, "Emote");
+
+        MessageReaction reaction = reactions.parallelStream()
+            .filter(r -> Objects.equals(r.getReactionEmote().getId(), emote.getId()))
+            .findFirst().orElse(null);
+
+        if (reaction == null || !reaction.isSelf())
+            return new RestAction.EmptyRestAction<>(getJDA(), null);
+
+        return reaction.removeReaction();
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(String unicode)
+    {
+        Checks.notEmpty(unicode, "Provided Unicode");
+
+        MessageReaction reaction = reactions.parallelStream()
+            .filter(r -> Objects.equals(r.getReactionEmote().getName(), unicode))
+            .findFirst().orElse(null);
+
+        if (reaction == null || !reaction.isSelf())
+            return new RestAction.EmptyRestAction<>(getJDA(), null);
+
+        return reaction.removeReaction();
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(Emote emote, User user)
+    {
+        Checks.notNull(emote, "Emote");
+
+        MessageReaction reaction = reactions.parallelStream()
+            .filter(r -> Objects.equals(r.getReactionEmote().getId(), emote.getId()))
+            .findFirst().orElse(null);
+
+        if (reaction == null)
+            return new RestAction.EmptyRestAction<>(getJDA(), null);
+
+        return reaction.removeReaction(user);
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(String unicode, User user)
+    {
+        Checks.notEmpty(unicode, "Provided Unicode");
+
+        MessageReaction reaction = reactions.parallelStream()
+            .filter(r -> Objects.equals(r.getReactionEmote().getName(), unicode))
+            .findFirst().orElse(null);
+
+        if (reaction == null)
+            return new RestAction.EmptyRestAction<>(getJDA(), null);
+
+        return reaction.removeReaction(user);
+    }
+
+    @Override
     public RestAction<Void> clearReactions()
     {
         if (!isFromType(ChannelType.TEXT))

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
@@ -117,8 +117,8 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notNull(emote, "Emote");
 
-        MessageReaction reaction = reactions.parallelStream()
-                .filter(r -> Objects.equals(r.getReactionEmote().getId(), emote.getId()))
+        MessageReaction reaction = reactions.stream()
+                .filter(r -> r.getReactionEmote().getIdLong() == emote.getIdLong())
                 .findFirst().orElse(null);
 
         if (reaction == null)
@@ -139,7 +139,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notEmpty(unicode, "Provided Unicode");
 
-        MessageReaction reaction = reactions.parallelStream()
+        MessageReaction reaction = reactions.stream()
                 .filter(r -> Objects.equals(r.getReactionEmote().getName(), unicode))
                 .findFirst().orElse(null);
 
@@ -154,8 +154,8 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notNull(emote, "Emote");
 
-        MessageReaction reaction = reactions.parallelStream()
-            .filter(r -> Objects.equals(r.getReactionEmote().getId(), emote.getId()))
+        MessageReaction reaction = reactions.stream()
+            .filter(r -> r.getReactionEmote().getIdLong() == emote.getIdLong())
             .findFirst().orElse(null);
 
         if (reaction == null || !reaction.isSelf())
@@ -169,7 +169,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notEmpty(unicode, "Provided Unicode");
 
-        MessageReaction reaction = reactions.parallelStream()
+        MessageReaction reaction = reactions.stream()
             .filter(r -> Objects.equals(r.getReactionEmote().getName(), unicode))
             .findFirst().orElse(null);
 
@@ -184,8 +184,8 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notNull(emote, "Emote");
 
-        MessageReaction reaction = reactions.parallelStream()
-            .filter(r -> Objects.equals(r.getReactionEmote().getId(), emote.getId()))
+        MessageReaction reaction = reactions.stream()
+            .filter(r -> r.getReactionEmote().getIdLong() == emote.getIdLong())
             .findFirst().orElse(null);
 
         if (reaction == null)
@@ -199,7 +199,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notEmpty(unicode, "Provided Unicode");
 
-        MessageReaction reaction = reactions.parallelStream()
+        MessageReaction reaction = reactions.stream()
             .filter(r -> Objects.equals(r.getReactionEmote().getName(), unicode))
             .findFirst().orElse(null);
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/SystemMessage.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/SystemMessage.java
@@ -62,6 +62,30 @@ public class SystemMessage extends ReceivedMessage
     }
 
     @Override
+    public RestAction<Void> removeReaction(Emote emote)
+    {
+        throw new UnsupportedOperationException("Cannot remove reactions from message of this Message Type. MessageType: " + getType());
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(String unicode)
+    {
+        throw new UnsupportedOperationException("Cannot remove reactions from message of this Message Type. MessageType: " + getType());
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(Emote emote, User user)
+    {
+        throw new UnsupportedOperationException("Cannot remove reactions from message of this Message Type. MessageType: " + getType());
+    }
+
+    @Override
+    public RestAction<Void> removeReaction(String unicode, User user)
+    {
+        throw new UnsupportedOperationException("Cannot remove reactions from message of this Message Type. MessageType: " + getType());
+    }
+
+    @Override
     public RestAction<Void> clearReactions()
     {
         throw new UnsupportedOperationException("Cannot clear reactions for message of this Message Type. MessageType: " + getType());


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds four methods:
- Message#removeReaction(String)
- Message#removeReaction(Emote)
- Message#removeReaction(String, User)
- Message#removeReaction(Emote, User)

such that the user doesn't need to do `message.getChannel().removeReactionById(message.getId(), ...)` - it's consistent with `Message#addReaction`.

Additionally marginally changes some docs.

---

I truly hope I have not messed up all the `@throws` and `ErrorResponse` things in the docs 🙏 

Praise hacktoberfest and have a nice day!