### PR TITLE
Add release flag to compiler arguments when available

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,9 +161,16 @@ val javadocJar = task<Jar>("javadocJar") {
 }
 
 tasks.withType<JavaCompile> {
+    val arguments = mutableListOf("-Xlint:deprecation", "-Xlint:unchecked")
     options.encoding = "UTF-8"
     options.isIncremental = true
-    options.compilerArgs = listOf("-Xlint:deprecation", "-Xlint:unchecked")
+    if (JavaVersion.current().isJava9Compatible) doLast {
+        arguments += "release"
+        arguments += "8"
+    }
+    doLast {
+        options.compilerArgs = arguments
+    }
 }
 
 compileJava.apply {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Update build file
<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

It is recommended to use the `-release` flag in javac 9+ for specifying the target compatibility.