### PR TITLE
Use RW-Lock for more efficient cache view access

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/JDA.java
+++ b/src/main/java/net/dv8tion/jda/core/JDA.java
@@ -358,6 +358,11 @@ public interface JDA
      * <p>If the developer is sharding, then only users from guilds connected to the specifically logged in
      * shard will be returned in the List.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getUserCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return List of all {@link net.dv8tion.jda.core.entities.User Users} that are visible to JDA.
      */
     default List<User> getUsers()
@@ -508,6 +513,11 @@ public interface JDA
      * <br>Guild connected if shardId == (guildId {@literal >>} 22) % totalShards;
      * <br>Source for formula: <a href="https://discordapp.com/developers/docs/topics/gateway#sharding">Discord Documentation</a>
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getGuildCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.core.entities.Guild Guilds} that this account is connected to.
      */
     default List<Guild> getGuilds()
@@ -576,6 +586,11 @@ public interface JDA
      * All {@link net.dv8tion.jda.core.entities.Role Roles} this JDA instance can see. <br>This will iterate over each
      * {@link net.dv8tion.jda.core.entities.Guild Guild} retrieved from {@link #getGuilds()} and collect its {@link
      * net.dv8tion.jda.core.entities.Guild#getRoles() Guild.getRoles()}.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getRoleCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return Immutable List of all visible Roles
      */
@@ -669,6 +684,11 @@ public interface JDA
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.Category Categories} visible to the currently logged in account.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getCategoryCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return An immutable list of all visible {@link net.dv8tion.jda.core.entities.Category Categories}.
      */
     default List<Category> getCategories()
@@ -710,6 +730,11 @@ public interface JDA
      * client, it is possible that you will see fewer channels than this returns. This is because the discord
      * client hides any {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} that you don't have the
      * {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} permission in.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getTextChannelCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return Possibly-empty list of all known {@link net.dv8tion.jda.core.entities.TextChannel TextChannels}.
      */
@@ -797,6 +822,11 @@ public interface JDA
      * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels} of all connected
      * {@link net.dv8tion.jda.core.entities.Guild Guilds}.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getVoiceChannelCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Possible-empty list of all known {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels}.
      */
     default List<VoiceChannel> getVoiceChannels()
@@ -864,6 +894,11 @@ public interface JDA
     /**
      * An unmodifiable list of all known {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannels}.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getPrivateChannelCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Possibly-empty list of all {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannels}.
      */
     default List<PrivateChannel> getPrivateChannels()
@@ -922,6 +957,11 @@ public interface JDA
      * Emote#canInteract(net.dv8tion.jda.core.entities.User, net.dv8tion.jda.core.entities.MessageChannel)}
      *
      * <p><b>Unicode emojis are not included as {@link net.dv8tion.jda.core.entities.Emote Emote}!</b>
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getEmoteCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return An immutable list of Emotes (which may or may not be available to usage).
      */

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.core.requests.restaction.MemberAction;
 import net.dv8tion.jda.core.requests.restaction.pagination.AuditLogPaginationAction;
 import net.dv8tion.jda.core.utils.cache.MemberCacheView;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
+import net.dv8tion.jda.core.utils.cache.SortedSnowflakeCacheView;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.CheckReturnValue;
@@ -591,7 +592,7 @@ public interface Guild extends ISnowflake
      *
      * @return Sorted {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    SnowflakeCacheView<Category> getCategoryCache();
+    SortedSnowflakeCacheView<Category> getCategoryCache();
 
     /**
      * Gets a {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} from this guild that has the same id as the
@@ -670,7 +671,7 @@ public interface Guild extends ISnowflake
      *
      * @return Sorted {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    SnowflakeCacheView<TextChannel> getTextChannelCache();
+    SortedSnowflakeCacheView<TextChannel> getTextChannelCache();
 
     /**
      * Gets a {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannel} from this guild that has the same id as the
@@ -749,7 +750,7 @@ public interface Guild extends ISnowflake
      *
      * @return Sorted {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    SnowflakeCacheView<VoiceChannel> getVoiceChannelCache();
+    SortedSnowflakeCacheView<VoiceChannel> getVoiceChannelCache();
 
     /**
      * Populated list of {@link GuildChannel channels} for this guild.
@@ -878,7 +879,7 @@ public interface Guild extends ISnowflake
      *
      * @return Sorted {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    SnowflakeCacheView<Role> getRoleCache();
+    SortedSnowflakeCacheView<Role> getRoleCache();
 
     /**
      * Gets an {@link net.dv8tion.jda.core.entities.Emote Emote} from this guild that has the same id as the

--- a/src/main/java/net/dv8tion/jda/core/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Guild.java
@@ -409,6 +409,11 @@ public interface Guild extends ISnowflake
      * A list of all {@link net.dv8tion.jda.core.entities.Member Members} in this Guild.
      * <br>The Members are not provided in any particular order.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getMemberCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Immutable list of all members in this Guild.
      */
     default List<Member> getMembers()
@@ -550,6 +555,11 @@ public interface Guild extends ISnowflake
      * Gets all {@link net.dv8tion.jda.core.entities.Category Categories} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
      * <br>The returned categories will be sorted according to their position.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getCategoryCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return An immutable list of all {@link net.dv8tion.jda.core.entities.Category Categories} in this Guild.
      */
     default List<Category> getCategories()
@@ -624,6 +634,11 @@ public interface Guild extends ISnowflake
      * Gets all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
      * <br>The channels returned will be sorted according to their position.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getTextChannelCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return An immutable List of all {@link net.dv8tion.jda.core.entities.TextChannel TextChannels} in this Guild.
      */
     default List<TextChannel> getTextChannels()
@@ -697,6 +712,11 @@ public interface Guild extends ISnowflake
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
      * <br>The channels returned will be sorted according to their position.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getVoiceChannelCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return An immutable List of {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels}.
      */
@@ -822,6 +842,11 @@ public interface Guild extends ISnowflake
      * Gets all {@link net.dv8tion.jda.core.entities.Role Roles} in this {@link net.dv8tion.jda.core.entities.Guild Guild}.
      * <br>The roles returned will be sorted according to their position.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getRoleCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return An immutable List of {@link net.dv8tion.jda.core.entities.Role Roles}.
      */
     default List<Role> getRoles()
@@ -901,6 +926,11 @@ public interface Guild extends ISnowflake
      * <br>Emotes are not ordered in any specific way in the returned list.
      *
      * <p><b>Unicode emojis are not included as {@link net.dv8tion.jda.core.entities.Emote Emote}!</b>
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getEmoteCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return An immutable List of {@link net.dv8tion.jda.core.entities.Emote Emotes}.
      */

--- a/src/main/java/net/dv8tion/jda/core/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/core/sharding/ShardManager.java
@@ -208,6 +208,11 @@ public interface ShardManager
     /**
      * Gets all {@link net.dv8tion.jda.core.entities.Category Categories} visible to the currently logged in account.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getCategoryCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return An immutable list of all visible {@link net.dv8tion.jda.core.entities.Category Categories}.
      */
     default List<Category> getCategories()
@@ -314,6 +319,11 @@ public interface ShardManager
      * Unified {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView} of
      * all cached {@link net.dv8tion.jda.core.entities.Emote Emotes} visible to this ShardManager instance.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getEmoteCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Unified {@link net.dv8tion.jda.core.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
     default SnowflakeCacheView<Emote> getEmoteCache()
@@ -412,10 +422,16 @@ public interface ShardManager
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getGuildCache));
     }
+
     /**
      * An unmodifiable List of all {@link net.dv8tion.jda.core.entities.Guild Guilds} that the logged account is connected to.
      * <br>If this account is not connected to any {@link net.dv8tion.jda.core.entities.Guild Guilds}, this will return
      * an empty list.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getGuildCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.core.entities.Guild Guilds} that this account is connected to.
      */
@@ -585,6 +601,11 @@ public interface ShardManager
     /**
      * An unmodifiable list of all known {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannels}.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getPrivateChannelCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Possibly-empty list of all {@link net.dv8tion.jda.core.entities.PrivateChannel PrivateChannels}.
      */
     default List<PrivateChannel> getPrivateChannels()
@@ -640,6 +661,11 @@ public interface ShardManager
      * All {@link net.dv8tion.jda.core.entities.Role Roles} this ShardManager instance can see. <br>This will iterate over each
      * {@link net.dv8tion.jda.core.entities.Guild Guild} retrieved from {@link #getGuilds()} and collect its {@link
      * net.dv8tion.jda.core.entities.Guild#getRoles() Guild.getRoles()}.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getRoleCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return Immutable List of all visible Roles
      */
@@ -705,6 +731,11 @@ public interface ShardManager
 
     /**
      * Gets all {@link net.dv8tion.jda.core.JDA JDA} instances bound to this ShardManager.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getShardCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return An immutable list of all managed {@link net.dv8tion.jda.core.JDA JDA} instances.
      */
@@ -803,6 +834,11 @@ public interface ShardManager
      * hides any {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} that you don't have the
      * {@link net.dv8tion.jda.core.Permission#MESSAGE_READ Permission.MESSAGE_READ} permission in.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getTextChannelCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return Possibly-empty list of all known {@link net.dv8tion.jda.core.entities.TextChannel TextChannels}.
      */
     default List<TextChannel> getTextChannels()
@@ -858,6 +894,11 @@ public interface ShardManager
      * <p>If the developer is sharding, then only users from guilds connected to the specifically logged in
      * shard will be returned in the List.
      *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getUserCache()} and use its more efficient
+     * versions of handling these values.
+     *
      * @return List of all {@link net.dv8tion.jda.core.entities.User Users} that are visible to JDA.
      */
     default List<User> getUsers()
@@ -908,6 +949,11 @@ public interface ShardManager
     /**
      * An unmodifiable list of all {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels} of all connected
      * {@link net.dv8tion.jda.core.entities.Guild Guilds}.
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getVoiceChannelCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return Possible-empty list of all known {@link net.dv8tion.jda.core.entities.VoiceChannel VoiceChannels}.
      */

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIterator.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIterator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.utils;
+
+import java.util.Iterator;
+
+public interface ClosableIterator<T> extends Iterator<T>, AutoCloseable
+{
+    @Override
+    void close();
+}

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIterator.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIterator.java
@@ -18,6 +18,25 @@ package net.dv8tion.jda.core.utils;
 
 import java.util.Iterator;
 
+/**
+ * Iterator holding a resource that must be free'd by the consumer.
+ * <br>Close is an idempotent function and can be performed multiple times without effects beyond first invocation.
+ *
+ * <p>This closes automatically when {@link #hasNext()} returns {@code false} but
+ * its recommended to only be used within a {@code try-with-resources} block for safety.
+ *
+ * <h3>Example</h3>
+ * This can handle any exceptions thrown while iterating and ensures the lock is released correctly.
+ * <pre>{@code
+ * try (ClosableIterator<T> it = cacheView.lockedIterator()) {
+ *     while (it.hasNext()) {
+ *         consume(it.next());
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T>
+ */
 public interface ClosableIterator<T> extends Iterator<T>, AutoCloseable
 {
     @Override

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
@@ -44,12 +44,6 @@ public class ClosableIteratorImpl<T> implements ClosableIterator<T>
     }
 
     @Override
-    public void remove()
-    {
-        throw new IllegalStateException("Cannot remove from this iterator!");
-    }
-
-    @Override
     public boolean hasNext()
     {
         if (lock == null)

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.utils;
+
+import net.dv8tion.jda.internal.utils.JDALogger;
+import org.slf4j.Logger;
+
+import java.util.Iterator;
+import java.util.concurrent.locks.Lock;
+
+public class ClosableIteratorImpl<T> implements ClosableIterator<T>
+{
+    private final static Logger log = JDALogger.getLog(ClosableIterator.class);
+    private final Iterator<T> it;
+    private Lock lock;
+
+    public ClosableIteratorImpl(Iterator<T> it, Lock lock)
+    {
+        this.it = it;
+        this.lock = lock;
+    }
+
+    @Override
+    public void close()
+    {
+        if (lock != null)
+            lock.unlock();
+        lock = null;
+    }
+
+    @Override
+    public void remove()
+    {
+        throw new IllegalStateException("Cannot remove from this iterator!");
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return it.hasNext();
+    }
+
+    @Override
+    public T next()
+    {
+        return it.next();
+    }
+
+    @Override
+    @Deprecated
+    protected void finalize()
+    {
+        if (lock != null)
+        {
+            log.error("Finalizing without closing, performing force close on lock");
+            close();
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.locks.Lock;
 
 public class ClosableIteratorImpl<T> implements ClosableIterator<T>
@@ -51,6 +52,8 @@ public class ClosableIteratorImpl<T> implements ClosableIterator<T>
     @Override
     public boolean hasNext()
     {
+        if (lock == null)
+            return false;
         boolean hasNext = it.hasNext();
         if (!hasNext)
             close();
@@ -60,6 +63,8 @@ public class ClosableIteratorImpl<T> implements ClosableIterator<T>
     @Override
     public T next()
     {
+        if (lock == null)
+            throw new NoSuchElementException();
         return it.next();
     }
 

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
@@ -51,7 +51,10 @@ public class ClosableIteratorImpl<T> implements ClosableIterator<T>
     @Override
     public boolean hasNext()
     {
-        return it.hasNext();
+        boolean hasNext = it.hasNext();
+        if (!hasNext)
+            close();
+        return hasNext;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/ClosableIteratorImpl.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.core.utils;
 
+import net.dv8tion.jda.core.utils.cache.CacheView;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
 
@@ -23,13 +24,35 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.locks.Lock;
 
+/**
+ * Simple implementation of a {@link ClosableIterator} that uses a lock.
+ * <br>Close is an idempotent function and can be performed multiple times without effects beyond first invocation.
+ * <br>This is deployed by {@link CacheView#lockedIterator()} to allow read-only access
+ * to the underlying structure without the need to clone it, unlike the normal iterator.
+ *
+ * <p>This closes automatically when {@link #hasNext()} returns {@code false} but
+ * its recommended to only be used within a {@code try-with-resources} block for safety.
+ *
+ * <h3>Example</h3>
+ * This can handle any exceptions thrown while iterating and ensures the lock is released correctly.
+ * <pre>{@code
+ * try (ClosableIterator<T> it = cacheView.lockedIterator()) {
+ *     while (it.hasNext()) {
+ *         consume(it.next());
+ *     }
+ * }
+ * }</pre>
+ *
+ * @param <T>
+ *        The element type for this iterator
+ */
 public class ClosableIteratorImpl<T> implements ClosableIterator<T>
 {
     private final static Logger log = JDALogger.getLog(ClosableIterator.class);
-    private final Iterator<T> it;
+    private final Iterator<? extends T> it;
     private Lock lock;
 
-    public ClosableIteratorImpl(Iterator<T> it, Lock lock)
+    public ClosableIteratorImpl(Iterator<? extends T> it, Lock lock)
     {
         this.it = it;
         this.lock = lock;

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.internal.utils.cache.UnifiedCacheViewImpl;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -35,6 +36,18 @@ import java.util.stream.Stream;
  * Read-only view on internal JDA cache of items.
  * <br>This can be useful to check information such as size without creating
  * an immutable snapshot first.
+ *
+ * <h2>Memory Efficient Usage</h2>
+ * The {@link #forEach(Consumer)} method can be used to avoid creating a snapshot
+ * of the backing data store, it is implemented by first acquiring a read-lock and then iterating the code.
+ * The enhanced-for-loop uses the {@link #iterator()} which has to first create a snapshot to avoid
+ * concurrent modifications. Alternatively the {@link #lockedIterator()} can be used to acquire an iterator
+ * which holds a read-lock on the data store and thus prohibits concurrent modifications, for more details
+ * read the documentation of {@link ClosableIterator}. Streams from {@link #stream()}/{@link #parallelStream()}
+ * both use {@link #iterator()} with a snapshot of the backing data store to avoid concurrent modifications.
+ * <br>Using {@link #getElementsByName(String)} is more efficient than {@link #asList()} as it uses {@link #forEach(Consumer)}
+ * for pattern matching and thus does not need to create a snapshot of the entire data store like {@link #asList()} does.
+ * <br>Both {@link #size()} and {@link #isEmpty()} are atomic operations.
  *
  * @param  <T>
  *         The cache type

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.core.utils.ClosableIterator;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.ShardCacheViewImpl;
+import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.UnifiedCacheViewImpl;
 
 import java.util.Collection;
@@ -50,7 +51,9 @@ import java.util.stream.Stream;
  * <br>Both {@link #size()} and {@link #isEmpty()} are atomic operations.
  *
  * <p>Note that making a copy is a requirement if a specific order is desired. If using {@link #lockedIterator()}
- * or {@link #forEach(Consumer)} the order is not guaranteed as it directly iterates the backing cache.
+ * the order is not guaranteed as it directly iterates the backing cache.
+ * Using {@link #forEach(Consumer)} on a {@link SortedSnowflakeCacheView} will copy the cache in order to sort
+ * it, use {@link SortedSnowflakeCacheView#forEachUnordered(Consumer)} to avoid this overhead.
  * The backing cache is stored using an un-ordered hash map.
  *
  * @param  <T>
@@ -61,7 +64,7 @@ public interface CacheView<T> extends Iterable<T>
     /**
      * Creates an immutable snapshot of the current cache state.
      * <br>This will copy all elements contained in this cache into a list.
-     * <br>This will be sorted for a {@link net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}.
+     * <br>This will be sorted for a {@link SortedSnowflakeCacheViewImpl SortedSnowflakeCacheView}.
      *
      * @return Immutable list of cached elements
      */
@@ -148,7 +151,7 @@ public interface CacheView<T> extends Iterable<T>
 
     /**
      * Creates a {@link java.util.stream.Stream Stream} of all cached elements.
-     * <br>This will be sorted for a {@link net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}.
+     * <br>This will be sorted for a {@link SortedSnowflakeCacheViewImpl SortedSnowflakeCacheView}.
      *
      * @return Stream of elements
      */
@@ -156,7 +159,7 @@ public interface CacheView<T> extends Iterable<T>
 
     /**
      * Creates a parallel {@link java.util.stream.Stream Stream} of all cached elements.
-     * <br>This will be sorted for a {@link net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}.
+     * <br>This will be sorted for a {@link SortedSnowflakeCacheViewImpl SortedSnowflakeCacheView}.
      *
      * @return Parallel Stream of elements
      */

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
@@ -49,6 +49,10 @@ import java.util.stream.Stream;
  * for pattern matching and thus does not need to create a snapshot of the entire data store like {@link #asList()} does.
  * <br>Both {@link #size()} and {@link #isEmpty()} are atomic operations.
  *
+ * <p>Note that making a copy is a requirement if a specific order is desired. If using {@link #lockedIterator()}
+ * or {@link #forEach(Consumer)} the order is not guaranteed as it directly iterates the backing cache.
+ * The backing cache is stored using an un-ordered hash map.
+ *
  * @param  <T>
  *         The cache type
  */
@@ -75,6 +79,9 @@ public interface CacheView<T> extends Iterable<T>
      * Returns an iterator with direct access to the underlying data store.
      * This iterator does not support removing elements.
      * <br>After usage this iterator should be closed to allow modifications by the library internals.
+     *
+     * <p><b>Note: Order is not preserved in this iterator to be more efficient,
+     * if order is desired use {@link #iterator()} instead!</b>
      *
      * @return {@link ClosableIterator} holding a read-lock on the data structure.
      */

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/CacheView.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.core.utils.cache;
 
 import net.dv8tion.jda.core.entities.ISnowflake;
+import net.dv8tion.jda.core.utils.ClosableIterator;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.ShardCacheViewImpl;
@@ -56,6 +57,15 @@ public interface CacheView<T> extends Iterable<T>
      * @return Immutable set of cached elements
      */
     Set<T> asSet();
+
+    /**
+     * Returns an iterator with direct access to the underlying data store.
+     * This iterator does not support removing elements.
+     * <br>After usage this iterator should be closed to allow modifications by the library internals.
+     *
+     * @return {@link ClosableIterator} holding a read-lock on the data structure.
+     */
+    ClosableIterator<T> lockedIterator();
 
     /**
      * The current size of this cache

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/MemberCacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/MemberCacheView.java
@@ -30,6 +30,8 @@ import java.util.List;
  *
  * <p>This is done because Members do not implement {@link net.dv8tion.jda.core.entities.ISnowflake ISnowflake} as
  * they are not globally unique but only unique per {@link net.dv8tion.jda.core.entities.Guild Guild}!
+ *
+ * @see CacheView CacheView for details on Efficient Memory Usage
  */
 public interface MemberCacheView extends CacheView<Member>
 {

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/ShardCacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/ShardCacheView.java
@@ -21,6 +21,8 @@ import net.dv8tion.jda.core.JDA;
  * Read-only view on internal ShardManager cache of JDA instances.
  * <br>This can be useful to check information such as size without creating
  * an immutable snapshot first.
+ *
+ * @see CacheView CacheView for details on Efficient Memory Usage
  */
 public interface ShardCacheView extends CacheView<JDA>
 {

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/SnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/SnowflakeCacheView.java
@@ -22,6 +22,8 @@ import net.dv8tion.jda.core.utils.MiscUtil;
 /**
  * {@link net.dv8tion.jda.core.utils.cache.CacheView CacheView} implementation
  * specifically to view {@link net.dv8tion.jda.core.entities.ISnowflake ISnowflake} implementations.
+ *
+ * @see CacheView CacheView for details on Efficient Memory Usage
  */
 public interface SnowflakeCacheView<T extends ISnowflake> extends CacheView<T>
 {

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/SortedSnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/SortedSnowflakeCacheView.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.utils.cache;
+
+import net.dv8tion.jda.core.entities.ISnowflake;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+/**
+ * Specialized {@link CacheView} for entities that occur in a specified order.
+ * <br>In this specialization {@link #forEach(Consumer)} will copy the underlying data store
+ * in order to preserve order on iterations, use {@link #forEachUnordered(Consumer)} to avoid this overhead.
+ *
+ * @param <T>
+ *        The entity type
+ *
+ * @see   CacheView CacheView for details on Efficient Memory Usage
+ */
+public interface SortedSnowflakeCacheView<T extends Comparable<T> & ISnowflake> extends SnowflakeCacheView<T>
+{
+    /**
+     * Behavior similar to {@link CacheView#forEach(Consumer)} which does not preserve order.
+     * <br>This will not copy the data store as sorting is not needed.
+     *
+     * @param  action
+     *         The action to perform
+     *
+     * @throws NullPointerException
+     *         If provided with null
+     */
+    void forEachUnordered(final Consumer<? super T> action);
+
+    /**
+     * Behavior similar to {@link CacheView#stream()} which does not preserve order.
+     *
+     * @return Stream of the contained elements
+     */
+    Stream<T> streamUnordered();
+
+    /**
+     * Behavior similar to {@link CacheView#parallelStream()} which does not preserve order.
+     *
+     * @return (Parallel) Stream of contained elements
+     */
+    Stream<T> parallelStreamUnordered();
+}

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/SortedSnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/SortedSnowflakeCacheView.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.core.utils.cache;
 
 import net.dv8tion.jda.core.entities.ISnowflake;
 
+import java.util.NavigableSet;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -44,6 +45,9 @@ public interface SortedSnowflakeCacheView<T extends Comparable<T> & ISnowflake> 
      *         If provided with null
      */
     void forEachUnordered(final Consumer<? super T> action);
+
+    @Override
+    NavigableSet<T> asSet();
 
     /**
      * Behavior similar to {@link CacheView#stream()} which does not preserve order.

--- a/src/main/java/net/dv8tion/jda/core/utils/cache/UnifiedMemberCacheView.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/cache/UnifiedMemberCacheView.java
@@ -30,6 +30,8 @@ import java.util.List;
  *
  * <p>This is done because Members do not implement {@link net.dv8tion.jda.core.entities.ISnowflake ISnowflake} as
  * they are not globally unique but only unique per {@link net.dv8tion.jda.core.entities.Guild Guild}!
+ *
+ * @see CacheView CacheView for details on Efficient Memory Usage
  */
 public interface UnifiedMemberCacheView extends CacheView<Member>
 {

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -53,6 +53,7 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.UpstreamReference;
@@ -635,13 +636,14 @@ public class JDAImpl implements JDA
 
     private void closeAudioConnections()
     {
-        TLongObjectMap<AudioManager> managerMap = getAudioManagerMap();
-        synchronized (managerMap)
+        AbstractCacheView<AudioManager> view = getAudioManagerMap();
+        try (UnlockHook hook = view.writeLock())
         {
-            managerMap.valueCollection().stream()
-                      .map(AudioManagerImpl.class::cast)
-                      .forEach(m -> m.closeAudioConnection(ConnectionStatus.SHUTTING_DOWN));
-            managerMap.clear();
+            TLongObjectMap<AudioManager> map = view.getMap();
+            map.valueCollection().stream()
+               .map(AudioManagerImpl.class::cast)
+               .forEach(m -> m.closeAudioConnection(ConnectionStatus.SHUTTING_DOWN));
+            map.clear();
         }
     }
 
@@ -856,34 +858,34 @@ public class JDAImpl implements JDA
         return client == null ? null : client.get();
     }
 
-    public TLongObjectMap<User> getUserMap()
+    public SnowflakeCacheViewImpl<User> getUserMap()
     {
-        return userCache.getMap();
+        return userCache;
     }
 
-    public TLongObjectMap<Guild> getGuildMap()
+    public SnowflakeCacheViewImpl<Guild> getGuildMap()
     {
-        return guildCache.getMap();
+        return guildCache;
     }
 
-    public TLongObjectMap<Category> getCategoryMap()
+    public SnowflakeCacheViewImpl<Category> getCategoryMap()
     {
-        return categories.getMap();
+        return categories;
     }
 
-    public TLongObjectMap<TextChannel> getTextChannelMap()
+    public SnowflakeCacheViewImpl<TextChannel> getTextChannelMap()
     {
-        return textChannelCache.getMap();
+        return textChannelCache;
     }
 
-    public TLongObjectMap<VoiceChannel> getVoiceChannelMap()
+    public SnowflakeCacheViewImpl<VoiceChannel> getVoiceChannelMap()
     {
-        return voiceChannelCache.getMap();
+        return voiceChannelCache;
     }
 
-    public TLongObjectMap<PrivateChannel> getPrivateChannelMap()
+    public SnowflakeCacheViewImpl<PrivateChannel> getPrivateChannelMap()
     {
-        return privateChannelCache.getMap();
+        return privateChannelCache;
     }
 
     public TLongObjectMap<User> getFakeUserMap()
@@ -896,9 +898,9 @@ public class JDAImpl implements JDA
         return fakePrivateChannels;
     }
 
-    public TLongObjectMap<AudioManager> getAudioManagerMap()
+    public AbstractCacheView<AudioManager> getAudioManagerMap()
     {
-        return audioManagers.getMap();
+        return audioManagers;
     }
 
     public void setSelfUser(SelfUser selfUser)

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -636,7 +636,7 @@ public class JDAImpl implements JDA
 
     private void closeAudioConnections()
     {
-        AbstractCacheView<AudioManager> view = getAudioManagerMap();
+        AbstractCacheView<AudioManager> view = getAudioManagersView();
         try (UnlockHook hook = view.writeLock())
         {
             TLongObjectMap<AudioManager> map = view.getMap();
@@ -858,34 +858,39 @@ public class JDAImpl implements JDA
         return client == null ? null : client.get();
     }
 
-    public SnowflakeCacheViewImpl<User> getUserMap()
+    public SnowflakeCacheViewImpl<User> getUsersView()
     {
         return userCache;
     }
 
-    public SnowflakeCacheViewImpl<Guild> getGuildMap()
+    public SnowflakeCacheViewImpl<Guild> getGuildsView()
     {
         return guildCache;
     }
 
-    public SnowflakeCacheViewImpl<Category> getCategoryMap()
+    public SnowflakeCacheViewImpl<Category> getCategoriesView()
     {
         return categories;
     }
 
-    public SnowflakeCacheViewImpl<TextChannel> getTextChannelMap()
+    public SnowflakeCacheViewImpl<TextChannel> getTextChannelsView()
     {
         return textChannelCache;
     }
 
-    public SnowflakeCacheViewImpl<VoiceChannel> getVoiceChannelMap()
+    public SnowflakeCacheViewImpl<VoiceChannel> getVoiceChannelsView()
     {
         return voiceChannelCache;
     }
 
-    public SnowflakeCacheViewImpl<PrivateChannel> getPrivateChannelMap()
+    public SnowflakeCacheViewImpl<PrivateChannel> getPrivateChannelsView()
     {
         return privateChannelCache;
+    }
+
+    public AbstractCacheView<AudioManager> getAudioManagersView()
+    {
+        return audioManagers;
     }
 
     public TLongObjectMap<User> getFakeUserMap()
@@ -896,11 +901,6 @@ public class JDAImpl implements JDA
     public TLongObjectMap<PrivateChannel> getFakePrivateChannelMap()
     {
         return fakePrivateChannels;
-    }
-
-    public AbstractCacheView<AudioManager> getAudioManagerMap()
-    {
-        return audioManagers;
     }
 
     public void setSelfUser(SelfUser selfUser)

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -17,7 +17,6 @@
 package net.dv8tion.jda.internal.audio;
 
 import com.neovisionaries.ws.client.*;
-import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.core.JDAInfo;
 import net.dv8tion.jda.core.audio.SpeakingMode;
 import net.dv8tion.jda.core.audio.hooks.ConnectionListener;
@@ -26,7 +25,6 @@ import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.entities.VoiceChannel;
 import net.dv8tion.jda.core.events.ExceptionEvent;
-import net.dv8tion.jda.core.managers.AudioManager;
 import net.dv8tion.jda.core.utils.MiscUtil;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
@@ -192,11 +190,7 @@ class AudioWebSocket extends WebSocketAdapter
             else if (status == ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD)
             {
                 //Remove audio manager as we are no longer in the guild
-                TLongObjectMap<AudioManager> audioManagerMap = api.getAudioManagerMap();
-                synchronized (audioManagerMap)
-                {
-                    audioManagerMap.remove(guild.getIdLong());
-                }
+                api.getAudioManagerMap().remove(guild.getIdLong());
             }
             else if (status != ConnectionStatus.AUDIO_REGION_CHANGE)
             {

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -190,7 +190,7 @@ class AudioWebSocket extends WebSocketAdapter
             else if (status == ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD)
             {
                 //Remove audio manager as we are no longer in the guild
-                api.getAudioManagerMap().remove(guild.getIdLong());
+                api.getAudioManagersView().remove(guild.getIdLong());
             }
             else if (status != ConnectionStatus.AUDIO_REGION_CHANGE)
             {

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -76,7 +76,7 @@ public abstract class AbstractChannelImpl<T extends AbstractChannelImpl<T>> impl
     @Override
     public Category getParent()
     {
-        return getGuild().getCategoriesMap().get(parentId);
+        return getGuild().getCategoriesView().get(parentId);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -518,10 +518,10 @@ public class GuildImpl implements Guild
     public TextChannel getDefaultChannel()
     {
         final Role role = getPublicRole();
-        return getTextChannelsMap().stream()
-                .filter(c -> role.hasPermission(c, Permission.MESSAGE_READ))
-                .sorted(Comparator.naturalOrder())
-                .findFirst().orElse(null);
+        return getTextChannelsView().stream()
+                                    .filter(c -> role.hasPermission(c, Permission.MESSAGE_READ))
+                                    .sorted(Comparator.naturalOrder())
+                                    .findFirst().orElse(null);
     }
 
     @Override
@@ -624,7 +624,7 @@ public class GuildImpl implements Guild
         if (!getJDA().isAudioEnabled())
             throw new IllegalStateException("Audio is disabled. Cannot retrieve an AudioManager while audio is disabled.");
 
-        final AbstractCacheView<AudioManager> managerMap = getJDA().getAudioManagerMap();
+        final AbstractCacheView<AudioManager> managerMap = getJDA().getAudioManagersView();
         AudioManager mng = managerMap.get(id);
         if (mng == null)
         {
@@ -654,7 +654,8 @@ public class GuildImpl implements Guild
     @Override
     public List<GuildVoiceState> getVoiceStates()
     {
-        return Collections.unmodifiableList(getMembersMap().stream().map(Member::getVoiceState).filter(Objects::nonNull).collect(Collectors.toList()));
+        return Collections.unmodifiableList(
+                getMembersView().stream().map(Member::getVoiceState).filter(Objects::nonNull).collect(Collectors.toList()));
     }
 
     @Override
@@ -827,34 +828,34 @@ public class GuildImpl implements Guild
 
     // -- Map getters --
 
-    public SnowflakeCacheViewImpl<Category> getCategoriesMap()
+    public SnowflakeCacheViewImpl<Category> getCategoriesView()
     {
         return categoryCache;
     }
 
-    public SnowflakeCacheViewImpl<TextChannel> getTextChannelsMap()
+    public SnowflakeCacheViewImpl<TextChannel> getTextChannelsView()
     {
         return textChannelCache;
     }
 
-    public SnowflakeCacheViewImpl<VoiceChannel> getVoiceChannelsMap()
+    public SnowflakeCacheViewImpl<VoiceChannel> getVoiceChannelsView()
     {
         return voiceChannelCache;
     }
 
-    public MemberCacheViewImpl getMembersMap()
-    {
-        return memberCache;
-    }
-
-    public SnowflakeCacheViewImpl<Role> getRolesMap()
+    public SnowflakeCacheViewImpl<Role> getRolesView()
     {
         return roleCache;
     }
 
-    public SnowflakeCacheViewImpl<Emote> getEmoteMap()
+    public SnowflakeCacheViewImpl<Emote> getEmotesView()
     {
         return emoteCache;
+    }
+
+    public MemberCacheViewImpl getMembersView()
+    {
+        return memberCache;
     }
 
     public TLongObjectMap<JSONObject> getCachedPresenceMap()

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.core.requests.restaction.pagination.AuditLogPaginationAct
 import net.dv8tion.jda.core.utils.MiscUtil;
 import net.dv8tion.jda.core.utils.cache.MemberCacheView;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
+import net.dv8tion.jda.core.utils.cache.SortedSnowflakeCacheView;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.requests.Route;
@@ -59,10 +60,10 @@ public class GuildImpl implements Guild
     private final long id;
     private final UpstreamReference<JDAImpl> api;
 
-    private final SortedSnowflakeCacheView<Category> categoryCache = new SortedSnowflakeCacheView<>(Category.class, GuildChannel::getName, Comparator.naturalOrder());
-    private final SortedSnowflakeCacheView<VoiceChannel> voiceChannelCache = new SortedSnowflakeCacheView<>(VoiceChannel.class, GuildChannel::getName, Comparator.naturalOrder());
-    private final SortedSnowflakeCacheView<TextChannel> textChannelCache = new SortedSnowflakeCacheView<>(TextChannel.class, GuildChannel::getName, Comparator.naturalOrder());
-    private final SortedSnowflakeCacheView<Role> roleCache = new SortedSnowflakeCacheView<>(Role.class, Role::getName, Comparator.reverseOrder());
+    private final SortedSnowflakeCacheViewImpl<Category> categoryCache = new SortedSnowflakeCacheViewImpl<>(Category.class, GuildChannel::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<VoiceChannel> voiceChannelCache = new SortedSnowflakeCacheViewImpl<>(VoiceChannel.class, GuildChannel::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<TextChannel> textChannelCache = new SortedSnowflakeCacheViewImpl<>(TextChannel.class, GuildChannel::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<Role> roleCache = new SortedSnowflakeCacheViewImpl<>(Role.class, Role::getName, Comparator.reverseOrder());
     private final SnowflakeCacheViewImpl<Emote> emoteCache = new SnowflakeCacheViewImpl<>(Emote.class, Emote::getName);
     private final MemberCacheViewImpl memberCache = new MemberCacheViewImpl();
 
@@ -301,21 +302,33 @@ public class GuildImpl implements Guild
     }
 
     @Override
-    public SnowflakeCacheView<Category> getCategoryCache()
+    public SortedSnowflakeCacheView<Category> getCategoryCache()
     {
         return categoryCache;
     }
 
     @Override
-    public SnowflakeCacheView<TextChannel> getTextChannelCache()
+    public SortedSnowflakeCacheView<TextChannel> getTextChannelCache()
     {
         return textChannelCache;
     }
 
     @Override
-    public SnowflakeCacheView<VoiceChannel> getVoiceChannelCache()
+    public SortedSnowflakeCacheView<VoiceChannel> getVoiceChannelCache()
     {
         return voiceChannelCache;
+    }
+
+    @Override
+    public SortedSnowflakeCacheView<Role> getRoleCache()
+    {
+        return roleCache;
+    }
+
+    @Override
+    public SnowflakeCacheView<Emote> getEmoteCache()
+    {
+        return emoteCache;
     }
 
     @Override
@@ -375,18 +388,6 @@ public class GuildImpl implements Guild
         }
 
         return Collections.unmodifiableList(channels);
-    }
-
-    @Override
-    public SnowflakeCacheView<Role> getRoleCache()
-    {
-        return roleCache;
-    }
-
-    @Override
-    public SnowflakeCacheView<Emote> getEmoteCache()
-    {
-        return emoteCache;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -279,7 +279,7 @@ public class GuildImpl implements Guild
     @Override
     public boolean isMember(User user)
     {
-        return memberCache.getMap().containsKey(user.getIdLong());
+        return memberCache.get(user.getIdLong()) != null;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -264,7 +264,7 @@ public class MemberImpl implements Member
     @Override
     public TextChannel getDefaultChannel()
     {
-        return getGuild().getTextChannelsMap().valueCollection().stream()
+        return getGuild().getTextChannelsMap().stream()
                 .sorted(Comparator.reverseOrder())
                 .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
                 .findFirst().orElse(null);

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -265,8 +265,8 @@ public class MemberImpl implements Member
     public TextChannel getDefaultChannel()
     {
         return getGuild().getTextChannelsView().stream()
-                         .sorted(Comparator.reverseOrder())
-                         .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
-                         .findFirst().orElse(null);
+                 .sorted(Comparator.reverseOrder())
+                 .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
+                 .findFirst().orElse(null);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -264,9 +264,9 @@ public class MemberImpl implements Member
     @Override
     public TextChannel getDefaultChannel()
     {
-        return getGuild().getTextChannelsMap().stream()
-                .sorted(Comparator.reverseOrder())
-                .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
-                .findFirst().orElse(null);
+        return getGuild().getTextChannelsView().stream()
+                         .sorted(Comparator.reverseOrder())
+                         .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
+                         .findFirst().orElse(null);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -278,8 +278,8 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     public List<Member> getMembers()
     {
         return Collections.unmodifiableList(getGuild().getMembersView().stream()
-                                                      .filter(m -> m.hasPermission(this, Permission.MESSAGE_READ))
-                                                      .collect(Collectors.toList()));
+                  .filter(m -> m.hasPermission(this, Permission.MESSAGE_READ))
+                  .collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -277,15 +277,15 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getGuild().getMembersMap().stream()
-                .filter(m -> m.hasPermission(this, Permission.MESSAGE_READ))
-                .collect(Collectors.toList()));
+        return Collections.unmodifiableList(getGuild().getMembersView().stream()
+                                                      .filter(m -> m.hasPermission(this, Permission.MESSAGE_READ))
+                                                      .collect(Collectors.toList()));
     }
 
     @Override
     public int getPosition()
     {
-        //We call getTextChannels instead of directly accessing the GuildImpl.getTextChannelMap because
+        //We call getTextChannels instead of directly accessing the GuildImpl.getTextChannelsView because
         // getTextChannels does the sorting logic.
         List<TextChannel> channels = getGuild().getTextChannels();
         for (int i = 0; i < channels.size(); i++)

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -277,7 +277,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
     @Override
     public List<Member> getMembers()
     {
-        return Collections.unmodifiableList(getGuild().getMembersMap().valueCollection().stream()
+        return Collections.unmodifiableList(getGuild().getMembersMap().stream()
                 .filter(m -> m.hasPermission(this, Permission.MESSAGE_READ))
                 .collect(Collectors.toList()));
     }

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
@@ -56,15 +56,15 @@ public class ChannelDeleteHandler extends SocketHandler
         {
             case TEXT:
             {
-                GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(guildId);
-                TextChannel channel = getJDA().getTextChannelMap().remove(channelId);
+                GuildImpl guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+                TextChannel channel = getJDA().getTextChannelsView().remove(channelId);
                 if (channel == null)
                 {
                     WebSocketClient.LOG.debug("CHANNEL_DELETE attempted to delete a text channel that is not yet cached. JSON: {}", content);
                     return null;
                 }
 
-                guild.getTextChannelsMap().remove(channel.getIdLong());
+                guild.getTextChannelsView().remove(channel.getIdLong());
                 getJDA().getEventManager().handle(
                     new TextChannelDeleteEvent(
                         getJDA(), responseNumber,
@@ -73,8 +73,8 @@ public class ChannelDeleteHandler extends SocketHandler
             }
             case VOICE:
             {
-                GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(guildId);
-                VoiceChannel channel = guild.getVoiceChannelsMap().remove(channelId);
+                GuildImpl guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
+                VoiceChannel channel = guild.getVoiceChannelsView().remove(channelId);
                 if (channel == null)
                 {
                     WebSocketClient.LOG.debug("CHANNEL_DELETE attempted to delete a voice channel that is not yet cached. JSON: {}", content);
@@ -82,13 +82,13 @@ public class ChannelDeleteHandler extends SocketHandler
                 }
 
                 //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
-                AudioManagerImpl manager = (AudioManagerImpl) getJDA().getAudioManagerMap().get(guild.getIdLong());
+                AudioManagerImpl manager = (AudioManagerImpl) getJDA().getAudioManagersView().get(guild.getIdLong());
                 if (manager != null && manager.isConnected()
                         && manager.getConnectedChannel().getIdLong() == channel.getIdLong())
                 {
                     manager.closeAudioConnection(ConnectionStatus.DISCONNECTED_CHANNEL_DELETED);
                 }
-                guild.getVoiceChannelsMap().remove(channel.getIdLong());
+                guild.getVoiceChannelsView().remove(channel.getIdLong());
                 getJDA().getEventManager().handle(
                     new VoiceChannelDeleteEvent(
                         getJDA(), responseNumber,
@@ -98,14 +98,14 @@ public class ChannelDeleteHandler extends SocketHandler
             case CATEGORY:
             {
                 GuildImpl guild = (GuildImpl) getJDA().getGuildById(guildId);
-                Category category = getJDA().getCategoryMap().remove(channelId);
+                Category category = getJDA().getCategoriesView().remove(channelId);
                 if (category == null)
                 {
                     WebSocketClient.LOG.debug("CHANNEL_DELETE attempted to delete a category channel that is not yet cached. JSON: {}", content);
                     return null;
                 }
 
-                guild.getCategoriesMap().remove(channelId);
+                guild.getCategoriesView().remove(channelId);
                 getJDA().getEventManager().handle(
                     new CategoryDeleteEvent(
                         getJDA(), responseNumber,
@@ -114,7 +114,7 @@ public class ChannelDeleteHandler extends SocketHandler
             }
             case PRIVATE:
             {
-                SnowflakeCacheViewImpl<PrivateChannel> privateView = getJDA().getPrivateChannelMap();
+                SnowflakeCacheViewImpl<PrivateChannel> privateView = getJDA().getPrivateChannelsView();
                 PrivateChannel channel = privateView.remove(channelId);
 
                 if (channel == null)

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
@@ -69,7 +69,7 @@ public class ChannelUpdateHandler extends SocketHandler
             case TEXT:
             {
                 String topic = content.optString("topic", null);
-                TextChannelImpl textChannel = (TextChannelImpl) getJDA().getTextChannelMap().get(channelId);
+                TextChannelImpl textChannel = (TextChannelImpl) getJDA().getTextChannelsView().get(channelId);
                 if (textChannel == null)
                 {
                     getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);
@@ -150,7 +150,7 @@ public class ChannelUpdateHandler extends SocketHandler
             }
             case VOICE:
             {
-                VoiceChannelImpl voiceChannel = (VoiceChannelImpl) getJDA().getVoiceChannelMap().get(channelId);
+                VoiceChannelImpl voiceChannel = (VoiceChannelImpl) getJDA().getVoiceChannelsView().get(channelId);
                 int userLimit = content.getInt("user_limit");
                 int bitrate = content.getInt("bitrate");
                 if (voiceChannel == null)

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildBanHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildBanHandler.java
@@ -41,7 +41,7 @@ public class GuildBanHandler extends SocketHandler
             return id;
 
         JSONObject userJson = content.getJSONObject("user");
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(id);
         if (guild == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.GUILD, id, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildCreateHandler.java
@@ -34,7 +34,7 @@ public class GuildCreateHandler extends SocketHandler
     protected Long handleInternally(JSONObject content)
     {
         final long id = content.getLong("id");
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(id);
         if (guild == null)
         {
             getJDA().getGuildSetupController().onCreate(id, content);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.handle;
 
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.set.TLongSet;
-import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.core.audio.hooks.ConnectionStatus;
+import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.core.events.guild.GuildUnavailableEvent;
 import net.dv8tion.jda.core.managers.AudioManager;
@@ -31,6 +31,9 @@ import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.Helpers;
+import net.dv8tion.jda.internal.utils.UnlockHook;
+import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
+import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import org.json.JSONObject;
 
 public class GuildDeleteHandler extends SocketHandler
@@ -48,12 +51,15 @@ public class GuildDeleteHandler extends SocketHandler
         if (wasInit)
             return null;
 
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(id);
         boolean unavailable = Helpers.optBoolean(content, "unavailable");
         if (guild == null)
         {
             //getJDA().getEventCache().cache(EventCache.Type.GUILD, id, () -> handle(responseNumber, allContent));
-            WebSocketClient.LOG.debug("Received GUILD_DELETE for a Guild that is not currently cached. ID: {} unavailable: {}", id, unavailable);
+            WebSocketClient.LOG
+                    .debug("Received GUILD_DELETE for a Guild that is not currently cached. ID: {} unavailable: {}", id,
+                           unavailable
+                    );
             return null;
         }
 
@@ -66,23 +72,40 @@ public class GuildDeleteHandler extends SocketHandler
         {
             guild.setAvailable(false);
             getJDA().getEventManager().handle(
-                new GuildUnavailableEvent(
-                    getJDA(), responseNumber,
-                    guild));
+                    new GuildUnavailableEvent(
+                            getJDA(), responseNumber,
+                            guild
+                    ));
             return null;
         }
 
         //Remove everything from global cache
         // this prevents some race-conditions for getting audio managers from guilds
-        getJDA().getGuildMap().remove(id);
-        guild.getTextChannelCache().forEach(chan -> getJDA().getTextChannelMap().remove(chan.getIdLong()));
-        guild.getVoiceChannelCache().forEach(chan -> getJDA().getVoiceChannelMap().remove(chan.getIdLong()));
-        guild.getCategoryCache().forEach(chan -> getJDA().getCategoryMap().remove(chan.getIdLong()));
-
-        getJDA().getClient().removeAudioConnection(id);
-        final TLongObjectMap<AudioManager> audioManagerMap = getJDA().getAudioManagerMap();
-        synchronized (audioManagerMap)
+        SnowflakeCacheViewImpl<Guild> guildView = getJDA().getGuildMap();
+        SnowflakeCacheViewImpl<TextChannel> textView = getJDA().getTextChannelMap();
+        SnowflakeCacheViewImpl<VoiceChannel> voiceView = getJDA().getVoiceChannelMap();
+        SnowflakeCacheViewImpl<Category> categoryView = getJDA().getCategoryMap();
+        guildView.remove(id);
+        try (UnlockHook hook = textView.writeLock())
         {
+            guild.getTextChannelCache()
+                 .forEach(chan -> textView.getMap().remove(chan.getIdLong()));
+        }
+        try (UnlockHook hook = voiceView.writeLock())
+        {
+            guild.getVoiceChannelCache()
+                 .forEach(chan -> voiceView.getMap().remove(chan.getIdLong()));
+        }
+        try (UnlockHook hook = categoryView.writeLock())
+        {
+            guild.getCategoryCache()
+                 .forEach(chan -> categoryView.getMap().remove(chan.getIdLong()));
+        }
+        getJDA().getClient().removeAudioConnection(id);
+        final AbstractCacheView<AudioManager> audioManagerView = getJDA().getAudioManagerMap();
+        try (UnlockHook hook = audioManagerView.writeLock())
+        {
+            final TLongObjectMap<AudioManager> audioManagerMap = audioManagerView.getMap();
             final AudioManagerImpl manager = (AudioManagerImpl) audioManagerMap.get(id);
             if (manager != null) // close existing audio connection if needed
             {
@@ -99,29 +122,31 @@ public class GuildDeleteHandler extends SocketHandler
         //cleaning up all users that we do not share a guild with anymore
         // Anything left in memberIds will be removed from the main userMap
         //Use a new HashSet so that we don't actually modify the Member map so it doesn't affect Guild#getMembers for the leave event.
-        TLongSet memberIds = new TLongHashSet(guild.getMembersMap().keySet());
+        TLongSet memberIds = guild.getMembersMap().keySet(); // copies keys
         getJDA().getGuildCache().stream()
                 .map(GuildImpl.class::cast)
                 .forEach(g -> memberIds.removeAll(g.getMembersMap().keySet()));
-
         // Remember, everything left in memberIds is removed from the userMap
-        long selfId = getJDA().getSelfUser().getIdLong();
-        memberIds.forEach(memberId ->
+        SnowflakeCacheViewImpl<User> userView = getJDA().getUserMap();
+        try (UnlockHook hook = userView.writeLock())
         {
-            if (memberId == selfId)
-                return true; // don't remove selfUser from cache
-            UserImpl user = (UserImpl) getJDA().getUserMap().remove(memberId);
-            if (user.hasPrivateChannel())
-            {
-                PrivateChannelImpl priv = (PrivateChannelImpl) user.getPrivateChannel();
-                user.setFake(true);
-                priv.setFake(true);
-                getJDA().getFakeUserMap().put(user.getIdLong(), user);
-                getJDA().getFakePrivateChannelMap().put(priv.getIdLong(), priv);
-            }
-            getJDA().getEventCache().clear(EventCache.Type.USER, memberId);
-            return true;
-        });
+            long selfId = getJDA().getSelfUser().getIdLong();
+            memberIds.forEach(memberId -> {
+                if (memberId == selfId)
+                    return true; // don't remove selfUser from cache
+                UserImpl user = (UserImpl) userView.getMap().remove(memberId);
+                if (user.hasPrivateChannel())
+                {
+                    PrivateChannelImpl priv = (PrivateChannelImpl) user.getPrivateChannel();
+                    user.setFake(true);
+                    priv.setFake(true);
+                    getJDA().getFakeUserMap().put(user.getIdLong(), user);
+                    getJDA().getFakePrivateChannelMap().put(priv.getIdLong(), priv);
+                }
+                getJDA().getEventCache().clear(EventCache.Type.USER, memberId);
+                return true;
+            });
+        }
 
         getJDA().getEventManager().handle(
             new GuildLeaveEvent(

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
@@ -56,10 +56,7 @@ public class GuildDeleteHandler extends SocketHandler
         if (guild == null)
         {
             //getJDA().getEventCache().cache(EventCache.Type.GUILD, id, () -> handle(responseNumber, allContent));
-            WebSocketClient.LOG
-                    .debug("Received GUILD_DELETE for a Guild that is not currently cached. ID: {} unavailable: {}", id,
-                           unavailable
-                    );
+            WebSocketClient.LOG.debug("Received GUILD_DELETE for a Guild that is not currently cached. ID: {} unavailable: {}", id, unavailable);
             return null;
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
@@ -81,10 +81,10 @@ public class GuildDeleteHandler extends SocketHandler
 
         //Remove everything from global cache
         // this prevents some race-conditions for getting audio managers from guilds
-        SnowflakeCacheViewImpl<Guild> guildView = getJDA().getGuildMap();
-        SnowflakeCacheViewImpl<TextChannel> textView = getJDA().getTextChannelMap();
-        SnowflakeCacheViewImpl<VoiceChannel> voiceView = getJDA().getVoiceChannelMap();
-        SnowflakeCacheViewImpl<Category> categoryView = getJDA().getCategoryMap();
+        SnowflakeCacheViewImpl<Guild> guildView = getJDA().getGuildsView();
+        SnowflakeCacheViewImpl<TextChannel> textView = getJDA().getTextChannelsView();
+        SnowflakeCacheViewImpl<VoiceChannel> voiceView = getJDA().getVoiceChannelsView();
+        SnowflakeCacheViewImpl<Category> categoryView = getJDA().getCategoriesView();
         guildView.remove(id);
         try (UnlockHook hook = textView.writeLock())
         {
@@ -102,7 +102,7 @@ public class GuildDeleteHandler extends SocketHandler
                  .forEach(chan -> categoryView.getMap().remove(chan.getIdLong()));
         }
         getJDA().getClient().removeAudioConnection(id);
-        final AbstractCacheView<AudioManager> audioManagerView = getJDA().getAudioManagerMap();
+        final AbstractCacheView<AudioManager> audioManagerView = getJDA().getAudioManagersView();
         try (UnlockHook hook = audioManagerView.writeLock())
         {
             final TLongObjectMap<AudioManager> audioManagerMap = audioManagerView.getMap();
@@ -122,12 +122,12 @@ public class GuildDeleteHandler extends SocketHandler
         //cleaning up all users that we do not share a guild with anymore
         // Anything left in memberIds will be removed from the main userMap
         //Use a new HashSet so that we don't actually modify the Member map so it doesn't affect Guild#getMembers for the leave event.
-        TLongSet memberIds = guild.getMembersMap().keySet(); // copies keys
+        TLongSet memberIds = guild.getMembersView().keySet(); // copies keys
         getJDA().getGuildCache().stream()
                 .map(GuildImpl.class::cast)
-                .forEach(g -> memberIds.removeAll(g.getMembersMap().keySet()));
+                .forEach(g -> memberIds.removeAll(g.getMembersView().keySet()));
         // Remember, everything left in memberIds is removed from the userMap
-        SnowflakeCacheViewImpl<User> userView = getJDA().getUserMap();
+        SnowflakeCacheViewImpl<User> userView = getJDA().getUsersView();
         try (UnlockHook hook = userView.writeLock())
         {
             long selfId = getJDA().getSelfUser().getIdLong();

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildEmojisUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildEmojisUpdateHandler.java
@@ -27,6 +27,8 @@ import net.dv8tion.jda.core.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.EmoteImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.utils.UnlockHook;
+import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import org.apache.commons.collections4.CollectionUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -49,7 +51,7 @@ public class GuildEmojisUpdateHandler extends SocketHandler
         if (getJDA().getGuildSetupController().isLocked(guildId))
             return guildId;
 
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(guildId);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(guildId);
         if (guild == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);
@@ -57,61 +59,67 @@ public class GuildEmojisUpdateHandler extends SocketHandler
         }
 
         JSONArray array = content.getJSONArray("emojis");
-        TLongObjectMap<Emote> emoteMap = guild.getEmoteMap();
-        List<Emote> oldEmotes = new ArrayList<>(emoteMap.valueCollection()); //snapshot of emote cache
-        List<Emote> newEmotes = new ArrayList<>();
-        for (int i = 0; i < array.length(); i++)
+        List<Emote> oldEmotes, newEmotes;
+        SnowflakeCacheViewImpl<Emote> emoteView = guild.getEmoteMap();
+        try (UnlockHook hook = emoteView.writeLock())
         {
-            JSONObject current = array.getJSONObject(i);
-            final long emoteId = current.getLong("id");
-            EmoteImpl emote = (EmoteImpl) emoteMap.get(emoteId);
-            EmoteImpl oldEmote = null;
+            TLongObjectMap<Emote> emoteMap = emoteView.getMap();
+            oldEmotes = new ArrayList<>(emoteMap.valueCollection()); //snapshot of emote cache
+            newEmotes = new ArrayList<>();
+            for (int i = 0; i < array.length(); i++)
+            {
+                JSONObject current = array.getJSONObject(i);
+                final long emoteId = current.getLong("id");
+                EmoteImpl emote = (EmoteImpl) emoteMap.get(emoteId);
+                EmoteImpl oldEmote = null;
 
-            if (emote == null)
-            {
-                emote = new EmoteImpl(emoteId, guild);
-                newEmotes.add(emote);
-            }
-            else
-            {
-                // emote is in our cache which is why we don't want to remove it in cleanup later
-                oldEmotes.remove(emote);
-                oldEmote = emote.clone();
-            }
-
-            emote.setName(current.getString("name"))
-                 .setAnimated(current.optBoolean("animated"))
-                 .setManaged(current.getBoolean("managed"));
-            //update roles
-            JSONArray roles = current.getJSONArray("roles");
-            Set<Role> newRoles = emote.getRoleSet();
-            Set<Role> oldRoles = new HashSet<>(newRoles); //snapshot of cached roles
-            for (int j = 0; j < roles.length(); j++)
-            {
-                Role role = guild.getRoleById(roles.getString(j));
-                if (role != null)
+                if (emote == null)
                 {
-                    newRoles.add(role);
-                    oldRoles.remove(role);
+                    emote = new EmoteImpl(emoteId, guild);
+                    newEmotes.add(emote);
                 }
-            }
+                else
+                {
+                    // emote is in our cache which is why we don't want to remove it in cleanup later
+                    oldEmotes.remove(emote);
+                    oldEmote = emote.clone();
+                }
 
-            //cleanup old cached roles that were not found in the JSONArray
-            for (Role r : oldRoles)
-            {
-                // newRoles directly writes to the set contained in the emote
-                newRoles.remove(r);
-            }
+                emote.setName(current.getString("name"))
+                     .setAnimated(current.optBoolean("animated"))
+                     .setManaged(current.getBoolean("managed"));
+                //update roles
+                JSONArray roles = current.getJSONArray("roles");
+                Set<Role> newRoles = emote.getRoleSet();
+                Set<Role> oldRoles = new HashSet<>(newRoles); //snapshot of cached roles
+                for (int j = 0; j < roles.length(); j++)
+                {
+                    Role role = guild.getRoleById(roles.getString(j));
+                    if (role != null)
+                    {
+                        newRoles.add(role);
+                        oldRoles.remove(role);
+                    }
+                }
 
-            // finally, update the emote
-            emoteMap.put(emote.getIdLong(), emote);
-            // check for updated fields and fire events
-            handleReplace(oldEmote, emote);
+                //cleanup old cached roles that were not found in the JSONArray
+                for (Role r : oldRoles)
+                {
+                    // newRoles directly writes to the set contained in the emote
+                    newRoles.remove(r);
+                }
+
+                // finally, update the emote
+                emoteMap.put(emote.getIdLong(), emote);
+                // check for updated fields and fire events
+                handleReplace(oldEmote, emote);
+            }
+            for (Emote e : oldEmotes)
+                emoteMap.remove(e.getIdLong());
         }
         //cleanup old emotes that don't exist anymore
         for (Emote e : oldEmotes)
         {
-            emoteMap.remove(e.getIdLong());
             getJDA().getEventManager().handle(
                 new EmoteRemovedEvent(
                     getJDA(), responseNumber,

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildEmojisUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildEmojisUpdateHandler.java
@@ -60,7 +60,7 @@ public class GuildEmojisUpdateHandler extends SocketHandler
 
         JSONArray array = content.getJSONArray("emojis");
         List<Emote> oldEmotes, newEmotes;
-        SnowflakeCacheViewImpl<Emote> emoteView = guild.getEmoteMap();
+        SnowflakeCacheViewImpl<Emote> emoteView = guild.getEmotesView();
         try (UnlockHook hook = emoteView.writeLock())
         {
             TLongObjectMap<Emote> emoteMap = emoteView.getMap();

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberAddHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberAddHandler.java
@@ -37,7 +37,7 @@ public class GuildMemberAddHandler extends SocketHandler
         if (setup)
             return null;
 
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(id);
         if (guild == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.GUILD, id, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
@@ -42,7 +42,7 @@ public class GuildMemberRemoveHandler extends SocketHandler
         if (setup)
             return null;
 
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildsView().get(id);
         if (guild == null)
         {
             //We probably just left the guild and this event is trying to remove us from the guild, therefore ignore
@@ -55,7 +55,7 @@ public class GuildMemberRemoveHandler extends SocketHandler
             //We probably just left the guild and this event is trying to remove us from the guild, therefore ignore
             return null;
         }
-        MemberImpl member = (MemberImpl) guild.getMembersMap().remove(userId);
+        MemberImpl member = (MemberImpl) guild.getMembersView().remove(userId);
 
         if (member == null)
         {
@@ -76,13 +76,13 @@ public class GuildMemberRemoveHandler extends SocketHandler
         }
 
         //The user is not in a different guild that we share
-        SnowflakeCacheViewImpl<User> userView = getJDA().getUserMap();
+        SnowflakeCacheViewImpl<User> userView = getJDA().getUsersView();
         try (UnlockHook hook = userView.writeLock())
         {
             if (userId != getJDA().getSelfUser().getIdLong() // don't remove selfUser from cache
-                    && getJDA().getGuildMap().stream()
+                    && getJDA().getGuildsView().stream()
                                .map(GuildImpl.class::cast)
-                               .noneMatch(g -> g.getMembersMap().get(userId) != null))
+                               .noneMatch(g -> g.getMembersView().get(userId) != null))
             {
                 UserImpl user = (UserImpl) userView.getMap().remove(userId);
                 if (user.hasPrivateChannel())

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberUpdateHandler.java
@@ -44,7 +44,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
 
         JSONObject userJson = content.getJSONObject("user");
         final long userId = userJson.getLong("id");
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(id);
         if (guild == null)
         {
             //Do not cache this here, it will be outdated once we receive the GUILD_CREATE and could cause invalid cache

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberUpdateHandler.java
@@ -53,7 +53,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
             return null;
         }
 
-        MemberImpl member = (MemberImpl) guild.getMembersMap().get(userId);
+        MemberImpl member = (MemberImpl) guild.getMembersView().get(userId);
         if (member == null)
         {
             long hashId = id ^ userId;
@@ -126,7 +126,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
         for(int i = 0; i < array.length(); i++)
         {
             final long id = array.getLong(i);
-            Role r = guild.getRolesMap().get(id);
+            Role r = guild.getRolesView().get(id);
             if (r != null)
             {
                 roles.add(r);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleCreateHandler.java
@@ -36,7 +36,7 @@ public class GuildRoleCreateHandler extends SocketHandler
         if (getJDA().getGuildSetupController().isLocked(guildId))
             return guildId;
 
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(guildId);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(guildId);
         if (guild == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleDeleteHandler.java
@@ -48,7 +48,7 @@ public class GuildRoleDeleteHandler extends SocketHandler
         }
 
         final long roleId = content.getLong("role_id");
-        Role removedRole = guild.getRolesMap().remove(roleId);
+        Role removedRole = guild.getRolesView().remove(roleId);
         if (removedRole == null)
         {
             //getJDA().getEventCache().cache(EventCache.Type.ROLE, roleId, () -> handle(responseNumber, allContent));
@@ -57,7 +57,7 @@ public class GuildRoleDeleteHandler extends SocketHandler
         }
 
         //Now that the role is removed from the Guild, remove it from all users and emotes.
-        guild.getMembersMap().forEach(m ->
+        guild.getMembersView().forEach(m ->
         {
             MemberImpl member = (MemberImpl) m;
             member.getRoleSet().remove(removedRole);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleDeleteHandler.java
@@ -16,7 +16,6 @@
 package net.dv8tion.jda.internal.handle;
 
 import net.dv8tion.jda.core.entities.Emote;
-import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
 import net.dv8tion.jda.core.events.role.RoleDeleteEvent;
 import net.dv8tion.jda.internal.JDAImpl;
@@ -40,7 +39,7 @@ public class GuildRoleDeleteHandler extends SocketHandler
         if (getJDA().getGuildSetupController().isLocked(guildId))
             return guildId;
 
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(guildId);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(guildId);
         if (guild == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);
@@ -58,11 +57,11 @@ public class GuildRoleDeleteHandler extends SocketHandler
         }
 
         //Now that the role is removed from the Guild, remove it from all users and emotes.
-        for (Member m : guild.getMembersMap().valueCollection())
+        guild.getMembersMap().forEach(m ->
         {
             MemberImpl member = (MemberImpl) m;
             member.getRoleSet().remove(removedRole);
-        }
+        });
 
         for (Emote emote : guild.getEmoteCache())
         {

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleUpdateHandler.java
@@ -39,7 +39,7 @@ public class GuildRoleUpdateHandler extends SocketHandler
             return guildId;
 
         JSONObject rolejson = content.getJSONObject("role");
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(guildId);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(guildId);
         if (guild == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildRoleUpdateHandler.java
@@ -48,7 +48,7 @@ public class GuildRoleUpdateHandler extends SocketHandler
         }
 
         final long roleId = rolejson.getLong("id");
-        RoleImpl role = (RoleImpl) guild.getRolesMap().get(roleId);
+        RoleImpl role = (RoleImpl) guild.getRolesView().get(roleId);
         if (role == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.ROLE, roleId, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
@@ -429,7 +429,7 @@ public class GuildSetupNode
     private void updateAudioManagerReference(GuildImpl guild)
     {
         JDAImpl api = getController().getJDA();
-        AbstractCacheView<AudioManager> managerView = api.getAudioManagerMap();
+        AbstractCacheView<AudioManager> managerView = api.getAudioManagersView();
         try (UnlockHook hook = managerView.writeLock())
         {
             TLongObjectMap<AudioManager> audioManagerMap = managerView.getMap();

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
@@ -29,11 +29,13 @@ import net.dv8tion.jda.core.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.core.events.guild.GuildReadyEvent;
 import net.dv8tion.jda.core.events.guild.UnavailableGuildJoinedEvent;
 import net.dv8tion.jda.core.managers.AudioManager;
-import net.dv8tion.jda.internal.utils.cache.UpstreamReference;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.utils.Helpers;
+import net.dv8tion.jda.internal.utils.UnlockHook;
+import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
+import net.dv8tion.jda.internal.utils.cache.UpstreamReference;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -427,9 +429,10 @@ public class GuildSetupNode
     private void updateAudioManagerReference(GuildImpl guild)
     {
         JDAImpl api = getController().getJDA();
-        TLongObjectMap<AudioManager> audioManagerMap = api.getAudioManagerMap();
-        synchronized (audioManagerMap)
+        AbstractCacheView<AudioManager> managerView = api.getAudioManagerMap();
+        try (UnlockHook hook = managerView.writeLock())
         {
+            TLongObjectMap<AudioManager> audioManagerMap = managerView.getMap();
             AudioManagerImpl mng = (AudioManagerImpl) audioManagerMap.get(id);
             if (mng == null)
                 return;

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
@@ -63,9 +63,9 @@ public class GuildUpdateHandler extends SocketHandler
         Guild.ExplicitContentLevel explicitContentLevel = Guild.ExplicitContentLevel.fromKey(content.getInt("explicit_content_filter"));
         Guild.Timeout afkTimeout = Guild.Timeout.fromKey(content.getInt("afk_timeout"));
         VoiceChannel afkChannel = content.isNull("afk_channel_id")
-                ? null : guild.getVoiceChannelsMap().get(content.getLong("afk_channel_id"));
+                ? null : guild.getVoiceChannelsView().get(content.getLong("afk_channel_id"));
         TextChannel systemChannel = content.isNull("system_channel_id")
-                ? null : guild.getTextChannelsMap().get(content.getLong("system_channel_id"));
+                ? null : guild.getTextChannelsView().get(content.getLong("system_channel_id"));
         Set<String> features;
         if (!content.isNull("features"))
         {
@@ -80,7 +80,7 @@ public class GuildUpdateHandler extends SocketHandler
         if (ownerId != guild.getOwnerIdLong())
         {
             Member oldOwner = guild.getOwner();
-            Member newOwner = guild.getMembersMap().get(ownerId);
+            Member newOwner = guild.getMembersView().get(ownerId);
             if (newOwner == null)
                 WebSocketClient.LOG.warn("Received {} with owner not in cache. UserId: {} GuildId: {}", allContent.get("t"), ownerId, id);
             guild.setOwner(newOwner);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
@@ -51,7 +51,7 @@ public class GuildUpdateHandler extends SocketHandler
         //  WARNING //
         //Do not rely on allContent past this point, this method is also called from GuildCreateHandler!
         //////////////
-        GuildImpl guild = (GuildImpl) getJDA().getGuildMap().get(id);
+        GuildImpl guild = (GuildImpl) getJDA().getGuildById(id);
         long ownerId = content.getLong("owner_id");
         String name = content.getString("name");
         String iconId = content.optString("icon", null);

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageBulkDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageBulkDeleteHandler.java
@@ -55,7 +55,7 @@ public class MessageBulkDeleteHandler extends SocketHandler
         }
         else
         {
-            TextChannel channel = getJDA().getTextChannelMap().get(channelId);
+            TextChannel channel = getJDA().getTextChannelById(channelId);
             if (channel == null)
             {
                 getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageUpdateHandler.java
@@ -154,9 +154,9 @@ public class MessageUpdateHandler extends SocketHandler
         final long messageId = content.getLong("id");
         final long channelId = content.getLong("channel_id");
         LinkedList<MessageEmbed> embeds = new LinkedList<>();
-        MessageChannel channel = getJDA().getTextChannelMap().get(channelId);
+        MessageChannel channel = getJDA().getTextChannelsView().get(channelId);
         if (channel == null)
-            channel = getJDA().getPrivateChannelMap().get(channelId);
+            channel = getJDA().getPrivateChannelsView().get(channelId);
         if (channel == null)
             channel = getJDA().getFakePrivateChannelMap().get(channelId);
         if (channel == null)

--- a/src/main/java/net/dv8tion/jda/internal/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/PresenceUpdateHandler.java
@@ -64,7 +64,7 @@ public class PresenceUpdateHandler extends SocketHandler
 
         JSONObject jsonUser = content.getJSONObject("user");
         final long userId = jsonUser.getLong("id");
-        UserImpl user = (UserImpl) getJDA().getUserMap().get(userId);
+        UserImpl user = (UserImpl) getJDA().getUsersView().get(userId);
 
         //If we do know about the user, lets update the user's specific info.
         // Afterwards, we will see if we already have them cached in the specific guild

--- a/src/main/java/net/dv8tion/jda/internal/handle/TypingStartHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/TypingStartHandler.java
@@ -45,9 +45,9 @@ public class TypingStartHandler extends SocketHandler
         }
 
         final long channelId = content.getLong("channel_id");
-        MessageChannel channel = getJDA().getTextChannelMap().get(channelId);
+        MessageChannel channel = getJDA().getTextChannelsView().get(channelId);
         if (channel == null)
-            channel = getJDA().getPrivateChannelMap().get(channelId);
+            channel = getJDA().getPrivateChannelsView().get(channelId);
         if (channel == null)
             channel = getJDA().getFakePrivateChannelMap().get(channelId);
         if (channel == null)
@@ -67,7 +67,7 @@ public class TypingStartHandler extends SocketHandler
         if (channel instanceof PrivateChannel)
             user = ((PrivateChannel) channel).getUser();
         else
-            user = getJDA().getUserMap().get(userId);
+            user = getJDA().getUsersView().get(userId);
 
         if (user == null)
             return null;    //Just like in the comment above, if for some reason we don't have the user

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceServerUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceServerUpdateHandler.java
@@ -37,7 +37,7 @@ public class VoiceServerUpdateHandler extends SocketHandler
         final long guildId = content.getLong("guild_id");
         if (getJDA().getGuildSetupController().isLocked(guildId))
             return guildId;
-        Guild guild = getJDA().getGuildMap().get(guildId);
+        Guild guild = getJDA().getGuildById(guildId);
         if (guild == null)
             throw new IllegalArgumentException("Attempted to start audio connection with Guild that doesn't exist!");
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -156,7 +156,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
             }
             else
             {
-                AudioManagerImpl mng = (AudioManagerImpl) getJDA().getAudioManagerMap().get(guildId);
+                AudioManagerImpl mng = (AudioManagerImpl) getJDA().getAudioManagersView().get(guildId);
 
                 //If the currently connected account is the one that is being moved
                 if (guild.getSelfMember().equals(member) && mng != null)

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -666,12 +666,12 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
         locked("Interrupted while trying to invalidate chunk/sync queue", chunkSyncQueue::clear);
 
-        api.getTextChannelMap().clear();
-        api.getVoiceChannelMap().clear();
-        api.getCategoryMap().clear();
-        api.getGuildMap().clear();
-        api.getUserMap().clear();
-        api.getPrivateChannelMap().clear();
+        api.getTextChannelsView().clear();
+        api.getVoiceChannelsView().clear();
+        api.getCategoriesView().clear();
+        api.getGuildsView().clear();
+        api.getUsersView().clear();
+        api.getPrivateChannelsView().clear();
         api.getFakeUserMap().clear();
         api.getFakePrivateChannelMap().clear();
         api.getEventCache().clear();
@@ -680,7 +680,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected void updateAudioManagerReferences()
     {
-        AbstractCacheView<AudioManager> managerView = api.getAudioManagerMap();
+        AbstractCacheView<AudioManager> managerView = api.getAudioManagersView();
         try (UnlockHook hook = managerView.writeLock())
         {
             final TLongObjectMap<AudioManager> managerMap = managerView.getMap();

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -39,6 +39,8 @@ import net.dv8tion.jda.internal.handle.*;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.managers.PresenceImpl;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import net.dv8tion.jda.internal.utils.UnlockHook;
+import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -678,12 +680,13 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected void updateAudioManagerReferences()
     {
-        final TLongObjectMap<AudioManager> managerMap = api.getAudioManagerMap();
-        if (managerMap.size() > 0)
-            LOG.trace("Updating AudioManager references");
-
-        synchronized (managerMap)
+        AbstractCacheView<AudioManager> managerView = api.getAudioManagerMap();
+        try (UnlockHook hook = managerView.writeLock())
         {
+            final TLongObjectMap<AudioManager> managerMap = managerView.getMap();
+            if (managerMap.size() > 0)
+                LOG.trace("Updating AudioManager references");
+
             for (TLongObjectIterator<AudioManager> it = managerMap.iterator(); it.hasNext(); )
             {
                 it.advance();

--- a/src/main/java/net/dv8tion/jda/internal/utils/ChainedClosableIterator.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/ChainedClosableIterator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils;
+
+import net.dv8tion.jda.core.utils.ClosableIterator;
+import net.dv8tion.jda.core.utils.cache.CacheView;
+import org.slf4j.Logger;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class ChainedClosableIterator<T> implements ClosableIterator<T>
+{
+    private final static Logger log = JDALogger.getLog(ClosableIterator.class);
+    private final Iterator<? extends CacheView<T>> generator;
+    private ClosableIterator<T> currentIterator;
+
+    public ChainedClosableIterator(Iterator<? extends CacheView<T>> generator)
+    {
+        this.generator = generator;
+    }
+
+    @Override
+    public void close()
+    {
+        if (currentIterator != null)
+            currentIterator.close();
+        currentIterator = null;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        if (currentIterator != null && !currentIterator.hasNext())
+        {
+            currentIterator.close();
+            currentIterator = null;
+        }
+        if (currentIterator == null)
+        {
+            CacheView<T> view = null;
+            while (generator.hasNext())
+            {
+                view = generator.next();
+                if (!view.isEmpty())
+                    break;
+                view = null;
+            }
+            if (view == null)
+                return false;
+            currentIterator = view.lockedIterator();
+        }
+        return true;
+    }
+
+    @Override
+    public T next()
+    {
+        if (!hasNext())
+            throw new NoSuchElementException();
+        return currentIterator.next();
+    }
+
+    @Override
+    @Deprecated
+    protected void finalize()
+    {
+        if (currentIterator != null)
+        {
+            log.error("Finalizing without closing, performing force close on lock");
+            close();
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/utils/UnlockHook.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/UnlockHook.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils;
+
+import java.util.concurrent.locks.Lock;
+
+public class UnlockHook implements AutoCloseable
+{
+    private final Lock lock;
+
+    public UnlockHook(Lock lock)
+    {
+        this.lock = lock;
+    }
+
+    @Override
+    public void close()
+    {
+        lock.unlock();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -51,16 +51,26 @@ public abstract class AbstractCacheView<T> implements CacheView<T>
         this.emptyArray = (T[]) Array.newInstance(type, 0);
     }
 
-    public void clear()
-    {
-        elements.clear();
-    }
-
     public UnlockHook writeLock()
     {
         ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
         writeLock.lock();
         return new UnlockHook(writeLock);
+    }
+
+    public UnlockHook readLock()
+    {
+        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+        readLock.lock();
+        return new UnlockHook(readLock);
+    }
+
+    public void clear()
+    {
+        try (UnlockHook hook = writeLock())
+        {
+            elements.clear();
+        }
     }
 
     public TLongObjectMap<T> getMap()
@@ -105,13 +115,6 @@ public abstract class AbstractCacheView<T> implements CacheView<T>
                 action.accept(elem);
             }
         }
-    }
-
-    public UnlockHook readLock()
-    {
-        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
-        readLock.lock();
-        return new UnlockHook(readLock);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -174,7 +174,7 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache implements
             if (elementName != null && equals(ignoreCase, elementName, name))
                 list.add(elem);
         });
-        return list;
+        return list; // must be modifiable because of SortedSnowflakeCacheView
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -35,7 +35,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public abstract class AbstractCacheView<T> extends ReadWriteLockCache implements CacheView<T>
+public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> implements CacheView<T>
 {
     protected final TLongObjectMap<T> elements = new TLongObjectHashMap<>();
     protected final T[] emptyArray;
@@ -126,9 +126,12 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache implements
             return Collections.emptyList();
         try (UnlockHook hook = readLock())
         {
-            ArrayList<T> list = new ArrayList<>(elements.size());
+            List<T> list = getCachedList();
+            if (list != null)
+                return list;
+            list = new ArrayList<>(elements.size());
             elements.forEachValue(list::add);
-            return Collections.unmodifiableList(list);
+            return cache(list);
         }
     }
 
@@ -139,9 +142,12 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache implements
             return Collections.emptySet();
         try (UnlockHook hook = readLock())
         {
-            HashSet<T> set = new HashSet<>(elements.size());
+            Set<T> set = getCachedSet();
+            if (set != null)
+                return set;
+            set = new HashSet<>(elements.size());
             elements.forEachValue(set::add);
-            return Collections.unmodifiableSet(set);
+            return cache(set);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -17,24 +17,31 @@
 package net.dv8tion.jda.internal.utils.cache;
 
 import gnu.trove.map.TLongObjectMap;
-import net.dv8tion.jda.core.utils.MiscUtil;
+import gnu.trove.map.hash.TLongObjectHashMap;
+import gnu.trove.set.TLongSet;
+import gnu.trove.set.hash.TLongHashSet;
+import net.dv8tion.jda.core.utils.ClosableIteratorImpl;
 import net.dv8tion.jda.core.utils.cache.CacheView;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.UnlockHook;
 import org.apache.commons.collections4.iterators.ObjectArrayIterator;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Array;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public abstract class AbstractCacheView<T> implements CacheView<T>
 {
-    protected final TLongObjectMap<T> elements = MiscUtil.newLongMap();
+    protected final TLongObjectMap<T> elements = new TLongObjectHashMap<>();
     protected final T[] emptyArray;
     protected final Function<T, String> nameMapper;
     protected final Class<T> type;
+    protected final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     @SuppressWarnings("unchecked")
     protected AbstractCacheView(Class<T> type, Function<T, String> nameMapper)
@@ -49,25 +56,105 @@ public abstract class AbstractCacheView<T> implements CacheView<T>
         elements.clear();
     }
 
+    public UnlockHook writeLock()
+    {
+        ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+        writeLock.lock();
+        return new UnlockHook(writeLock);
+    }
+
     public TLongObjectMap<T> getMap()
     {
+        if (!lock.writeLock().isHeldByCurrentThread())
+            throw new IllegalStateException("Cannot access map directly without holding write lock!");
         return elements;
+    }
+
+    public T get(long id)
+    {
+        try (UnlockHook hook = readLock())
+        {
+            return elements.get(id);
+        }
+    }
+
+    public T remove(long id)
+    {
+        try (UnlockHook hook = writeLock())
+        {
+            return elements.remove(id);
+        }
+    }
+
+    public TLongSet keySet()
+    {
+        try (UnlockHook hook = readLock())
+        {
+            return new TLongHashSet(elements.keySet());
+        }
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> action)
+    {
+        Objects.requireNonNull(action);
+        try (UnlockHook hook = readLock())
+        {
+            for (T elem : elements.valueCollection())
+            {
+                action.accept(elem);
+            }
+        }
+    }
+
+    public UnlockHook readLock()
+    {
+        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+        readLock.lock();
+        return new UnlockHook(readLock);
+    }
+
+    @Override
+    public ClosableIteratorImpl<T> lockedIterator()
+    {
+        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+        readLock.lock();
+        try
+        {
+            Iterator<T> directIterator = elements.valueCollection().iterator();
+            return new ClosableIteratorImpl<>(directIterator, readLock);
+        }
+        catch (Throwable t)
+        {
+            readLock.unlock();
+            throw t;
+        }
     }
 
     @Override
     public List<T> asList()
     {
-        ArrayList<T> list = new ArrayList<>(elements.size());
-        elements.forEachValue(list::add);
-        return Collections.unmodifiableList(list);
+        if (isEmpty())
+            return Collections.emptyList();
+        try (UnlockHook hook = readLock())
+        {
+            ArrayList<T> list = new ArrayList<>(elements.size());
+            elements.forEachValue(list::add);
+            return Collections.unmodifiableList(list);
+        }
     }
 
     @Override
     public Set<T> asSet()
     {
-        HashSet<T> set = new HashSet<>(elements.size());
-        elements.forEachValue(set::add);
-        return Collections.unmodifiableSet(set);
+        if (isEmpty())
+            return Collections.emptySet();
+        try (UnlockHook hook = readLock())
+        {
+            HashSet<T> set = new HashSet<>(elements.size());
+            elements.forEachValue(set::add);
+            return Collections.unmodifiableSet(set);
+        }
     }
 
     @Override
@@ -90,22 +177,25 @@ public abstract class AbstractCacheView<T> implements CacheView<T>
             return Collections.emptyList();
         if (nameMapper == null) // no getName method available
             throw new UnsupportedOperationException("The contained elements are not assigned with names.");
-
+        if (isEmpty())
+            return Collections.emptyList();
         List<T> list = new ArrayList<>();
-        for (T elem : this)
+        forEach(elem ->
         {
             String elementName = nameMapper.apply(elem);
             if (elementName != null && equals(ignoreCase, elementName, name))
                 list.add(elem);
-        }
-
+        });
         return list;
     }
 
     @Override
     public Spliterator<T> spliterator()
     {
-        return Spliterators.spliterator(elements.values(), Spliterator.IMMUTABLE);
+        try (UnlockHook hook = readLock())
+        {
+            return Spliterators.spliterator(elements.values(), Spliterator.IMMUTABLE);
+        }
     }
 
     @Override
@@ -122,15 +212,16 @@ public abstract class AbstractCacheView<T> implements CacheView<T>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public Iterator<T> iterator()
     {
-        return new ObjectArrayIterator<>(elements.values(emptyArray));
+        try (UnlockHook hook = readLock())
+        {
+            return new ObjectArrayIterator<>(elements.values(emptyArray));
+        }
     }
 
-    @SuppressWarnings("StringEquality")
     protected boolean equals(boolean ignoreCase, String first, String second)
     {
-        return first == second || ignoreCase ? first.equalsIgnoreCase(second) : first.equals(second);
+        return ignoreCase ? first.equalsIgnoreCase(second) : first.equals(second);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -208,6 +208,35 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache implements
         }
     }
 
+    @Override
+    public String toString()
+    {
+        return asList().toString();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        try (UnlockHook hook = readLock())
+        {
+            return elements.hashCode();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this)
+            return true;
+        if (!(obj instanceof AbstractCacheView))
+            return false;
+        AbstractCacheView view = (AbstractCacheView) obj;
+        try (UnlockHook hook = readLock(); UnlockHook otherHook = view.readLock())
+        {
+            return this.elements.equals(view.elements);
+        }
+    }
+
     protected boolean equals(boolean ignoreCase, String first, String second)
     {
         return ignoreCase ? first.equalsIgnoreCase(second) : first.equals(second);

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -35,13 +35,12 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public abstract class AbstractCacheView<T> implements CacheView<T>
+public abstract class AbstractCacheView<T> extends ReadWriteLockCache implements CacheView<T>
 {
     protected final TLongObjectMap<T> elements = new TLongObjectHashMap<>();
     protected final T[] emptyArray;
     protected final Function<T, String> nameMapper;
     protected final Class<T> type;
-    protected final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     @SuppressWarnings("unchecked")
     protected AbstractCacheView(Class<T> type, Function<T, String> nameMapper)
@@ -49,20 +48,6 @@ public abstract class AbstractCacheView<T> implements CacheView<T>
         this.nameMapper = nameMapper;
         this.type = type;
         this.emptyArray = (T[]) Array.newInstance(type, 0);
-    }
-
-    public UnlockHook writeLock()
-    {
-        ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
-        writeLock.lock();
-        return new UnlockHook(writeLock);
-    }
-
-    public UnlockHook readLock()
-    {
-        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
-        readLock.lock();
-        return new UnlockHook(readLock);
     }
 
     public void clear()

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ReadWriteLockCache.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ReadWriteLockCache.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils.cache;
+
+import net.dv8tion.jda.internal.utils.UnlockHook;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public abstract class ReadWriteLockCache
+{
+    protected final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public UnlockHook writeLock()
+    {
+        if (lock.getReadHoldCount() > 0)
+            throw new IllegalStateException("Unable to acquire write-lock while holding read-lock!");
+        ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+        writeLock.lock();
+        return new UnlockHook(writeLock);
+    }
+
+    public UnlockHook readLock()
+    {
+        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+        readLock.lock();
+        return new UnlockHook(readLock);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ReadWriteLockCache.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ReadWriteLockCache.java
@@ -18,11 +18,18 @@ package net.dv8tion.jda.internal.utils.cache;
 
 import net.dv8tion.jda.internal.utils.UnlockHook;
 
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public abstract class ReadWriteLockCache
+public abstract class ReadWriteLockCache<T>
 {
     protected final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    protected WeakReference<List<T>> cachedList;
+    protected WeakReference<Set<T>>  cachedSet;
 
     public UnlockHook writeLock()
     {
@@ -30,6 +37,8 @@ public abstract class ReadWriteLockCache
             throw new IllegalStateException("Unable to acquire write-lock while holding read-lock!");
         ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
         writeLock.lock();
+        onAcquireWriteLock();
+        clearCache();
         return new UnlockHook(writeLock);
     }
 
@@ -37,6 +46,47 @@ public abstract class ReadWriteLockCache
     {
         ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
         readLock.lock();
+        onAcquireReadLock();
         return new UnlockHook(readLock);
+    }
+
+    private void clearCache()
+    {
+        cachedList = null;
+        cachedSet = null;
+    }
+
+    protected void onAcquireWriteLock() {}
+    protected void onAcquireReadLock() {}
+
+    protected List<T> getCachedList()
+    {
+        return cachedList == null ? null : cachedList.get();
+    }
+
+    protected Set<T> getCachedSet()
+    {
+        return cachedSet == null ? null : cachedSet.get();
+    }
+
+    protected List<T> cache(List<T> list)
+    {
+        list = Collections.unmodifiableList(list);
+        cachedList = new WeakReference<>(list);
+        return list;
+    }
+
+    protected Set<T> cache(Set<T> set)
+    {
+        set = Collections.unmodifiableSet(set);
+        cachedSet = new WeakReference<>(set);
+        return set;
+    }
+
+    protected NavigableSet<T> cache(NavigableSet<T> set)
+    {
+        set = Collections.unmodifiableNavigableSet(set);
+        cachedSet = new WeakReference<>(set);
+        return set;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
@@ -38,12 +38,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class ShardCacheViewImpl implements ShardCacheView
+public class ShardCacheViewImpl extends ReadWriteLockCache implements ShardCacheView
 {
     protected static final JDA[] EMPTY_ARRAY = new JDA[0];
     protected final TIntObjectMap<JDA> elements;
-
-    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public ShardCacheViewImpl()
     {
@@ -53,20 +51,6 @@ public class ShardCacheViewImpl implements ShardCacheView
     public ShardCacheViewImpl(int initialCapacity)
     {
         this.elements = new TIntObjectHashMap<>(initialCapacity);
-    }
-
-    public UnlockHook writeLock()
-    {
-        ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
-        writeLock.lock();
-        return new UnlockHook(writeLock);
-    }
-
-    public UnlockHook readLock()
-    {
-        ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
-        readLock.lock();
-        return new UnlockHook(readLock);
     }
 
     public void clear()

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-public class ShardCacheViewImpl extends ReadWriteLockCache implements ShardCacheView
+public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements ShardCacheView
 {
     protected static final JDA[] EMPTY_ARRAY = new JDA[0];
     protected final TIntObjectMap<JDA> elements;
@@ -96,7 +96,10 @@ public class ShardCacheViewImpl extends ReadWriteLockCache implements ShardCache
             return Collections.emptyList();
         try (UnlockHook hook = readLock())
         {
-            return Collections.unmodifiableList(new ArrayList<>(elements.valueCollection()));
+            List<JDA> list = getCachedList();
+            if (list != null)
+                return list;
+            return cache(new ArrayList<>(elements.valueCollection()));
         }
     }
 
@@ -107,7 +110,10 @@ public class ShardCacheViewImpl extends ReadWriteLockCache implements ShardCache
             return Collections.emptySet();
         try (UnlockHook hook = readLock())
         {
-            return Collections.unmodifiableSet(new HashSet<>(elements.valueCollection()));
+            Set<JDA> set = getCachedSet();
+            if (set != null)
+                return set;
+            return cache(new HashSet<>(elements.valueCollection()));
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
@@ -213,6 +213,35 @@ public class ShardCacheViewImpl extends ReadWriteLockCache implements ShardCache
         }
     }
 
+    @Override
+    public int hashCode()
+    {
+        try (UnlockHook hook = readLock())
+        {
+            return elements.hashCode();
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj == this)
+            return true;
+        if (!(obj instanceof ShardCacheViewImpl))
+            return false;
+        ShardCacheViewImpl view = (ShardCacheViewImpl) obj;
+        try (UnlockHook hook = readLock(); UnlockHook otherHook = view.readLock())
+        {
+            return this.elements.equals(view.elements);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return asList().toString();
+    }
+
     public static class UnifiedShardCacheViewImpl implements ShardCacheView
     {
         protected final Supplier<Stream<ShardCacheView>> generator;

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeCacheViewImpl.java
@@ -18,7 +18,6 @@ package net.dv8tion.jda.internal.utils.cache;
 
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
-import net.dv8tion.jda.internal.utils.UnlockHook;
 
 import java.util.function.Function;
 
@@ -34,9 +33,6 @@ public class SnowflakeCacheViewImpl<T extends ISnowflake> extends AbstractCacheV
     {
         if (elements.isEmpty())
             return null;
-        try (UnlockHook hook = readLock())
-        {
-            return elements.get(id);
-        }
+        return get(id);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeCacheViewImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.utils.cache;
 
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
+import net.dv8tion.jda.internal.utils.UnlockHook;
 
 import java.util.function.Function;
 
@@ -31,6 +32,11 @@ public class SnowflakeCacheViewImpl<T extends ISnowflake> extends AbstractCacheV
     @Override
     public T getElementById(long id)
     {
-        return elements.get(id);
+        if (elements.isEmpty())
+            return null;
+        try (UnlockHook hook = readLock())
+        {
+            return elements.get(id);
+        }
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheView.java
@@ -92,7 +92,6 @@ public class SortedSnowflakeCacheView<T extends ISnowflake & Comparable<T>> exte
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public Iterator<T> iterator()
     {
         try (UnlockHook hook = readLock())

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheView.java
@@ -70,6 +70,14 @@ public class SortedSnowflakeCacheView<T extends ISnowflake & Comparable<T>> exte
     }
 
     @Override
+    public List<T> getElementsByName(String name, boolean ignoreCase)
+    {
+        List<T> filtered = super.getElementsByName(name, ignoreCase);
+        filtered.sort(comparator);
+        return filtered;
+    }
+
+    @Override
     public Spliterator<T> spliterator()
     {
         try (UnlockHook hook = readLock())

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
@@ -67,10 +67,13 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<T>>
             return Collections.emptyList();
         try (UnlockHook hook = readLock())
         {
-            List<T> list = new ArrayList<>(elements.size());
+            List<T> list = getCachedList();
+            if (list != null)
+                return list;
+            list = new ArrayList<>(elements.size());
             elements.forEachValue(list::add);
             list.sort(comparator);
-            return Collections.unmodifiableList(list);
+            return cache(list);
         }
     }
 
@@ -81,9 +84,12 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<T>>
             return Collections.emptyNavigableSet();
         try (UnlockHook hook = readLock())
         {
-            TreeSet<T> set = new TreeSet<>(comparator);
+            NavigableSet<T> set = (NavigableSet<T>) getCachedSet();
+            if (set != null)
+                return set;
+            set = new TreeSet<>(comparator);
             elements.forEachValue(set::add);
-            return Collections.unmodifiableNavigableSet(set);
+            return cache(set);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
@@ -75,15 +75,15 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<T>>
     }
 
     @Override
-    public SortedSet<T> asSet()
+    public NavigableSet<T> asSet()
     {
         if (isEmpty())
-            return Collections.emptySortedSet();
+            return Collections.emptyNavigableSet();
         try (UnlockHook hook = readLock())
         {
-            SortedSet<T> set = new TreeSet<>(comparator);
+            TreeSet<T> set = new TreeSet<>(comparator);
             elements.forEachValue(set::add);
-            return Collections.unmodifiableSortedSet(set);
+            return Collections.unmodifiableNavigableSet(set);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -19,10 +19,12 @@ package net.dv8tion.jda.internal.utils.cache;
 import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
+import net.dv8tion.jda.core.utils.ClosableIterator;
 import net.dv8tion.jda.core.utils.cache.CacheView;
 import net.dv8tion.jda.core.utils.cache.MemberCacheView;
 import net.dv8tion.jda.core.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.core.utils.cache.UnifiedMemberCacheView;
+import net.dv8tion.jda.internal.utils.ChainedClosableIterator;
 
 import javax.annotation.Nonnull;
 import java.util.*;
@@ -54,17 +56,30 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     @Override
     public List<T> asList()
     {
-        List<T> list = new ArrayList<>();
-        stream().forEach(list::add);
-        return Collections.unmodifiableList(list);
+        try (ClosableIterator<T> it = lockedIterator())
+        {
+            List<T> list = new ArrayList<>();
+            it.forEachRemaining(list::add);
+            return Collections.unmodifiableList(list);
+        }
     }
 
     @Override
     public Set<T> asSet()
     {
-        Set<T> set = new HashSet<>();
-        generator.get().flatMap(CacheView::stream).forEach(set::add);
-        return Collections.unmodifiableSet(set);
+        try (ClosableIterator<T> it = lockedIterator())
+        {
+            Set<T> set = new HashSet<>();
+            it.forEachRemaining(set::add);
+            return Collections.unmodifiableSet(set);
+        }
+    }
+
+    @Override
+    public ClosableIterator<T> lockedIterator()
+    {
+        Iterator<E> gen = generator.get().iterator();
+        return new ChainedClosableIterator<>(gen);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Changes internals for `CacheView` to synchronize with a read-write lock rather than using an implicit mutex.

Example usage:

```java
List<Member> matches = new ArrayList<>(5);
MemberCacheView view = guild.getMemberCache();
try (ClosableIterator<Member> it = view.lockedIterator()) { // acquires read-lock until closed or drained
    while (it.hasNext() && matches.size() < 5) {
        Member m = it.next();
        if (m.getRoles().size() >= 3)
            matches.add(m);
    }
}

AtomicInteger totalCount = new AtomicInteger();
view.forEach(m -> { // acquires read-lock until done
    if (m.getRoles().size() >= 3) totalCount.incrementAndGet()
});
```
