### PR TITLE
Ensure the ChainedClosableIterator does not produce duplicates

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/utils/ChainedClosableIterator.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/ChainedClosableIterator.java
@@ -20,18 +20,29 @@ import net.dv8tion.jda.api.utils.ClosableIterator;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import org.slf4j.Logger;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Set;
 
 public class ChainedClosableIterator<T> implements ClosableIterator<T>
 {
     private final static Logger log = JDALogger.getLog(ClosableIterator.class);
+    private final Set<T> items;
     private final Iterator<? extends CacheView<T>> generator;
     private ClosableIterator<T> currentIterator;
 
+    private T item;
+
     public ChainedClosableIterator(Iterator<? extends CacheView<T>> generator)
     {
+        this.items = new HashSet<>();
         this.generator = generator;
+    }
+
+    public Set<T> getItems()
+    {
+        return items;
     }
 
     @Override
@@ -45,12 +56,30 @@ public class ChainedClosableIterator<T> implements ClosableIterator<T>
     @Override
     public boolean hasNext()
     {
-        if (currentIterator != null && !currentIterator.hasNext())
+        if (item != null)
+            return true;
+        // get next item from current iterator if exists
+        if (currentIterator != null)
         {
-            currentIterator.close();
-            currentIterator = null;
+            if (!currentIterator.hasNext())
+            {
+                currentIterator.close();
+                currentIterator = null;
+            }
+            else
+            {
+                if (findNext()) return true;
+                currentIterator.close();
+                currentIterator = null;
+            }
         }
-        if (currentIterator == null)
+        // get next iterator in chain
+        return processChain();
+    }
+
+    private boolean processChain()
+    {
+        while (item == null)
         {
             CacheView<T> view = null;
             while (generator.hasNext())
@@ -62,9 +91,26 @@ public class ChainedClosableIterator<T> implements ClosableIterator<T>
             }
             if (view == null)
                 return false;
+
+            // find next item in this iterator
             currentIterator = view.lockedIterator();
+            if (findNext()) break;
         }
         return true;
+    }
+
+    private boolean findNext()
+    {
+        while (currentIterator.hasNext())
+        {
+            T next = currentIterator.next();
+            if (items.contains(next))
+                continue;
+            item = next;
+            items.add(item); // avoid duplicates
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -72,7 +118,9 @@ public class ChainedClosableIterator<T> implements ClosableIterator<T>
     {
         if (!hasNext())
             throw new NoSuchElementException();
-        return currentIterator.next();
+        T tmp = item;
+        item = null;
+        return tmp;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -67,16 +67,17 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     @Override
     public Set<T> asSet()
     {
-        try (ClosableIterator<T> it = lockedIterator())
+        try (ChainedClosableIterator<T> it = lockedIterator())
         {
-            Set<T> set = new HashSet<>();
-            it.forEachRemaining(set::add);
-            return Collections.unmodifiableSet(set);
+            //because the iterator needs to retain elements to avoid duplicates,
+            // we can use the resulting HashSet as our return value!
+            while (it.hasNext()) it.next();
+            return it.getItems();
         }
     }
 
     @Override
-    public ClosableIterator<T> lockedIterator()
+    public ChainedClosableIterator<T> lockedIterator()
     {
         Iterator<? extends E> gen = generator.get().iterator();
         return new ChainedClosableIterator<>(gen);
@@ -87,19 +88,20 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     {
         return Collections.unmodifiableList(distinctStream()
                 .flatMap(view -> view.getElementsByName(name, ignoreCase).stream())
+                .distinct()
                 .collect(Collectors.toList()));
     }
 
     @Override
     public Stream<T> stream()
     {
-        return generator.get().flatMap(CacheView::stream).distinct();
+        return distinctStream().flatMap(CacheView::stream).distinct();
     }
 
     @Override
     public Stream<T> parallelStream()
     {
-        return generator.get().flatMap(CacheView::parallelStream).distinct();
+        return distinctStream().flatMap(CacheView::parallelStream).distinct();
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -68,7 +68,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     @Override
     public List<T> asList()
     {
-        List<T> list = new ArrayList<>();
+        List<T> list = new LinkedList<>();
         forEach(list::add);
         return Collections.unmodifiableList(list);
     }
@@ -81,7 +81,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
             //because the iterator needs to retain elements to avoid duplicates,
             // we can use the resulting HashSet as our return value!
             while (it.hasNext()) it.next();
-            return it.getItems();
+            return Collections.unmodifiableSet(it.getItems());
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.internal.utils.ChainedClosableIterator;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -54,14 +55,22 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
     }
 
     @Override
-    public List<T> asList()
+    public void forEach(Consumer<? super T> action)
     {
+        Objects.requireNonNull(action);
         try (ClosableIterator<T> it = lockedIterator())
         {
-            List<T> list = new ArrayList<>();
-            it.forEachRemaining(list::add);
-            return Collections.unmodifiableList(list);
+            while (it.hasNext())
+                action.accept(it.next());
         }
+    }
+
+    @Override
+    public List<T> asList()
+    {
+        List<T> list = new ArrayList<>();
+        forEach(list::add);
+        return Collections.unmodifiableList(list);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Lists produced by this iterator had duplicates due to the fact it did not check for elements appearing again. This is problematic when using something like `ShardManager#getUsers()`.

This has been resolved by adding a `HashSet` to de-duplicate the iterated elements, adding more complexity to the iterator but allowing the resulting iteration to be duplicate-free. Luckily we can re-use the internal `Set` used for de-duplication again in `CacheView#asSet`.

This only affected `UnifiedCacheView` implementations and is a regression from an earlier change in v4. Since v3 did not receive the same change it is still unaffected.