### PR TITLE
Use ByteBuffer for sending audio

### DIFF
--- a/src/examples/java/AudioEchoExample.java
+++ b/src/examples/java/AudioEchoExample.java
@@ -212,10 +212,10 @@ public class AudioEchoExample extends ListenerAdapter
         @Override
         public void handleCombinedAudio(CombinedAudio combinedAudio)
         {
+            // we only want to send data when a user actually sent something, otherwise we would just send silence
             if (combinedAudio.getUsers().isEmpty())
                 return;
 
-            // we only want to send data when a user actually sent something, otherwise we just send silence
             byte[] data = combinedAudio.getAudioData(1.0f); // volume at 100% = 1.0 (50% = 0.5 / 55% = 0.55)
             queue.add(data);
         }

--- a/src/examples/java/AudioEchoExample.java
+++ b/src/examples/java/AudioEchoExample.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.audio.AudioReceiveHandler;
+import net.dv8tion.jda.api.audio.AudioSendHandler;
+import net.dv8tion.jda.api.audio.CombinedAudio;
+import net.dv8tion.jda.api.audio.UserAudio;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.managers.AudioManager;
+
+import javax.security.auth.login.LoginException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class AudioEchoExample extends ListenerAdapter
+{
+    public static void main(String[] args) throws LoginException
+    {
+        if (args.length == 0)
+        {
+            System.err.println("Unable to start without token!");
+            System.exit(1);
+        }
+        String token = args[0];
+
+        new JDABuilder(token)                            // Use provided token from command line arguments
+             .addEventListeners(new AudioEchoExample())  // Start listening with this listener
+             .setActivity(Activity.listening("to jams")) // Inform users that we are jammin' it out
+             .setStatus(OnlineStatus.DO_NOT_DISTURB)     // Please don't disturb us while we're jammin'
+             .build();                                   // Login with these options
+        // Note that its not needed to explicitly enable audio here
+    }
+
+    @Override
+    public void onGuildMessageReceived(GuildMessageReceivedEvent event)
+    {
+        Message message = event.getMessage();
+        User author = message.getAuthor();
+        String content = message.getContentRaw();
+        Guild guild = event.getGuild();
+
+        // Ignore message if bot
+        if (author.isBot())
+            return;
+
+        if (content.startsWith("!echo "))
+        {
+            String arg = content.substring("!echo ".length());
+            onEchoCommand(event, guild, arg);
+        }
+        else if (content.equals("!echo"))
+        {
+            onEchoCommand(event);
+        }
+    }
+
+    /**
+     * Handle command without arguments.
+     *
+     * @param event
+     *        The event for this command
+     */
+    private void onEchoCommand(GuildMessageReceivedEvent event)
+    {
+        Member member = event.getMember();                              // Member is the context of the user for the specific guild, containing voice state and roles
+        GuildVoiceState voiceState = member.getVoiceState();            // Check the current voice state of the user
+        VoiceChannel channel = voiceState.getChannel();                 // Use the channel the user is currently connected to
+        if (channel != null)
+        {
+            connectTo(channel);                                         // Join the channel of the user
+            onConnecting(channel, event.getChannel());                  // Tell the user about our success
+        }
+        else
+        {
+            onUnknownChannel(event.getChannel(), "your voice channel"); // Tell the user about our failure
+        }
+    }
+
+    /**
+     * Handle command with arguments.
+     *
+     * @param event
+     *        The event for this command
+     * @param guild
+     *        The guild where its happening
+     * @param arg
+     *        The input argument
+     */
+    private void onEchoCommand(GuildMessageReceivedEvent event, Guild guild, String arg)
+    {
+        boolean isNumber = arg.matches("\\d+"); // This is a regular expression that ensures the input consists of digits
+        VoiceChannel channel = null;
+        if (isNumber)                           // The input is an id?
+        {
+            channel = guild.getVoiceChannelById(arg);
+        }
+        if (channel == null)                    // Then the input must be a name?
+        {
+            List<VoiceChannel> channels = guild.getVoiceChannelsByName(arg, true);
+            if (!channels.isEmpty())            // Make sure we found at least one exact match
+                channel = channels.get(0);      // We found a channel! This cannot be null.
+        }
+
+        TextChannel textChannel = event.getChannel();
+        if (channel == null)                    // I have no idea what you want mr user
+        {
+            onUnknownChannel(textChannel, arg); // Let the user know about our failure
+            return;
+        }
+        connectTo(channel);                     // We found a channel to connect to!
+        onConnecting(channel, textChannel);     // Let the user know, we were successful!
+    }
+
+    /**
+     * Inform user about successful connection.
+     *
+     * @param channel
+     *        The voice channel we connected to
+     * @param textChannel
+     *        The text channel to send the message in
+     */
+    private void onConnecting(VoiceChannel channel, TextChannel textChannel)
+    {
+        textChannel.sendMessage("Connecting to " + channel.getName()).queue(); // never forget to queue()!
+    }
+
+    /**
+     * The channel to connect to is not known to us.
+     *
+     * @param channel
+     *        The message channel (text channel abstraction) to send failure information to
+     * @param comment
+     *        The information of this channel
+     */
+    private void onUnknownChannel(MessageChannel channel, String comment)
+    {
+        channel.sendMessage("Unable to connect to ``" + comment + "``, no such channel!").queue(); // never forget to queue()!
+    }
+
+    /**
+     * Connect to requested channel and start echo handler
+     *
+     * @param channel
+     *        The channel to connect to
+     */
+    private void connectTo(VoiceChannel channel)
+    {
+        Guild guild = channel.getGuild();
+        // Get an audio manager for this guild, this will be created upon first use for each guild
+        AudioManager audioManager = guild.getAudioManager();
+        // Create our Send/Receive handler for the audio connection
+        EchoHandler handler = new EchoHandler();
+
+        // The order of the following instructions does not matter!
+
+        // Set the sending handler to our echo system
+        audioManager.setSendingHandler(handler);
+        // Set the receiving handler to the same echo system, otherwise we can't echo anything
+        audioManager.setReceivingHandler(handler);
+        // Connect to the voice channel
+        audioManager.openAudioConnection(channel);
+    }
+
+    public static class EchoHandler implements AudioSendHandler, AudioReceiveHandler
+    {
+        /*
+            All methods in this class are called by JDA threads when resources are available/ready for processing.
+
+            The receiver will be provided with the latest 20ms of PCM stereo audio
+            Note you can receive even while setting yourself to deafened!
+
+            The sender will provide 20ms of PCM stereo audio (pass-through) once requested by JDA
+            When audio is provided JDA will automatically set the bot to speaking!
+         */
+        private final Queue<byte[]> queue = new ConcurrentLinkedQueue<>();
+
+        /* Receive Handling */
+
+        @Override // combine multiple user audio-streams into a single one
+        public boolean canReceiveCombined()
+        {
+            // limit queue to 10 entries, if that is exceeded we can not receive more until the send system catches up
+            return queue.size() < 10;
+        }
+
+        @Override // give audio separately for each user that is speaking
+        public boolean canReceiveUser()
+        {
+            // this is not useful if we want to echo the audio of the voice channel, thus disabled for this purpose
+            return false;
+        }
+
+        @Override
+        public void handleCombinedAudio(CombinedAudio combinedAudio)
+        {
+            if (combinedAudio.getUsers().isEmpty())
+                return;
+
+            // we only want to send data when a user actually sent something, otherwise we just send silence
+            byte[] data = combinedAudio.getAudioData(1.0f); // volume at 100% = 1.0 (50% = 0.5 / 55% = 0.55)
+            queue.add(data);
+        }
+
+        @Override
+        public void handleUserAudio(UserAudio userAudio) {} // per-user is not helpful in an echo system
+
+        /* Send Handling */
+
+        @Override
+        public boolean canProvide()
+        {
+            // If we have something in our buffer we can provide it to the send system
+            return !queue.isEmpty();
+        }
+
+        @Override
+        public ByteBuffer provide20MsAudio()
+        {
+            // use what we have in our buffer to send audio as PCM
+            byte[] data = queue.poll();
+            return data == null ? null : ByteBuffer.wrap(data); // Wrap this in a java.nio.ByteBuffer
+        }
+
+        @Override
+        public boolean isOpus()
+        {
+            // since we send audio that is received from discord we don't have opus but PCM
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/audio/AudioSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/AudioSendHandler.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.audio;
 
 import javax.sound.sampled.AudioFormat;
+import java.nio.ByteBuffer;
 
 /**
  * Interface used to send audio to Discord through JDA.
@@ -40,7 +41,7 @@ public interface AudioSendHandler
 
     /**
      * If {@link #canProvide()} returns true JDA will call this method in an attempt to retrieve audio data from the
-     * handler. This method need to provide 20 Milliseconds of audio data as a byte array.
+     * handler. This method need to provide 20 Milliseconds of audio data as a <b>heap buffer</b>.
      * <p>
      * Considering this system needs to be low-latency / high-speed, it is recommended that the loading of audio data
      * be done before hand or in parallel and not loaded from disk when this method is called by JDA. Attempting to load
@@ -50,9 +51,9 @@ public interface AudioSendHandler
      * <br>Defined by: {@link net.dv8tion.jda.api.audio.AudioSendHandler#INPUT_FORMAT AudioSendHandler.INPUT_FORMAT}.
      * <br>If {@link #isOpus()} is set to return true, then it should be in pre-encoded Opus format instead.
      *
-     * @return Should return a byte[] containing 20 Milliseconds of audio.
+     * @return Should return a {@link java.nio.ByteBuffer} containing 20 Milliseconds of audio.
      */
-    byte[] provide20MsAudio();
+    ByteBuffer provide20MsAudio();
 
     /**
      * If this method returns true JDA will treat the audio data provided by {@link #provide20MsAudio()} as a pre-encoded

--- a/src/main/java/net/dv8tion/jda/api/audio/AudioSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/AudioSendHandler.java
@@ -41,7 +41,8 @@ public interface AudioSendHandler
 
     /**
      * If {@link #canProvide()} returns true JDA will call this method in an attempt to retrieve audio data from the
-     * handler. This method need to provide 20 Milliseconds of audio data as a <b>heap buffer</b>.
+     * handler. This method need to provide 20 Milliseconds of audio data as a <b>array-backed</b> {@link java.nio.ByteBuffer}.
+     * Use either {@link java.nio.ByteBuffer#allocate(int)} or {@link java.nio.ByteBuffer#wrap(byte[])}.
      * <p>
      * Considering this system needs to be low-latency / high-speed, it is recommended that the loading of audio data
      * be done before hand or in parallel and not loaded from disk when this method is called by JDA. Attempting to load
@@ -52,6 +53,11 @@ public interface AudioSendHandler
      * <br>If {@link #isOpus()} is set to return true, then it should be in pre-encoded Opus format instead.
      *
      * @return Should return a {@link java.nio.ByteBuffer} containing 20 Milliseconds of audio.
+     *
+     * @see    #isOpus()
+     * @see    #canProvide()
+     * @see    java.nio.ByteBuffer#allocate(int)
+     * @see    java.nio.ByteBuffer#wrap(byte[])
      */
     ByteBuffer provide20MsAudio();
 

--- a/src/main/java/net/dv8tion/jda/api/audio/factory/IPacketProvider.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/factory/IPacketProvider.java
@@ -74,6 +74,9 @@ public interface IPacketProvider
      * encrypted, and as such is completely ready to be sent to Discord. The {@code changeTalking} parameter is used
      * to control whether or not the talking indicator should be changed if the
      * {@link net.dv8tion.jda.api.audio.AudioSendHandler AudioSendHandler} cannot provide an audio packet.
+     * <br>The {@link java.nio.ByteBuffer#position()} will be positioned on the start of the packet to send
+     * and the {@link java.nio.ByteBuffer#limit()} at the end of it. Use {@link java.nio.ByteBuffer#remaining()}
+     * to check the length of the packet.
      *
      * <p>Use case for this parameter would be front-loading or queuing many audio packets ahead of send time, and if the AudioSendHandler
      * did not have enough to fill the entire queue, you would have {@code changeTalking} set to {@code false} until the queue

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -747,8 +747,8 @@ public class AudioConnection
         {
             byte[] data = b.array();
             int offset = b.arrayOffset();
-            int position = b.position();
-            return new DatagramPacket(data, offset, position - offset, webSocket.getAddress());
+            int length = b.remaining();
+            return new DatagramPacket(data, offset, length, webSocket.getAddress());
         }
 
         private ByteBuffer getPacketData(ByteBuffer rawAudio)

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -662,7 +662,7 @@ public class AudioConnection
                 {
                     silenceCounter = -1;
                     ByteBuffer rawAudio = sendHandler.provide20MsAudio();
-                    if (rawAudio == null || rawAudio.remaining() == 0)
+                    if (rawAudio == null || !rawAudio.hasRemaining() || !rawAudio.hasArray()) // no array = cannot encrypt
                     {
                         if (speaking && changeTalking)
                             setSpeaking(0);

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -667,7 +667,12 @@ public class AudioConnection
                 {
                     silenceCounter = -1;
                     ByteBuffer rawAudio = sendHandler.provide20MsAudio();
-                    if (rawAudio == null || !rawAudio.hasRemaining() || !rawAudio.hasArray()) // no array = cannot encrypt
+                    if (rawAudio != null && !rawAudio.hasArray())
+                    {
+                        // we can't use the boxer without an array so encryption would not work
+                        LOG.error("AudioSendHandler provided ByteBuffer without a backing array! This is unsupported.");
+                    }
+                    if (rawAudio == null || !rawAudio.hasRemaining() || !rawAudio.hasArray())
                     {
                         if (speaking && changeTalking)
                             setSpeaking(0);

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -564,7 +564,7 @@ public class AudioConnection
     {
         ShortBuffer nonEncodedBuffer = ShortBuffer.allocate(rawAudio.remaining() / 2);
         ByteBuffer encoded = ByteBuffer.allocate(4096);
-        for (int i = rawAudio.arrayOffset(); i < rawAudio.limit(); i += 2)
+        for (int i = rawAudio.position(); i < rawAudio.limit(); i += 2)
         {
             int firstByte =  (0x000000FF & rawAudio.get(i));      //Promotes to int and handles the fact that it was unsigned.
             int secondByte = (0x000000FF & rawAudio.get(i + 1));
@@ -746,7 +746,7 @@ public class AudioConnection
         private DatagramPacket getDatagramPacket(ByteBuffer b)
         {
             byte[] data = b.array();
-            int offset = b.arrayOffset();
+            int offset = b.arrayOffset() + b.position();
             int length = b.remaining();
             return new DatagramPacket(data, offset, length, webSocket.getAddress());
         }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
@@ -176,7 +176,11 @@ public class AudioPacket
             extendedNonce = getNoncePadded();
 
         //Create our SecretBox encoder with the secretKey provided by Discord.
-        byte[] encryptedAudio = boxer.box(encodedAudio.array(), encodedAudio.arrayOffset(), encodedAudio.remaining(), extendedNonce);
+        byte[] array = encodedAudio.array();
+        int offset = encodedAudio.arrayOffset() + encodedAudio.position();
+        int length = encodedAudio.remaining();
+        byte[] encryptedAudio = boxer.box(array, offset, length, extendedNonce);
+
         ((Buffer) buffer).clear();
         int capacity = RTP_HEADER_BYTE_LENGTH + encryptedAudio.length + nlen;
         if (capacity > buffer.remaining())
@@ -218,7 +222,7 @@ public class AudioPacket
 
         ByteBuffer encodedAudio = encryptedPacket.encodedAudio;
         int length = encodedAudio.remaining();
-        int offset = encodedAudio.arrayOffset();
+        int offset = encodedAudio.arrayOffset() + encodedAudio.position();
         switch (encryption)
         {
             case XSALSA20_POLY1305:

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
@@ -93,7 +93,7 @@ public class AudioPacket
 
         this.encodedAudio = ByteBuffer.allocate(data.length - offset);
         this.encodedAudio.put(data, offset, encodedAudio.capacity());
-        this.encodedAudio.flip();
+        ((Buffer) this.encodedAudio).flip();
     }
 
     public AudioPacket(ByteBuffer buffer, char seq, int timestamp, int ssrc, ByteBuffer encodedAudio)
@@ -166,7 +166,7 @@ public class AudioPacket
         return timestamp;
     }
 
-    public ByteBuffer asEncryptedPacket(ByteBuffer buffer, byte[] secretKey, byte[] nonce, int nlen)
+    public ByteBuffer asEncryptedPacket(TweetNaclFast.SecretBox boxer, ByteBuffer buffer, byte[] nonce, int nlen)
     {
         //Xsalsa20's Nonce is 24 bytes long, however RTP (and consequently Discord)'s nonce is a different length
         // so we need to create a 24 byte array, and copy the nonce into it.
@@ -176,7 +176,6 @@ public class AudioPacket
             extendedNonce = getNoncePadded();
 
         //Create our SecretBox encoder with the secretKey provided by Discord.
-        TweetNaclFast.SecretBox boxer = new TweetNaclFast.SecretBox(secretKey);
         byte[] encryptedAudio = boxer.box(encodedAudio.array(), encodedAudio.arrayOffset(), encodedAudio.remaining(), extendedNonce);
         ((Buffer) buffer).clear();
         int capacity = RTP_HEADER_BYTE_LENGTH + encryptedAudio.length + nlen;
@@ -267,6 +266,6 @@ public class AudioPacket
         buffer.putInt(timestamp);
         buffer.putInt(ssrc);
         buffer.put(data);
-        data.flip();
+        ((Buffer) data).flip();
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
@@ -61,8 +61,8 @@ public class AudioPacket
     private final char seq;
     private final int timestamp;
     private final int ssrc;
-    private final byte[] encodedAudio;
     private final byte[] rawPacket;
+    private final ByteBuffer encodedAudio;
 
     public AudioPacket(DatagramPacket packet)
     {
@@ -91,16 +91,12 @@ public class AudioPacket
         if (hasExtension && extension == RTP_DISCORD_EXTENSION)
             offset = getPayloadOffset(data, csrcLength);
 
-        this.encodedAudio = new byte[data.length - offset];
-        System.arraycopy(data, offset, this.encodedAudio, 0, this.encodedAudio.length);
+        this.encodedAudio = ByteBuffer.allocate(data.length - offset);
+        this.encodedAudio.put(data, offset, encodedAudio.capacity());
+        this.encodedAudio.flip();
     }
 
-    public AudioPacket(char seq, int timestamp, int ssrc, byte[] encodedAudio)
-    {
-        this(null, seq, timestamp, ssrc, encodedAudio);
-    }
-
-    public AudioPacket(ByteBuffer buffer, char seq, int timestamp, int ssrc, byte[] encodedAudio)
+    public AudioPacket(ByteBuffer buffer, char seq, int timestamp, int ssrc, ByteBuffer encodedAudio)
     {
         this.seq = seq;
         this.ssrc = ssrc;
@@ -150,16 +146,9 @@ public class AudioPacket
         return rawPacket;
     }
 
-    public byte[] getEncodedAudio()
+    public ByteBuffer getEncodedAudio()
     {
         return encodedAudio;
-    }
-
-    public byte[] getEncodedAudio(int nonceLength)
-    {
-        if (nonceLength == 0)
-            return encodedAudio;
-        return Arrays.copyOf(encodedAudio, encodedAudio.length - nonceLength);
     }
 
     public char getSequence()
@@ -188,12 +177,12 @@ public class AudioPacket
 
         //Create our SecretBox encoder with the secretKey provided by Discord.
         TweetNaclFast.SecretBox boxer = new TweetNaclFast.SecretBox(secretKey);
-        byte[] encryptedAudio = boxer.box(encodedAudio, extendedNonce);
+        byte[] encryptedAudio = boxer.box(encodedAudio.array(), encodedAudio.arrayOffset(), encodedAudio.remaining(), extendedNonce);
         ((Buffer) buffer).clear();
         int capacity = RTP_HEADER_BYTE_LENGTH + encryptedAudio.length + nlen;
         if (capacity > buffer.remaining())
             buffer = ByteBuffer.allocate(capacity);
-        populateBuffer(seq, timestamp, ssrc, encryptedAudio, buffer);
+        populateBuffer(seq, timestamp, ssrc, ByteBuffer.wrap(encryptedAudio), buffer);
         if (nonce != null)
             buffer.put(nonce, 0, nlen);
 
@@ -227,24 +216,26 @@ public class AudioPacket
                 return null;
         }
 
-        byte[] encodedAudio;
+        ByteBuffer encodedAudio = encryptedPacket.encodedAudio;
+        int length = encodedAudio.remaining();
+        int offset = encodedAudio.arrayOffset();
         switch (encryption)
         {
             case XSALSA20_POLY1305:
-                encodedAudio = encryptedPacket.getEncodedAudio();
+//                length = encodedAudio.remaining();
                 break;
             case XSALSA20_POLY1305_LITE:
-                encodedAudio = encryptedPacket.getEncodedAudio(4);
+                length -= 4;
                 break;
             case XSALSA20_POLY1305_SUFFIX:
-                encodedAudio = encryptedPacket.getEncodedAudio(TweetNaclFast.SecretBox.nonceLength);
+                length -= TweetNaclFast.SecretBox.nonceLength;
                 break;
             default:
                 AudioConnection.LOG.debug("Failed to decrypt audio packet, unsupported encryption mode!");
                 return null;
         }
 
-        final byte[] decryptedAudio = boxer.open(encodedAudio, extendedNonce);
+        final byte[] decryptedAudio = boxer.open(encodedAudio.array(), offset, length, extendedNonce);
         if (decryptedAudio == null)
         {
             AudioConnection.LOG.trace("Failed to decrypt audio packet");
@@ -260,15 +251,15 @@ public class AudioPacket
         return new AudioPacket(decryptedRawPacket);
     }
 
-    private static byte[] generateRawPacket(ByteBuffer buffer, char seq, int timestamp, int ssrc, byte[] data)
+    private static byte[] generateRawPacket(ByteBuffer buffer, char seq, int timestamp, int ssrc, ByteBuffer data)
     {
         if (buffer == null)
-            buffer = ByteBuffer.allocate(RTP_HEADER_BYTE_LENGTH + data.length);
+            buffer = ByteBuffer.allocate(RTP_HEADER_BYTE_LENGTH + data.remaining());
         populateBuffer(seq, timestamp, ssrc, data, buffer);
         return buffer.array();
     }
 
-    private static void populateBuffer(char seq, int timestamp, int ssrc, byte[] data, ByteBuffer buffer)
+    private static void populateBuffer(char seq, int timestamp, int ssrc, ByteBuffer data, ByteBuffer buffer)
     {
         buffer.put(RTP_VERSION_PAD_EXTEND);
         buffer.put(RTP_PAYLOAD_TYPE);
@@ -276,5 +267,6 @@ public class AudioPacket
         buffer.putInt(timestamp);
         buffer.putInt(ssrc);
         buffer.put(data);
+        data.flip();
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
@@ -185,6 +185,7 @@ public class AudioPacket
         if (nonce != null)
             buffer.put(nonce, 0, nlen);
 
+        ((Buffer) buffer).flip();
         return buffer;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/audio/Decoder.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/Decoder.java
@@ -71,8 +71,11 @@ public class Decoder
             this.lastTimestamp = decryptedPacket.getTimestamp();
 
             ByteBuffer encodedAudio = decryptedPacket.getEncodedAudio();
-            byte[] buf = new byte[encodedAudio.remaining()];
-            System.arraycopy(encodedAudio.array(), encodedAudio.arrayOffset(), buf, 0, encodedAudio.remaining());
+            int length = encodedAudio.remaining();
+            int offset = encodedAudio.arrayOffset() + encodedAudio.position();
+            byte[] buf = new byte[length];
+            byte[] data = encodedAudio.array();
+            System.arraycopy(data, offset, buf, 0, length);
             result = Opus.INSTANCE.opus_decode(opusDecoder, buf, buf.length, decoded, AudioConnection.OPUS_FRAME_SIZE, 0);
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/audio/Decoder.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/Decoder.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.audio;
 import com.sun.jna.ptr.PointerByReference;
 import tomp2p.opuswrapper.Opus;
 
+import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
 
@@ -69,10 +70,10 @@ public class Decoder
             this.lastSeq = decryptedPacket.getSequence();
             this.lastTimestamp = decryptedPacket.getTimestamp();
 
-            byte[] encodedAudio = decryptedPacket.getEncodedAudio();
-
-            result = Opus.INSTANCE.opus_decode(opusDecoder, encodedAudio, encodedAudio.length, decoded,
-                    AudioConnection.OPUS_FRAME_SIZE, 0);
+            ByteBuffer encodedAudio = decryptedPacket.getEncodedAudio();
+            byte[] buf = new byte[encodedAudio.remaining()];
+            System.arraycopy(encodedAudio.array(), encodedAudio.arrayOffset(), buf, 0, encodedAudio.remaining());
+            result = Opus.INSTANCE.opus_decode(opusDecoder, buf, buf.length, decoded, AudioConnection.OPUS_FRAME_SIZE, 0);
         }
 
         //If we get a result that is less than 0, then there was an error. Return null as a signifier.


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This change allows send handlers to re-use a single buffer for all packets.

### Example Usage

```java
public class AudioSender implements AudioSendHandler {
    private AudioPlayer player;
    private AudioFrame frame;
    private ByteBuffer buffer = ByteBuffer.allocate(1024);

    public AudioSender(AudioPlayer player) {
        this.player = player;
    }

    @Override
    public boolean canProvide() {
        frame = player.provide();
        return frame != null;
    }

    @Override
    public ByteBuffer provide20MsAudio() {
        frame.getData(buffer.array(), frame.getDataLength()); // lavaplayer still had the old broken behavior where it used offset as length in arraycopy
        buffer.position(0);
        buffer.limit(frame.getDataLength());
        return buffer;
    }

    @Override
    public boolean isOpus() {
        return true;
    }
}
```