### PR TITLE
Add forEachUnordered to CacheView interface

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
@@ -90,6 +90,21 @@ public interface CacheView<T> extends Iterable<T>
     ClosableIterator<T> lockedIterator();
 
     /**
+     * Behavior similar to {@link #forEach(Consumer)} but does not preserve order.
+     * <br>This will not copy the data store as sorting is not needed.
+     *
+     * @param  action
+     *         The action to perform
+     *
+     * @throws NullPointerException
+     *         If provided with null
+     */
+    default void forEachUnordered(final Consumer<? super T> action)
+    {
+        forEach(action);
+    }
+
+    /**
      * Creates an unordered sequenced stream of the elements in this cache.
      * <br>This does not copy the backing cache prior to consumption unlike {@link #stream()}.
      *

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/SortedSnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/SortedSnowflakeCacheView.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 public interface SortedSnowflakeCacheView<T extends Comparable<T> & ISnowflake> extends SnowflakeCacheView<T>
 {
     /**
-     * Behavior similar to {@link CacheView#forEach(Consumer)} which does not preserve order.
+     * Behavior similar to {@link CacheView#forEach(Consumer)} but does not preserve order.
      * <br>This will not copy the data store as sorting is not needed.
      *
      * @param  action


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Allows to call `forEachUnordered` on every `CacheView` type. If order doesn't exist it just delegates to `forEach`.
