### PR TITLE
Use OkHTTP3 snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,11 @@ Be sure to replace the **VERSION** key below with the one of the versions shown 
     <name>jcenter-bintray</name>
     <url>http://jcenter.bintray.com</url>
 </repository>
-
+<repository> <!-- Required for OkHTTP 3.13.0-SNAPSHOT -->
+    <id>sonatype</id>
+    <name>sonatype-snapshots</name>
+    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+</repository>
 ```
 
 **Maven without Audio**
@@ -225,6 +229,8 @@ dependencies {
 
 repositories {
     jcenter()
+    // Required for OkHTTP 3.13.0-SNAPSHOT
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ All dependencies are managed automatically by Gradle.
    * [Github](https://github.com/TakahikoKawasaki/nv-websocket-client)
    * [JCenter Repository](https://bintray.com/bintray/jcenter/com.neovisionaries%3Anv-websocket-client/view)
  * OkHttp
-   * Version: **3.12.0**
+   * Version: **3.13.0-SNAPSHOT**
    * [Github](https://github.com/square/okhttp)
    * [JCenter Repository](https://bintray.com/bintray/jcenter/com.squareup.okhttp3:okhttp)
  * Apache Commons Collections4

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ sourceCompatibility = targetCompatibility = 1.8
 
 repositories {
     jcenter()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 
 sourceSets {
@@ -60,12 +61,14 @@ dependencies {
 
     //Web Connection Support
     api 'com.neovisionaries:nv-websocket-client:2.5'
-    api 'com.squareup.okhttp3:okhttp:3.12.0'
+    api 'com.squareup.okhttp3:okhttp:3.13.0-SNAPSHOT'
 
     //Opus library support
     api ('club.minnced:opus-java:1.0.4@pom') {
         transitive = true
     }
+    
+    compileOnly 'net.java.dev.jna:jna:4.4.0'
 
     /* Internal dependencies */
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Update dependency

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

It seems like OkHTTP 3.13.0 is not coming any closer to being released, this is a solution that would work for us if we decide to just give up on waiting.
