### PR TITLE
Fixed a refactoring issue with PermissionOverride not being Auditable.

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
@@ -18,7 +18,6 @@ package net.dv8tion.jda.api.requests.restaction;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.CheckReturnValue;
@@ -27,7 +26,7 @@ import java.util.EnumSet;
 import java.util.function.BooleanSupplier;
 
 /**
- * Extension of {@link net.dv8tion.jda.api.requests.RestAction RestAction} specifically
+ * Extension of {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} specifically
  * designed to create a {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}
  * for a {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}.
  * This extension allows setting properties before executing the action.
@@ -39,7 +38,7 @@ import java.util.function.BooleanSupplier;
  * @see    net.dv8tion.jda.api.entities.GuildChannel#putPermissionOverride(Role)
  * @see    net.dv8tion.jda.api.entities.GuildChannel#putPermissionOverride(Member)
  */
-public interface PermissionOverrideAction extends RestAction<PermissionOverride>
+public interface PermissionOverrideAction extends AuditableRestAction<PermissionOverride>
 {
     @Override
     PermissionOverrideAction setCheck(BooleanSupplier checks);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Commit 1ba4536faa1fe4f22c1540f68a1089b2130f4a47 broke `PermissionOverrideAction` by accidentally making it a non-auditable `RestAction`.
This PR reverts that.
