### PR TITLE
Add attachment options to apply to files

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -447,7 +447,7 @@ public class EmbedBuilder
      *
      * <p><b>Uploading images with Embeds</b>
      * <br>When uploading an <u>image</u>
-     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File) MessageChannel.sendFile(...)})
+     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel.sendFile(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
      *
      * <p><u>Example</u>
@@ -493,7 +493,7 @@ public class EmbedBuilder
      *
      * <p><b>Uploading images with Embeds</b>
      * <br>When uploading an <u>image</u>
-     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File) MessageChannel.sendFile(...)})
+     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel.sendFile(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
      *
      * <p><u>Example</u>
@@ -517,7 +517,7 @@ public class EmbedBuilder
      *
      * @return the builder after the image has been set
      *
-     * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, String) MessageChannel.sendFile(...)
+     * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, String, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel.sendFile(...)
      */
     @Nonnull
     public EmbedBuilder setImage(@Nullable String url)
@@ -586,7 +586,7 @@ public class EmbedBuilder
      *
      * <p><b>Uploading images with Embeds</b>
      * <br>When uploading an <u>image</u>
-     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File) MessageChannel.sendFile(...)})
+     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel.sendFile(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
      *
      * <p><u>Example</u>
@@ -660,7 +660,7 @@ public class EmbedBuilder
      *
      * <p><b>Uploading images with Embeds</b>
      * <br>When uploading an <u>image</u>
-     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File) MessageChannel.sendFile(...)})
+     * (using {@link net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel.sendFile(...)})
      * you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
      *
      * <p><u>Example</u>

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -98,21 +98,21 @@ public interface Message extends ISnowflake, Formattable
     /**
      * The maximum sendable file size (8 MiB)
      *
-     * @see MessageAction#addFile(java.io.File) MessageAction.addFile(...)
+     * @see MessageAction#addFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageAction.addFile(...)
      */
     int MAX_FILE_SIZE = 8 << 20;
 
     /**
      * The maximum sendable file size for nitro (50 MiB)
      *
-     * @see MessageAction#addFile(java.io.File) MessageAction.addFile(...)
+     * @see MessageAction#addFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageAction.addFile(...)
      */
     int MAX_FILE_SIZE_NITRO = 50 << 20;
 
     /**
      * The maximum amount of files sendable within a single message ({@value})
      *
-     * @see MessageAction#addFile(java.io.File) MessageAction.addFile(...)
+     * @see MessageAction#addFile(java.io.File, net.dv8tion.jda.api.utils.AttachmentOption...) MessageAction.addFile(...)
      */
     int MAX_FILE_AMOUNT = 10;
 

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.MessagePaginationAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction;
+import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
@@ -532,7 +533,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * <br>If you want to send a Message with the uploaded file, you can add the file to the {@link net.dv8tion.jda.api.requests.restaction.MessageAction}
      * returned by {@link #sendMessage(Message)}.
      *
-     * <p>This is a shortcut to {@link #sendFile(java.io.File, String)} by way of using {@link java.io.File#getName()}.
+     * <p>This is a shortcut to {@link #sendFile(java.io.File, String, AttachmentOption...)} by way of using {@link java.io.File#getName()}.
      * <pre>sendFile(file, file.getName())</pre>
      *
      * <p><b>Uploading images with Embeds</b>
@@ -548,10 +549,12 @@ public interface MessageChannel extends ISnowflake, Formattable
      * channel.sendFile(file).embed(embed.build()).queue();
      * </code></pre>
      *
-     * <p>For {@link net.dv8tion.jda.api.requests.ErrorResponse} information, refer to the documentation for {@link #sendFile(java.io.File, String)}.
+     * <p>For {@link net.dv8tion.jda.api.requests.ErrorResponse} information, refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)}.
      *
      * @param  file
      *         The file to upload to the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -576,11 +579,11 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     @Nonnull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull File file)
+    default MessageAction sendFile(@Nonnull File file, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(file, "file");
 
-        return sendFile(file, file.getName());
+        return sendFile(file, file.getName(), options);
     }
 
     /**
@@ -640,6 +643,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         The file to upload to the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
      * @param  fileName
      *         The name that should be sent to discord
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -664,7 +669,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     @Nonnull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull File file, @Nonnull String fileName)
+    default MessageAction sendFile(@Nonnull File file, @Nonnull String fileName, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(file, "file");
         Checks.check(file.exists() && file.canRead(),
@@ -675,7 +680,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
         try
         {
-            return sendFile(new FileInputStream(file), fileName);
+            return sendFile(new FileInputStream(file), fileName, options);
         }
         catch (FileNotFoundException ex)
         {
@@ -690,8 +695,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      * returned by {@link #sendMessage(Message)}.
      * <br>This allows you to send an {@link java.io.InputStream InputStream} as substitute to a file.
      *
-     * <p>For information about the {@code fileName} parameter, Refer to the documentation for {@link #sendFile(java.io.File, String)}.
-     * <br>For {@link net.dv8tion.jda.api.requests.ErrorResponse} information, refer to the documentation for {@link #sendFile(java.io.File, String)}.
+     * <p>For information about the {@code fileName} parameter, Refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)}.
+     * <br>For {@link net.dv8tion.jda.api.requests.ErrorResponse} information, refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)}.
      *
      * <p><b>Uploading images with Embeds</b>
      * <br>When uploading an <u>image</u> you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
@@ -710,7 +715,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         The InputStream data to upload to the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
      * @param  fileName
      *         The name that should be sent to discord
-     *         <br>Refer to the documentation for {@link #sendFile(java.io.File, String)} for information about this parameter.
+     *         <br>Refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)} for information about this parameter.
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalArgumentException
      *         If the provided file or filename is {@code null} or {@code empty}.
@@ -730,13 +737,13 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     @Nonnull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName)
+    default MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(data, "data InputStream");
         Checks.notNull(fileName, "fileName");
 
         Route.CompiledRoute route = Route.Messages.SEND_MESSAGE.compile(getId());
-        return new MessageActionImpl(getJDA(), route, this).addFile(data, fileName);
+        return new MessageActionImpl(getJDA(), route, this).addFile(data, fileName, options);
     }
 
     /**
@@ -746,8 +753,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      * returned by {@link #sendMessage(Message)}.
      * <br>This allows you to send an {@code byte[]} as substitute to a file.
      *
-     * <p>For information about the {@code fileName} parameter, Refer to the documentation for {@link #sendFile(java.io.File, String)}.
-     * <br>For {@link net.dv8tion.jda.api.requests.ErrorResponse} information, refer to the documentation for {@link #sendFile(java.io.File, String)}.
+     * <p>For information about the {@code fileName} parameter, Refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)}.
+     * <br>For {@link net.dv8tion.jda.api.requests.ErrorResponse} information, refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)}.
      *
      * <p><b>Uploading images with Embeds</b>
      * <br>When uploading an <u>image</u> you can reference said image using the specified filename as URI {@code attachment://filename.ext}.
@@ -766,7 +773,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         The {@code byte[]} data to upload to the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
      * @param  fileName
      *         The name that should be sent to discord.
-     *         <br>Refer to the documentation for {@link #sendFile(java.io.File, String)} for information about this parameter.
+     *         <br>Refer to the documentation for {@link #sendFile(java.io.File, String, AttachmentOption...)} for information about this parameter.
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -789,13 +798,13 @@ public interface MessageChannel extends ISnowflake, Formattable
      */
     @Nonnull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName)
+    default MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(data, "data");
         Checks.notNull(fileName, "fileName");
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
         Checks.check(data.length <= maxSize, "File is too big! Max file-size is %d bytes", maxSize);
-        return sendFile(new ByteArrayInputStream(data), fileName);
+        return sendFile(new ByteArrayInputStream(data), fileName, options);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -75,10 +75,10 @@ import java.util.function.Consumer;
  * @see    net.dv8tion.jda.api.entities.MessageChannel#sendMessage(CharSequence)
  * @see    net.dv8tion.jda.api.entities.MessageChannel#sendMessage(MessageEmbed)
  * @see    net.dv8tion.jda.api.entities.MessageChannel#sendMessageFormat(String, Object...)
- * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(File)
- * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, String)
- * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(InputStream, String)
- * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(byte[], String)
+ * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, AttachmentOption...)
+ * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(File, String, AttachmentOption...)
+ * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(InputStream, String, AttachmentOption...)
+ * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(byte[], String, AttachmentOption...)
  */
 public interface MessageAction extends RestAction<Message>, Appendable
 {

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -304,7 +305,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @return Updated MessageAction for chaining convenience
      */
     @CheckReturnValue
-    MessageAction addFile(final InputStream data, final String name, AttachmentOption... options);
+    MessageAction addFile(@Nonnull final InputStream data, @Nonnull final String name, @Nonnull AttachmentOption... options);
 
     /**
      * Adds the provided byte[] as file data.
@@ -335,7 +336,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
     @CheckReturnValue
-    default MessageAction addFile(final byte[] data, final String name, AttachmentOption... options)
+    default MessageAction addFile(@Nonnull final byte[] data, @Nonnull final String name, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(data, "Data");
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
@@ -366,7 +367,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
     @CheckReturnValue
-    default MessageAction addFile(final File file, AttachmentOption... options)
+    default MessageAction addFile(@Nonnull final File file, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(file, "File");
         return addFile(file, file.getName(), options);
@@ -403,7 +404,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
     @CheckReturnValue
-    MessageAction addFile(final File file, final String name, AttachmentOption... options);
+    MessageAction addFile(@Nonnull final File file, @Nonnull final String name, @Nonnull AttachmentOption... options);
 
     /**
      * Clears all previously added files

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.CheckReturnValue;
@@ -288,6 +289,8 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *         The file name that should be used to interpret the type of the given data
      *         using the file-name extension. This name is similar to what will be visible
      *         through {@link net.dv8tion.jda.api.entities.Message.Attachment#getFileName() Message.Attachment.getFileName()}
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalStateException
      *         If the file limit of {@value Message#MAX_FILE_AMOUNT} has been reached prior to calling this method,
@@ -301,7 +304,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @return Updated MessageAction for chaining convenience
      */
     @CheckReturnValue
-    MessageAction addFile(final InputStream data, final String name);
+    MessageAction addFile(final InputStream data, final String name, AttachmentOption... options);
 
     /**
      * Adds the provided byte[] as file data.
@@ -314,6 +317,8 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *         The file name that should be used to interpret the type of the given data
      *         using the file-name extension. This name is similar to what will be visible
      *         through {@link net.dv8tion.jda.api.entities.Message.Attachment#getFileName() Message.Attachment.getFileName()}
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalStateException
      *         If the file limit of {@value Message#MAX_FILE_AMOUNT} has been reached prior to calling this method,
@@ -330,20 +335,22 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
     @CheckReturnValue
-    default MessageAction addFile(final byte[] data, final String name)
+    default MessageAction addFile(final byte[] data, final String name, AttachmentOption... options)
     {
         Checks.notNull(data, "Data");
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
         Checks.check(data.length <= maxSize, "File may not exceed the maximum file length of %d bytes!", maxSize);
-        return addFile(new ByteArrayInputStream(data), name);
+        return addFile(new ByteArrayInputStream(data), name, options);
     }
 
     /**
      * Adds the provided {@link java.io.File File} as file data.
-     * <br>Shortcut for {@link #addFile(java.io.File, String) addFile(file, file.getName())} with the same side-effects.
+     * <br>Shortcut for {@link #addFile(java.io.File, String, net.dv8tion.jda.api.utils.AttachmentOption...) addFile(file, file.getName())} with the same side-effects.
      *
      * @param  file
      *         The File that will be interpreted as file data
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalStateException
      *         If the file limit of {@value Message#MAX_FILE_AMOUNT} has been reached prior to calling this method,
@@ -359,13 +366,13 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
     @CheckReturnValue
-    default MessageAction addFile(final File file)
+    default MessageAction addFile(final File file, AttachmentOption... options)
     {
         Checks.notNull(file, "File");
-        return addFile(file, file.getName());
+        return addFile(file, file.getName(), options);
     }
 
-    /**
+        /**
      * Adds the provided {@link java.io.File File} as file data.
      *
      * <p>To reset all files use {@link #clearFiles()}
@@ -377,6 +384,8 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *         The file name that should be used to interpret the type of the given data
      *         using the file-name extension. This name is similar to what will be visible
      *         through {@link net.dv8tion.jda.api.entities.Message.Attachment#getFileName() Message.Attachment.getFileName()}
+     * @param  options
+     *         Possible options to apply to this attachment, such as marking it as spoiler image
      *
      * @throws java.lang.IllegalStateException
      *         If the file limit of {@value Message#MAX_FILE_AMOUNT} has been reached prior to calling this method,
@@ -394,12 +403,12 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
     @CheckReturnValue
-    MessageAction addFile(final File file, final String name);
+    MessageAction addFile(final File file, final String name, AttachmentOption... options);
 
     /**
      * Clears all previously added files
-     * <br>And closes {@code FileInputStreams} generated by {@link #addFile(File, String)}.
-     * <br>To close all stream (including ones given by {@link #addFile(InputStream, String)}) use {@link #clearFiles(Consumer)}.
+     * <br>And closes {@code FileInputStreams} generated by {@link #addFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...)}.
+     * <br>To close all stream (including ones given by {@link #addFile(InputStream, String, net.dv8tion.jda.api.utils.AttachmentOption...)}) use {@link #clearFiles(Consumer)}.
      *
      * @return Updated MessageAction for chaining convenience
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -372,7 +372,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
         return addFile(file, file.getName(), options);
     }
 
-        /**
+    /**
      * Adds the provided {@link java.io.File File} as file data.
      *
      * <p>To reset all files use {@link #clearFiles()}

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentOption.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentOption.java
@@ -16,7 +16,11 @@
 
 package net.dv8tion.jda.api.utils;
 
+/**
+ * Options that can be applied to attachments in {@link net.dv8tion.jda.api.requests.restaction.MessageAction}.
+ */
 public enum AttachmentOption
 {
+    /** Marks an image attachment as a spoiler by prefixing the name with {@code SPOILER_} */
     SPOILER
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentOption.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentOption.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils;
+
+public enum AttachmentOption
+{
+    SPOILER
+}

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.cache.UpstreamReference;
@@ -147,10 +148,10 @@ public class PrivateChannelImpl implements PrivateChannel
 
     @Nonnull
     @Override
-    public MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName)
+    public MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
     {
         checkBot();
-        return PrivateChannel.super.sendFile(data, fileName);
+        return PrivateChannel.super.sendFile(data, fileName, options);
     }
 
     public PrivateChannelImpl setFake(boolean fake)

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.api.requests.restaction.WebhookAction;
+import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.internal.JDAImpl;
@@ -352,7 +353,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
 
     @Nonnull
     @Override
-    public MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName)
+    public MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
     {
         checkVerification();
         checkPermission(Permission.MESSAGE_READ);
@@ -360,7 +361,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         checkPermission(Permission.MESSAGE_ATTACH_FILES);
 
         //Call MessageChannel's default method
-        return TextChannel.super.sendFile(data, fileName);
+        return TextChannel.super.sendFile(data, fileName, options);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -37,6 +37,7 @@ import okhttp3.RequestBody;
 import org.json.JSONObject;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -182,12 +183,12 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
 
     @Override
     @CheckReturnValue
-    public MessageActionImpl addFile(final InputStream data, String name, AttachmentOption... options)
+    public MessageActionImpl addFile(@Nonnull final InputStream data, @Nonnull String name, @Nonnull AttachmentOption... options)
     {
         checkEdit();
         Checks.notNull(data, "Data");
         Checks.notBlank(name, "Name");
-        Checks.notNull(options, "Options");
+        Checks.noneNull(options, "Options");
         checkFileAmount();
         checkPermission(Permission.MESSAGE_ATTACH_FILES);
         name = applyOptions(name, options);
@@ -197,10 +198,10 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
 
     @Override
     @CheckReturnValue
-    public MessageActionImpl addFile(final File file, String name, AttachmentOption... options)
+    public MessageActionImpl addFile(@Nonnull final File file, @Nonnull String name, @Nonnull AttachmentOption... options)
     {
         Checks.notNull(file, "File");
-        Checks.notNull(options, "Options");
+        Checks.noneNull(options, "Options");
         Checks.check(file.exists() && file.canRead(), "Provided file either does not exist or cannot be read from!");
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
         Checks.check(file.length() <= maxSize, "File may not exceed the maximum file length of %d bytes!", maxSize);
@@ -265,15 +266,12 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
 
     private String applyOptions(String name, AttachmentOption[] options)
     {
-        if (options.length > 0)
+        for (AttachmentOption opt : options)
         {
-            for (AttachmentOption opt : options)
+            if (opt == AttachmentOption.SPOILER)
             {
-                if (opt == AttachmentOption.SPOILER)
-                {
-                    name = "SPOILER_" + name;
-                    break;
-                }
+                name = "SPOILER_" + name;
+                break;
             }
         }
         return name;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds options to `addFile` overloads allowing to specify how the attachments should be used.
Currently the only option is `SPOILER` which marks the attachment as a spoiler. This is best for maintainability in the future, compared to simply adding a boolean flag.

### Example

```java
channel.sendMessage("SPOILER FOR XYZ:")
    .addFile(image, AttachmentOption.SPOILER)
    .queue();
```