### PR TITLE
Don't check admin on permission overrides

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/core/exceptions/ErrorResponseException.java
@@ -47,6 +47,8 @@ public class ErrorResponseException extends RuntimeException
         super(code + ": " + meaning);
 
         this.response = response;
+        if (response != null && response.getException() != null)
+            initCause(response.getException());
         this.errorResponse = errorResponse;
         this.code = code;
         this.meaning = meaning;
@@ -105,12 +107,6 @@ public class ErrorResponseException extends RuntimeException
     public Response getResponse()
     {
         return response;
-    }
-
-    @Override
-    public synchronized Throwable getCause()
-    {
-        return response != null ? response.getException() : null;
     }
 
     public static ErrorResponseException create(ErrorResponse errorResponse, Response response)

--- a/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/PermissionUtil.java
@@ -85,7 +85,7 @@ public class PermissionUtil
         List<Role> issuerRoles = issuer.getRoles();
         return !issuerRoles.isEmpty() && canInteract(issuerRoles.get(0), target);
     }
-    
+
     /**
      * Checks if one given Role can interact with a 2nd given Role - in a permission sense (kick/ban/modify perms).
      * This only checks the Role-Position and does not check the actual permission (kick/ban/manage_role/...)
@@ -299,14 +299,8 @@ public class PermissionUtil
         GuildImpl guild = (GuildImpl) channel.getGuild();
         checkGuild(guild, member.getGuild(), "Member");
 
-//        if (guild.getOwner().equals(member) // Admin or owner? If yes: no need to iterate
-//                || guild.getPublicRole().hasPermission(Permission.ADMINISTRATOR)
-//                || member.getRoles().stream().anyMatch(role -> role.hasPermission(Permission.ADMINISTRATOR)))
-//            return true; // can be removed as getEffectivePermissions calculates these cases in
-
         long effectivePerms = getEffectivePermission(channel, member);
-        return isApplied(effectivePerms, Permission.ADMINISTRATOR.getRawValue())
-                || isApplied(effectivePerms, Permission.getRaw(permissions));
+        return isApplied(effectivePerms, Permission.getRaw(permissions));
     }
 
     /**


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This fixes a small issue with some permission overrides. If a permission override has ADMINISTRATOR set we would act as if it means all permissions are granted, however ADMINISTRATOR makes no difference on channel overrides.
