### PR TITLE
Allow adding reactions with code-point representation

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -901,6 +901,16 @@ public interface Message extends ISnowflake, Formattable
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
+     * <h2>Examples</h2>
+     * <code>
+     * // custom<br>
+     * message.addReaction("minn:245267426227388416").queue();<br>
+     * // unicode escape<br>
+     * message.addReaction("&#92;uD83D&#92;uDE02").queue();<br>
+     * // codepoint notation<br>
+     * message.addReaction("U+1F602").queue();
+     * </code>
+     *
      * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1862,6 +1862,16 @@ public interface MessageChannel extends ISnowflake, Formattable
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
      *
+     * <h2>Examples</h2>
+     * <code>
+     * // custom<br>
+     * channel.addReactionById(messageId, "minn:245267426227388416").queue();<br>
+     * // unicode escape<br>
+     * channel.addReactionById(messageId, "&#92;uD83D&#92;uDE02").queue();<br>
+     * // codepoint notation<br>
+     * channel.addReactionById(messageId, "U+1F602").queue();
+     * </code>
+     *
      * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
@@ -1949,6 +1959,16 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * <p>This method encodes the provided unicode for you.
      * <b>Do not encode the emoji before providing the unicode.</b>
+     *
+     * <h2>Examples</h2>
+     * <code>
+     * // custom<br>
+     * channel.addReactionById(messageId, "minn:245267426227388416").queue();<br>
+     * // unicode escape<br>
+     * channel.addReactionById(messageId, "&#92;uD83D&#92;uDE02").queue();<br>
+     * // codepoint notation<br>
+     * channel.addReactionById(messageId, "U+1F602").queue();
+     * </code>
      *
      * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1914,10 +1914,10 @@ public interface MessageChannel extends ISnowflake, Formattable
     default RestAction<Void> addReactionById(String messageId, String unicode)
     {
         Checks.isSnowflake(messageId, "Message ID");
-        Checks.notEmpty(unicode, "Provided Unicode");
-        Checks.noWhitespace(unicode, "Provided Unicode");
-
+        Checks.notNull(unicode, "Provided Unicode");
         unicode = unicode.trim();
+        Checks.notEmpty(unicode, "Provided Unicode");
+
         String encoded;
         if (unicode.startsWith("U+"))
             encoded = MiscUtil.encodeCodePointsUTF8(unicode);

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1917,7 +1917,12 @@ public interface MessageChannel extends ISnowflake, Formattable
         Checks.notEmpty(unicode, "Provided Unicode");
         Checks.noWhitespace(unicode, "Provided Unicode");
 
-        String encoded = MiscUtil.encodeUTF8(unicode);
+        unicode = unicode.trim();
+        String encoded;
+        if (unicode.startsWith("U+"))
+            encoded = MiscUtil.encodeCodePointsUTF8(unicode);
+        else
+            encoded = MiscUtil.encodeUTF8(unicode);
         Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, encoded);
         return new RestAction<Void>(getJDA(), route)
         {

--- a/src/main/java/net/dv8tion/jda/api/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MiscUtil.java
@@ -128,6 +128,21 @@ public class MiscUtil
         }
     }
 
+    public static String encodeCodePointsUTF8(String input)
+    {
+        if (!input.startsWith("U+"))
+            throw new IllegalArgumentException("Invalid format");
+        String[] codePoints = input.substring(2).split("\\s*U\\+\\s*");
+        StringBuilder encoded = new StringBuilder();
+        for (String part : codePoints)
+        {
+            int codePoint = Integer.parseUnsignedInt(part, 16);
+            char[] chars = Character.toChars(codePoint);
+            encoded.append(encodeUTF8(String.valueOf(chars)));
+        }
+        return encoded.toString();
+    }
+
     public static long parseSnowflake(String input)
     {
         Checks.notEmpty(input, "ID");

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -117,7 +117,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notNull(emote, "Emote");
 
-        MessageReaction reaction = reactions.parallelStream()
+        MessageReaction reaction = reactions.stream()
                 .filter(r -> Objects.equals(r.getReactionEmote().getId(), emote.getId()))
                 .findFirst().orElse(null);
 
@@ -139,7 +139,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notEmpty(unicode, "Provided Unicode");
 
-        MessageReaction reaction = reactions.parallelStream()
+        MessageReaction reaction = reactions.stream()
                 .filter(r -> Objects.equals(r.getReactionEmote().getName(), unicode))
                 .findFirst().orElse(null);
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This will allow adding reactions with code-point representations like `U+1F44D`.

![image](https://user-images.githubusercontent.com/18090140/50384570-a7cc8300-06c6-11e9-9b23-8fb1f4fc5fa4.png)

The conversion is quite simple, we first parse each code-point and then split them into
the respective characters. This is possible because custom emote names cannot contain `U+` making this a valid conversion without breaking existing code.
