### PR TITLE
Add ChannelAction#setPosition(Integer)

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
@@ -46,6 +46,7 @@ public class ChannelAction extends AuditableRestAction<Channel>
     protected final ChannelType type;
     protected String name;
     protected Category parent;
+    protected Integer position;
 
     // --text only--
     protected String topic = null;
@@ -124,6 +125,29 @@ public class ChannelAction extends AuditableRestAction<Channel>
     {
         Checks.check(category == null || category.getGuild().equals(guild), "Category is not from same guild!");
         this.parent = category;
+        return this;
+    }
+
+    /**
+     * Sets the position where the new Channel should be inserted into.
+     * This refers to the raw position value, not the computed (relative) position.
+     * <p>
+     * By default (or by providing this method with {@code null}),
+     * the position will automatically be computed based on the other channels.
+     *
+     * @param  position
+     *         The raw position value that should be used for the new Channel
+     *
+     * @throws IllegalArgumentException
+     *         If the provided position value is {@code <0}
+     *
+     * @return The current ChannelAction, for chaining convenience
+     */
+    @CheckReturnValue
+    public ChannelAction setPosition(Integer position)
+    {
+        Checks.check(position == null || position >= 0, "Position must be >= 0!");
+        this.position = position;
         return this;
     }
 
@@ -358,6 +382,8 @@ public class ChannelAction extends AuditableRestAction<Channel>
         object.put("name", name);
         object.put("type", type.getId());
         object.put("permission_overwrites", new JSONArray(overrides));
+        if (position != null)
+            object.put("position", position);
         switch (type)
         {
             case VOICE:

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/ChannelAction.java
@@ -133,7 +133,11 @@ public class ChannelAction extends AuditableRestAction<Channel>
      * This refers to the raw position value, not the computed (relative) position.
      * <p>
      * By default (or by providing this method with {@code null}),
-     * the position will automatically be computed based on the other channels.
+     * the position will automatically be computed based on the other Channels (inserted last in its respective group).
+     * <p>
+     * Note: This does not shift the position values of existing Channels if the values collide.
+     * <br>As a reminder: The ordering of Channels is determined first by its Category's position, then by its raw
+     * position value and finally by its id (younger Channels are below older ones)
      *
      * @param  position
      *         The raw position value that should be used for the new Channel


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #818 

## Description

This PR will allow users to set the raw position value used when creating a new (Guild-)Channel.

While the actual change was not yet made on Discords end, this PR is on hold.

It will probably also need the doc addition about what happens when a position is set that already exists on another Channel with same Parent (including null parent). But since that depends on testing, it also has to wait until this feature is allowed on Discords end.
