### PR TITLE
Provide access to JDA pools

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -25,10 +25,14 @@ import net.dv8tion.jda.api.requests.restaction.GuildAction;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
+import okhttp3.OkHttpClient;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * The core of JDA. Acts as a registry system of JDA. All parts of the the API can be accessed starting from this class.
@@ -247,6 +251,38 @@ public interface JDA
      * @return List of all websocket traces
      */
     List<String> getWebSocketTrace();
+
+    /**
+     * {@link ScheduledExecutorService} used to handle rate-limits for {@link RestAction}
+     * executions. This is also used in other parts of JDA related to http requests.
+     *
+     * @return The {@link ScheduledExecutorService} used for http request handling
+     */
+    ScheduledExecutorService getRateLimitPool();
+
+    /**
+     * {@link ScheduledExecutorService} used to send WebSocket messages to discord.
+     * <br>This involves initial setup of guilds as well as keeping the connection alive.
+     *
+     * @return The {@link ScheduledExecutorService} used for WebSocket transmissions
+     */
+    ScheduledExecutorService getGatewayPool();
+
+    /**
+     * {@link ExecutorService} used to handle {@link RestAction} callbacks
+     * and completions.
+     * <br>By default this uses the {@link ForkJoinPool#commonPool() CommonPool} of the runtime.
+     *
+     * @return The {@link ExecutorService} used for callbacks
+     */
+    ExecutorService getCallbackPool();
+
+    /**
+     * The {@link OkHttpClient} used for handling http requests from {@link RestAction RestActions}.
+     *
+     * @return The http client
+     */
+    OkHttpClient getHttpClient();
 
     /**
      * Changes the internal EventManager.

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -437,6 +437,30 @@ public class JDAImpl implements JDA
     }
 
     @Override
+    public ScheduledExecutorService getRateLimitPool()
+    {
+        return rateLimitPool;
+    }
+
+    @Override
+    public ScheduledExecutorService getGatewayPool()
+    {
+        return gatewayPool;
+    }
+
+    @Override
+    public ExecutorService getCallbackPool()
+    {
+        return callbackPool;
+    }
+
+    @Override
+    public OkHttpClient getHttpClient()
+    {
+        return httpClient;
+    }
+
+    @Override
     public List<String> getCloudflareRays()
     {
         WebSocketClient client = getClient();
@@ -676,12 +700,6 @@ public class JDAImpl implements JDA
     {
         return eventManager;
     }
-
-    //@Override
-    //public AuditableRestAction<Void> installAuxiliaryCable(int port) throws UnsupportedOperationException
-    //{
-    //    return new AuditableRestAction.FailedRestAction<>(new UnsupportedOperationException("nice try but next time think first :)"));
-    //}
 
     @Override
     public AccountType getAccountType()
@@ -926,11 +944,6 @@ public class JDAImpl implements JDA
         return eventCache;
     }
 
-    public OkHttpClient getHttpClient()
-    {
-        return httpClient;
-    }
-
     public String getGatewayUrl()
     {
         return gatewayUrl;
@@ -954,20 +967,5 @@ public class JDAImpl implements JDA
             }
         }
         return pool;
-    }
-
-    public ScheduledExecutorService getRateLimitPool()
-    {
-        return rateLimitPool;
-    }
-
-    public ScheduledExecutorService getGatewayPool()
-    {
-        return gatewayPool;
-    }
-
-    public ExecutorService getCallbackPool()
-    {
-        return callbackPool;
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Since these can be configured through the JDABuilder anyway
we should allow users to access them from the JDA instances
as well. This opens up a few possibilities for abstractions
within JDA as well.
