### PR TITLE
Mini modification to ReceivedMessage#getContentStripped in order to p…

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
@@ -464,6 +464,8 @@ public class ReceivedMessage extends AbstractMessage
             if (strippedContent != null)
                 return strippedContent;
             String tmp = getContentDisplay();
+            if(tmp.startsWith("\\"))
+                return tmp;
             //all the formatting keys to keep track of
             String[] keys = new String[]{ "*", "_", "`", "~~" };
 

--- a/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/core/entities/impl/ReceivedMessage.java
@@ -465,7 +465,7 @@ public class ReceivedMessage extends AbstractMessage
                 return strippedContent;
             String tmp = getContentDisplay();
             if(tmp.startsWith("\\"))
-                return tmp;
+                return tmp.substring(1);
             //all the formatting keys to keep track of
             String[] keys = new String[]{ "*", "_", "`", "~~" };
 


### PR DESCRIPTION
…reserve escaped markdown characters

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #838 

## Description

Added an if statement at the start of ReceivedMessage#getContentStripped in order to test if a message started with "\" and if so, returns everything literally, preserving the markdown characters.
