### PR TITLE
Don't catch rejection of worker schedule

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -375,25 +375,18 @@ public class DefaultShardManager implements ShardManager
     {
         if (worker != null)
             return;
-        try
+        worker = executor.submit(() ->
         {
-            worker = executor.submit(() ->
+            while (!queue.isEmpty())
+                processQueue();
+            this.gatewayURL = null;
+            synchronized (queue)
             {
-                while (!queue.isEmpty())
-                    processQueue();
-                this.gatewayURL = null;
-                synchronized (queue)
-                {
-                    worker = null;
-                    if (!shutdown.get() && !queue.isEmpty())
-                        runQueueWorker();
-                }
-            });
-        }
-        catch (RejectedExecutionException ex)
-        {
-            LOG.debug("ThreadPool rejected queue worker thread", ex);
-        }
+                worker = null;
+                if (!shutdown.get() && !queue.isEmpty())
+                    runQueueWorker();
+            }
+        });
     }
 
     protected void processQueue()

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -953,8 +953,11 @@ public interface ShardManager
     /**
      * Restarts all shards, shutting old ones down first.
      * 
-     * As all shards need to connect to discord again this will take equally long as the startup of a new ShardManager
-     * (using the 5000ms + backoff as delay between starting new JDA instances). 
+     * <p>As all shards need to connect to discord again this will take equally long as the startup of a new ShardManager
+     * (using the 5000ms + backoff as delay between starting new JDA instances).
+     *
+     * @throws java.util.concurrent.RejectedExecutionException
+     *         If {@link #shutdown()} has already been invoked
      */
     void restart();
 
@@ -967,6 +970,8 @@ public interface ShardManager
      *
      * @throws java.lang.IllegalArgumentException
      *         If shardId is negative or higher than maxShardId
+     * @throws java.util.concurrent.RejectedExecutionException
+     *         If {@link #shutdown()} has already been invoked
      */
     void restart(int id);
 
@@ -1117,12 +1122,16 @@ public interface ShardManager
     /**
      * Shuts down all JDA shards, closing all their connections.
      * After this method has been called the ShardManager instance can not be used anymore.
+     *
+     * <br>This will shutdown the internal queue worker for (re-)starts of shards.
+     * This means {@link #restart(int)}, {@link #restart()}, and {@link #start(int)} will throw
+     * {@link java.util.concurrent.RejectedExecutionException}.
      */
     void shutdown();
 
     /**
      * Shuts down the shard with the given id only.
-     * <br> This does nothing if there is no shard with the given id.
+     * <br>This does nothing, if there is no shard with the given id.
      *
      * @param shardId
      *        The id of the shard that should be stopped
@@ -1132,9 +1141,11 @@ public interface ShardManager
     /**
      * Adds a new shard with the given id to this ShardManager and starts it.
      *
-     * @param shardId
-     *        The id of the shard that should be started
+     * @param  shardId
+     *         The id of the shard that should be started
+     *
+     * @throws java.util.concurrent.RejectedExecutionException
+     *         If {@link #shutdown()} has already been invoked
      */
     void start(int shardId);
-
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

We should not swallow rejected executions of the startup worker in DefaultShardManager.