### PR TITLE
Fixed a javadoc typo in ShardManager

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * This class acts as a manager for multiple shards.
  * It contains several methods to make your life with sharding easier.
  *
- * <br>Custom implementations my not support all methods and throw
+ * <br>Custom implementations may not support all methods and throw
  * {@link java.lang.UnsupportedOperationException UnsupportedOperationExceptions} instead.
  *
  * @since  3.4


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixed a typo in `net.dv8tion.jda.bot.sharding.ShardManager`'s documentation by replacing the word "my" to "may" in the interface javadoc.