### PR TITLE
Add skipTo option for PaginationAction

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/AuditLogPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/AuditLogPaginationAction.java
@@ -172,7 +172,7 @@ public class AuditLogPaginationAction extends PaginationAction<AuditLogEntry, Au
         Route.CompiledRoute route = super.finalizeRoute();
 
         final String limit = String.valueOf(this.limit.get());
-        final AuditLogEntry last = this.last;
+        final long last = this.lastKey;
 
         route = route.withQueryParams("limit", limit);
 
@@ -182,8 +182,8 @@ public class AuditLogPaginationAction extends PaginationAction<AuditLogEntry, Au
         if (userId != null)
             route = route.withQueryParams("user_id", userId);
 
-        if (last != null)
-            route = route.withQueryParams("before", last.getId());
+        if (last != 0)
+            route = route.withQueryParams("before", Long.toUnsignedString(last));
 
         return route;
     }
@@ -231,6 +231,7 @@ public class AuditLogPaginationAction extends PaginationAction<AuditLogEntry, Au
                 if (this.useCache)
                     this.cached.add(result);
                 this.last = result;
+                this.lastKey = last.getIdLong();
             }
             catch (JSONException | NullPointerException e)
             {

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/MessagePaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/MessagePaginationAction.java
@@ -110,12 +110,12 @@ public class MessagePaginationAction extends PaginationAction<Message, MessagePa
         Route.CompiledRoute route = super.finalizeRoute();
 
         final String limit = String.valueOf(this.getLimit());
-        final Message last = this.last;
+        final long last = this.lastKey;
 
         route = route.withQueryParams("limit", limit);
 
-        if (last != null)
-            route = route.withQueryParams("before", last.getId());
+        if (last != 0)
+            route = route.withQueryParams("before", Long.toUnsignedString(last));
 
         return route;
     }
@@ -141,6 +141,7 @@ public class MessagePaginationAction extends PaginationAction<Message, MessagePa
                 if (useCache)
                     cached.add(msg);
                 last = msg;
+                lastKey = last.getIdLong();
             }
             catch (JSONException | NullPointerException e)
             {

--- a/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/ReactionPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/core/requests/restaction/pagination/ReactionPaginationAction.java
@@ -95,9 +95,9 @@ public class ReactionPaginationAction extends PaginationAction<User, ReactionPag
 
         String after = null;
         String limit = String.valueOf(getLimit());
-        User last = this.last;
-        if (last != null)
-            after = last.getId();
+        long last = this.lastKey;
+        if (last != 0)
+            after = Long.toUnsignedString(last);
 
         route = route.withQueryParams("limit", limit);
 
@@ -128,6 +128,7 @@ public class ReactionPaginationAction extends PaginationAction<User, ReactionPag
                 if (useCache)
                     cached.add(user);
                 last = user;
+                lastKey = last.getIdLong();
             }
             catch (JSONException | NullPointerException e)
             {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This allows skipping pages when using a `PaginationAction`

### Example

```java
 public MessagePaginationAction getOlderThan(MessageChannel channel, long time) {
     final long timestamp = TimeUtil.getDiscordTimestamp(time);
     final MessagePaginationAction paginator = channel.getIterableHistory();
     return paginator.skipTo(timestamp);
 }

 getOlderThan(channel, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(14))
     .forEachAsync((message) -> {
         boolean empty = message.getContentRaw().isEmpty();
         if (!empty)
             System.out.printf("%#s%n", message); // means: print display content
         return !empty; // means: continue if not empty
     });
```
