### PR TITLE
Use the same route for removing own reaction

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -2153,8 +2153,8 @@ public interface MessageChannel extends ISnowflake, Formattable
         Checks.noWhitespace(unicode, "Emoji");
 
         final String code = MiscUtil.encodeUTF8(unicode);
-        final Route.CompiledRoute route = Route.Messages.REMOVE_OWN_REACTION.compile(getId(), messageId, code);
-        return new RestActionImpl<Void>(getJDA(), route);
+        final Route.CompiledRoute route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, code, "@me");
+        return new RestActionImpl<>(getJDA(), route);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -351,7 +351,7 @@ public class MessageReaction
                     : MiscUtil.encodeUTF8(emote.getName());
         Route.CompiledRoute route;
         if (user.equals(getJDA().getSelfUser()))
-            route = Route.Messages.REMOVE_OWN_REACTION.compile(channel.getId(), getMessageId(), code);
+            route = Route.Messages.REMOVE_REACTION.compile(channel.getId(), getMessageId(), code, "@me");
         else
             route = Route.Messages.REMOVE_REACTION.compile(channel.getId(), getMessageId(), code, user.getId());
         return new RestActionImpl<>(getJDA(), route);

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -436,7 +436,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         final String code = MiscUtil.encodeUTF8(unicode);
         Route.CompiledRoute route;
         if (user.equals(getJDA().getSelfUser()))
-            route = Route.Messages.REMOVE_OWN_REACTION.compile(getId(), messageId, code);
+            route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, code, "@me");
         else
             route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, code, user.getId());
         return new RestActionImpl<>(getJDA(), route);

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -204,7 +204,6 @@ public class Route
 
         public static final Route ADD_REACTION =             new Route(PUT,    new RateLimit(1, 250),
                                                                                "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/@me",       "channel_id");
-        public static final Route REMOVE_OWN_REACTION =      new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/@me",       "channel_id");
         public static final Route REMOVE_REACTION =          new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}", "channel_id");
         public static final Route REMOVE_ALL_REACTIONS =     new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions",                           "channel_id");
         public static final Route GET_REACTION_USERS =       new Route(GET,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}",           "channel_id");


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Apparently discord uses the same rate-limit bucket here but not for getting the self user. Just another inconsistency in the API.