### PR TITLE
Remove FredBoat as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,14 @@ public class MessageListener extends ListenerAdapter
 ### More Examples
 We provide a small set of Examples in the [Example Directory](https://github.com/DV8FromTheWorld/JDA/tree/master/src/examples/java).
 
-In addition you can look at the many Discord Bots that were implemented using JDA:
-- [Yui](https://github.com/DV8FromTheWorld/Yui)
-- [Vortex](https://github.com/jagrosh/Vortex)
-- [FredBoat](https://github.com/Frederikam/FredBoat)
-
-[And many more!](https://github.com/search?q=JDA+discord+bot&type=Repositories&utf8=%E2%9C%93)
-
 > **Note**: In these examples we override methods from the inheriting class `ListenerAdapter`.<br>
 > The usage of the `@Override` annotation is recommended to validate methods.
+
+In addition, you can look at the many Discord Bots that were implemented using JDA:
+- [Yui](https://github.com/DV8FromTheWorld/Yui)
+- [Vortex](https://github.com/jagrosh/Vortex)
+
+[And many more!](https://github.com/search?q=JDA+discord+bot&type=Repositories&utf8=%E2%9C%93)
 
 ## Sharding a Bot
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [ ] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
FredBoat has moved to use JDA by proxy. It doesn't actually contain JDA in its classpath, making it a misleading example.

Also moved a notice closer to the text it actually refers to.
