### PR TITLE
Add methods to use stream in secured environment

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
@@ -98,7 +98,7 @@ public interface CacheView<T> extends Iterable<T>
      * <h2>Example</h2>
      * <code>
      * {@literal CacheView<User>} view = jda.getUserCache();<br>
-     * long shortNames = view.applyStream(stream -> stream.filter(it -> it.getName().length() < 4).count());<br>
+     * long shortNames = view.applyStream(stream {@literal ->} stream.filter(it {@literal ->} it.getName().length() {@literal <} 4).count());<br>
      * System.out.println(shortNames + " users with less than 4 characters in their name");
      * </code>
      *
@@ -134,7 +134,7 @@ public interface CacheView<T> extends Iterable<T>
      * <h2>Example</h2>
      * <code>
      * {@literal CacheView<TextChannel>} view = guild.getTextChannelCache();<br>
-     * view.acceptStream(stream -> stream.filter(it -> it.isNSFW()).forEach(it -> it.sendMessage("lewd").queue()));
+     * view.acceptStream(stream {@literal ->} stream.filter(it {@literal ->} it.isNSFW()).forEach(it {@literal ->} it.sendMessage("lewd").queue()));
      * </code>
      *
      * @param  action


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds 2 methods to consume and convert streams on a CacheView without exposing the possibility to deadlock.

### Example

```java
CacheView<User> view = jda.getUserCache(); 
long shortNames = view.applyStream(
    stream -> stream.filter(it -> 
        it.getName().length() < 4).count()); 
System.out.println(shortNames + " users with less than 4 characters in their name"); 
```
