### PR TITLE
Add Automatic-Module-Name for jigsaw

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ processTestResources.enabled = false
 jar {
     baseName = project.name
     manifest.attributes 'Implementation-Version': version
+    manifest.attributes 'Automatic-Module-Name': 'net.dv8tion.jda'
 }
 
 shadowJar.classifier = 'withDependencies'
@@ -139,9 +140,7 @@ task noOpusJar(type: ShadowJar, dependsOn: shadowJar) {
     exclude 'club/minnced/opus/util/*'
     exclude 'tomp2p/opuswrapper/*'
 
-    manifest {
-        inheritFrom jar.manifest
-    }
+    manifest.inheritFrom jar.manifest
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This makes the name for the JDA dependency a little more consistent and makes it not depend on the jar name.

### Example

```java
module com.example.bot {
    requires net.dv8tion.jda;
    requires slf4j.api;
}
```