### PR TITLE
Consistent handling of isEmpty logic in embeds

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -114,6 +114,8 @@ public class EmbedBuilder
             throw new IllegalStateException("Cannot build an empty embed!");
         if (description.length() > MessageEmbed.TEXT_MAX_LENGTH)
             throw new IllegalStateException(String.format("Description is longer than %d! Please limit your input!", MessageEmbed.TEXT_MAX_LENGTH));
+        if (length() > MessageEmbed.EMBED_MAX_LENGTH_BOT)
+            throw new IllegalStateException("Cannot build an embed with more than " + MessageEmbed.EMBED_MAX_LENGTH_BOT + " characters!");
         final String descrip = this.description.length() < 1 ? null : this.description.toString();
 
         return EntityBuilder.createMessageEmbed(url, title, descrip, EmbedType.RICH, timestamp,
@@ -149,14 +151,14 @@ public class EmbedBuilder
     public boolean isEmpty()
     {
         return title == null
-                && description.length() == 0
-                && timestamp == null
-                //&& color == null color alone is not enough to send
-                && thumbnail == null
-                && author == null
-                && footer == null
-                && image == null
-                && fields.isEmpty();
+            && timestamp == null
+            && thumbnail == null
+            && author == null
+            && footer == null
+            && image == null
+            && color == Role.DEFAULT_COLOR_RAW
+            && description.length() == 0
+            && fields.isEmpty();
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -301,9 +301,11 @@ public class MessageEmbed
      */
     public boolean isEmpty()
     {
-        return getLength() == 0
+        return color == Role.DEFAULT_COLOR_RAW
+            && timestamp == null
             && getImage() == null
-            && getThumbnail() == null;
+            && getThumbnail() == null
+            && getLength() == 0;
     }
 
     /**


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This wasn't handled in the same way, an embed created with the builder should be valid for sending.