### PR TITLE
Updated okhttp to 3.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ All dependencies are managed automatically by Gradle.
    * [Github](https://github.com/TakahikoKawasaki/nv-websocket-client)
    * [JCenter Repository](https://bintray.com/bintray/jcenter/com.neovisionaries%3Anv-websocket-client/view)
  * OkHttp
-   * Version: **3.12.0**
+   * Version: **3.12.1**
    * [Github](https://github.com/square/okhttp)
    * [JCenter Repository](https://bintray.com/bintray/jcenter/com.squareup.okhttp3:okhttp)
  * Apache Commons Collections4

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
     //Web Connection Support
     api 'com.neovisionaries:nv-websocket-client:2.5'
-    api 'com.squareup.okhttp3:okhttp:3.12.0'
+    api 'com.squareup.okhttp3:okhttp:3.12.1'
 
     //Opus library support
     api ('club.minnced:opus-java:1.0.4@pom') {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Dependency

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #861 

## Description

The okhttp issue that caused https://github.com/DV8FromTheWorld/JDA/issues/861 seems to be [closed](https://github.com/square/okhttp/pull/4489) in their master branch.
Their latest version is `3.12.1` instead of `3.12.0` that JDA uses, and this PR fixes that.
