### PR TITLE
Add takeUntilAsync

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -355,7 +355,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
         List<T> result = new ArrayList<>();
         CompletableFuture<List<T>> future = new CompletableFuture<>();
         CompletableFuture<?> handle = forEachAsync((element) -> {
-            if (!rule.test(element))
+            if (rule.test(element))
                 return false;
             result.add(element);
             return limit == 0 || limit > result.size();

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -274,7 +274,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         If the provided rule is {@code null}
      *
      * @return {@link CompletableFuture} - Type: {@link List List}
-     *         <br>Future representing the fetch task
+     *         <br>Future representing the fetch task, the list will be sorted most recent to oldest
      *
      * @see    #takeWhileAsync(int, Predicate)
      * @see    #takeUntilAsync(Predicate)
@@ -298,7 +298,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         If the provided rule is {@code null} or the limit is negative
      *
      * @return {@link CompletableFuture} - Type: {@link List List}
-     *         <br>Future representing the fetch task
+     *         <br>Future representing the fetch task, the list will be sorted most recent to oldest
      *
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
@@ -320,7 +320,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         If the provided rule is {@code null} or the limit is negative
      *
      * @return {@link CompletableFuture} - Type: {@link List List}
-     *         <br>Future representing the fetch task
+     *         <br>Future representing the fetch task, the list will be sorted most recent to oldest
      *
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
@@ -343,7 +343,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         If the provided rule is {@code null} or the limit is negative
      *
      * @return {@link CompletableFuture} - Type: {@link List List}
-     *         <br>Future representing the fetch task
+     *         <br>Future representing the fetch task, the list will be sorted most recent to oldest
      *
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
@@ -352,11 +352,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
     {
         Checks.notNull(rule, "Rule");
         Checks.notNegative(limit, "Limit");
-        List<T> result;
-        if (limit == 0)
-            result = new ArrayList<>();
-        else
-            result = new ArrayList<>(limit);
+        List<T> result = new ArrayList<>();
         CompletableFuture<List<T>> future = new CompletableFuture<>();
         CompletableFuture<?> handle = forEachAsync((element) -> {
             if (!rule.test(element))

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -317,7 +317,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         returns true to discard the element and finish the task
      *
      * @throws IllegalArgumentException
-     *         If the provided rule is {@code null} or the limit is negative
+     *         If the provided rule is {@code null}
      *
      * @return {@link CompletableFuture} - Type: {@link List List}
      *         <br>Future representing the fetch task, the list will be sorted most recent to oldest

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -263,11 +263,91 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      */
     int getLimit();
 
+    /**
+     * Retrieves elements while the specified condition is met.
+     *
+     * @param  rule
+     *         The rule which must be fulfilled for an element to be added,
+     *         returns false to discard the element and finish the task
+     *
+     * @throws IllegalArgumentException
+     *         If the provided rule is {@code null}
+     *
+     * @return {@link CompletableFuture} - Type: {@link List List}
+     *         <br>Future representing the fetch task
+     *
+     * @see    #takeWhileAsync(int, Predicate)
+     * @see    #takeUntilAsync(Predicate)
+     */
+    default CompletableFuture<List<T>> takeWhileAsync(Predicate<T> rule)
+    {
+        Checks.notNull(rule, "Rule");
+        return takeUntilAsync(rule.negate());
+    }
+
+    /**
+     * Retrieves elements while the specified condition is met.
+     *
+     * @param  limit
+     *         The maximum amount of elements to collect or {@code 0} for no limit
+     * @param  rule
+     *         The rule which must be fulfilled for an element to be added,
+     *         returns false to discard the element and finish the task
+     *
+     * @throws IllegalArgumentException
+     *         If the provided rule is {@code null} or the limit is negative
+     *
+     * @return {@link CompletableFuture} - Type: {@link List List}
+     *         <br>Future representing the fetch task
+     *
+     * @see    #takeWhileAsync(Predicate)
+     * @see    #takeUntilAsync(int, Predicate)
+     */
+    default CompletableFuture<List<T>> takeWhileAsync(int limit, Predicate<T> rule)
+    {
+        Checks.notNull(rule, "Rule");
+        return takeUntilAsync(limit, rule.negate());
+    }
+
+    /**
+     * Retrieves elements until the specified condition is met.
+     *
+     * @param  rule
+     *         The rule which must be fulfilled for an element to be discarded,
+     *         returns true to discard the element and finish the task
+     *
+     * @throws IllegalArgumentException
+     *         If the provided rule is {@code null} or the limit is negative
+     *
+     * @return {@link CompletableFuture} - Type: {@link List List}
+     *         <br>Future representing the fetch task
+     *
+     * @see    #takeWhileAsync(Predicate)
+     * @see    #takeUntilAsync(int, Predicate)
+     */
     default CompletableFuture<List<T>> takeUntilAsync(Predicate<T> rule)
     {
         return takeUntilAsync(0, rule);
     }
 
+    /**
+     * Retrieves elements until the specified condition is met.
+     *
+     * @param  limit
+     *         The maximum amount of elements to collect or {@code 0} for no limit
+     * @param  rule
+     *         The rule which must be fulfilled for an element to be discarded,
+     *         returns true to discard the element and finish the task
+     *
+     * @throws IllegalArgumentException
+     *         If the provided rule is {@code null} or the limit is negative
+     *
+     * @return {@link CompletableFuture} - Type: {@link List List}
+     *         <br>Future representing the fetch task
+     *
+     * @see    #takeWhileAsync(Predicate)
+     * @see    #takeUntilAsync(int, Predicate)
+     */
     default CompletableFuture<List<T>> takeUntilAsync(int limit, Predicate<T> rule)
     {
         Checks.notNull(rule, "Rule");

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -279,7 +279,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(int, Predicate)
      * @see    #takeUntilAsync(Predicate)
      */
-    default CompletableFuture<List<T>> takeWhileAsync(Predicate<T> rule)
+    default CompletableFuture<List<T>> takeWhileAsync(final Predicate<? super T> rule)
     {
         Checks.notNull(rule, "Rule");
         return takeUntilAsync(rule.negate());
@@ -303,7 +303,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
      */
-    default CompletableFuture<List<T>> takeWhileAsync(int limit, Predicate<T> rule)
+    default CompletableFuture<List<T>> takeWhileAsync(int limit, final Predicate<? super T> rule)
     {
         Checks.notNull(rule, "Rule");
         return takeUntilAsync(limit, rule.negate());
@@ -325,7 +325,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
      */
-    default CompletableFuture<List<T>> takeUntilAsync(Predicate<T> rule)
+    default CompletableFuture<List<T>> takeUntilAsync(final Predicate<? super T> rule)
     {
         return takeUntilAsync(0, rule);
     }
@@ -348,7 +348,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
      */
-    default CompletableFuture<List<T>> takeUntilAsync(int limit, Predicate<T> rule)
+    default CompletableFuture<List<T>> takeUntilAsync(int limit, final Predicate<? super T> rule)
     {
         Checks.notNull(rule, "Rule");
         Checks.notNegative(limit, "Limit");
@@ -429,7 +429,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    default CompletableFuture<?> forEachAsync(final Procedure<T> action)
+    default CompletableFuture<?> forEachAsync(final Procedure<? super T> action)
     {
         return forEachAsync(action, RestActionImpl.getDefaultFailure());
     }
@@ -471,7 +471,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    CompletableFuture<?> forEachAsync(final Procedure<T> action, final Consumer<? super Throwable> failure);
+    CompletableFuture<?> forEachAsync(final Procedure<? super T> action, final Consumer<? super Throwable> failure);
 
     /**
      * Iterates over all remaining entities until the provided action returns {@code false}!
@@ -508,7 +508,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    default CompletableFuture<?> forEachRemainingAsync(final Procedure<T> action)
+    default CompletableFuture<?> forEachRemainingAsync(final Procedure<? super T> action)
     {
         return forEachRemainingAsync(action, RestActionImpl.getDefaultFailure());
     }
@@ -550,7 +550,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    CompletableFuture<?> forEachRemainingAsync(final Procedure<T> action, final Consumer<? super Throwable> failure);
+    CompletableFuture<?> forEachRemainingAsync(final Procedure<? super T> action, final Consumer<? super Throwable> failure);
 
     /**
      * Iterates over all remaining entities until the provided action returns {@code false}!
@@ -562,7 +562,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         The {@link net.dv8tion.jda.api.utils.Procedure Procedure}
      *         which should return {@code true} to continue iterating
      */
-    void forEachRemaining(final Procedure<T> action);
+    void forEachRemaining(final Procedure<? super T> action);
 
     @Override
     default Spliterator<T> spliterator()

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
@@ -228,7 +228,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     }
 
     @Override
-    public CompletableFuture<?> forEachAsync(final Procedure<T> action, final Consumer<? super Throwable> failure)
+    public CompletableFuture<?> forEachAsync(final Procedure<? super T> action, final Consumer<? super Throwable> failure)
     {
         Checks.notNull(action, "Procedure");
         Checks.notNull(failure, "Failure Consumer");
@@ -252,7 +252,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     }
 
     @Override
-    public CompletableFuture<?> forEachRemainingAsync(final Procedure<T> action, final Consumer<? super Throwable> failure)
+    public CompletableFuture<?> forEachRemainingAsync(final Procedure<? super T> action, final Consumer<? super Throwable> failure)
     {
         Checks.notNull(action, "Procedure");
         Checks.notNull(failure, "Failure Consumer");
@@ -277,7 +277,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     }
 
     @Override
-    public void forEachRemaining(final Procedure<T> action)
+    public void forEachRemaining(final Procedure<? super T> action)
     {
         Checks.notNull(action, "Procedure");
         Queue<T> queue = new LinkedList<>();
@@ -306,11 +306,11 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     protected class ChainedConsumer implements Consumer<List<T>>
     {
         protected final CompletableFuture<?> task;
-        protected final Procedure<T> action;
+        protected final Procedure<? super T> action;
         protected final Consumer<Throwable> throwableConsumer;
         protected boolean initial = true;
 
-        protected ChainedConsumer(final CompletableFuture<?> task, final Procedure<T> action,
+        protected ChainedConsumer(final CompletableFuture<?> task, final Procedure<? super T> action,
                                   final Consumer<Throwable> throwableConsumer)
         {
             this.task = task;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Greatly simplifies retrieving a bunch of elements until a certain condition is met.

### Example

```java
private static CompletableFuture<List<Message>> getMessagesBetween(long startId, long endId, MessageChannel channel) {
    return channel.getIterableHistory()
            .cache(false).skipTo(endId)
            .takeUntilAsync(it -> Long.compareUnsigned(it.getIdLong(), startId) < 0);
}
```