### PR TITLE
Close socket on malformed zip data

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/WebSocketClient.java
@@ -935,6 +935,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         catch (IOException e)
         {
             decompressBuffer.reset();
+            close(4000, "MALFORMED_PACKAGE");
             throw (DataFormatException) new DataFormatException("Malformed").initCause(e);
         }
         finally { readBuffer = null; }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

As per Minn's recommendation.

Closes the websocket when receiving malformed data from Discord, allowing JDA to potentially resume.

Not tested in the wild yet.