### PR TITLE
Fixing missspelling of "Channel" as "Role"

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/Channel.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/Channel.java
@@ -85,11 +85,11 @@ public interface Channel extends ISnowflake
 
     /**
      * The actual position of the {@link net.dv8tion.jda.core.entities.Channel Channel} as stored and given by Discord.
-     * Role positions are actually based on a pairing of the creation time (as stored in the snowflake id)
-     * and the position. If 2 or more roles share the same position then they are sorted based on their creation date.
-     * The more recent a role was created, the lower it is in the hierarchy. This is handled by {@link #getPosition()}
+     * Channel positions are actually based on a pairing of the creation time (as stored in the snowflake id)
+     * and the position. If 2 or more channels share the same position then they are sorted based on their creation date.
+     * The more recent a channel was created, the lower it is in the hierarchy. This is handled by {@link #getPosition()}
      * and it is most likely the method you want. If, for some reason, you want the actual position of the
-     * Role then this method will give you that value.
+     * channel then this method will give you that value.
      *
      * @return The true, Discord stored, position of the {@link net.dv8tion.jda.core.entities.Channel Channel}.
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

[Channel#getPositionRaw()](/DV8FromTheWorld/JDA/blob/development/src/main/java/net/dv8tion/jda/core/entities/Channel.java#L86-L96) mentions Roles in its description, while it actually is in the Channels-class, which (obviously) is about the channels.
This PR replaces the mentions of roles/role with channels/channel