### PR TITLE
Add getRestPing and rename getPing to getGatewayPing

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -196,6 +196,13 @@ public interface JDA
      * The time in milliseconds that discord took to respond to a REST request.
      * <br>This will request the current user from the API and calculate the time the response took.
      *
+     * <h2>Example</h2>
+     * <pre><code>
+     * jda.getRestPing().queue( (time) {@literal ->}
+     *     channel.sendMessageFormat("Ping: %d ms", time).queue()
+     * );
+     * </code></pre>
+     *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: long
      *
      * @see    #getGatewayPing()

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -20,13 +20,12 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.hooks.IEventManager;
 import net.dv8tion.jda.api.managers.AudioManager;
 import net.dv8tion.jda.api.managers.Presence;
-import net.dv8tion.jda.api.requests.Request;
-import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.GuildAction;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
+import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import okhttp3.OkHttpClient;
 
@@ -211,20 +210,12 @@ public interface JDA
     {
         AtomicLong time = new AtomicLong();
         Route.CompiledRoute route = Route.Self.GET_SELF.compile();
-        return new RestAction<Long>(this, route)
-        {
-            @Override
-            protected void handleResponse(Response response, Request<Long> request)
-            {
-                if (response.isOk())
-                    request.onSuccess(System.currentTimeMillis() - time.get());
-                else
-                    request.onFailure(response);
-            }
-        }.setCheck(() -> {
+        RestActionImpl<Long> action = new RestActionImpl<>(this, route, (response, request) -> System.currentTimeMillis() - time.get());
+        action.setCheck(() -> {
             time.set(System.currentTimeMillis());
             return true;
         });
+        return action;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -195,11 +195,11 @@ public interface ShardManager
      *
      * @return The average time in milliseconds between heartbeat and the heartbeat ack response
      */
-    default double getAveragePing()
+    default double getAverageGatewayPing()
     {
         return this.getShardCache()
                 .stream()
-                .mapToLong(JDA::getPing)
+                .mapToLong(JDA::getGatewayPing)
                 .filter(ping -> ping != -1)
                 .average()
                 .orElse(-1D);

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -414,7 +414,7 @@ public class JDAImpl implements JDA
     }
 
     @Override
-    public long getPing()
+    public long getGatewayPing()
     {
         return ping;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Make names of ping getters more representative of their meaning and create new method to retrieve
RestAction ping more easily.

Waiting for #852 to be completed.

### Example

```java
MessageChannel channel = event.getChannel();
RestAction<Long> action = event.getJDA().getRestPing();
action.queue( (time) -> channel.sendMessageFormat("Ping %d ms", time).queue() );
```
