### PR TITLE
Entity Proxies

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Category.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Category.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.api.entities.proxy.CategoryProxy;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
 import net.dv8tion.jda.api.requests.restaction.order.ChannelOrderAction;
@@ -32,6 +33,9 @@ import java.util.List;
  */
 public interface Category extends GuildChannel, Comparable<Category>
 {
+    @Override
+    CategoryProxy getProxy();
+
     /**
      * All {@link GuildChannel Channels} listed
      * for this Category

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -19,6 +19,8 @@ package net.dv8tion.jda.api.entities;
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.proxy.EmoteProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 import net.dv8tion.jda.api.managers.EmoteManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
@@ -44,7 +46,7 @@ import java.util.List;
  *
  * @since  2.2
  */
-public interface Emote extends ISnowflake, IMentionable, IFakeable
+public interface Emote extends ISnowflake, IMentionable, IFakeable, ProxySubject<Emote, EmoteProxy>
 {
     /**
      * The {@link net.dv8tion.jda.api.entities.Guild Guild} this emote is attached to.

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -46,8 +46,11 @@ import java.util.List;
  *
  * @since  2.2
  */
-public interface Emote extends ISnowflake, IMentionable, IFakeable, ProxySubject<Emote, EmoteProxy>
+public interface Emote extends ISnowflake, IMentionable, IFakeable, ProxySubject
 {
+    @Override
+    EmoteProxy getProxy();
+
     /**
      * The {@link net.dv8tion.jda.api.entities.Guild Guild} this emote is attached to.
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -18,6 +18,8 @@ package net.dv8tion.jda.api.entities;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.Region;
+import net.dv8tion.jda.api.entities.proxy.GuildProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 import net.dv8tion.jda.api.managers.AudioManager;
 import net.dv8tion.jda.api.managers.GuildController;
 import net.dv8tion.jda.api.managers.GuildManager;
@@ -43,7 +45,7 @@ import java.util.Set;
  * Represents a Discord {@link net.dv8tion.jda.api.entities.Guild Guild}.
  * This should contain all information provided from Discord about a Guild.
  */
-public interface Guild extends ISnowflake
+public interface Guild extends ISnowflake, ProxySubject<Guild, GuildProxy>
 {
     /**
      * Retrieves the available regions for this Guild

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -45,8 +45,11 @@ import java.util.Set;
  * Represents a Discord {@link net.dv8tion.jda.api.entities.Guild Guild}.
  * This should contain all information provided from Discord about a Guild.
  */
-public interface Guild extends ISnowflake, ProxySubject<Guild, GuildProxy>
+public interface Guild extends ISnowflake, ProxySubject
 {
+    @Override
+    GuildProxy getProxy();
+
     /**
      * Retrieves the available regions for this Guild
      * <br>Shortcut for {@link #retrieveRegions(boolean) retrieveRegions(true)}

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -31,8 +31,11 @@ import java.util.List;
 /**
  * Represents a {@link net.dv8tion.jda.api.entities.Guild Guild} channel.
  */
-public interface GuildChannel extends ISnowflake, ProxySubject<GuildChannel, GuildChannelProxy>
+public interface GuildChannel extends ISnowflake, ProxySubject
 {
+    @Override
+    GuildChannelProxy getProxy();
+
     /**
      * The {@link net.dv8tion.jda.api.entities.ChannelType ChannelType} for this GuildChannel
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -16,6 +16,8 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.proxy.GuildChannelProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
@@ -29,7 +31,7 @@ import java.util.List;
 /**
  * Represents a {@link net.dv8tion.jda.api.entities.Guild Guild} channel.
  */
-public interface GuildChannel extends ISnowflake
+public interface GuildChannel extends ISnowflake, ProxySubject<GuildChannel, GuildChannelProxy>
 {
     /**
      * The {@link net.dv8tion.jda.api.entities.ChannelType ChannelType} for this GuildChannel

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
+import net.dv8tion.jda.api.utils.MiscUtil;
 
 import javax.annotation.CheckReturnValue;
 import java.util.List;
@@ -106,6 +107,13 @@ public interface GuildChannel extends ISnowflake, ProxySubject
      * @return the corresponding JDA instance
      */
     JDA getJDA();
+
+    //TODO: Documentation
+    PermissionOverride getPermissionOverrideById(long id);
+    default PermissionOverride getPermissionOverrideById(String id)
+    {
+        return getPermissionOverrideById(MiscUtil.parseSnowflake(id));
+    }
 
     /**
      * The {@link PermissionOverride} relating to the specified {@link net.dv8tion.jda.api.entities.Member Member}.

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -23,8 +23,11 @@ import net.dv8tion.jda.api.entities.proxy.ProxySubject;
  * Represents the voice state of a {@link net.dv8tion.jda.api.entities.Member Member} in a
  * {@link net.dv8tion.jda.api.entities.Guild Guild}.
  */
-public interface GuildVoiceState extends VoiceState, ProxySubject<GuildVoiceState, GuildVoiceStateProxy>
+public interface GuildVoiceState extends VoiceState, ProxySubject
 {
+    @Override
+    GuildVoiceStateProxy getProxy();
+
     /**
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} is muted, either
      * by choice {@link #isSelfMuted()} or deafened by an admin {@link #isGuildMuted()}

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -16,11 +16,14 @@
 
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.api.entities.proxy.GuildVoiceStateProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
+
 /**
  * Represents the voice state of a {@link net.dv8tion.jda.api.entities.Member Member} in a
  * {@link net.dv8tion.jda.api.entities.Guild Guild}.
  */
-public interface GuildVoiceState extends VoiceState
+public interface GuildVoiceState extends VoiceState, ProxySubject<GuildVoiceState, GuildVoiceStateProxy>
 {
     /**
      * Returns whether the {@link net.dv8tion.jda.api.entities.Member Member} is muted, either

--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -19,6 +19,8 @@ package net.dv8tion.jda.api.entities;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.proxy.MemberProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 
 import javax.annotation.Nullable;
 import java.awt.Color;
@@ -33,7 +35,7 @@ import java.util.List;
  *
  * @since 3.0
  */
-public interface Member extends IMentionable, IPermissionHolder
+public interface Member extends IMentionable, IPermissionHolder, ProxySubject<Member, MemberProxy>
 {
     /**
      * The user wrapped by this Entity.

--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -35,8 +35,11 @@ import java.util.List;
  *
  * @since 3.0
  */
-public interface Member extends IMentionable, IPermissionHolder, ProxySubject<Member, MemberProxy>
+public interface Member extends IMentionable, IPermissionHolder, ProxySubject
 {
+    @Override
+    MemberProxy getProxy();
+
     /**
      * The user wrapped by this Entity.
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -17,6 +17,8 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.proxy.MessageChannelProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
@@ -69,8 +71,11 @@ import java.util.function.Function;
  * <br><b>{@link net.dv8tion.jda.api.entities.TextChannel TextChannel} is a special case which uses {@link IMentionable#getAsMention() IMentionable.getAsMention()}
  * by default and uses the <code>#{@link #getName()}</code> format as <u>alternative</u></b>
  */
-public interface MessageChannel extends ISnowflake, Formattable
+public interface MessageChannel extends ISnowflake, Formattable, ProxySubject
 {
+    @Override
+    MessageChannelProxy getProxy();
+
     /**
      * The id for the most recent message sent
      * in this current MessageChannel.

--- a/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
@@ -17,6 +17,8 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.proxy.PermissionOverrideProxy;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 import net.dv8tion.jda.api.managers.PermOverrideManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 
@@ -27,8 +29,11 @@ import java.util.EnumSet;
  * Represents the specific {@link net.dv8tion.jda.api.entities.Member Member} or {@link net.dv8tion.jda.api.entities.Role Role}
  * permission overrides that can be set for channels.
  */
-public interface PermissionOverride
+public interface PermissionOverride extends ProxySubject
 {
+    @Override
+    PermissionOverrideProxy getProxy();
+
     /**
      * This is the raw binary representation (as a base 10 long) of the permissions <b>allowed</b> by this override.
      * <br>The long relates to the offsets used by each {@link net.dv8tion.jda.api.Permission Permission}.

--- a/src/main/java/net/dv8tion/jda/api/entities/PrivateChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PrivateChannel.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.proxy.PrivateChannelProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 
 import javax.annotation.CheckReturnValue;
@@ -25,6 +26,9 @@ import javax.annotation.CheckReturnValue;
  */
 public interface PrivateChannel extends MessageChannel, IFakeable
 {
+    @Override
+    PrivateChannelProxy getProxy();
+
     /**
      * The {@link net.dv8tion.jda.api.entities.User User} that this {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} communicates with.
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Role.java
@@ -28,8 +28,11 @@ import java.awt.Color;
 /**
  * Represents a {@link net.dv8tion.jda.api.entities.Guild Guild}'s Role. Used to control permissions for Members.
  */
-public interface Role extends ISnowflake, IMentionable, IPermissionHolder, Comparable<Role>, ProxySubject<Role, RoleProxy>
+public interface Role extends ISnowflake, IMentionable, IPermissionHolder, Comparable<Role>, ProxySubject
 {
+    @Override
+    RoleProxy getProxy();
+
     /** Used to keep consistency between color values used in the API */
     int DEFAULT_COLOR_RAW = 0x1FFFFFFF; // java.awt.Color fills the MSB with FF, we just use 1F to provide better consistency
 

--- a/src/main/java/net/dv8tion/jda/api/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Role.java
@@ -16,6 +16,8 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
+import net.dv8tion.jda.api.entities.proxy.RoleProxy;
 import net.dv8tion.jda.api.managers.RoleManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.RoleAction;
@@ -26,7 +28,7 @@ import java.awt.Color;
 /**
  * Represents a {@link net.dv8tion.jda.api.entities.Guild Guild}'s Role. Used to control permissions for Members.
  */
-public interface Role extends ISnowflake, IMentionable, IPermissionHolder, Comparable<Role>
+public interface Role extends ISnowflake, IMentionable, IPermissionHolder, Comparable<Role>, ProxySubject<Role, RoleProxy>
 {
     /** Used to keep consistency between color values used in the API */
     int DEFAULT_COLOR_RAW = 0x1FFFFFFF; // java.awt.Color fills the MSB with FF, we just use 1F to provide better consistency

--- a/src/main/java/net/dv8tion/jda/api/entities/SelfUser.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/SelfUser.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.api.entities.proxy.SelfUserProxy;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import net.dv8tion.jda.api.managers.AccountManager;
 
@@ -23,6 +24,8 @@ import net.dv8tion.jda.api.managers.AccountManager;
  */
 public interface SelfUser extends User
 {
+    @Override
+    SelfUserProxy getProxy();
 
     /**
      * The status of this account's verification.

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -15,6 +15,8 @@
  */
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
+import net.dv8tion.jda.api.entities.proxy.TextChannelProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
@@ -36,7 +38,7 @@ import java.util.List;
  * {@link net.dv8tion.jda.internal.entities.TextChannelImpl TextChannelImpl}.
  * <br>Note: Internal implementation should not be used directly.
  */
-public interface TextChannel extends GuildChannel, MessageChannel, Comparable<TextChannel>, IMentionable
+public interface TextChannel extends GuildChannel, MessageChannel, Comparable<TextChannel>, ProxySubject<TextChannel, TextChannelProxy>, IMentionable
 {
     /**
      * The topic set for this TextChannel.

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -15,7 +15,6 @@
  */
 package net.dv8tion.jda.api.entities;
 
-import net.dv8tion.jda.api.entities.proxy.ProxySubject;
 import net.dv8tion.jda.api.entities.proxy.TextChannelProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
@@ -38,8 +37,11 @@ import java.util.List;
  * {@link net.dv8tion.jda.internal.entities.TextChannelImpl TextChannelImpl}.
  * <br>Note: Internal implementation should not be used directly.
  */
-public interface TextChannel extends GuildChannel, MessageChannel, Comparable<TextChannel>, ProxySubject<TextChannel, TextChannelProxy>, IMentionable
+public interface TextChannel extends GuildChannel, MessageChannel, Comparable<TextChannel>, IMentionable
 {
+    @Override
+    TextChannelProxy getProxy();
+
     /**
      * The topic set for this TextChannel.
      * <br>If no topic has been set, this returns null.

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -53,8 +53,11 @@ import java.util.List;
  *
  * <p>More information on formatting syntax can be found in the {@link java.util.Formatter format syntax documentation}!
  */
-public interface User extends ISnowflake, IMentionable, IFakeable, ProxySubject<User, UserProxy>
+public interface User extends ISnowflake, IMentionable, IFakeable, ProxySubject
 {
+    @Override
+    UserProxy getProxy();
+
     /**
      * The username of the {@link net.dv8tion.jda.api.entities.User User}. Length is between 2 and 32 characters (inclusive).
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -17,6 +17,8 @@ package net.dv8tion.jda.api.entities;
 
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.proxy.ProxySubject;
+import net.dv8tion.jda.api.entities.proxy.UserProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 
 import javax.annotation.CheckReturnValue;
@@ -51,9 +53,8 @@ import java.util.List;
  *
  * <p>More information on formatting syntax can be found in the {@link java.util.Formatter format syntax documentation}!
  */
-public interface User extends ISnowflake, IMentionable, IFakeable
+public interface User extends ISnowflake, IMentionable, IFakeable, ProxySubject<User, UserProxy>
 {
-
     /**
      * The username of the {@link net.dv8tion.jda.api.entities.User User}. Length is between 2 and 32 characters (inclusive).
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/VoiceChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/VoiceChannel.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.api.entities.proxy.VoiceChannelProxy;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 
 /**
@@ -26,6 +27,9 @@ import net.dv8tion.jda.api.requests.restaction.ChannelAction;
  */
 public interface VoiceChannel extends GuildChannel, AudioChannel, Comparable<VoiceChannel>
 {
+    @Override
+    VoiceChannelProxy getProxy();
+
     /**
      * The maximum amount of {@link net.dv8tion.jda.api.entities.Member Members} that can be in this
      * {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} at once.

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/CategoryProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/CategoryProxy.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
+import net.dv8tion.jda.api.requests.restaction.ChannelAction;
+import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class CategoryProxy extends GuildChannelProxy implements Category
+{
+    public CategoryProxy(Category channel)
+    {
+        super(channel);
+    }
+
+    @Override
+    public Category getSubject()
+    {
+        Category channel = api.getCategoryById(id);
+        if (channel == null)
+            throw new ProxyResolutionException("Category(" + getId() + ")");
+        return channel;
+    }
+
+    @Override
+    public CategoryProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public List<GuildChannel> getChannels()
+    {
+        return getSubject().getChannels();
+    }
+
+    @Override
+    public List<TextChannel> getTextChannels()
+    {
+        return getSubject().getTextChannels();
+    }
+
+    @Override
+    public List<VoiceChannel> getVoiceChannels()
+    {
+        return getSubject().getVoiceChannels();
+    }
+
+    @Override
+    public ChannelAction<TextChannel> createTextChannel(String name)
+    {
+        return getSubject().createTextChannel(name);
+    }
+
+    @Override
+    public ChannelAction<VoiceChannel> createVoiceChannel(String name)
+    {
+        return getSubject().createVoiceChannel(name);
+    }
+
+    @Override
+    public CategoryOrderAction<TextChannel> modifyTextChannelPositions()
+    {
+        return getSubject().modifyTextChannelPositions();
+    }
+
+    @Override
+    public CategoryOrderAction<VoiceChannel> modifyVoiceChannelPositions()
+    {
+        return getSubject().modifyVoiceChannelPositions();
+    }
+
+    @Override
+    public ChannelAction<Category> createCopy(Guild guild)
+    {
+        return getSubject().createCopy(guild);
+    }
+
+    @Override
+    public ChannelAction<Category> createCopy()
+    {
+        return getSubject().createCopy();
+    }
+
+    @Override
+    public int compareTo(@NotNull Category o)
+    {
+        return getSubject().compareTo(o);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/EmoteProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/EmoteProxy.java
@@ -125,6 +125,7 @@ public class EmoteProxy implements Emote, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/EmoteProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/EmoteProxy.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Emote;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
+import net.dv8tion.jda.api.managers.EmoteManager;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+
+import java.util.List;
+
+public class EmoteProxy implements Emote, ProxyEntity<Emote>
+{
+    private final GuildProxy guild;
+    private final long id;
+
+    public EmoteProxy(Emote emote)
+    {
+        this.guild = emote.getGuild().getProxy();
+        this.id = emote.getIdLong();
+    }
+
+    @Override
+    public Emote getSubject()
+    {
+        Emote emote = getGuild().getEmoteById(id);
+        if (emote == null)
+            throw new ProxyResolutionException("Emote(" + getId() + ")");
+        return emote;
+    }
+
+    @Override
+    public EmoteProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return guild.getSubject();
+    }
+
+    @Override
+    public List<Role> getRoles()
+    {
+        return getSubject().getRoles();
+    }
+
+    @Override
+    public boolean canProvideRoles()
+    {
+        return getSubject().canProvideRoles();
+    }
+
+    @Override
+    public String getName()
+    {
+        return getSubject().getName();
+    }
+
+    @Override
+    public boolean isManaged()
+    {
+        return getSubject().isManaged();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return getGuild().getJDA();
+    }
+
+    @Override
+    public AuditableRestAction<Void> delete()
+    {
+        return getSubject().delete();
+    }
+
+    @Override
+    public EmoteManager getManager()
+    {
+        return getSubject().getManager();
+    }
+
+    @Override
+    public boolean isAnimated()
+    {
+        return getSubject().isAnimated();
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public boolean isFake()
+    {
+        return false;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
@@ -95,6 +95,12 @@ public abstract class GuildChannelProxy implements GuildChannel, ProxyEntity
     }
 
     @Override
+    public PermissionOverride getPermissionOverrideById(long id)
+    {
+        return getSubject().getPermissionOverrideById(id);
+    }
+
+    @Override
     public PermissionOverride getPermissionOverride(Member member)
     {
         return getSubject().getPermissionOverride(member);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
@@ -185,6 +185,7 @@ public abstract class GuildChannelProxy implements GuildChannel, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.managers.ChannelManager;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import net.dv8tion.jda.api.requests.restaction.InviteAction;
+import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
+
+import java.util.List;
+
+public abstract class GuildChannelProxy implements GuildChannel, ProxyEntity<GuildChannel>
+{
+    protected final long id;
+    protected final JDA api;
+
+    public GuildChannelProxy(GuildChannel channel)
+    {
+        this.id = channel.getIdLong();
+        this.api = channel.getJDA();
+    }
+
+    @Override
+    public ChannelType getType()
+    {
+        return getSubject().getType();
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public String getName()
+    {
+        return getSubject().getName();
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return getSubject().getGuild();
+    }
+
+    @Override
+    public Category getParent()
+    {
+        return getSubject().getParent();
+    }
+
+    @Override
+    public List<Member> getMembers()
+    {
+        return getSubject().getMembers();
+    }
+
+    @Override
+    public int getPosition()
+    {
+        return getSubject().getPosition();
+    }
+
+    @Override
+    public int getPositionRaw()
+    {
+        return getSubject().getPositionRaw();
+    }
+
+    @Override
+    public PermissionOverride getPermissionOverride(Member member)
+    {
+        return getSubject().getPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverride getPermissionOverride(Role role)
+    {
+        return getSubject().getPermissionOverride(role);
+    }
+
+    @Override
+    public List<PermissionOverride> getPermissionOverrides()
+    {
+        return getSubject().getPermissionOverrides();
+    }
+
+    @Override
+    public List<PermissionOverride> getMemberPermissionOverrides()
+    {
+        return getSubject().getMemberPermissionOverrides();
+    }
+
+    @Override
+    public List<PermissionOverride> getRolePermissionOverrides()
+    {
+        return getSubject().getRolePermissionOverrides();
+    }
+
+    @Override
+    public ChannelManager getManager()
+    {
+        return getSubject().getManager();
+    }
+
+    @Override
+    public AuditableRestAction<Void> delete()
+    {
+        return getSubject().delete();
+    }
+
+    @Override
+    public PermissionOverrideAction createPermissionOverride(Member member)
+    {
+        return getSubject().createPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverrideAction createPermissionOverride(Role role)
+    {
+        return getSubject().createPermissionOverride(role);
+    }
+
+    @Override
+    public PermissionOverrideAction putPermissionOverride(Member member)
+    {
+        return getSubject().putPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverrideAction putPermissionOverride(Role role)
+    {
+        return getSubject().putPermissionOverride(role);
+    }
+
+    @Override
+    public InviteAction createInvite()
+    {
+        return getSubject().createInvite();
+    }
+
+    @Override
+    public RestAction<List<Invite>> getInvites()
+    {
+        return getSubject().getInvites();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildChannelProxy.java
@@ -26,7 +26,7 @@ import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
 
 import java.util.List;
 
-public abstract class GuildChannelProxy implements GuildChannel, ProxyEntity<GuildChannel>
+public abstract class GuildChannelProxy implements GuildChannel, ProxyEntity
 {
     protected final long id;
     protected final JDA api;
@@ -36,6 +36,9 @@ public abstract class GuildChannelProxy implements GuildChannel, ProxyEntity<Gui
         this.id = channel.getIdLong();
         this.api = channel.getJDA();
     }
+
+    @Override
+    public abstract GuildChannel getSubject();
 
     @Override
     public ChannelType getType()

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildProxy.java
@@ -36,7 +36,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-public class GuildProxy implements Guild, ProxyEntity<Guild>
+public class GuildProxy implements Guild, ProxyEntity
 {
     private final long id;
     private final JDA api;

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildProxy.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Region;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
+import net.dv8tion.jda.api.managers.AudioManager;
+import net.dv8tion.jda.api.managers.GuildController;
+import net.dv8tion.jda.api.managers.GuildManager;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.MemberAction;
+import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
+import net.dv8tion.jda.api.utils.cache.MemberCacheView;
+import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
+import net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+public class GuildProxy implements Guild, ProxyEntity<Guild>
+{
+    private final long id;
+    private final JDA api;
+
+    public GuildProxy(Guild guild)
+    {
+        this.id = guild.getIdLong();
+        this.api = guild.getJDA();
+    }
+
+    @Override
+    public Guild getSubject()
+    {
+        Guild guild = getJDA().getGuildById(id);
+        if (guild == null)
+            throw new ProxyResolutionException("Guild(" + getId() + ")");
+        return guild;
+    }
+
+    @Override
+    public GuildProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public RestAction<EnumSet<Region>> retrieveRegions(boolean includeDeprecated)
+    {
+        return getSubject().retrieveRegions(includeDeprecated);
+    }
+
+    @Override
+    public MemberAction addMember(String accessToken, String userId)
+    {
+        return getSubject().addMember(accessToken, userId);
+    }
+
+    @Override
+    public String getName()
+    {
+        return getSubject().getName();
+    }
+
+    @Override
+    public String getIconId()
+    {
+        return getSubject().getIconId();
+    }
+
+    @Override
+    public String getIconUrl()
+    {
+        return getSubject().getIconUrl();
+    }
+
+    @Override
+    public Set<String> getFeatures()
+    {
+        return getSubject().getFeatures();
+    }
+
+    @Override
+    public String getSplashId()
+    {
+        return getSubject().getSplashId();
+    }
+
+    @Override
+    public String getSplashUrl()
+    {
+        return getSubject().getSplashUrl();
+    }
+
+    @Override
+    public RestAction<String> getVanityUrl()
+    {
+        return getSubject().getVanityUrl();
+    }
+
+    @Override
+    public VoiceChannel getAfkChannel()
+    {
+        return getSubject().getAfkChannel();
+    }
+
+    @Override
+    public TextChannel getSystemChannel()
+    {
+        return getSubject().getSystemChannel();
+    }
+
+    @Override
+    public Member getOwner()
+    {
+        return getSubject().getOwner();
+    }
+
+    @Override
+    public long getOwnerIdLong()
+    {
+        return getSubject().getOwnerIdLong();
+    }
+
+    @Override
+    public Timeout getAfkTimeout()
+    {
+        return getSubject().getAfkTimeout();
+    }
+
+    @Override
+    public String getRegionRaw()
+    {
+        return getSubject().getRegionRaw();
+    }
+
+    @Override
+    public boolean isMember(User user)
+    {
+        return getSubject().isMember(user);
+    }
+
+    @Override
+    public Member getSelfMember()
+    {
+        return getSubject().getSelfMember();
+    }
+
+    @Override
+    public Member getMember(User user)
+    {
+        return getSubject().getMember(user);
+    }
+
+    @Override
+    public MemberCacheView getMemberCache()
+    {
+        return getSubject().getMemberCache();
+    }
+
+    @Override
+    public SortedSnowflakeCacheView<Category> getCategoryCache()
+    {
+        return getSubject().getCategoryCache();
+    }
+
+    @Override
+    public SortedSnowflakeCacheView<TextChannel> getTextChannelCache()
+    {
+        return getSubject().getTextChannelCache();
+    }
+
+    @Override
+    public SortedSnowflakeCacheView<VoiceChannel> getVoiceChannelCache()
+    {
+        return getSubject().getVoiceChannelCache();
+    }
+
+    @Override
+    public List<GuildChannel> getChannels(boolean includeHidden)
+    {
+        return getSubject().getChannels(includeHidden);
+    }
+
+    @Override
+    public SortedSnowflakeCacheView<Role> getRoleCache()
+    {
+        return getSubject().getRoleCache();
+    }
+
+    @Override
+    public SnowflakeCacheView<Emote> getEmoteCache()
+    {
+        return getSubject().getEmoteCache();
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<List<ListedEmote>> retrieveEmotes()
+    {
+        return getSubject().retrieveEmotes();
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<ListedEmote> retrieveEmoteById(@Nonnull String id)
+    {
+        return getSubject().retrieveEmoteById(id);
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<List<Ban>> getBanList()
+    {
+        return getSubject().getBanList();
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Ban> getBanById(@Nonnull String userId)
+    {
+        return getSubject().getBanById(userId);
+    }
+
+    @Override
+    public RestAction<Integer> getPrunableMemberCount(int days)
+    {
+        return getSubject().getPrunableMemberCount(days);
+    }
+
+    @Override
+    public Role getPublicRole()
+    {
+        return getSubject().getPublicRole();
+    }
+
+    @Nullable
+    @Override
+    public TextChannel getDefaultChannel()
+    {
+        return getSubject().getDefaultChannel();
+    }
+
+    @Override
+    public GuildManager getManager()
+    {
+        return getSubject().getManager();
+    }
+
+    @Override
+    public GuildController getController()
+    {
+        return getSubject().getController();
+    }
+
+    @Override
+    public AuditLogPaginationAction getAuditLogs()
+    {
+        return getSubject().getAuditLogs();
+    }
+
+    @Override
+    public RestAction<Void> leave()
+    {
+        return getSubject().leave();
+    }
+
+    @Override
+    public RestAction<Void> delete()
+    {
+        return getSubject().delete();
+    }
+
+    @Override
+    public RestAction<Void> delete(String mfaCode)
+    {
+        return getSubject().delete(mfaCode);
+    }
+
+    @Override
+    public AudioManager getAudioManager()
+    {
+        return getSubject().getAudioManager();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public RestAction<List<Invite>> getInvites()
+    {
+        return getSubject().getInvites();
+    }
+
+    @Override
+    public RestAction<List<Webhook>> getWebhooks()
+    {
+        return getSubject().getWebhooks();
+    }
+
+    @Override
+    public List<GuildVoiceState> getVoiceStates()
+    {
+        return getSubject().getVoiceStates();
+    }
+
+    @Override
+    public VerificationLevel getVerificationLevel()
+    {
+        return getSubject().getVerificationLevel();
+    }
+
+    @Override
+    public NotificationLevel getDefaultNotificationLevel()
+    {
+        return getSubject().getDefaultNotificationLevel();
+    }
+
+    @Override
+    public MFALevel getRequiredMFALevel()
+    {
+        return getSubject().getRequiredMFALevel();
+    }
+
+    @Override
+    public ExplicitContentLevel getExplicitContentLevel()
+    {
+        return getSubject().getExplicitContentLevel();
+    }
+
+    @Override
+    public boolean checkVerification()
+    {
+        return getSubject().checkVerification();
+    }
+
+    @Override
+    public boolean isAvailable()
+    {
+        return getSubject().isAvailable();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildProxy.java
@@ -374,6 +374,7 @@ public class GuildProxy implements Guild, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildVoiceStateProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildVoiceStateProxy.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+
+public class GuildVoiceStateProxy implements GuildVoiceState, ProxyEntity<GuildVoiceState>
+{
+    private final MemberProxy member;
+
+    public GuildVoiceStateProxy(Member member)
+    {
+        this.member = member.getProxy();
+    }
+
+    @Override
+    public GuildVoiceState getSubject()
+    {
+        return getMember().getVoiceState();
+    }
+
+    @Override
+    public GuildVoiceStateProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean isMuted()
+    {
+        return getSubject().isMuted();
+    }
+
+    @Override
+    public boolean isDeafened()
+    {
+        return getSubject().isDeafened();
+    }
+
+    @Override
+    public boolean isGuildMuted()
+    {
+        return getSubject().isGuildMuted();
+    }
+
+    @Override
+    public boolean isGuildDeafened()
+    {
+        return getSubject().isGuildDeafened();
+    }
+
+    @Override
+    public boolean isSuppressed()
+    {
+        return getSubject().isSuppressed();
+    }
+
+    @Override
+    public VoiceChannel getChannel()
+    {
+        return getSubject().getChannel();
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return member.getGuild();
+    }
+
+    @Override
+    public Member getMember()
+    {
+        return member.getSubject();
+    }
+
+    @Override
+    public boolean inVoiceChannel()
+    {
+        return getSubject().inVoiceChannel();
+    }
+
+    @Override
+    public boolean isSelfMuted()
+    {
+        return getSubject().isSelfMuted();
+    }
+
+    @Override
+    public boolean isSelfDeafened()
+    {
+        return getSubject().isSelfDeafened();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return getMember().getJDA();
+    }
+
+    @Override
+    public AudioChannel getAudioChannel()
+    {
+        return getSubject().getAudioChannel();
+    }
+
+    @Override
+    public String getSessionId()
+    {
+        return getSubject().getSessionId();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildVoiceStateProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildVoiceStateProxy.java
@@ -19,7 +19,7 @@ package net.dv8tion.jda.api.entities.proxy;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 
-public class GuildVoiceStateProxy implements GuildVoiceState, ProxyEntity<GuildVoiceState>
+public class GuildVoiceStateProxy implements GuildVoiceState, ProxyEntity
 {
     private final MemberProxy member;
 

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildVoiceStateProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/GuildVoiceStateProxy.java
@@ -131,6 +131,7 @@ public class GuildVoiceStateProxy implements GuildVoiceState, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/MemberProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/MemberProxy.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 
-public class MemberProxy implements Member, ProxyEntity<Member>
+public class MemberProxy implements Member, ProxyEntity
 {
     private final GuildProxy guild;
     private final long id;

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/MemberProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/MemberProxy.java
@@ -207,6 +207,7 @@ public class MemberProxy implements Member, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/MemberProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/MemberProxy.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
+
+import javax.annotation.Nullable;
+import java.awt.Color;
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+
+public class MemberProxy implements Member, ProxyEntity<Member>
+{
+    private final GuildProxy guild;
+    private final long id;
+
+    public MemberProxy(Member member)
+    {
+        this.guild = member.getGuild().getProxy();
+        this.id = member.getUser().getIdLong();
+    }
+
+    @Override
+    public Member getSubject()
+    {
+        Member member = getGuild().getMemberById(id);
+        if (member == null)
+            throw new ProxyResolutionException("Member(" + Long.toUnsignedString(id) + ")");
+        return member;
+    }
+
+    @Override
+    public MemberProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public User getUser()
+    {
+        return getSubject().getUser();
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return guild.getSubject();
+    }
+
+    @Override
+    public EnumSet<Permission> getPermissions()
+    {
+        return getSubject().getPermissions();
+    }
+
+    @Override
+    public boolean hasPermission(Permission... permissions)
+    {
+        return getSubject().hasPermission(permissions);
+    }
+
+    @Override
+    public boolean hasPermission(Collection<Permission> permissions)
+    {
+        return getSubject().hasPermission(permissions);
+    }
+
+    @Override
+    public boolean hasPermission(GuildChannel channel, Permission... permissions)
+    {
+        return getSubject().hasPermission(channel, permissions);
+    }
+
+    @Override
+    public boolean hasPermission(GuildChannel channel, Collection<Permission> permissions)
+    {
+        return getSubject().hasPermission(channel, permissions);
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return getGuild().getJDA();
+    }
+
+    @Override
+    public OffsetDateTime getTimeJoined()
+    {
+        return getSubject().getTimeJoined();
+    }
+
+    @Override
+    public GuildVoiceState getVoiceState()
+    {
+        return getSubject().getVoiceState();
+    }
+
+    @Override
+    public List<Activity> getActivities()
+    {
+        return getSubject().getActivities();
+    }
+
+    @Override
+    public OnlineStatus getOnlineStatus()
+    {
+        return getSubject().getOnlineStatus();
+    }
+
+    @Override
+    public String getNickname()
+    {
+        return getSubject().getNickname();
+    }
+
+    @Override
+    public String getEffectiveName()
+    {
+        return getSubject().getEffectiveName();
+    }
+
+    @Override
+    public List<Role> getRoles()
+    {
+        return getSubject().getRoles();
+    }
+
+    @Override
+    public Color getColor()
+    {
+        return getSubject().getColor();
+    }
+
+    @Override
+    public int getColorRaw()
+    {
+        return getSubject().getColorRaw();
+    }
+
+    @Override
+    public EnumSet<Permission> getPermissions(GuildChannel channel)
+    {
+        return getSubject().getPermissions(channel);
+    }
+
+    @Override
+    public boolean canInteract(Member member)
+    {
+        return getSubject().canInteract(member);
+    }
+
+    @Override
+    public boolean canInteract(Role role)
+    {
+        return getSubject().canInteract(role);
+    }
+
+    @Override
+    public boolean canInteract(Emote emote)
+    {
+        return getSubject().canInteract(emote);
+    }
+
+    @Override
+    public boolean isOwner()
+    {
+        return getSubject().isOwner();
+    }
+
+    @Nullable
+    @Override
+    public TextChannel getDefaultChannel()
+    {
+        return getSubject().getDefaultChannel();
+    }
+
+    @Override
+    public String getAsMention()
+    {
+        return getSubject().getAsMention();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/MessageChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/MessageChannelProxy.java
@@ -16,7 +16,10 @@
 
 package net.dv8tion.jda.api.entities.proxy;
 
-public interface ProxyEntity
+import net.dv8tion.jda.api.entities.MessageChannel;
+
+public interface MessageChannelProxy extends MessageChannel, ProxyEntity
 {
-    ProxySubject getSubject();
+    @Override
+    MessageChannel getSubject();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/PermissionOverrideProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/PermissionOverrideProxy.java
@@ -149,6 +149,7 @@ public class PermissionOverrideProxy implements PermissionOverride, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/PermissionOverrideProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/PermissionOverrideProxy.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
+import net.dv8tion.jda.api.managers.PermOverrideManager;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+
+import java.util.EnumSet;
+
+public class PermissionOverrideProxy implements PermissionOverride, ProxyEntity
+{
+    private final GuildChannelProxy channel;
+    private final long id;
+
+    public PermissionOverrideProxy(PermissionOverride override)
+    {
+        this.channel = override.getChannel().getProxy();
+        this.id = override.isMemberOverride() ? override.getMember().getUser().getIdLong() : override.getRole().getIdLong();
+    }
+
+    @Override
+    public PermissionOverride getSubject()
+    {
+        GuildChannel channel = getChannel();
+        PermissionOverride override = channel.getPermissionOverrideById(id);
+        if (override == null)
+            throw new ProxyResolutionException("PermissionOverride(" + Long.toUnsignedString(id) + ")");
+        return override;
+    }
+
+    @Override
+    public PermissionOverrideProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public long getAllowedRaw()
+    {
+        return getSubject().getAllowedRaw();
+    }
+
+    @Override
+    public long getInheritRaw()
+    {
+        return getSubject().getInheritRaw();
+    }
+
+    @Override
+    public long getDeniedRaw()
+    {
+        return getSubject().getDeniedRaw();
+    }
+
+    @Override
+    public EnumSet<Permission> getAllowed()
+    {
+        return getSubject().getAllowed();
+    }
+
+    @Override
+    public EnumSet<Permission> getInherit()
+    {
+        return getSubject().getInherit();
+    }
+
+    @Override
+    public EnumSet<Permission> getDenied()
+    {
+        return getSubject().getDenied();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return getChannel().getJDA();
+    }
+
+    @Override
+    public Member getMember()
+    {
+        return getSubject().getMember();
+    }
+
+    @Override
+    public Role getRole()
+    {
+        return getSubject().getRole();
+    }
+
+    @Override
+    public GuildChannel getChannel()
+    {
+        return channel.getSubject();
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return getChannel().getGuild();
+    }
+
+    @Override
+    public boolean isMemberOverride()
+    {
+        return getSubject().isMemberOverride();
+    }
+
+    @Override
+    public boolean isRoleOverride()
+    {
+        return getSubject().isRoleOverride();
+    }
+
+    @Override
+    public PermOverrideManager getManager()
+    {
+        return getSubject().getManager();
+    }
+
+    @Override
+    public AuditableRestAction<Void> delete()
+    {
+        return getSubject().delete();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/PrivateChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/PrivateChannelProxy.java
@@ -110,6 +110,7 @@ public class PrivateChannelProxy implements PrivateChannel, MessageChannelProxy
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/PrivateChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/PrivateChannelProxy.java
@@ -88,7 +88,7 @@ public class PrivateChannelProxy implements PrivateChannel, MessageChannelProxy
     @Override
     public ChannelType getType()
     {
-        return getSubject().getType();
+        return ChannelType.PRIVATE;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/PrivateChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/PrivateChannelProxy.java
@@ -17,57 +17,66 @@
 package net.dv8tion.jda.api.entities.proxy;
 
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.Emote;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.PrivateChannel;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
-import net.dv8tion.jda.api.managers.EmoteManager;
-import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import net.dv8tion.jda.api.requests.RestAction;
 
-import java.util.List;
-
-public class EmoteProxy implements Emote, ProxyEntity
+public class PrivateChannelProxy implements PrivateChannel, MessageChannelProxy
 {
-    private final GuildProxy guild;
     private final long id;
+    private final JDA api;
 
-    public EmoteProxy(Emote emote)
+    public PrivateChannelProxy(PrivateChannel channel)
     {
-        this.guild = emote.getGuild().getProxy();
-        this.id = emote.getIdLong();
+        this.id = channel.getIdLong();
+        this.api = channel.getJDA();
     }
 
     @Override
-    public Emote getSubject()
+    public PrivateChannel getSubject()
     {
-        Emote emote = getGuild().getEmoteById(id);
-        if (emote == null)
-            throw new ProxyResolutionException("Emote(" + getId() + ")");
-        return emote;
+        PrivateChannel channel = api.getPrivateChannelById(id);
+        if (channel == null)
+            throw new ProxyResolutionException("PrivateChannel(" + getId() + ")");
+        return channel;
     }
 
     @Override
-    public EmoteProxy getProxy()
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public RestAction<Void> close()
+    {
+        return getSubject().close();
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public PrivateChannelProxy getProxy()
     {
         return this;
     }
 
     @Override
-    public Guild getGuild()
+    public long getLatestMessageIdLong()
     {
-        return guild.getSubject();
+        return getSubject().getLatestMessageIdLong();
     }
 
     @Override
-    public List<Role> getRoles()
+    public boolean hasLatestMessage()
     {
-        return getSubject().getRoles();
-    }
-
-    @Override
-    public boolean canProvideRoles()
-    {
-        return getSubject().canProvideRoles();
+        return getSubject().hasLatestMessage();
     }
 
     @Override
@@ -77,39 +86,15 @@ public class EmoteProxy implements Emote, ProxyEntity
     }
 
     @Override
-    public boolean isManaged()
+    public ChannelType getType()
     {
-        return getSubject().isManaged();
+        return getSubject().getType();
     }
 
     @Override
-    public JDA getJDA()
+    public User getUser()
     {
-        return getGuild().getJDA();
-    }
-
-    @Override
-    public AuditableRestAction<Void> delete()
-    {
-        return getSubject().delete();
-    }
-
-    @Override
-    public EmoteManager getManager()
-    {
-        return getSubject().getManager();
-    }
-
-    @Override
-    public boolean isAnimated()
-    {
-        return getSubject().isAnimated();
-    }
-
-    @Override
-    public long getIdLong()
-    {
-        return id;
+        return getSubject().getUser();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/ProxyEntity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/ProxyEntity.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+public interface ProxyEntity<T>
+{
+    T getSubject();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/ProxySubject.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/ProxySubject.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+public interface ProxySubject<E, T extends ProxyEntity<E>>
+{
+    T getProxy();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/ProxySubject.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/ProxySubject.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.entities.proxy;
 
-public interface ProxySubject<E, T extends ProxyEntity<E>>
+public interface ProxySubject
 {
-    T getProxy();
+    ProxyEntity getProxy();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -31,7 +31,7 @@ import java.awt.Color;
 import java.util.Collection;
 import java.util.EnumSet;
 
-public class RoleProxy implements Role, ProxyEntity<Role>
+public class RoleProxy implements Role, ProxyEntity
 {
     private final GuildProxy guild;
     private final long id;

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
 import net.dv8tion.jda.api.managers.RoleManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.RoleAction;
@@ -46,7 +47,10 @@ public class RoleProxy implements Role, ProxyEntity<Role>
     @Override
     public Role getSubject()
     {
-        return getGuild().getRoleById(id);
+        Role role = getGuild().getRoleById(id);
+        if (role == null)
+            throw new ProxyResolutionException("Role(" + getId() + ")");
+        return role;
     }
 
     @Override
@@ -124,7 +128,10 @@ public class RoleProxy implements Role, ProxyEntity<Role>
     @Override
     public Guild getGuild()
     {
-        return api.getGuildById(guildId);
+        Guild guild = api.getGuildById(guildId);
+        if (guild == null)
+            throw new ProxyResolutionException("Guild(" + Long.toUnsignedString(guildId) + ")");
+        return guild;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -208,6 +208,7 @@ public class RoleProxy implements Role, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -33,13 +33,13 @@ import java.util.EnumSet;
 
 public class RoleProxy implements Role, ProxyEntity<Role>
 {
-    private final long guildId; // TODO: Replace with GuildProxy
+    private final GuildProxy guild;
     private final long id;
     private final JDA api;
 
     public RoleProxy(Role role)
     {
-        this.guildId = role.getGuild().getIdLong();
+        this.guild = role.getGuild().getProxy();
         this.id = role.getIdLong();
         this.api = role.getJDA();
     }
@@ -128,10 +128,7 @@ public class RoleProxy implements Role, ProxyEntity<Role>
     @Override
     public Guild getGuild()
     {
-        Guild guild = api.getGuildById(guildId);
-        if (guild == null)
-            throw new ProxyResolutionException("Guild(" + Long.toUnsignedString(guildId) + ")");
-        return guild;
+        return guild.getSubject();
     }
 
     @Override
@@ -153,8 +150,7 @@ public class RoleProxy implements Role, ProxyEntity<Role>
     }
 
     @Override
-    public boolean hasPermission(
-            GuildChannel channel, Permission... permissions)
+    public boolean hasPermission(GuildChannel channel, Permission... permissions)
     {
         return getSubject().hasPermission(channel, permissions);
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -33,15 +33,15 @@ import java.util.EnumSet;
 
 public class RoleProxy implements Role, ProxyEntity<Role>
 {
-    private final long guildId;
+    private final long guildId; // TODO: Replace with GuildProxy
     private final long id;
     private final JDA api;
 
-    public RoleProxy(long guildId, long id, JDA api)
+    public RoleProxy(Role role)
     {
-        this.guildId = guildId;
-        this.id = id;
-        this.api = api;
+        this.guildId = role.getGuild().getIdLong();
+        this.id = role.getIdLong();
+        this.api = role.getJDA();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.managers.RoleManager;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import net.dv8tion.jda.api.requests.restaction.RoleAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.Color;
+import java.util.Collection;
+import java.util.EnumSet;
+
+public class RoleProxy implements Role, ProxyEntity<Role>
+{
+    private final long guildId;
+    private final long id;
+    private final JDA api;
+
+    public RoleProxy(long guildId, long id, JDA api)
+    {
+        this.guildId = guildId;
+        this.id = id;
+        this.api = api;
+    }
+
+    @Override
+    public Role getSubject()
+    {
+        return getGuild().getRoleById(id);
+    }
+
+    @Override
+    public RoleProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public int getPosition()
+    {
+        return getSubject().getPosition();
+    }
+
+    @Override
+    public int getPositionRaw()
+    {
+        return getSubject().getPositionRaw();
+    }
+
+    @Override
+    public String getName()
+    {
+        return getSubject().getName();
+    }
+
+    @Override
+    public boolean isManaged()
+    {
+        return getSubject().isManaged();
+    }
+
+    @Override
+    public boolean isHoisted()
+    {
+        return getSubject().isHoisted();
+    }
+
+    @Override
+    public boolean isMentionable()
+    {
+        return getSubject().isMentionable();
+    }
+
+    @Override
+    public long getPermissionsRaw()
+    {
+        return getSubject().getPermissionsRaw();
+    }
+
+    @Override
+    public Color getColor()
+    {
+        return getSubject().getColor();
+    }
+
+    @Override
+    public int getColorRaw()
+    {
+        return getSubject().getColorRaw();
+    }
+
+    @Override
+    public boolean isPublicRole()
+    {
+        return getSubject().isPublicRole();
+    }
+
+    @Override
+    public boolean canInteract(Role role)
+    {
+        return getSubject().canInteract(role);
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return api.getGuildById(guildId);
+    }
+
+    @Override
+    public EnumSet<Permission> getPermissions()
+    {
+        return getSubject().getPermissions();
+    }
+
+    @Override
+    public boolean hasPermission(Permission... permissions)
+    {
+        return getSubject().hasPermission(permissions);
+    }
+
+    @Override
+    public boolean hasPermission(Collection<Permission> permissions)
+    {
+        return getSubject().hasPermission(permissions);
+    }
+
+    @Override
+    public boolean hasPermission(
+            GuildChannel channel, Permission... permissions)
+    {
+        return getSubject().hasPermission(channel, permissions);
+    }
+
+    @Override
+    public boolean hasPermission(GuildChannel channel, Collection<Permission> permissions)
+    {
+        return getSubject().hasPermission(channel, permissions);
+    }
+
+    @Override
+    public RoleAction createCopy(Guild guild)
+    {
+        return getSubject().createCopy(guild);
+    }
+
+    @Override
+    public RoleManager getManager()
+    {
+        return getSubject().getManager();
+    }
+
+    @Override
+    public AuditableRestAction<Void> delete()
+    {
+        return getSubject().delete();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public int compareTo(@NotNull Role o)
+    {
+        return getSubject().compareTo(o);
+    }
+
+    @Override
+    public String getAsMention()
+    {
+        return getSubject().getAsMention();
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/RoleProxy.java
@@ -35,13 +35,11 @@ public class RoleProxy implements Role, ProxyEntity<Role>
 {
     private final GuildProxy guild;
     private final long id;
-    private final JDA api;
 
     public RoleProxy(Role role)
     {
         this.guild = role.getGuild().getProxy();
         this.id = role.getIdLong();
-        this.api = role.getJDA();
     }
 
     @Override
@@ -182,7 +180,7 @@ public class RoleProxy implements Role, ProxyEntity<Role>
     @Override
     public JDA getJDA()
     {
-        return api;
+        return getGuild().getJDA();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/SelfUserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/SelfUserProxy.java
@@ -23,9 +23,9 @@ import net.dv8tion.jda.api.managers.AccountManager;
 
 public class SelfUserProxy extends UserProxy implements SelfUser
 {
-    public SelfUserProxy(long id, JDA api)
+    public SelfUserProxy(SelfUser user)
     {
-        super(id, api);
+        super(user);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/SelfUserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/SelfUserProxy.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.exceptions.AccountTypeException;
+import net.dv8tion.jda.api.managers.AccountManager;
+
+public class SelfUserProxy extends UserProxy implements SelfUser
+{
+    public SelfUserProxy(long id, JDA api)
+    {
+        super(id, api);
+    }
+
+    @Override
+    public SelfUser getSubject()
+    {
+        return (SelfUser) super.getSubject();
+    }
+
+    @Override
+    public SelfUserProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public boolean isVerified()
+    {
+        return getSubject().isVerified();
+    }
+
+    @Override
+    public boolean isMfaEnabled()
+    {
+        return getSubject().isMfaEnabled();
+    }
+
+    @Override
+    public String getEmail() throws AccountTypeException
+    {
+        return getSubject().getEmail();
+    }
+
+    @Override
+    public boolean isMobile() throws AccountTypeException
+    {
+        return getSubject().isMobile();
+    }
+
+    @Override
+    public boolean isNitro() throws AccountTypeException
+    {
+        return getSubject().isNitro();
+    }
+
+    @Override
+    public String getPhoneNumber() throws AccountTypeException
+    {
+        return getSubject().getPhoneNumber();
+    }
+
+    @Override
+    public long getAllowedFileSize()
+    {
+        return getSubject().getAllowedFileSize();
+    }
+
+    @Override
+    public AccountManager getManager()
+    {
+        return getSubject().getManager();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/SelfUserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/SelfUserProxy.java
@@ -16,9 +16,9 @@
 
 package net.dv8tion.jda.api.entities.proxy;
 
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.SelfUser;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
 import net.dv8tion.jda.api.managers.AccountManager;
 
 public class SelfUserProxy extends UserProxy implements SelfUser
@@ -31,7 +31,10 @@ public class SelfUserProxy extends UserProxy implements SelfUser
     @Override
     public SelfUser getSubject()
     {
-        return (SelfUser) super.getSubject();
+        SelfUser user = getJDA().getSelfUser();
+        if (user == null) // should be impossible but you never know
+            throw new ProxyResolutionException("SelfUser");
+        return user;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
@@ -32,10 +32,10 @@ public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
     private final long id;
     private final JDA api;
 
-    public TextChannelProxy(long id, JDA api)
+    public TextChannelProxy(TextChannel channel)
     {
-        this.id = id;
-        this.api = api;
+        this.id = channel.getIdLong();
+        this.api = channel.getJDA();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 import java.util.List;
 
-public class TextChannelProxy extends GuildChannelProxy implements TextChannel
+public class TextChannelProxy extends GuildChannelProxy implements TextChannel, MessageChannelProxy
 {
     public TextChannelProxy(TextChannel channel)
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
@@ -16,26 +16,22 @@
 
 package net.dv8tion.jda.api.entities.proxy;
 
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
-import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.api.requests.restaction.*;
+import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import net.dv8tion.jda.api.requests.restaction.ChannelAction;
+import net.dv8tion.jda.api.requests.restaction.WebhookAction;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
 
-public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
+public class TextChannelProxy extends GuildChannelProxy implements TextChannel
 {
-    private final long id;
-    private final JDA api;
-
     public TextChannelProxy(TextChannel channel)
     {
-        this.id = channel.getIdLong();
-        this.api = channel.getJDA();
+        super(channel);
     }
 
     @Override
@@ -45,6 +41,24 @@ public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
         if (channel == null)
             throw new ProxyResolutionException("TextChannel(" + getId() + ")");
         return channel;
+    }
+
+    @Override
+    public TextChannelProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public ChannelAction<TextChannel> createCopy()
+    {
+        return getSubject().createCopy();
+    }
+
+    @Override
+    public ChannelAction<TextChannel> createCopy(Guild guild)
+    {
+        return getSubject().createCopy(guild);
     }
 
     @Override
@@ -66,12 +80,6 @@ public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
     }
 
     @Override
-    public ChannelType getType()
-    {
-        return ChannelType.TEXT;
-    }
-
-    @Override
     public long getLatestMessageIdLong()
     {
         return getSubject().getLatestMessageIdLong();
@@ -81,138 +89,6 @@ public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
     public boolean hasLatestMessage()
     {
         return getSubject().hasLatestMessage();
-    }
-
-    @Override
-    public String getName()
-    {
-        return getSubject().getName();
-    }
-
-    @Override
-    public Guild getGuild()
-    {
-        return getSubject().getGuild();
-    }
-
-    @Override
-    public Category getParent()
-    {
-        return getSubject().getParent();
-    }
-
-    @Override
-    public List<Member> getMembers()
-    {
-        return getSubject().getMembers();
-    }
-
-    @Override
-    public int getPosition()
-    {
-        return getSubject().getPosition();
-    }
-
-    @Override
-    public int getPositionRaw()
-    {
-        return getSubject().getPositionRaw();
-    }
-
-    @Override
-    public JDA getJDA()
-    {
-        return api;
-    }
-
-    @Override
-    public PermissionOverride getPermissionOverride(Member member)
-    {
-        return getSubject().getPermissionOverride(member);
-    }
-
-    @Override
-    public PermissionOverride getPermissionOverride(Role role)
-    {
-        return getSubject().getPermissionOverride(role);
-    }
-
-    @Override
-    public List<PermissionOverride> getPermissionOverrides()
-    {
-        return getSubject().getPermissionOverrides();
-    }
-
-    @Override
-    public List<PermissionOverride> getMemberPermissionOverrides()
-    {
-        return getSubject().getMemberPermissionOverrides();
-    }
-
-    @Override
-    public List<PermissionOverride> getRolePermissionOverrides()
-    {
-        return getSubject().getRolePermissionOverrides();
-    }
-
-    @Override
-    public ChannelAction<TextChannel> createCopy(Guild guild)
-    {
-        return getSubject().createCopy(guild);
-    }
-
-    @Override
-    public ChannelAction<TextChannel> createCopy()
-    {
-        return getSubject().createCopy();
-    }
-
-    @Override
-    public ChannelManager getManager()
-    {
-        return getSubject().getManager();
-    }
-
-    @Override
-    public AuditableRestAction<Void> delete()
-    {
-        return getSubject().delete();
-    }
-
-    @Override
-    public PermissionOverrideAction createPermissionOverride(Member member)
-    {
-        return getSubject().createPermissionOverride(member);
-    }
-
-    @Override
-    public PermissionOverrideAction createPermissionOverride(Role role)
-    {
-        return getSubject().createPermissionOverride(role);
-    }
-
-    @Override
-    public PermissionOverrideAction putPermissionOverride(Member member)
-    {
-        return getSubject().putPermissionOverride(member);
-    }
-
-    @Override
-    public PermissionOverrideAction putPermissionOverride(Role role)
-    {
-        return getSubject().putPermissionOverride(role);
-    }
-
-    @Override
-    public InviteAction createInvite()
-    {
-        return getSubject().createInvite();
-    }
-
-    @Override
-    public RestAction<List<Invite>> getInvites()
-    {
-        return getSubject().getInvites();
     }
 
     @Override
@@ -279,35 +155,5 @@ public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
     public String getAsMention()
     {
         return getSubject().getAsMention();
-    }
-
-    @Override
-    public long getIdLong()
-    {
-        return id;
-    }
-
-    @Override
-    public TextChannelProxy getProxy()
-    {
-        return this;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return getSubject().hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        return obj == this || getSubject().equals(obj);
-    }
-
-    @Override
-    public String toString()
-    {
-        return getSubject().toString();
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.managers.ChannelManager;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
+{
+    private final long id;
+    private final JDA api;
+
+    public TextChannelProxy(long id, JDA api)
+    {
+        this.id = id;
+        this.api = api;
+    }
+
+    @Override
+    public TextChannel getSubject()
+    {
+        return api.getTextChannelById(id);
+    }
+
+    @Override
+    public String getTopic()
+    {
+        return getSubject().getTopic();
+    }
+
+    @Override
+    public boolean isNSFW()
+    {
+        return getSubject().isNSFW();
+    }
+
+    @Override
+    public int getSlowmode()
+    {
+        return getSubject().getSlowmode();
+    }
+
+    @Override
+    public ChannelType getType()
+    {
+        return ChannelType.TEXT;
+    }
+
+    @Override
+    public long getLatestMessageIdLong()
+    {
+        return getSubject().getLatestMessageIdLong();
+    }
+
+    @Override
+    public boolean hasLatestMessage()
+    {
+        return getSubject().hasLatestMessage();
+    }
+
+    @Override
+    public String getName()
+    {
+        return getSubject().getName();
+    }
+
+    @Override
+    public Guild getGuild()
+    {
+        return getSubject().getGuild();
+    }
+
+    @Override
+    public Category getParent()
+    {
+        return getSubject().getParent();
+    }
+
+    @Override
+    public List<Member> getMembers()
+    {
+        return getSubject().getMembers();
+    }
+
+    @Override
+    public int getPosition()
+    {
+        return getSubject().getPosition();
+    }
+
+    @Override
+    public int getPositionRaw()
+    {
+        return getSubject().getPositionRaw();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public PermissionOverride getPermissionOverride(Member member)
+    {
+        return getSubject().getPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverride getPermissionOverride(Role role)
+    {
+        return getSubject().getPermissionOverride(role);
+    }
+
+    @Override
+    public List<PermissionOverride> getPermissionOverrides()
+    {
+        return getSubject().getPermissionOverrides();
+    }
+
+    @Override
+    public List<PermissionOverride> getMemberPermissionOverrides()
+    {
+        return getSubject().getMemberPermissionOverrides();
+    }
+
+    @Override
+    public List<PermissionOverride> getRolePermissionOverrides()
+    {
+        return getSubject().getRolePermissionOverrides();
+    }
+
+    @Override
+    public ChannelAction<TextChannel> createCopy(Guild guild)
+    {
+        return getSubject().createCopy(guild);
+    }
+
+    @Override
+    public ChannelAction<TextChannel> createCopy()
+    {
+        return getSubject().createCopy();
+    }
+
+    @Override
+    public ChannelManager getManager()
+    {
+        return getSubject().getManager();
+    }
+
+    @Override
+    public AuditableRestAction<Void> delete()
+    {
+        return getSubject().delete();
+    }
+
+    @Override
+    public PermissionOverrideAction createPermissionOverride(Member member)
+    {
+        return getSubject().createPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverrideAction createPermissionOverride(Role role)
+    {
+        return getSubject().createPermissionOverride(role);
+    }
+
+    @Override
+    public PermissionOverrideAction putPermissionOverride(Member member)
+    {
+        return getSubject().putPermissionOverride(member);
+    }
+
+    @Override
+    public PermissionOverrideAction putPermissionOverride(Role role)
+    {
+        return getSubject().putPermissionOverride(role);
+    }
+
+    @Override
+    public InviteAction createInvite()
+    {
+        return getSubject().createInvite();
+    }
+
+    @Override
+    public RestAction<List<Invite>> getInvites()
+    {
+        return getSubject().getInvites();
+    }
+
+    @Override
+    public RestAction<List<Webhook>> getWebhooks()
+    {
+        return getSubject().getWebhooks();
+    }
+
+    @Override
+    public WebhookAction createWebhook(String name)
+    {
+        return getSubject().createWebhook(name);
+    }
+
+    @Override
+    public RestAction<Void> deleteMessages(Collection<Message> messages)
+    {
+        return getSubject().deleteMessages(messages);
+    }
+
+    @Override
+    public RestAction<Void> deleteMessagesByIds(Collection<String> messageIds)
+    {
+        return getSubject().deleteMessagesByIds(messageIds);
+    }
+
+    @Override
+    public AuditableRestAction<Void> deleteWebhookById(String id)
+    {
+        return getSubject().deleteWebhookById(id);
+    }
+
+    @Override
+    public RestAction<Void> clearReactionsById(String messageId)
+    {
+        return getSubject().clearReactionsById(messageId);
+    }
+
+    @Override
+    public RestAction<Void> removeReactionById(String messageId, String unicode, User user)
+    {
+        return getSubject().removeReactionById(messageId, unicode, user);
+    }
+
+    @Override
+    public boolean canTalk()
+    {
+        return getSubject().canTalk();
+    }
+
+    @Override
+    public boolean canTalk(Member member)
+    {
+        return getSubject().canTalk(member);
+    }
+
+    @Override
+    public int compareTo(@NotNull TextChannel o)
+    {
+        return getSubject().compareTo(o);
+    }
+
+    @Override
+    public String getAsMention()
+    {
+        return getSubject().getAsMention();
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public TextChannelProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/TextChannelProxy.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.entities.proxy;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
 import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.*;
@@ -40,7 +41,10 @@ public class TextChannelProxy implements TextChannel, ProxyEntity<TextChannel>
     @Override
     public TextChannel getSubject()
     {
-        return api.getTextChannelById(id);
+        TextChannel channel = api.getTextChannelById(id);
+        if (channel == null)
+            throw new ProxyResolutionException("TextChannel(" + getId() + ")");
+        return channel;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.PrivateChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.requests.RestAction;
+
+import java.util.List;
+
+public class UserProxy implements User, ProxyEntity<User>
+{
+    private final long id;
+    private final JDA api;
+
+    public UserProxy(long id, JDA api)
+    {
+        this.id = id;
+        this.api = api;
+    }
+
+    @Override
+    public User getSubject()
+    {
+        return api.getUserById(id);
+    }
+
+    @Override
+    public UserProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public String getName()
+    {
+        return getSubject().getName();
+    }
+
+    @Override
+    public String getDiscriminator()
+    {
+        return getSubject().getDiscriminator();
+    }
+
+    @Override
+    public String getAvatarId()
+    {
+        return getSubject().getAvatarId();
+    }
+
+    @Override
+    public String getAvatarUrl()
+    {
+        return getSubject().getAvatarUrl();
+    }
+
+    @Override
+    public String getDefaultAvatarId()
+    {
+        return getSubject().getDefaultAvatarId();
+    }
+
+    @Override
+    public String getDefaultAvatarUrl()
+    {
+        return getSubject().getDefaultAvatarUrl();
+    }
+
+    @Override
+    public String getEffectiveAvatarUrl()
+    {
+        return getSubject().getEffectiveAvatarUrl();
+    }
+
+    @Override
+    public String getAsTag()
+    {
+        return getSubject().getAsTag();
+    }
+
+    @Override
+    public boolean hasPrivateChannel()
+    {
+        return getSubject().hasPrivateChannel();
+    }
+
+    @Override
+    public RestAction<PrivateChannel> openPrivateChannel()
+    {
+        return getSubject().openPrivateChannel();
+    }
+
+    @Override
+    public List<Guild> getMutualGuilds()
+    {
+        return getSubject().getMutualGuilds();
+    }
+
+    @Override
+    public boolean isBot()
+    {
+        return getSubject().isBot();
+    }
+
+    @Override
+    public JDA getJDA()
+    {
+        return api;
+    }
+
+    @Override
+    public boolean isFake()
+    {
+        return false; // can't be fake
+    }
+
+    @Override
+    public String getAsMention()
+    {
+        return getSubject().getAsMention();
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getSubject().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj == this || getSubject().equals(obj);
+    }
+
+    @Override
+    public String toString()
+    {
+        return getSubject().toString();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
@@ -30,10 +30,10 @@ public class UserProxy implements User, ProxyEntity<User>
     private final long id;
     private final JDA api;
 
-    public UserProxy(long id, JDA api)
+    public UserProxy(User user)
     {
-        this.id = id;
-        this.api = api;
+        this.id = user.getIdLong();
+        this.api = user.getJDA();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
@@ -25,7 +25,7 @@ import net.dv8tion.jda.api.requests.RestAction;
 
 import java.util.List;
 
-public class UserProxy implements User, ProxyEntity<User>
+public class UserProxy implements User, ProxyEntity
 {
     private final long id;
     private final JDA api;

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
 import net.dv8tion.jda.api.requests.RestAction;
 
 import java.util.List;
@@ -38,7 +39,10 @@ public class UserProxy implements User, ProxyEntity<User>
     @Override
     public User getSubject()
     {
-        return api.getUserById(id);
+        User user = api.getUserById(id);
+        if (user == null)
+            throw new ProxyResolutionException("User(" + getId() + ")");
+        return user;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/UserProxy.java
@@ -154,6 +154,7 @@ public class UserProxy implements User, ProxyEntity
     }
 
     @Override
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj)
     {
         return obj == this || getSubject().equals(obj);

--- a/src/main/java/net/dv8tion/jda/api/entities/proxy/VoiceChannelProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/proxy/VoiceChannelProxy.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.proxy;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.VoiceChannel;
+import net.dv8tion.jda.api.exceptions.ProxyResolutionException;
+import net.dv8tion.jda.api.requests.restaction.ChannelAction;
+import org.jetbrains.annotations.NotNull;
+
+public class VoiceChannelProxy extends GuildChannelProxy implements VoiceChannel
+{
+    public VoiceChannelProxy(VoiceChannel channel)
+    {
+        super(channel);
+    }
+
+    @Override
+    public VoiceChannel getSubject()
+    {
+        VoiceChannel channel = api.getVoiceChannelById(id);
+        if (channel == null)
+            throw new ProxyResolutionException("VoiceChannel(" + id + ")");
+        return channel;
+    }
+
+    @Override
+    public VoiceChannelProxy getProxy()
+    {
+        return this;
+    }
+
+    @Override
+    public ChannelAction<VoiceChannel> createCopy(Guild guild)
+    {
+        return getSubject().createCopy(guild);
+    }
+
+    @Override
+    public ChannelAction<VoiceChannel> createCopy()
+    {
+        return getSubject().createCopy();
+    }
+
+    @Override
+    public int getUserLimit()
+    {
+        return getSubject().getUserLimit();
+    }
+
+    @Override
+    public int getBitrate()
+    {
+        return getSubject().getBitrate();
+    }
+
+    @Override
+    public int compareTo(@NotNull VoiceChannel o)
+    {
+        return getSubject().compareTo(o);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/exceptions/ProxyResolutionException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ProxyResolutionException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.exceptions;
+
+public class ProxyResolutionException extends IllegalStateException
+{
+    public ProxyResolutionException(String message)
+    {
+        super("Subject of type " + message + " is no longer available");
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildController.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildController.java
@@ -33,7 +33,6 @@ import net.dv8tion.jda.api.requests.restaction.order.RoleOrderAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
-import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.requests.EmptyRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
@@ -63,7 +62,7 @@ import java.util.stream.Stream;
  */
 public class GuildController
 {
-    protected final UpstreamReference<GuildImpl> guild;
+    protected final UpstreamReference<Guild> guild;
 
     /**
      * Creates a new GuildController instance
@@ -75,7 +74,7 @@ public class GuildController
      */
     public GuildController(Guild guild)
     {
-        this.guild = new UpstreamReference<>((GuildImpl) guild);
+        this.guild = new UpstreamReference<>(guild);
     }
 
     /**
@@ -1381,7 +1380,7 @@ public class GuildController
             Checks.check(!role.isManaged(), "Cannot remove a Managed role from a Member. Role: %s", role.toString());
         });
 
-        Set<Role> currentRoles = new HashSet<>(((MemberImpl) member).getRoleSet());
+        Set<Role> currentRoles = new HashSet<>(member.getRoles());
         Set<Role> newRolesToAdd = new HashSet<>(rolesToAdd);
         newRolesToAdd.removeAll(rolesToRemove);
 
@@ -1881,7 +1880,8 @@ public class GuildController
         return new AuditableRestActionImpl<>(jda, route, body, (response, request) ->
         {
             JSONObject obj = response.getObject();
-            return jda.getEntityBuilder().createEmote((GuildImpl) getGuild(), obj, true);
+            GuildImpl realGuild = (GuildImpl) getJDA().getGuildById(getGuild().getIdLong());
+            return jda.getEntityBuilder().createEmote(realGuild, obj, true);
         });
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -106,6 +106,12 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     }
 
     @Override
+    public PermissionOverride getPermissionOverrideById(long id)
+    {
+        return overrides.get(id);
+    }
+
+    @Override
     public PermissionOverride getPermissionOverride(Member member)
     {
         return member != null ? overrides.get(member.getUser().getIdLong()) : null;

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -20,6 +20,7 @@ import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.GuildChannelProxy;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.ChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -259,6 +260,8 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     {
         if (obj == this)
             return true;
+        if (obj instanceof GuildChannelProxy)
+            return obj.equals(this); // resolve subject
         if (!(obj instanceof GuildChannel))
             return false;
         GuildChannel channel = (GuildChannel) obj;

--- a/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.entities;
 
 import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.CategoryProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
@@ -116,6 +117,12 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
     public RestAction<List<Invite>> getInvites()
     {
         return new EmptyRestAction<>(getJDA(), Collections.emptyList());
+    }
+
+    @Override
+    public CategoryProxy getProxy()
+    {
+        return new CategoryProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -185,6 +185,8 @@ public class EmoteImpl implements ListedEmote
     @Override
     public EmoteProxy getProxy()
     {
+        if (isFake())
+            throw new IllegalStateException("Cannot create a proxy for a fake emote");
         return new EmoteProxy(this);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ListedEmote;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.proxy.EmoteProxy;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.EmoteManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
@@ -179,6 +180,12 @@ public class EmoteImpl implements ListedEmote
 
         Route.CompiledRoute route = Route.Emotes.DELETE_EMOTE.compile(getGuild().getId(), getId());
         return new AuditableRestActionImpl<Void>(getJDA(), route);
+    }
+
+    @Override
+    public EmoteProxy getProxy()
+    {
+        return new EmoteProxy(this);
     }
 
     // -- Setters --

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -230,6 +230,8 @@ public class EmoteImpl implements ListedEmote
     {
         if (obj == this)
             return true;
+        if (obj instanceof EmoteProxy)
+            return obj.equals(this); // resolve subject
         if (!(obj instanceof EmoteImpl))
             return false;
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -832,6 +832,8 @@ public class GuildImpl implements Guild
     {
         if (o == this)
             return true;
+        if (o instanceof GuildProxy)
+            return o.equals(this);  // resolve subject
         if (!(o instanceof GuildImpl))
             return false;
         GuildImpl oGuild = (GuildImpl) o;

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -139,6 +139,8 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     {
         if (obj == this)
             return true;
+        if (obj instanceof GuildVoiceStateProxy)
+            return obj.equals(this); // resolve subject
         if (!(obj instanceof GuildVoiceState))
             return false;
         GuildVoiceState oStatus = (GuildVoiceState) obj;

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.GuildVoiceStateProxy;
 import net.dv8tion.jda.internal.utils.cache.UpstreamReference;
 
 public class GuildVoiceStateImpl implements GuildVoiceState
@@ -119,6 +120,12 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     public boolean inVoiceChannel()
     {
         return getChannel() != null;
+    }
+
+    @Override
+    public GuildVoiceStateProxy getProxy()
+    {
+        return new GuildVoiceStateProxy(getMember());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.MemberProxy;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -204,6 +205,28 @@ public class MemberImpl implements Member
         return this.equals(getGuild().getOwner());
     }
 
+    @Override
+    public String getAsMention()
+    {
+        return nickname == null ? user.getAsMention() : "<@!" + user.getIdLong() + '>';
+    }
+
+    @Nullable
+    @Override
+    public TextChannel getDefaultChannel()
+    {
+        return getGuild().getTextChannelsView().stream()
+                .sorted(Comparator.reverseOrder())
+                .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
+                .findFirst().orElse(null);
+    }
+
+    @Override
+    public MemberProxy getProxy()
+    {
+        return new MemberProxy(this);
+    }
+
     public MemberImpl setNickname(String nickname)
     {
         this.nickname = nickname;
@@ -255,21 +278,5 @@ public class MemberImpl implements Member
     public String toString()
     {
         return "MB:" + getEffectiveName() + '(' + user.toString() + " / " + getGuild().toString() +')';
-    }
-
-    @Override
-    public String getAsMention()
-    {
-        return nickname == null ? user.getAsMention() : "<@!" + user.getIdLong() + '>';
-    }
-
-    @Nullable
-    @Override
-    public TextChannel getDefaultChannel()
-    {
-        return getGuild().getTextChannelsView().stream()
-                 .sorted(Comparator.reverseOrder())
-                 .filter(c -> hasPermission(c, Permission.MESSAGE_READ))
-                 .findFirst().orElse(null);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -261,6 +261,8 @@ public class MemberImpl implements Member
     {
         if (o == this)
             return true;
+        if (o instanceof MemberProxy)
+            return o.equals(this); // resolve subject
         if (!(o instanceof Member))
             return false;
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -179,6 +179,8 @@ public class PermissionOverrideImpl implements PermissionOverride
     {
         if (o == this)
             return true;
+        if (o instanceof PermissionOverrideProxy)
+            return o.equals(this); // resolve subject
         if (!(o instanceof PermissionOverrideImpl))
             return false;
         PermissionOverrideImpl oPerm = (PermissionOverrideImpl) o;

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.entities;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.PermissionOverrideProxy;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.PermOverrideManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
@@ -48,6 +49,12 @@ public class PermissionOverrideImpl implements PermissionOverride
         this.channel = new UpstreamReference<>(channel);
         this.id = id;
         this.permissionHolder = permissionHolder;
+    }
+
+    @Override
+    public PermissionOverrideProxy getProxy()
+    {
+        return new PermissionOverrideProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -179,6 +179,8 @@ public class PrivateChannelImpl implements PrivateChannel
     {
         if (obj == this)
             return true;
+        if (obj instanceof PrivateChannelProxy)
+            return obj.equals(this); // resolve subject
         if (!(obj instanceof PrivateChannelImpl))
             return false;
         PrivateChannelImpl impl = (PrivateChannelImpl) obj;

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.entities;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.PrivateChannelProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
@@ -42,6 +43,12 @@ public class PrivateChannelImpl implements PrivateChannel
     {
         this.id = id;
         this.user = new UpstreamReference<>(user);
+    }
+
+    @Override
+    public PrivateChannelProxy getProxy()
+    {
+        return new PrivateChannelProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -48,6 +48,8 @@ public class PrivateChannelImpl implements PrivateChannel
     @Override
     public PrivateChannelProxy getProxy()
     {
+        if (isFake())
+            throw new IllegalStateException("Cannot create a proxy for a fake channel");
         return new PrivateChannelProxy(this);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -265,6 +265,8 @@ public class RoleImpl implements Role
     {
         if (o == this)
             return true;
+        if (o instanceof RoleProxy)
+            return o.equals(this); // resolve subject
         if (!(o instanceof Role))
             return false;
         Role oRole = (Role) o;

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -257,7 +257,7 @@ public class RoleImpl implements Role
     @Override
     public RoleProxy getProxy()
     {
-        return new RoleProxy(getGuild().getIdLong(), id, getJDA());
+        return new RoleProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.proxy.RoleProxy;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.RoleManager;
@@ -251,6 +252,12 @@ public class RoleImpl implements Role
     public long getIdLong()
     {
         return id;
+    }
+
+    @Override
+    public RoleProxy getProxy()
+    {
+        return new RoleProxy(getGuild().getIdLong(), id, getJDA());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
@@ -51,7 +51,7 @@ public class SelfUserImpl extends UserImpl implements SelfUser
     @Override
     public SelfUserProxy getProxy()
     {
-        return new SelfUserProxy(id, getJDA());
+        return new SelfUserProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.SelfUser;
+import net.dv8tion.jda.api.entities.proxy.SelfUserProxy;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import net.dv8tion.jda.api.managers.AccountManager;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -45,6 +46,12 @@ public class SelfUserImpl extends UserImpl implements SelfUser
     public SelfUserImpl(long id, JDAImpl api)
     {
         super(id, api);
+    }
+
+    @Override
+    public SelfUserProxy getProxy()
+    {
+        return new SelfUserProxy(id, getJDA());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -19,10 +19,9 @@ package net.dv8tion.jda.internal.entities;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.TextChannelProxy;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.exceptions.VerificationLevelException;
-import net.dv8tion.jda.api.requests.Request;
-import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
@@ -472,6 +471,12 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
 
         //Call MessageChannel's default
         return TextChannel.super.editMessageById(id, newContent);
+    }
+
+    @Override
+    public TextChannelProxy getProxy()
+    {
+        return new TextChannelProxy(id, getJDA());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -476,7 +476,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
     @Override
     public TextChannelProxy getProxy()
     {
-        return new TextChannelProxy(id, getJDA());
+        return new TextChannelProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -182,6 +182,8 @@ public class UserImpl implements User
     {
         if (o == this)
             return true;
+        if (o instanceof UserProxy)
+            return o.equals(this); // resolve subject
         if (!(o instanceof UserImpl))
             return false;
         UserImpl oUser = (UserImpl) o;

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -174,7 +174,7 @@ public class UserImpl implements User
     {
         if (isFake())
             throw new IllegalStateException("Cannot create a proxy for a fake user");
-        return new UserProxy(id, getJDA());
+        return new UserProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.entities;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.proxy.UserProxy;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.JDAImpl;
@@ -166,6 +167,14 @@ public class UserImpl implements User
     public boolean isFake()
     {
         return fake;
+    }
+
+    @Override
+    public UserProxy getProxy()
+    {
+        if (isFake())
+            throw new IllegalStateException("Cannot create a proxy for a fake user");
+        return new UserProxy(id, getJDA());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.entities;
 
 import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.proxy.VoiceChannelProxy;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -35,6 +36,12 @@ public class VoiceChannelImpl extends AbstractChannelImpl<VoiceChannel, VoiceCha
     public VoiceChannelImpl(long id, GuildImpl guild)
     {
         super(id, guild);
+    }
+
+    @Override
+    public VoiceChannelProxy getProxy()
+    {
+        return new VoiceChannelProxy(this);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
@@ -133,7 +133,8 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
     @Override
     protected void handleSuccess(Response response, Request<Role> request)
     {
-        request.onSuccess(api.get().getEntityBuilder().createRole((GuildImpl) guild, response.getObject(), guild.getIdLong()));
+        GuildImpl realGuild = (GuildImpl) getJDA().getGuildById(guild.getIdLong());
+        request.onSuccess(api.get().getEntityBuilder().createRole(realGuild, response.getObject(), this.guild.getIdLong()));
     }
 
     private void checkPermission(Permission permission)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
@@ -135,7 +135,8 @@ public class AuditLogPaginationActionImpl
             JSONObject webhook = webhooks.getJSONObject(i);
             webhookMap.put(webhook.getLong("id"), webhook);
         }
-        
+
+        GuildImpl realGuild = (GuildImpl) getJDA().getGuildById(guild.getIdLong());
         for (int i = 0; i < entries.length(); i++)
         {
             try
@@ -143,7 +144,7 @@ public class AuditLogPaginationActionImpl
                 JSONObject entry = entries.getJSONObject(i);
                 JSONObject user = userMap.get(Helpers.optLong(entry, "user_id", 0));
                 JSONObject webhook = webhookMap.get(Helpers.optLong(entry, "target_id", 0));
-                AuditLogEntry result = builder.createAuditLogEntry((GuildImpl) guild, entry, user, webhook);
+                AuditLogEntry result = builder.createAuditLogEntry(realGuild, entry, user, webhook);
                 list.add(result);
                 if (this.useCache)
                     this.cached.add(result);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Introduces proxy classes that indirectly access the JDA cache by only storing ID and JDA references.

### Proxies

- [x] User
- [x] SelfUser
- [x] Guild
- [x] Role
- [x] Member
- [x] GuildVoiceState
- [x] GuildChannel
- [x] MessageChannel
- [x] Emote
- [x] PermissionOverride

[Package for a complete list](https://github.com/DV8FromTheWorld/JDA/tree/feature/v4/proxy/src/main/java/net/dv8tion/jda/api/entities/proxy)

Let me know if I missed any entities that rely on the cache. Things like Webhooks are not included as they are not actually cached and thus cannot be proxied.

Currently we tell people to store the id of entities and resolve those ids to local variables. With this we can change and start saying "if it implements ProxySubject, use the proxy". 

Since all the proxies actually implement the interfaces of the subjects they can easily be used in existing code.

### Example

```diff
public class NameManager extends ListenerAdapter {
    private final Guild guild;

    public NameManager(Guild guild) {
-        this.guild = guild;
+        this.guild = guild.getProxy();
    }
...
```