### PR TITLE
Added ShardManager#awaitReady

### DIFF
--- a/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/bot/sharding/ShardManager.java
@@ -740,7 +740,12 @@ public interface ShardManager
         return Collections.unmodifiableMap(this.getShardCache().stream()
                 .collect(Collectors.toMap(Function.identity(), JDA::getStatus)));
     }
-
+    
+    default ShardManger awaitReady()
+    {
+        this.getShards().forEach((shard) -> shard.awaitready());
+        return this;
+    }
     /**
      * This returns the {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} which has the same id as the one provided.
      * <br>If there is no known {@link net.dv8tion.jda.core.entities.TextChannel TextChannel} with an id that matches the provided


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Added ShardManager#awaitReady for consistency with JDA#awaitReady. 

TODO: Javadocs
