### PR TITLE
Add links to external references in javadoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -182,7 +182,19 @@ javadoc.apply {
     isFailOnError = false
     options.memberLevel = JavadocMemberLevel.PUBLIC
     options.encoding = "UTF-8"
-    options.optionFiles = mutableListOf(file("javadoc-options.txt"))
+
+    if (options is StandardJavadocDocletOptions) {
+        val opt = options as StandardJavadocDocletOptions
+        opt.author()
+        opt.tags("incubating:a:Incubating:")
+        opt.links(
+            "https://docs.oracle.com/javase/8/docs/api/",
+            "https://takahikokawasaki.github.io/nv-websocket-client/",
+            "https://square.github.io/okhttp/3.x/okhttp/")
+        if (JavaVersion.current().isJava9Compatible) {
+            opt.addBooleanOption("html5", true)
+        }
+    }
 
     //### excludes ###
 

--- a/javadoc-options.txt
+++ b/javadoc-options.txt
@@ -1,3 +1,6 @@
 -author
 -html5
 -tag incubating:a:Incubating:
+-link https://docs.oracle.com/javase/8/docs/api/
+-link https://takahikokawasaki.github.io/nv-websocket-client/
+-link https://square.github.io/okhttp/3.x/okhttp/

--- a/javadoc-options.txt
+++ b/javadoc-options.txt
@@ -1,6 +1,0 @@
--author
--html5
--tag incubating:a:Incubating:
--link https://docs.oracle.com/javase/8/docs/api/
--link https://takahikokawasaki.github.io/nv-websocket-client/
--link https://square.github.io/okhttp/3.x/okhttp/


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

With these options the javadoc will properly link to external references such as JDK or OkHTTP docs.

![image](https://user-images.githubusercontent.com/18090140/52406342-c5ff0e80-2acd-11e9-90ae-8d51b14155bf.png)
