### PR TITLE
Add correct boundaries to api methods in CacheView

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
@@ -129,7 +129,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @see    #acceptStream(Consumer)
      */
-    default <R> R applyStream(Function<Stream<T>, R> action)
+    default <R> R applyStream(Function<? super Stream<T>, ? extends R> action)
     {
         Checks.notNull(action, "Action");
         try (ClosableIterator<T> it = lockedIterator())
@@ -160,7 +160,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @see    #applyStream(Function)
      */
-    default void acceptStream(Consumer<Stream<T>> action)
+    default void acceptStream(Consumer<? super Stream<T>> action)
     {
         Checks.notNull(action, "Action");
         try (ClosableIterator<T> it = lockedIterator())
@@ -301,7 +301,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined CacheView spanning over all provided implementation instances
      */
-    static <E> CacheView<E> all(Supplier<Stream<CacheView<E>>> generator)
+    static <E> CacheView<E> all(Supplier<? extends Stream<? extends CacheView<E>>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl<>(generator);
@@ -331,7 +331,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined ShardCacheView spanning over all provided implementation instances
      */
-    static ShardCacheView allShards(Supplier<Stream<ShardCacheView>> generator)
+    static ShardCacheView allShards(Supplier<? extends Stream<? extends ShardCacheView>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new ShardCacheViewImpl.UnifiedShardCacheViewImpl(generator);
@@ -350,7 +350,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined SnowflakeCacheView spanning over all provided implementation instances
      */
-    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(Collection<SnowflakeCacheView<E>> cacheViews)
+    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(Collection<? extends SnowflakeCacheView<E>> cacheViews)
     {
         Checks.noneNull(cacheViews, "Collection");
         return new UnifiedCacheViewImpl.UnifiedSnowflakeCacheView<>(cacheViews::stream);
@@ -369,7 +369,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined SnowflakeCacheView spanning over all provided implementation instances
      */
-    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(Supplier<Stream<SnowflakeCacheView<E>>> generator)
+    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(Supplier<? extends Stream<? extends SnowflakeCacheView<E>>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl.UnifiedSnowflakeCacheView<>(generator);
@@ -385,7 +385,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined MemberCacheView spanning over all provided instances
      */
-    static UnifiedMemberCacheView allMembers(Collection<MemberCacheView> cacheViews)
+    static UnifiedMemberCacheView allMembers(Collection<? extends MemberCacheView> cacheViews)
     {
         Checks.noneNull(cacheViews, "Collection");
         return new UnifiedCacheViewImpl.UnifiedMemberCacheViewImpl(cacheViews::stream);
@@ -401,7 +401,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined MemberCacheView spanning over all provided instances
      */
-    static UnifiedMemberCacheView allMembers(Supplier<Stream<MemberCacheView>> generator)
+    static UnifiedMemberCacheView allMembers(Supplier<? extends Stream<? extends MemberCacheView>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl.UnifiedMemberCacheViewImpl(generator);

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
@@ -250,9 +250,9 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
 
     public static class UnifiedShardCacheViewImpl implements ShardCacheView
     {
-        protected final Supplier<Stream<ShardCacheView>> generator;
+        protected final Supplier<? extends Stream<? extends ShardCacheView>> generator;
 
-        public UnifiedShardCacheViewImpl(Supplier<Stream<ShardCacheView>> generator)
+        public UnifiedShardCacheViewImpl(Supplier<? extends Stream<? extends ShardCacheView>> generator)
         {
             this.generator = generator;
         }
@@ -288,7 +288,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         @Override
         public ClosableIterator<JDA> lockedIterator()
         {
-            Iterator<ShardCacheView> gen = this.generator.get().iterator();
+            Iterator<? extends ShardCacheView> gen = this.generator.get().iterator();
             return new ChainedClosableIterator<>(gen);
         }
 
@@ -328,7 +328,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
             return stream().iterator();
         }
 
-        protected Stream<ShardCacheView> distinctStream()
+        protected Stream<? extends ShardCacheView> distinctStream()
         {
             return generator.get().distinct();
         }

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -34,9 +34,9 @@ import java.util.stream.Stream;
 
 public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheView<T>
 {
-    protected final Supplier<Stream<E>> generator;
+    protected final Supplier<? extends Stream<? extends E>> generator;
 
-    public UnifiedCacheViewImpl(Supplier<Stream<E>> generator)
+    public UnifiedCacheViewImpl(Supplier<? extends Stream<? extends E>> generator)
     {
         this.generator = generator;
     }
@@ -78,7 +78,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     @Override
     public ClosableIterator<T> lockedIterator()
     {
-        Iterator<E> gen = generator.get().iterator();
+        Iterator<? extends E> gen = generator.get().iterator();
         return new ChainedClosableIterator<>(gen);
     }
 
@@ -109,7 +109,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         return stream().iterator();
     }
 
-    protected Stream<E> distinctStream()
+    protected Stream<? extends E> distinctStream()
     {
         return generator.get().distinct();
     }
@@ -117,7 +117,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     public static class UnifiedSnowflakeCacheView<T extends ISnowflake>
         extends UnifiedCacheViewImpl<T, SnowflakeCacheView<T>> implements SnowflakeCacheView<T>
     {
-        public UnifiedSnowflakeCacheView(Supplier<Stream<SnowflakeCacheView<T>>> generator)
+        public UnifiedSnowflakeCacheView(Supplier<? extends Stream<? extends SnowflakeCacheView<T>>> generator)
         {
             super(generator);
         }
@@ -136,7 +136,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         extends UnifiedCacheViewImpl<Member, MemberCacheView> implements UnifiedMemberCacheView
     {
 
-        public UnifiedMemberCacheViewImpl(Supplier<Stream<MemberCacheView>> generator)
+        public UnifiedMemberCacheViewImpl(Supplier<? extends Stream<? extends MemberCacheView>> generator)
         {
             super(generator);
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds proper boundaries to methods where producers/consumers are desired.
For anyone unfamiliar with the rule on how to apply these properly:

**PECS**: **P**roducer **E**xtends, **C**onsumer **S**uper

### Example

```java
Procedure<Object> contravariant = (x) -> {
    System.out.println(x);
    return true;
};
view.forEachAsync(contravariant);
```