### PR TITLE
Don't send presence update when reconnect is queued

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
@@ -34,7 +34,6 @@ import org.json.JSONObject;
  */
 public class PresenceImpl implements Presence
 {
-
     private final UpstreamReference<JDAImpl> api;
     private boolean idle = false;
     private Activity activity = null;
@@ -203,7 +202,11 @@ public class PresenceImpl implements Presence
 
     protected void update(JSONObject data)
     {
-        api.get().getClient().send(new JSONObject()
+        JDAImpl jda = api.get();
+        JDA.Status status = jda.getStatus();
+        if (status == JDA.Status.RECONNECT_QUEUED || status == JDA.Status.SHUTDOWN || status == JDA.Status.SHUTTING_DOWN)
+            return;
+        jda.getClient().send(new JSONObject()
             .put("d", data)
             .put("op", WebSocketCode.PRESENCE).toString());
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This prevents users from adding to the send queue while waiting for a reconnect.
It doesn't make sense to send 100 presence updates right on startup once the queue reaches the shard.
