### PR TITLE
Message deletion days validation on member ban

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
+++ b/src/main/java/net/dv8tion/jda/core/managers/GuildController.java
@@ -534,6 +534,7 @@ public class GuildController
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided amount of days (delDays) is less than 0.</li>
+     *             <li>If the provided amount of days (delDays) is bigger than 7.</li>
      *             <li>If the provided member is {@code null}</li>
      *         </ul>
      *
@@ -587,6 +588,7 @@ public class GuildController
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided amount of days (delDays) is less than 0.</li>
+     *             <li>If the provided amount of days (delDays) is bigger than 7.</li>
      *             <li>If the provided user is null</li>
      *         </ul>
      *
@@ -602,6 +604,8 @@ public class GuildController
             checkPosition(getGuild().getMember(user));
 
         Checks.notNegative(delDays, "Deletion Days");
+
+        Checks.notBiggerThan(delDays, 7, "Deletion Days");
 
         final String userId = user.getId();
 

--- a/src/main/java/net/dv8tion/jda/core/utils/Checks.java
+++ b/src/main/java/net/dv8tion/jda/core/utils/Checks.java
@@ -147,4 +147,10 @@ public class Checks
             throw new IllegalArgumentException(name + " may not be negative");
     }
 
+    public static void notBiggerThan(final int n, final int bound, String name)
+    {
+        if (n > bound)
+            throw new IllegalArgumentException(name + " may not be bigger than " + bound);
+    }
+
 }


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) [Non-breaking]
- [X] Documentation
- [ ] Other: \_____

Closes Issue: NaN

## Description

When banning a member and specifying a delDays bigger than 7, Discord will return a ErrorResponseException with code 400.

```
[ForkJoinPool.commonPool-worker-1] ERROR RestAction - RestAction queue returned failure: [ErrorResponseException] 400: {"delete-message-days":["int value should be less than or equal to 7."]}
```

This PR adds validation for that scenario following the same principle of the lower than 0 validation, which will throw an IllegalArgumentException.