### PR TITLE
Make names consistent for timestamp getters

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
@@ -51,9 +51,8 @@ public interface ISnowflake
      *
      * @see    net.dv8tion.jda.core.utils.MiscUtil#getCreationTime(long)
      */
-    default OffsetDateTime getCreationTime()
+    default OffsetDateTime getTimeCreated()
     {
         return MiscUtil.getCreationTime(getIdLong());
     }
-
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/ISnowflake.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.core.entities;
 
-import net.dv8tion.jda.core.utils.MiscUtil;
+import net.dv8tion.jda.core.utils.TimeUtil;
 
 import java.time.OffsetDateTime;
 
@@ -49,10 +49,10 @@ public interface ISnowflake
      *
      * @return OffsetDateTime - Time this entity was created at.
      *
-     * @see    net.dv8tion.jda.core.utils.MiscUtil#getCreationTime(long)
+     * @see    TimeUtil#getTimeCreated(long)
      */
     default OffsetDateTime getTimeCreated()
     {
-        return MiscUtil.getCreationTime(getIdLong());
+        return TimeUtil.getTimeCreated(getIdLong());
     }
 }

--- a/src/main/java/net/dv8tion/jda/core/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Member.java
@@ -61,7 +61,7 @@ public interface Member extends IMentionable, IPermissionHolder
      *
      * @return The Join Date.
      */
-    OffsetDateTime getJoinDate();
+    OffsetDateTime getTimeJoined();
 
     /**
      * The {@link net.dv8tion.jda.core.entities.GuildVoiceState VoiceState} of this Member.

--- a/src/main/java/net/dv8tion/jda/core/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Message.java
@@ -275,7 +275,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Time of the most recent edit, or {@code null} if the Message has never been edited.
      */
-    OffsetDateTime getEditedTime();
+    OffsetDateTime getTimeEdited();
 
     /**
      * The author of this Message

--- a/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/MessageHistory.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.utils.MiscUtil;
+import net.dv8tion.jda.core.utils.TimeUtil;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -346,7 +347,7 @@ public class MessageHistory
      * <br>{@code MessageHistory history = MessageHistory.getHistoryAfter(channel, messageId).limit(60).complete()}
      * <br>Will return a MessageHistory instance with the first 60 messages sent after the provided message ID.
      *
-     * <p>Alternatively you can provide an epoch millisecond timestamp using {@link net.dv8tion.jda.core.utils.MiscUtil#getDiscordTimestamp(long) MiscUtil.getDiscordTimestamp(long)}:
+     * <p>Alternatively you can provide an epoch millisecond timestamp using {@link TimeUtil#getDiscordTimestamp(long) MiscUtil.getDiscordTimestamp(long)}:
      * <br><pre><code>
      * long timestamp = System.currentTimeMillis(); // or any other epoch millis timestamp
      * String discordTimestamp = Long.toUnsignedString(MiscUtil.getDiscordTimestamp(timestamp));
@@ -389,7 +390,7 @@ public class MessageHistory
      * <br>{@code MessageHistory history = MessageHistory.getHistoryBefore(channel, messageId).limit(60).complete()}
      * <br>Will return a MessageHistory instance with the first 60 messages sent before the provided message ID.
      *
-     * <p>Alternatively you can provide an epoch millisecond timestamp using {@link net.dv8tion.jda.core.utils.MiscUtil#getDiscordTimestamp(long) MiscUtil.getDiscordTimestamp(long)}:
+     * <p>Alternatively you can provide an epoch millisecond timestamp using {@link TimeUtil#getDiscordTimestamp(long) MiscUtil.getDiscordTimestamp(long)}:
      * <br><pre><code>
      * long timestamp = System.currentTimeMillis(); // or any other epoch millis timestamp
      * String discordTimestamp = Long.toUnsignedString(MiscUtil.getDiscordTimestamp(timestamp));
@@ -432,7 +433,7 @@ public class MessageHistory
      * <br>{@code MessageHistory history = MessageHistory.getHistoryAround(channel, messageId).limit(60).complete()}
      * <br>Will return a MessageHistory instance with the first 60 messages sent around the provided message ID.
      *
-     * <p>Alternatively you can provide an epoch millisecond timestamp using {@link net.dv8tion.jda.core.utils.MiscUtil#getDiscordTimestamp(long) MiscUtil.getDiscordTimestamp(long)}:
+     * <p>Alternatively you can provide an epoch millisecond timestamp using {@link TimeUtil#getDiscordTimestamp(long) MiscUtil.getDiscordTimestamp(long)}:
      * <br><pre><code>
      * long timestamp = System.currentTimeMillis(); // or any other epoch millis timestamp
      * String discordTimestamp = Long.toUnsignedString(MiscUtil.getDiscordTimestamp(timestamp));

--- a/src/main/java/net/dv8tion/jda/core/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/DisconnectEvent.java
@@ -113,7 +113,7 @@ public class DisconnectEvent extends Event
      *
      * @return Time of closure
      */
-    public OffsetDateTime getTimeDisconnect()
+    public OffsetDateTime getTimeDisconnected()
     {
         return disconnectTime;
     }

--- a/src/main/java/net/dv8tion/jda/core/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/DisconnectEvent.java
@@ -113,7 +113,7 @@ public class DisconnectEvent extends Event
      *
      * @return Time of closure
      */
-    public OffsetDateTime getDisconnectTime()
+    public OffsetDateTime getTimeDisconnect()
     {
         return disconnectTime;
     }

--- a/src/main/java/net/dv8tion/jda/core/events/ShutdownEvent.java
+++ b/src/main/java/net/dv8tion/jda/core/events/ShutdownEvent.java
@@ -42,7 +42,7 @@ public class ShutdownEvent extends Event
      * @return {@link java.time.OffsetDateTime OffsetDateTime} representing
      *         the point in time when the connection was dropped.
      */
-    public OffsetDateTime getShutdownTime()
+    public OffsetDateTime getTimeShutdown()
     {
         return shutdownTime;
     }

--- a/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/MiscUtil.java
@@ -19,7 +19,6 @@ import gnu.trove.impl.sync.TSynchronizedLongObjectMap;
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.core.entities.Guild;
-import net.dv8tion.jda.core.entities.ISnowflake;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import okhttp3.MediaType;
@@ -32,82 +31,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Calendar;
 import java.util.Formatter;
-import java.util.TimeZone;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 public class MiscUtil
 {
-    public static final long DISCORD_EPOCH = 1420070400000L;
-    public static final long TIMESTAMP_OFFSET = 22;
-    private static final DateTimeFormatter dtFormatter = DateTimeFormatter.RFC_1123_DATE_TIME;
-
-    /**
-     * Converts the provided epoch millisecond timestamp to a Discord Snowflake.
-     * <br>This can be used as a marker/pivot for {@link net.dv8tion.jda.core.entities.MessageHistory MessageHistory} creation.
-     *
-     * @param  millisTimestamp
-     *         The epoch millis to convert
-     *
-     * @return Shifted epoch millis for Discord
-     */
-    public static long getDiscordTimestamp(long millisTimestamp)
-    {
-        return (millisTimestamp - DISCORD_EPOCH) << TIMESTAMP_OFFSET;
-    }
-
-    /**
-     * Gets the creation-time of a JDA-entity by doing the reverse snowflake algorithm on its id.
-     * This returns the creation-time of the actual entity on Discords side, not inside JDA.
-     *
-     * @param  entityId
-     *         The id of the JDA entity where the creation-time should be determined for
-     *
-     * @return The creation time of the JDA entity as OffsetDateTime
-     */
-    public static OffsetDateTime getCreationTime(long entityId)
-    {
-        long timestamp = (entityId >>> TIMESTAMP_OFFSET) + DISCORD_EPOCH;
-        Calendar gmt = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
-        gmt.setTimeInMillis(timestamp);
-        return OffsetDateTime.ofInstant(gmt.toInstant(), gmt.getTimeZone().toZoneId());
-    }
-
-    /**
-     * Gets the creation-time of a JDA-entity by doing the reverse snowflake algorithm on its id.
-     * This returns the creation-time of the actual entity on Discords side, not inside JDA.
-     *
-     * @param  entity
-     *         The JDA entity where the creation-time should be determined for
-     *
-     * @throws IllegalArgumentException
-     *         If the provided entity is {@code null}
-     *
-     * @return The creation time of the JDA entity as OffsetDateTime
-     */
-    public static OffsetDateTime getCreationTime(ISnowflake entity)
-    {
-        Checks.notNull(entity, "Entity");
-        return getCreationTime(entity.getIdLong());
-    }
-
-    /**
-     * Returns a prettier String-representation of a OffsetDateTime object
-     *
-     * @param  time
-     *         The OffsetDateTime object to format
-     *
-     * @return The String of the formatted OffsetDateTime
-     */
-    public static String getDateTimeString(OffsetDateTime time)
-    {
-        return time.format(dtFormatter);
-    }
-
     /**
      * Returns the shard id the given guild will be loaded on for the given amount of shards.
      *

--- a/src/main/java/net/dv8tion/jda/core/utils/TimeUtil.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/TimeUtil.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2018 Austin Keener & Michael Ritter & Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.core.utils;
+
+import net.dv8tion.jda.core.entities.ISnowflake;
+import net.dv8tion.jda.internal.utils.Checks;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+public class TimeUtil
+{
+    public static final long DISCORD_EPOCH = 1420070400000L;
+    public static final long TIMESTAMP_OFFSET = 22;
+    private static final DateTimeFormatter dtFormatter = DateTimeFormatter.RFC_1123_DATE_TIME;
+
+    /**
+     * Converts the provided epoch millisecond timestamp to a Discord Snowflake.
+     * <br>This can be used as a marker/pivot for {@link net.dv8tion.jda.core.entities.MessageHistory MessageHistory} creation.
+     *
+     * @param  millisTimestamp
+     *         The epoch millis to convert
+     *
+     * @return Shifted epoch millis for Discord
+     */
+    public static long getDiscordTimestamp(long millisTimestamp)
+    {
+        return (millisTimestamp - DISCORD_EPOCH) << TIMESTAMP_OFFSET;
+    }
+
+    /**
+     * Gets the creation-time of a JDA-entity by doing the reverse snowflake algorithm on its id.
+     * This returns the creation-time of the actual entity on Discords side, not inside JDA.
+     *
+     * @param  entityId
+     *         The id of the JDA entity where the creation-time should be determined for
+     *
+     * @return The creation time of the JDA entity as OffsetDateTime
+     */
+    public static OffsetDateTime getTimeCreated(long entityId)
+    {
+        long timestamp = (entityId >>> TIMESTAMP_OFFSET) + DISCORD_EPOCH;
+        Calendar gmt = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        gmt.setTimeInMillis(timestamp);
+        return OffsetDateTime.ofInstant(gmt.toInstant(), gmt.getTimeZone().toZoneId());
+    }
+
+    /**
+     * Gets the creation-time of a JDA-entity by doing the reverse snowflake algorithm on its id.
+     * This returns the creation-time of the actual entity on Discords side, not inside JDA.
+     *
+     * @param  entity
+     *         The JDA entity where the creation-time should be determined for
+     *
+     * @throws IllegalArgumentException
+     *         If the provided entity is {@code null}
+     *
+     * @return The creation time of the JDA entity as OffsetDateTime
+     */
+    public static OffsetDateTime getTimeCreated(ISnowflake entity)
+    {
+        Checks.notNull(entity, "Entity");
+        return getTimeCreated(entity.getIdLong());
+    }
+
+    /**
+     * Returns a prettier String-representation of a OffsetDateTime object
+     *
+     * @param  time
+     *         The OffsetDateTime object to format
+     *
+     * @return The String of the formatted OffsetDateTime
+     */
+    public static String getDateTimeString(OffsetDateTime time)
+    {
+        return time.format(dtFormatter);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -164,7 +164,7 @@ public abstract class AbstractMessage implements Message
     }
 
     @Override
-    public OffsetDateTime getEditedTime()
+    public OffsetDateTime getTimeEdited()
     {
         unsupported();
         return null;

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -703,7 +703,7 @@ public class GuildImpl implements Guild
                 if (ChronoUnit.MINUTES.between(getSelfMember().getTimeJoined(), OffsetDateTime.now()) < 10)
                     break;
             case MEDIUM:
-                if (ChronoUnit.MINUTES.between(MiscUtil.getCreationTime(getJDA().getSelfUser()), OffsetDateTime.now()) < 5)
+                if (ChronoUnit.MINUTES.between(getJDA().getSelfUser().getTimeCreated(), OffsetDateTime.now()) < 5)
                     break;
             case LOW:
                 if (!getJDA().getSelfUser().isVerified())

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -700,7 +700,7 @@ public class GuildImpl implements Guild
             case VERY_HIGH:
                 break; // we already checked for a verified phone number
             case HIGH:
-                if (ChronoUnit.MINUTES.between(getSelfMember().getJoinDate(), OffsetDateTime.now()) < 10)
+                if (ChronoUnit.MINUTES.between(getSelfMember().getTimeJoined(), OffsetDateTime.now()) < 10)
                     break;
             case MEDIUM:
                 if (ChronoUnit.MINUTES.between(MiscUtil.getCreationTime(getJDA().getSelfUser()), OffsetDateTime.now()) < 5)

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -74,7 +74,7 @@ public class MemberImpl implements Member
     }
 
     @Override
-    public OffsetDateTime getJoinDate()
+    public OffsetDateTime getTimeJoined()
     {
         return OffsetDateTime.ofInstant(Instant.ofEpochMilli(joinDate), OFFSET);
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -434,7 +434,7 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
-    public OffsetDateTime getEditedTime()
+    public OffsetDateTime getTimeEdited()
     {
         return editedTime;
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -296,8 +296,8 @@ public class RoleImpl implements Role
         if (this.getPositionRaw() != r.getPositionRaw())
             return this.getPositionRaw() - r.getPositionRaw();
 
-        OffsetDateTime thisTime = this.getCreationTime();
-        OffsetDateTime rTime = r.getCreationTime();
+        OffsetDateTime thisTime = this.getTimeCreated();
+        OffsetDateTime rTime = r.getTimeCreated();
 
         //We compare the provided role's time to this's time instead of the reverse as one would expect due to how
         // discord deals with hierarchy. The more recent a role was created, the lower its hierarchy ranking when

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.core.requests.restaction.ChannelAction;
 import net.dv8tion.jda.core.requests.restaction.MessageAction;
 import net.dv8tion.jda.core.requests.restaction.WebhookAction;
 import net.dv8tion.jda.core.utils.MiscUtil;
+import net.dv8tion.jda.core.utils.TimeUtil;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -126,7 +127,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
         if (messageIds.size() < 2 || messageIds.size() > 100)
             throw new IllegalArgumentException("Must provide at least 2 or at most 100 messages to be deleted.");
 
-        long twoWeeksAgo = MiscUtil.getDiscordTimestamp((System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000)));
+        long twoWeeksAgo = TimeUtil.getDiscordTimestamp((System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000)));
         for (String id : messageIds)
             Checks.check(MiscUtil.parseSnowflake(id) > twoWeeksAgo, "Message Id provided was older than 2 weeks. Id: " + id);
 
@@ -202,7 +203,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannelImpl> implem
         List<CompletableFuture<Void>> list = new LinkedList<>();
         TreeSet<Long> bulk = new TreeSet<>(Comparator.reverseOrder());
         TreeSet<Long> norm = new TreeSet<>(Comparator.reverseOrder());
-        long twoWeeksAgo = MiscUtil.getDiscordTimestamp(System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000) + 10000);
+        long twoWeeksAgo = TimeUtil.getDiscordTimestamp(System.currentTimeMillis() - (14 * 24 * 60 * 60 * 1000) + 10000);
         for (long messageId : messageIds)
         {
             if (messageId > twoWeeksAgo)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

More consistent names for getters to increase usability. This also makes auto-complete a little better since `getTime` will now display all timestamp getters.
