### PR TITLE
Add MarkdownSanitizer 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,8 @@ dependencies {
     //Sets the dependencies for the examples
     configurations.asMap["examplesCompile"] = configurations["apiElements"]
     configurations.asMap["examplesRuntime"] = configurations["implementation"]
+
+    testCompile("org.junit.jupiter:junit-jupiter:5.4.0")
 }
 
 val bintrayUpload: BintrayUploadTask by tasks

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -16,10 +16,6 @@
 
 package net.dv8tion.jda.api.utils;
 
-import net.dv8tion.jda.internal.utils.Checks;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.function.BiConsumer;
 
 public class MarkdownSanitizer
@@ -33,30 +29,19 @@ public class MarkdownSanitizer
     public static final int BLOCK =     1 << 5; // ```x```
     public static final int SPOILER =   1 << 6; // ||x||
     public static final int UNDERLINE = 1 << 7; // __x__
-    public static final int STRIKE =    1 << 8; // ~~x~~ TODO I FORGOT OK
+    public static final int STRIKE =    1 << 8; // ~~x~~
 
-
-    private final Deque<Integer> modeStack = new ArrayDeque<>();
     private int ignored = 0;
-    private boolean escape = false;
-    private CharSequence sequence;
     private SanitizationStrategy strategy = SanitizationStrategy.REMOVE;
 
-    private MarkdownSanitizer(CharSequence sequence)
+    public static String sanitize(String sequence)
     {
-        this.sequence = sequence;
+        return sanitize(sequence, SanitizationStrategy.REMOVE);
     }
 
-    public static MarkdownSanitizer sanitizer(CharSequence sequence)
+    public static String sanitize(String sequence, SanitizationStrategy strategy)
     {
-        Checks.notNull(sequence, "Input");
-        return new MarkdownSanitizer(sequence);
-    }
-
-    public MarkdownSanitizer withStrategy(int flags, SanitizationStrategy strategy)
-    {
-        //TODO: strategy per mode?
-        return this;
+        return new MarkdownSanitizer().withStrategy(strategy).compute(sequence);
     }
 
     public MarkdownSanitizer withStrategy(SanitizationStrategy strategy)
@@ -65,173 +50,140 @@ public class MarkdownSanitizer
         return this;
     }
 
-    public MarkdownSanitizer ignore(int flags)
+    public MarkdownSanitizer withIgnored(int ignored)
     {
-        ignored = flags;
+        this.ignored |= ignored;
         return this;
     }
 
-    private int getNextState(char x, int index, int mode) // TODO: Handle unclosed region? like "`clear" which has no mono end
+    private int getRegion(int index, String sequence)
     {
-        char next1 = index + 1 < sequence.length() ? sequence.charAt(index + 1) : ' ';
-        char next2 = index + 2 < sequence.length() ? sequence.charAt(index + 2) : ' ';
-        char next3 = index + 3 < sequence.length() ? sequence.charAt(index + 3) : ' ';
-        switch (x)
+        if (sequence.length() - index >= 3)
         {
-            default:
-                return mode;
-            case '*':
-                if (mode == ITALICS_A)
-                    return next1 == '*' ? BOLD : -1;        // *ab**c or *ab*
-                if (mode == BOLD)
-                    return next1 == '*' ? -1 : ITALICS_A;   // **ab** or **ab*c
-                if (mode == MONO || mode == MONO_TWO || mode == BLOCK)
-                    return mode;                               // `ab* or ``ab* or ```ab*
-                return next1 == '*' ? BOLD : ITALICS_A;
-            case '_':
-                if (mode == ITALICS_U)
-                    return next1 == '_' ? UNDERLINE : -1;   // _ab__c or _ab_
-                if (mode == MONO || mode == MONO_TWO || mode == BLOCK)
-                    return mode;                               // `ab_ or ``ab_ or ```ab_
-                return next1 == '_' ? UNDERLINE : ITALICS_U;
-            case '|':
-                if (mode == SPOILER)
-                    return next1 == '|' ? -1 : mode;
-                if (mode == MONO || mode == MONO_TWO || mode == BLOCK)
-                    return mode;
-                return next1 == '|' ? SPOILER : mode;
-            case '`':
-                if (mode == MONO)
-                    return -1;
-                if (mode == MONO_TWO)
-                    return next1 == '`' ? -1 : mode;
-                if (mode == BLOCK)
-                    return next1 == '`' && next2 == '`' ? -1 : mode;
-                if (next1 == '`')
-                    if (next2 == '`')
-                        return BLOCK;
-                    else
-                        return MONO_TWO;
-                return MONO;
-            case '\\': //TODO escaping modes? Handle stuff like "\\*test*" one end escaped? related to unclosed region
-                if (next1 == '`')
-                    return Integer.MIN_VALUE | (next2 == '`' ? (next3 == '`' ? BLOCK : MONO_TWO) : MONO);
-                if (next1 == '*')
-                    return Integer.MIN_VALUE | (next2 == '*' ? BOLD : ITALICS_A);
-                if (next1 == '_')
-                    return Integer.MIN_VALUE | (next2 == '_' ? UNDERLINE : ITALICS_U);
-                if (next1 == '|')
-                    return next2 == '|' ? Integer.MIN_VALUE | SPOILER : mode;
+            String threeChars = sequence.substring(index, index + 3);
+            switch (threeChars)
+            {
+                case "```":
+                    return BLOCK;
+                case "***":
+                    return BOLD | ITALICS_A;
+            }
         }
-        return mode;
+        if (sequence.length() - index >= 2)
+        {
+            String twoChars = sequence.substring(index, index + 2);
+            switch (twoChars)
+            {
+                case "**":
+                    return BOLD;
+                case "__":
+                    return UNDERLINE;
+                case "~~":
+                    return STRIKE;
+                case "``":
+                    return MONO_TWO;
+                case "||":
+                    return SPOILER;
+            }
+        }
+        char current = sequence.charAt(index);
+        switch (current)
+        {
+            case '*':
+                return ITALICS_A;
+            case '_':
+                return ITALICS_U;
+            case '`':
+                return MONO;
+        }
+        return NORMAL;
     }
 
-    private int getDelta(int state)
+    public int findEndIndex(int afterIndex, int region, String sequence)
     {
-        switch (state)
+        switch (region)
+        {
+            case BOLD | ITALICS_A:
+                return sequence.indexOf("***", afterIndex);
+            case BOLD:
+                return sequence.indexOf("**", afterIndex);
+            case ITALICS_A:
+                return sequence.indexOf('*', afterIndex);
+            case ITALICS_U:
+                return sequence.indexOf('_', afterIndex);
+            case UNDERLINE:
+                return sequence.indexOf("__", afterIndex);
+            case SPOILER:
+                return sequence.indexOf("||", afterIndex);
+            case MONO:
+                return sequence.indexOf('`', afterIndex);
+            case MONO_TWO:
+                return sequence.indexOf("``", afterIndex);
+            case BLOCK:
+                return sequence.indexOf("```", afterIndex);
+        }
+        return -1;
+    }
+
+    private String handleRegion(int start, int end, String sequence, int region)
+    {
+        String resolved = sequence.substring(start, end);
+        switch (region)
         {
             case BLOCK:
+            case MONO:
+                return resolved;
+            case MONO_TWO:
+                return new MarkdownSanitizer().withIgnored(MONO).compute(resolved);
+            default:
+                return sanitize(resolved);
+        }
+    }
+
+    private int getDelta(int region)
+    {
+        switch (region)
+        {
+            case BLOCK:
+            case BOLD | ITALICS_A:
                 return 3;
+            case MONO_TWO:
             case BOLD:
             case UNDERLINE:
-            case MONO_TWO:
             case SPOILER:
                 return 2;
-            case MONO:
             case ITALICS_A:
             case ITALICS_U:
+            case MONO:
                 return 1;
+            default:
+                return 0;
         }
-        return 0;
     }
 
-    private int appendToken(char c, int mode, StringBuilder builder)
+    public String compute(String sequence) //TODO: Use strategy?
     {
-        int delta = 1;
-        builder.append(c);
-        switch (mode)
-        {
-            case BOLD:
-                builder.append("*");
-                delta++;
-            case ITALICS_A:
-                break;
-            case UNDERLINE:
-                builder.append("_");
-                delta++;
-            case ITALICS_U:
-                break;
-            case SPOILER:
-                builder.append("|");
-                delta++;
-                break;
-            case BLOCK:
-                builder.append("`");
-                delta++;
-            case MONO_TWO:
-                builder.append("`");
-                delta++;
-            case MONO:
-                break;
-            case STRIKE:
-                builder.append("~");
-                delta++;
-                break;
-        }
-        return delta;
-    }
-
-    private boolean cleanupStack(int nextState)
-    {
-        if (modeStack.contains(nextState))
-        {
-            while (!modeStack.isEmpty() && modeStack.peek() != nextState)
-                modeStack.pop(); //TODO: Handle unclosed region here too
-            return true;
-        }
-        return false;
-    }
-
-    public String compute()
-    {
-        final StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         for (int i = 0; i < sequence.length();)
         {
-            char c = sequence.charAt(i);
-            int state = modeStack.isEmpty() ? NORMAL : modeStack.peek();
-            int nextState = getNextState(c, i, state);
-            if (nextState == -1)
+            int nextRegion = getRegion(i, sequence);
+            if (nextRegion == NORMAL)
             {
-                int delta = getDelta(state);
-                i += delta;
-                strategy.compute.accept(state, builder);
-                modeStack.pop();
+                builder.append(sequence.charAt(i++));
+                continue;
             }
-            else if (nextState != state && (nextState & ignored) == 0)
+
+            int endRegion = findEndIndex(i + 1, nextRegion, sequence);
+            if (endRegion == -1)
             {
-                strategy.compute.accept(nextState, builder);
-                if (cleanupStack(nextState))
-                {
-                    i += getDelta(nextState);
-                    continue;
-                }
-                if (nextState != NORMAL)
-                    modeStack.push(nextState);
-                int delta = getDelta(nextState);
-                if (delta == 0)
-                    i++;
-                else
-                    i += delta;
+                int delta = getDelta(nextRegion);
+                for (int j = 0; j < delta; j++)
+                    builder.append(sequence.charAt(i++));
+                continue;
             }
-            else if ((nextState & ignored) != 0)
-            {
-                i += appendToken(c, nextState, builder);
-            }
-            else
-            {
-                builder.append(c);
-                i++;
-            }
+            int delta = getDelta(nextRegion);
+            builder.append(handleRegion(i + delta, endRegion, sequence, nextRegion));
+            i = endRegion + delta;
         }
         return builder.toString();
     }
@@ -239,35 +191,7 @@ public class MarkdownSanitizer
     public enum SanitizationStrategy
     {
         REMOVE((m, b) -> {}),
-        ESCAPE((m, b) -> {
-            if (m == NORMAL)
-                return;
-            b.append('\\');
-            switch (m)
-            {
-                case BOLD:
-                    b.append("**");
-                    break;
-                case ITALICS_A:
-                    b.append('*');
-                    break;
-                case UNDERLINE:
-                    b.append('_');
-                case ITALICS_U:
-                    b.append('_');
-                    break;
-                case BLOCK:
-                    b.append('`');
-                case MONO_TWO:
-                    b.append('`');
-                case MONO:
-                    b.append('`');
-                    break;
-                case SPOILER:
-                    b.append("||");
-                    break;
-            }
-        });
+        ESCAPE((m, b) -> {}); //TODO
 
         private final BiConsumer<Integer, StringBuilder> compute;
 

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -1,0 +1,200 @@
+package net.dv8tion.jda.api.utils;
+
+import net.dv8tion.jda.internal.utils.Checks;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.BiConsumer;
+
+public class MarkdownSanitizer
+{
+    public static final int NORMAL =     0;
+    public static final int BOLD =      1 << 0; // **x**
+    public static final int ITALICS_U = 1 << 1; // _x_
+    public static final int ITALICS_A = 1 << 2; // *x*
+    public static final int MONO =      1 << 3; // `x`
+    public static final int MONO_TWO =  1 << 4; // ``x``
+    public static final int BLOCK =     1 << 5; // ```x```
+    public static final int SPOILER =   1 << 6; // ||x||
+    public static final int UNDERLINE = 1 << 7; // __x__
+
+
+    private final Deque<Integer> modeStack = new ArrayDeque<>();
+    private int ignored = 0;
+    private CharSequence sequence;
+    private SanitizationStrategy strategy = SanitizationStrategy.REMOVE;
+
+    private MarkdownSanitizer(CharSequence sequence)
+    {
+        this.sequence = sequence;
+    }
+
+    public static MarkdownSanitizer sanitizer(CharSequence sequence)
+    {
+        Checks.notNull(sequence, "Input");
+        return new MarkdownSanitizer(sequence);
+    }
+
+    public MarkdownSanitizer withStrategy(int flags, SanitizationStrategy strategy)
+    {
+        //TODO: strategy per mode?
+        return this;
+    }
+
+    public MarkdownSanitizer withStrategy(SanitizationStrategy strategy)
+    {
+        this.strategy = strategy;
+        return this;
+    }
+
+    public MarkdownSanitizer ignore(int flags)
+    {
+        ignored = flags;
+        return this;
+    }
+
+    private int getNextState(char x, int index, int mode)
+    {
+        char nextChar = index + 1 < sequence.length() ? sequence.charAt(index + 1) : ' ';
+        switch (x)
+        {
+            default:
+                return mode;
+            case '*':
+                if (mode == ITALICS_A)
+                    return nextChar == '*' ? BOLD : -1;        // *ab**c or *ab*
+                if (mode == BOLD)
+                    return nextChar == '*' ? -1 : ITALICS_A;   // **ab** or **ab*c
+                if (mode == MONO || mode == MONO_TWO || mode == BLOCK)
+                    return mode;                               // `ab* or ``ab* or ```ab*
+                return nextChar == '*' ? BOLD : ITALICS_A;
+            case '_':
+                if (mode == ITALICS_U)
+                    return nextChar == '_' ? UNDERLINE : -1;   // _ab__c or _ab_
+                if (mode == MONO || mode == MONO_TWO || mode == BLOCK)
+                    return mode;                               // `ab_ or ``ab_ or ```ab_
+                return nextChar == '_' ? UNDERLINE : ITALICS_U;
+            case '|':
+                if (mode == SPOILER)
+                    return nextChar == '|' ? -1 : mode;
+                if (mode == MONO || mode == MONO_TWO || mode == BLOCK)
+                    return mode;
+                return nextChar == '|' ? SPOILER : mode;
+            case '`':
+                char lateNext = index + 2 < sequence.length() ? sequence.charAt(index + 2) : ' ';
+                if (mode == MONO)
+                    return -1;
+                if (mode == MONO_TWO)
+                    return nextChar == '`' ? -1 : mode;
+                if (mode == BLOCK)
+                    return nextChar == '`' && lateNext == '`' ? -1 : mode;
+                if (nextChar == '`')
+                    if (lateNext == '`')
+                        return BLOCK;
+                    else
+                        return MONO_TWO;
+                return MONO;
+            case '\\': //TODO escaping modes?
+        }
+        return mode;
+    }
+
+    private int getDelta(int state)
+    {
+        switch (state)
+        {
+            case BLOCK:
+                return 3;
+            case BOLD:
+            case UNDERLINE:
+            case MONO_TWO:
+            case SPOILER:
+                return 2;
+            case MONO:
+            case ITALICS_A:
+            case ITALICS_U:
+                return 1;
+        }
+        return 0;
+    }
+
+    public String compute() // TODO: ignored
+    {
+        final StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < sequence.length();)
+        {
+            char c = sequence.charAt(i);
+            int state = modeStack.isEmpty() ? NORMAL : modeStack.peek();
+            int nextState = getNextState(c, i, state);
+            if (nextState == -1)
+            {
+                int delta = getDelta(state);
+                i += delta;
+                strategy.compute.accept(state, builder);
+                modeStack.pop();
+            }
+            else if (nextState != state)
+            {
+                strategy.compute.accept(nextState, builder);
+                modeStack.push(nextState);
+                int delta = getDelta(nextState);
+                if (delta == 0)
+                {
+                    builder.append(c);
+                    i++;
+                }
+                else
+                {
+                    i += delta;
+                }
+            }
+            else
+            {
+                builder.append(c);
+                i++;
+            }
+        }
+        return builder.toString();
+    }
+
+    public enum SanitizationStrategy
+    {
+        REMOVE((m, b) -> {}),
+        ESCAPE((m, b) -> {
+            if (m == NORMAL)
+                return;
+            b.append('\\');
+            switch (m)
+            {
+                case BOLD:
+                    b.append("**");
+                    break;
+                case ITALICS_A:
+                    b.append('*');
+                    break;
+                case UNDERLINE:
+                    b.append('_');
+                case ITALICS_U:
+                    b.append('_');
+                    break;
+                case BLOCK:
+                    b.append('`');
+                case MONO_TWO:
+                    b.append('`');
+                case MONO:
+                    b.append('`');
+                    break;
+                case SPOILER:
+                    b.append("||");
+                    break;
+            }
+        });
+
+        private final BiConsumer<Integer, StringBuilder> compute;
+
+        SanitizationStrategy(BiConsumer<Integer, StringBuilder> compute)
+        {
+            this.compute = compute;
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -132,6 +132,46 @@ public class MarkdownSanitizer
     }
 
     /**
+     * Escapes every markdown formatting found in the provided string.
+     *
+     * @param  sequence
+     *         The string to sanitize
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If provided with null
+     *
+     * @return The string with escaped markdown
+     *
+     * @see    #escape(String, int)
+     */
+    public static String escape(String sequence)
+    {
+        return escape(sequence, 0);
+    }
+
+    /**
+     * Escapes every markdown formatting found in the provided string.
+     * <br>Example: {@code escape("**Hello** ~~World~~!", MarkdownSanitizer.BOLD | MarkdownSanitizer.STRIKE)}
+     *
+     * @param  sequence
+     *         The string to sanitize
+     * @param  ignored
+     *         Formats to ignore
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If provided with null
+     *
+     * @return The string with escaped markdown
+     */
+    public static String escape(String sequence, int ignored)
+    {
+        return new MarkdownSanitizer()
+                .withIgnored(ignored)
+                .withStrategy(SanitizationStrategy.ESCAPE)
+                .compute(sequence);
+    }
+
+    /**
      * Switches the used {@link net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy}.
      *
      * @param  strategy

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -20,6 +20,8 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import net.dv8tion.jda.internal.utils.Checks;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.regex.Pattern;
 
 /**
@@ -88,7 +90,7 @@ public class MarkdownSanitizer
         this.strategy = SanitizationStrategy.REMOVE;
     }
 
-    public MarkdownSanitizer(int ignored, SanitizationStrategy strategy)
+    public MarkdownSanitizer(int ignored, @Nullable SanitizationStrategy strategy)
     {
         this.ignored = ignored;
         this.strategy = strategy == null ? SanitizationStrategy.REMOVE : strategy;
@@ -103,7 +105,8 @@ public class MarkdownSanitizer
      *
      * @return The sanitized string
      */
-    public static String sanitize(String sequence)
+    @Nonnull
+    public static String sanitize(@Nonnull String sequence)
     {
         return sanitize(sequence, SanitizationStrategy.REMOVE);
     }
@@ -124,7 +127,8 @@ public class MarkdownSanitizer
      * @see    MarkdownSanitizer#MarkdownSanitizer()
      * @see    #withIgnored(int)
      */
-    public static String sanitize(String sequence, SanitizationStrategy strategy)
+    @Nonnull
+    public static String sanitize(@Nonnull String sequence, @Nonnull SanitizationStrategy strategy)
     {
         Checks.notNull(sequence, "String");
         Checks.notNull(strategy, "Strategy");
@@ -144,7 +148,8 @@ public class MarkdownSanitizer
      *
      * @see    #escape(String, int)
      */
-    public static String escape(String sequence)
+    @Nonnull
+    public static String escape(@Nonnull String sequence)
     {
         return escape(sequence, NORMAL);
     }
@@ -163,7 +168,8 @@ public class MarkdownSanitizer
      *
      * @return The string with escaped markdown
      */
-    public static String escape(String sequence, int ignored)
+    @Nonnull
+    public static String escape(@Nonnull String sequence, int ignored)
     {
         return new MarkdownSanitizer()
                 .withIgnored(ignored)
@@ -182,7 +188,8 @@ public class MarkdownSanitizer
      *
      * @return The current sanitizer instance with the new strategy
      */
-    public MarkdownSanitizer withStrategy(SanitizationStrategy strategy)
+    @Nonnull
+    public MarkdownSanitizer withStrategy(@Nonnull SanitizationStrategy strategy)
     {
         Checks.notNull(strategy, "Strategy");
         this.strategy = strategy;
@@ -198,13 +205,14 @@ public class MarkdownSanitizer
      *
      * @return The current sanitizer instance with the new ignored regions
      */
+    @Nonnull
     public MarkdownSanitizer withIgnored(int ignored)
     {
         this.ignored |= ignored;
         return this;
     }
 
-    private int getRegion(int index, String sequence)
+    private int getRegion(int index, @Nonnull String sequence)
     {
         if (sequence.length() - index >= 3)
         {
@@ -247,14 +255,14 @@ public class MarkdownSanitizer
         return NORMAL;
     }
 
-    private boolean hasCollision(int index, String sequence, char c)
+    private boolean hasCollision(int index, @Nonnull String sequence, char c)
     {
         if (index < 0)
             return false;
         return index < sequence.length() - 1 && sequence.charAt(index + 1) == c;
     }
 
-    private int findEndIndex(int afterIndex, int region, String sequence)
+    private int findEndIndex(int afterIndex, int region, @Nonnull String sequence)
     {
         if (isEscape(region))
             return -1;
@@ -334,7 +342,8 @@ public class MarkdownSanitizer
         return -1;
     }
 
-    private String handleRegion(int start, int end, String sequence, int region)
+    @Nonnull
+    private String handleRegion(int start, int end, @Nonnull String sequence, int region)
     {
         String resolved = sequence.substring(start, end);
         switch (region)
@@ -381,7 +390,7 @@ public class MarkdownSanitizer
         }
     }
 
-    private void applyStrategy(int region, String seq, StringBuilder builder)
+    private void applyStrategy(int region, @Nonnull String seq, @Nonnull StringBuilder builder)
     {
         if (strategy == SanitizationStrategy.REMOVE)
         {
@@ -401,7 +410,7 @@ public class MarkdownSanitizer
                .append("\\").append(token);
     }
 
-    private boolean doesEscape(int index, String seq)
+    private boolean doesEscape(int index, @Nonnull String seq)
     {
         int backslashes = 0;
         for (int i = index - 1; i > -1; i--)
@@ -436,7 +445,8 @@ public class MarkdownSanitizer
      *
      * @return The resulting string after applying the computation
      */
-    public String compute(String sequence)
+    @Nonnull
+    public String compute(@Nonnull String sequence)
     {
         Checks.notNull(sequence, "Input");
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -32,6 +32,16 @@ public class MarkdownSanitizer
     public static final int UNDERLINE = 1 << 7; // __x__
     public static final int STRIKE =    1 << 8; // ~~x~~
 
+    public static final int ESCAPED_BOLD      = Integer.MIN_VALUE | BOLD;
+    public static final int ESCAPED_ITALICS_U = Integer.MIN_VALUE | ITALICS_U;
+    public static final int ESCAPED_ITALICS_A = Integer.MIN_VALUE | ITALICS_A;
+    public static final int ESCAPED_MONO      = Integer.MIN_VALUE | MONO;
+    public static final int ESCAPED_MONO_TWO  = Integer.MIN_VALUE | MONO_TWO;
+    public static final int ESCAPED_BLOCK     = Integer.MIN_VALUE | BLOCK;
+    public static final int ESCAPED_SPOILER   = Integer.MIN_VALUE | SPOILER;
+    public static final int ESCAPED_UNDERLINE = Integer.MIN_VALUE | UNDERLINE;
+    public static final int ESCAPED_STRIKE    = Integer.MIN_VALUE | STRIKE;
+
     private static final TIntObjectMap<String> tokens;
     static
     {
@@ -83,6 +93,14 @@ public class MarkdownSanitizer
 
     private int getRegion(int index, String sequence) //TODO: Handle escape?
     {
+        if (sequence.length() - index >= 4)
+        {
+            String fourChars = sequence.substring(index, index + 4);
+            if (fourChars.equals("\\```"))
+                return ESCAPED_BLOCK;
+            else if (fourChars.equals("\\***"))
+                return ESCAPED_BOLD | ITALICS_A;
+        }
         if (sequence.length() - index >= 3)
         {
             String threeChars = sequence.substring(index, index + 3);
@@ -92,6 +110,16 @@ public class MarkdownSanitizer
                     return BLOCK;
                 case "***":
                     return BOLD | ITALICS_A;
+                case "\\**":
+                    return ESCAPED_BOLD;
+                case "\\__":
+                    return ESCAPED_UNDERLINE;
+                case "\\~~":
+                    return ESCAPED_STRIKE;
+                case "\\``":
+                    return ESCAPED_MONO_TWO;
+                case "\\||":
+                    return ESCAPED_SPOILER;
             }
         }
         if (sequence.length() - index >= 2)
@@ -109,6 +137,12 @@ public class MarkdownSanitizer
                     return MONO_TWO;
                 case "||":
                     return SPOILER;
+                case "\\*":
+                    return ESCAPED_ITALICS_A;
+                case "\\_":
+                    return ESCAPED_ITALICS_U;
+                case "\\`":
+                    return ESCAPED_MONO;
             }
         }
         char current = sequence.charAt(index);
@@ -169,13 +203,23 @@ public class MarkdownSanitizer
     {
         switch (region)
         {
+            case ESCAPED_BLOCK:
+            case ESCAPED_BOLD | ITALICS_A:
+                return 4;
             case BLOCK:
             case BOLD | ITALICS_A:
+            case ESCAPED_MONO_TWO:
+            case ESCAPED_BOLD:
+            case ESCAPED_UNDERLINE:
+            case ESCAPED_SPOILER:
                 return 3;
             case MONO_TWO:
             case BOLD:
             case UNDERLINE:
             case SPOILER:
+            case ESCAPED_ITALICS_A:
+            case ESCAPED_ITALICS_U:
+            case ESCAPED_MONO:
                 return 2;
             case ITALICS_A:
             case ITALICS_U:
@@ -201,6 +245,11 @@ public class MarkdownSanitizer
                .append("\\").append(token);
     }
 
+    private boolean isEscape(int region)
+    {
+        return (Integer.MIN_VALUE & region) != 0;
+    }
+
     public String compute(String sequence)
     {
         StringBuilder builder = new StringBuilder();
@@ -214,7 +263,7 @@ public class MarkdownSanitizer
             }
 
             int endRegion = findEndIndex(i + 1, nextRegion, sequence);
-            if ((nextRegion & ignored) == nextRegion || endRegion == -1)
+            if (isEscape(nextRegion) || (nextRegion & ignored) == nextRegion || endRegion == -1)
             {
                 int delta = getDelta(nextRegion);
                 for (int j = 0; j < delta; j++)

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -84,7 +84,7 @@ public class MarkdownSanitizer
 
     public MarkdownSanitizer()
     {
-        this.ignored = 0;
+        this.ignored = NORMAL;
         this.strategy = SanitizationStrategy.REMOVE;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -18,29 +18,45 @@ package net.dv8tion.jda.api.utils;
 
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
+import net.dv8tion.jda.internal.utils.Checks;
 
+/**
+ * Implements and algorithm that can strip or replace markdown in any supplied string.
+ *
+ * @see #sanitize(String, net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy)
+ */
 public class MarkdownSanitizer
 {
+    /** Normal characters that are not special for markdown, ignoring this has no effect */
     public static final int NORMAL =     0;
-    public static final int BOLD =      1 << 0; // **x**
+    /** Bold region such as "**Hello**" */
+    public static final int BOLD      = 1 << 0; // **x**
+    /** Italics region for underline such as "_Hello_" */
     public static final int ITALICS_U = 1 << 1; // _x_
+    /** Italics region for asterisks such as "*Hello*" */
     public static final int ITALICS_A = 1 << 2; // *x*
-    public static final int MONO =      1 << 3; // `x`
-    public static final int MONO_TWO =  1 << 4; // ``x``
-    public static final int BLOCK =     1 << 5; // ```x```
-    public static final int SPOILER =   1 << 6; // ||x||
+    /** Monospace region such as "`Hello`" */
+    public static final int MONO      = 1 << 3; // `x`
+    /** Monospace region such as "``Hello``" */
+    public static final int MONO_TWO  = 1 << 4; // ``x``
+    /** Codeblock region such as "```Hello```" */
+    public static final int BLOCK     = 1 << 5; // ```x```
+    /** Spoiler region such as "||Hello||" */
+    public static final int SPOILER   = 1 << 6; // ||x||
+    /** Underline region such as "__Hello__" */
     public static final int UNDERLINE = 1 << 7; // __x__
-    public static final int STRIKE =    1 << 8; // ~~x~~
+    /** Strikethrough region such as "~~Hello~~" */
+    public static final int STRIKE    = 1 << 8; // ~~x~~
 
-    public static final int ESCAPED_BOLD      = Integer.MIN_VALUE | BOLD;
-    public static final int ESCAPED_ITALICS_U = Integer.MIN_VALUE | ITALICS_U;
-    public static final int ESCAPED_ITALICS_A = Integer.MIN_VALUE | ITALICS_A;
-    public static final int ESCAPED_MONO      = Integer.MIN_VALUE | MONO;
-    public static final int ESCAPED_MONO_TWO  = Integer.MIN_VALUE | MONO_TWO;
-    public static final int ESCAPED_BLOCK     = Integer.MIN_VALUE | BLOCK;
-    public static final int ESCAPED_SPOILER   = Integer.MIN_VALUE | SPOILER;
-    public static final int ESCAPED_UNDERLINE = Integer.MIN_VALUE | UNDERLINE;
-    public static final int ESCAPED_STRIKE    = Integer.MIN_VALUE | STRIKE;
+    private static final int ESCAPED_BOLD      = Integer.MIN_VALUE | BOLD;
+    private static final int ESCAPED_ITALICS_U = Integer.MIN_VALUE | ITALICS_U;
+    private static final int ESCAPED_ITALICS_A = Integer.MIN_VALUE | ITALICS_A;
+    private static final int ESCAPED_MONO      = Integer.MIN_VALUE | MONO;
+    private static final int ESCAPED_MONO_TWO  = Integer.MIN_VALUE | MONO_TWO;
+    private static final int ESCAPED_BLOCK     = Integer.MIN_VALUE | BLOCK;
+    private static final int ESCAPED_SPOILER   = Integer.MIN_VALUE | SPOILER;
+    private static final int ESCAPED_UNDERLINE = Integer.MIN_VALUE | UNDERLINE;
+    private static final int ESCAPED_STRIKE    = Integer.MIN_VALUE | STRIKE;
 
     private static final TIntObjectMap<String> tokens;
     static
@@ -66,32 +82,80 @@ public class MarkdownSanitizer
     public MarkdownSanitizer(int ignored, SanitizationStrategy strategy)
     {
         this.ignored = ignored;
-        this.strategy = strategy;
+        this.strategy = strategy == null ? SanitizationStrategy.REMOVE : strategy;
     }
 
+    /**
+     * Sanitize string with default settings.
+     * <br>Same as {@code sanitize(sequence, SanitizationStrategy.REMOVE)}
+     *
+     * @param  sequence
+     *         The string to sanitize
+     *
+     * @return The sanitized string
+     */
     public static String sanitize(String sequence)
     {
         return sanitize(sequence, SanitizationStrategy.REMOVE);
     }
 
+    /**
+     * Sanitize string without ignoring anything.
+     *
+     * @param  sequence
+     *         The string to sanitize
+     * @param  strategy
+     *         The {@link net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy} to apply
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If provided with null
+     *
+     * @return The sanitized string
+     *
+     * @see    MarkdownSanitizer#MarkdownSanitizer()
+     * @see    #withIgnored(int)
+     */
     public static String sanitize(String sequence, SanitizationStrategy strategy)
     {
+        Checks.notNull(sequence, "String");
+        Checks.notNull(strategy, "Strategy");
         return new MarkdownSanitizer().withStrategy(strategy).compute(sequence);
     }
 
+    /**
+     * Switches the used {@link net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy}.
+     *
+     * @param  strategy
+     *         The new strategy
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If provided with null
+     *
+     * @return The current sanitizer instance with the new strategy
+     */
     public MarkdownSanitizer withStrategy(SanitizationStrategy strategy)
     {
+        Checks.notNull(strategy, "Strategy");
         this.strategy = strategy;
         return this;
     }
 
+    /**
+     * Specific regions to ignore.
+     * <br>Example: {@code new MarkdownSanitizer().withIgnored(MarkdownSanitizer.BOLD | MarkdownSanitizer.UNDERLINE).compute("Hello __world__!")}
+     *
+     * @param  ignored
+     *         The regions to ignore
+     *
+     * @return The current sanitizer instance with the new ignored regions
+     */
     public MarkdownSanitizer withIgnored(int ignored)
     {
         this.ignored |= ignored;
         return this;
     }
 
-    private int getRegion(int index, String sequence) //TODO: Handle escape?
+    private int getRegion(int index, String sequence)
     {
         if (sequence.length() - index >= 4)
         {
@@ -158,7 +222,7 @@ public class MarkdownSanitizer
         return NORMAL;
     }
 
-    public int findEndIndex(int afterIndex, int region, String sequence)
+    private int findEndIndex(int afterIndex, int region, String sequence)
     {
         if (isEscape(region))
             return -1;
@@ -275,8 +339,22 @@ public class MarkdownSanitizer
         return (nextRegion & ignored) == nextRegion;
     }
 
+    /**
+     * Computes the provided input.
+     * <br>Uses the specified {@link net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy} and
+     * ignores any regions specified with {@link #withIgnored(int)}.
+     *
+     * @param  sequence
+     *         The string to compute
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided string is null
+     *
+     * @return The resulting string after applying the computation
+     */
     public String compute(String sequence)
     {
+        Checks.notNull(sequence, "Input");
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < sequence.length();)
         {
@@ -304,7 +382,16 @@ public class MarkdownSanitizer
 
     public enum SanitizationStrategy
     {
+        /**
+         * Remove any format tokens that are not escaped or within a special region.
+         * <br>{@code "**Hello** World!" -> "Hello World!"}
+         */
         REMOVE,
+
+        /**
+         * Escape any format tokens that are not escaped or within a special region.
+         * <br>{@code "**Hello** World!" -> "\**Hello\** World!"}
+         */
         ESCAPE,
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -20,6 +20,8 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import net.dv8tion.jda.internal.utils.Checks;
 
+import java.util.regex.Pattern;
+
 /**
  * Implements and algorithm that can strip or replace markdown in any supplied string.
  *
@@ -57,6 +59,8 @@ public class MarkdownSanitizer
     private static final int ESCAPED_SPOILER   = Integer.MIN_VALUE | SPOILER;
     private static final int ESCAPED_UNDERLINE = Integer.MIN_VALUE | UNDERLINE;
     private static final int ESCAPED_STRIKE    = Integer.MIN_VALUE | STRIKE;
+
+    private static final Pattern codeLanguage = Pattern.compile("^\\w+\n.*", Pattern.MULTILINE | Pattern.DOTALL);
 
     private static final TIntObjectMap<String> tokens;
     static
@@ -341,7 +345,10 @@ public class MarkdownSanitizer
     {
         if (strategy == SanitizationStrategy.REMOVE)
         {
-            builder.append(seq);
+            if (codeLanguage.matcher(seq).matches())
+                builder.append(seq.substring(seq.indexOf("\n") + 1));
+            else
+                builder.append(seq);
             return;
         }
         String token = tokens.get(region);

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -299,7 +299,7 @@ public class MarkdownSanitizer
             case MONO_TWO:
                 return resolved;
             default:
-                return sanitize(resolved);
+                return new MarkdownSanitizer(ignored, strategy).compute(resolved);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -74,10 +74,14 @@ public class MarkdownSanitizer
         tokens.put(STRIKE, "~~");
     }
 
-    private int ignored = 0;
-    private SanitizationStrategy strategy = SanitizationStrategy.REMOVE;
+    private int ignored;
+    private SanitizationStrategy strategy;
 
-    public MarkdownSanitizer() {}
+    public MarkdownSanitizer()
+    {
+        this.ignored = 0;
+        this.strategy = SanitizationStrategy.REMOVE;
+    }
 
     public MarkdownSanitizer(int ignored, SanitizationStrategy strategy)
     {
@@ -292,9 +296,8 @@ public class MarkdownSanitizer
         {
             case BLOCK:
             case MONO:
-                return resolved;
             case MONO_TWO:
-                return new MarkdownSanitizer(ignored | MONO, strategy).compute(resolved);
+                return resolved;
             default:
                 return sanitize(resolved);
         }

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -28,25 +28,25 @@ import net.dv8tion.jda.internal.utils.Checks;
 public class MarkdownSanitizer
 {
     /** Normal characters that are not special for markdown, ignoring this has no effect */
-    public static final int NORMAL =     0;
+    public static final int NORMAL    = 0;
     /** Bold region such as "**Hello**" */
-    public static final int BOLD      = 1 << 0; // **x**
+    public static final int BOLD      = 1 << 0;
     /** Italics region for underline such as "_Hello_" */
-    public static final int ITALICS_U = 1 << 1; // _x_
+    public static final int ITALICS_U = 1 << 1;
     /** Italics region for asterisks such as "*Hello*" */
-    public static final int ITALICS_A = 1 << 2; // *x*
+    public static final int ITALICS_A = 1 << 2;
     /** Monospace region such as "`Hello`" */
-    public static final int MONO      = 1 << 3; // `x`
+    public static final int MONO      = 1 << 3;
     /** Monospace region such as "``Hello``" */
-    public static final int MONO_TWO  = 1 << 4; // ``x``
+    public static final int MONO_TWO  = 1 << 4;
     /** Codeblock region such as "```Hello```" */
-    public static final int BLOCK     = 1 << 5; // ```x```
+    public static final int BLOCK     = 1 << 5;
     /** Spoiler region such as "||Hello||" */
-    public static final int SPOILER   = 1 << 6; // ||x||
+    public static final int SPOILER   = 1 << 6;
     /** Underline region such as "__Hello__" */
-    public static final int UNDERLINE = 1 << 7; // __x__
+    public static final int UNDERLINE = 1 << 7;
     /** Strikethrough region such as "~~Hello~~" */
-    public static final int STRIKE    = 1 << 8; // ~~x~~
+    public static final int STRIKE    = 1 << 8;
 
     private static final int ESCAPED_BOLD      = Integer.MIN_VALUE | BOLD;
     private static final int ESCAPED_ITALICS_U = Integer.MIN_VALUE | ITALICS_U;

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -146,7 +146,7 @@ public class MarkdownSanitizer
      */
     public static String escape(String sequence)
     {
-        return escape(sequence, 0);
+        return escape(sequence, NORMAL);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.dv8tion.jda.api.utils;
 
 import net.dv8tion.jda.internal.utils.Checks;

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -66,6 +66,7 @@ public class MarkdownSanitizer
         tokens.put(BOLD, "**");
         tokens.put(ITALICS_U, "_");
         tokens.put(ITALICS_A, "*");
+        tokens.put(BOLD | ITALICS_A, "***");
         tokens.put(MONO, "`");
         tokens.put(MONO_TWO, "``");
         tokens.put(BLOCK, "```");
@@ -345,7 +346,7 @@ public class MarkdownSanitizer
         }
         String token = tokens.get(region);
         if (token == null)
-            return;
+            throw new IllegalStateException("Found illegal region for strategy ESCAPE '" + region + "' with no known format token!");
         if (region == UNDERLINE)
             token = "_\\_"; // UNDERLINE needs special handling because the client thinks its ITALICS_U if you only escape once
         builder.append("\\").append(token)

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -346,6 +346,8 @@ public class MarkdownSanitizer
         String token = tokens.get(region);
         if (token == null)
             return;
+        if (region == UNDERLINE)
+            token = "_\\_"; // UNDERLINE needs special handling because the client thinks its ITALICS_U if you only escape once
         builder.append("\\").append(token)
                .append(seq)
                .append("\\").append(token);

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -34,6 +34,14 @@ public class MarkdownSanitizer
     private int ignored = 0;
     private SanitizationStrategy strategy = SanitizationStrategy.REMOVE;
 
+    public MarkdownSanitizer() {}
+
+    public MarkdownSanitizer(int ignored, SanitizationStrategy strategy)
+    {
+        this.ignored = ignored;
+        this.strategy = strategy;
+    }
+
     public static String sanitize(String sequence)
     {
         return sanitize(sequence, SanitizationStrategy.REMOVE);
@@ -134,7 +142,7 @@ public class MarkdownSanitizer
             case MONO:
                 return resolved;
             case MONO_TWO:
-                return new MarkdownSanitizer().withIgnored(MONO).compute(resolved);
+                return new MarkdownSanitizer(ignored | MONO, strategy).compute(resolved);
             default:
                 return sanitize(resolved);
         }
@@ -174,7 +182,7 @@ public class MarkdownSanitizer
             }
 
             int endRegion = findEndIndex(i + 1, nextRegion, sequence);
-            if (endRegion == -1)
+            if ((nextRegion & ignored) == nextRegion || endRegion == -1)
             {
                 int delta = getDelta(nextRegion);
                 for (int j = 0; j < delta; j++)

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.EmptyRestAction;
@@ -461,73 +462,10 @@ public class ReceivedMessage extends AbstractMessage
         {
             if (strippedContent != null)
                 return strippedContent;
-            String tmp = getContentDisplay();
-            //all the formatting keys to keep track of
-            String[] keys = new String[]{ "*", "_", "`", "~~", "||"};
-
-            //find all tokens (formatting strings described above)
-            TreeSet<FormatToken> tokens = new TreeSet<>(Comparator.comparingInt(t -> t.start));
-            for (String key : keys)
-            {
-                Matcher matcher = Pattern.compile(Pattern.quote(key)).matcher(tmp);
-                while (matcher.find())
-                    tokens.add(new FormatToken(key, matcher.start()));
-            }
-
-            //iterate over all tokens, find all matching pairs, and add them to the list toRemove
-            Deque<FormatToken> stack = new ArrayDeque<>();
-            List<FormatToken> toRemove = new ArrayList<>();
-            boolean inBlock = false;
-            for (FormatToken token : tokens)
-            {
-                if (stack.isEmpty() || !stack.peek().format.equals(token.format) || stack.peek().start + token
-                        .format.length() == token.start)
-
-                {
-                    //we are at opening tag
-                    if (!inBlock)
-                    {
-                        //we are outside of block -> handle normally
-                        if (token.format.equals("`"))
-                        {
-                            //block start... invalidate all previous tags
-                            stack.clear();
-                            inBlock = true;
-                        }
-                        stack.push(token);
-                    }
-                    else if (token.format.equals("`"))
-                    {
-                        //we are inside of a block -> handle only block tag
-                        stack.push(token);
-                    }
-                }
-                else if (!stack.isEmpty())
-                {
-                    //we found a matching close-tag
-                    toRemove.add(stack.pop());
-                    toRemove.add(token);
-                    if (token.format.equals("`") && stack.isEmpty())
-                        //close tag closed the block
-                        inBlock = false;
-                }
-            }
-
-            //sort tags to remove by their start-index and iteratively build the remaining string
-            toRemove.sort(Comparator.comparingInt(t -> t.start));
-            StringBuilder out = new StringBuilder();
-            int currIndex = 0;
-            for (FormatToken formatToken : toRemove)
-            {
-                if (currIndex < formatToken.start)
-                    out.append(tmp.substring(currIndex, formatToken.start));
-                currIndex = formatToken.start + formatToken.format.length();
-            }
-            if (currIndex < tmp.length())
-                out.append(tmp.substring(currIndex));
-            //return the stripped text, escape all remaining formatting characters (did not have matching
-            // open/close before or were left/right of block
-            return strippedContent = out.toString().replace("*", "\\*").replace("_", "\\_").replace("~", "\\~").replace("|", "\\|");
+            strippedContent = MarkdownSanitizer.sanitizer(getContentDisplay())
+                .withStrategy(MarkdownSanitizer.SanitizationStrategy.REMOVE)
+                .compute();
+            return strippedContent;
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -462,10 +462,7 @@ public class ReceivedMessage extends AbstractMessage
         {
             if (strippedContent != null)
                 return strippedContent;
-            strippedContent = MarkdownSanitizer.sanitizer(getContentDisplay())
-                .withStrategy(MarkdownSanitizer.SanitizationStrategy.REMOVE)
-                .compute();
-            return strippedContent;
+            return strippedContent = MarkdownSanitizer.sanitize(getContentDisplay());
         }
     }
 

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -40,6 +40,7 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("**Hello**"));
         Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
+        Assertions.assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
     }
 
     @Test
@@ -50,6 +51,17 @@ class MarkdownTest
 
         Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
         Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+
+        Assertions.assertEquals("\\*Hello*", markdown.compute("\\*Hello*"));
+        Assertions.assertEquals("\\_Hello_", markdown.compute("\\_Hello_"));
+    }
+
+    @Test
+    public void testBoldItalics()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("***Hello***"));
+        Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
+        Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }
 
     @Test
@@ -57,6 +69,7 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("__Hello__"));
         Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
+        Assertions.assertEquals("\\__Hello__", markdown.compute("\\__Hello__"));
     }
 
     @Test
@@ -64,6 +77,7 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("~~Hello~~"));
         Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
+        Assertions.assertEquals("\\~~Hello~~", markdown.compute("\\~~Hello~~"));
     }
 
     @Test
@@ -71,6 +85,7 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("||Hello||"));
         Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
+        Assertions.assertEquals("\\||Hello||", markdown.compute("\\||Hello||"));
     }
 
     @Test
@@ -78,9 +93,11 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("`Hello`"));
         Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
+        Assertions.assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
 
         Assertions.assertEquals("Hello **World**", markdown.compute("`Hello **World**`"));
         Assertions.assertEquals("`Hello World", markdown.compute("`Hello **World**"));
+        Assertions.assertEquals("\\`Hello World`", markdown.compute("\\`Hello **World**`"));
     }
 
     @Test
@@ -88,12 +105,15 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("``Hello``"));
         Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
+        Assertions.assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
 
         Assertions.assertEquals("Hello **World**", markdown.compute("``Hello **World**``"));
         Assertions.assertEquals("``Hello World", markdown.compute("``Hello **World**"));
+        Assertions.assertEquals("\\``Hello World``", markdown.compute("\\``Hello **World**``"));
 
         Assertions.assertEquals("Hello `to` World", markdown.compute("``Hello `to` World``"));
         Assertions.assertEquals("``Hello to World", markdown.compute("``Hello `to` World"));
+        Assertions.assertEquals("\\``Hello to World``", markdown.compute("\\``Hello `to` World``"));
     }
 
     @Test
@@ -101,12 +121,15 @@ class MarkdownTest
     {
         Assertions.assertEquals("Hello", markdown.compute("```Hello```"));
         Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
+        Assertions.assertEquals("\\```Hello```", markdown.compute("\\```Hello```"));
 
         Assertions.assertEquals("Hello **World**", markdown.compute("```Hello **World**```"));
         Assertions.assertEquals("```Hello World", markdown.compute("```Hello **World**"));
+        Assertions.assertEquals("\\```Hello World```", markdown.compute("\\```Hello **World**```"));
 
         Assertions.assertEquals("Hello `to` World", markdown.compute("```Hello `to` World```"));
         Assertions.assertEquals("```Hello to World", markdown.compute("```Hello `to` World"));
+        Assertions.assertEquals("\\```Hello to World```", markdown.compute("\\```Hello `to` World```"));
     }
 }
 
@@ -141,6 +164,14 @@ class IgnoreMarkdownTest
 
         Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
         Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+    }
+
+    @Test
+    public void testBoldItalics()
+    {
+        Assertions.assertEquals("***Hello***", markdown.compute("***Hello***"));
+        Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
+        Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }
 
     @Test
@@ -222,6 +253,7 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\**Hello\\**", markdown.compute("**Hello**"));
         Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
+        Assertions.assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
     }
 
     @Test
@@ -232,6 +264,17 @@ class EscapeMarkdownTest
 
         Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
         Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+
+        Assertions.assertEquals("\\*Hello*", markdown.compute("\\*Hello*"));
+        Assertions.assertEquals("\\_Hello_", markdown.compute("\\_Hello_"));
+    }
+
+    @Test
+    public void testBoldItalics()
+    {
+        Assertions.assertEquals("\\***Hello\\***", markdown.compute("***Hello***"));
+        Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
+        Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }
 
     @Test
@@ -239,6 +282,7 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\_\\_Hello\\_\\_", markdown.compute("__Hello__"));
         Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
+        Assertions.assertEquals("\\__Hello__", markdown.compute("\\__Hello__"));
     }
 
     @Test
@@ -246,6 +290,7 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\~~Hello\\~~", markdown.compute("~~Hello~~"));
         Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
+        Assertions.assertEquals("\\~~Hello~~", markdown.compute("\\~~Hello~~"));
     }
 
     @Test
@@ -253,6 +298,7 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\||Hello\\||", markdown.compute("||Hello||"));
         Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
+        Assertions.assertEquals("\\||Hello||", markdown.compute("\\||Hello||"));
     }
 
     @Test
@@ -260,9 +306,12 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\`Hello\\`", markdown.compute("`Hello`"));
         Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
+        Assertions.assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
 
         Assertions.assertEquals("\\`Hello **World**\\`", markdown.compute("`Hello **World**`"));
         Assertions.assertEquals("`Hello \\**World\\**", markdown.compute("`Hello **World**"));
+        Assertions.assertEquals("\\`Hello \\**World\\**`", markdown.compute("\\`Hello **World**`"));
+
     }
 
     @Test
@@ -270,12 +319,15 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\``Hello\\``", markdown.compute("``Hello``"));
         Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
+        Assertions.assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
 
         Assertions.assertEquals("\\``Hello **World**\\``", markdown.compute("``Hello **World**``"));
         Assertions.assertEquals("``Hello \\**World\\**", markdown.compute("``Hello **World**"));
+        Assertions.assertEquals("\\``Hello \\**World\\**``", markdown.compute("\\``Hello **World**``"));
 
         Assertions.assertEquals("\\``Hello `to` World\\``", markdown.compute("``Hello `to` World``"));
         Assertions.assertEquals("``Hello \\`to\\` World", markdown.compute("``Hello `to` World"));
+        Assertions.assertEquals("\\``Hello \\`to\\` World", markdown.compute("\\``Hello `to` World"));
     }
 
     @Test
@@ -283,11 +335,14 @@ class EscapeMarkdownTest
     {
         Assertions.assertEquals("\\```Hello\\```", markdown.compute("```Hello```"));
         Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
+        Assertions.assertEquals("\\```Hello", markdown.compute("\\```Hello"));
 
         Assertions.assertEquals("\\```Hello **World**\\```", markdown.compute("```Hello **World**```"));
         Assertions.assertEquals("```Hello \\**World\\**", markdown.compute("```Hello **World**"));
+        Assertions.assertEquals("\\```Hello \\**World\\**", markdown.compute("\\```Hello **World**"));
 
         Assertions.assertEquals("\\```Hello `to` World\\```", markdown.compute("```Hello `to` World```"));
         Assertions.assertEquals("```Hello \\`to\\` World", markdown.compute("```Hello `to` World"));
+        Assertions.assertEquals("\\```Hello \\`to\\` World", markdown.compute("\\```Hello `to` World"));
     }
 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -214,7 +214,7 @@ class EscapeMarkdownTest
     @Test
     public void testComplex()
     {
-        Assertions.assertEquals("\\**A\\_B\\||C\\~~D\\__E\\`F\\`\\__\\~~\\||\\_\\**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+        Assertions.assertEquals("\\**A\\_B\\||C\\~~D\\_\\_E\\`F\\`\\_\\_\\~~\\||\\_\\**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
     }
 
     @Test
@@ -237,7 +237,7 @@ class EscapeMarkdownTest
     @Test
     public void testUnderline()
     {
-        Assertions.assertEquals("\\__Hello\\__", markdown.compute("__Hello__"));
+        Assertions.assertEquals("\\_\\_Hello\\_\\_", markdown.compute("__Hello__"));
         Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
     }
 

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -188,3 +188,88 @@ class IgnoreMarkdownTest
         Assertions.assertEquals("```Hello `to` World", markdown.compute("```Hello `to` World"));
     }
 }
+
+class EscapeMarkdownTest
+{
+    private MarkdownSanitizer markdown;
+
+    @BeforeEach
+    public void setup()
+    {
+        markdown = new MarkdownSanitizer().withStrategy(MarkdownSanitizer.SanitizationStrategy.ESCAPE);
+    }
+
+    @Test
+    public void testBold()
+    {
+        Assertions.assertEquals("\\**Hello\\**", markdown.compute("**Hello**"));
+        Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
+    }
+
+    @Test
+    public void testItalics()
+    {
+        Assertions.assertEquals("\\*Hello\\*", markdown.compute("*Hello*"));
+        Assertions.assertEquals("\\_Hello\\_", markdown.compute("_Hello_"));
+
+        Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
+        Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+    }
+
+    @Test
+    public void testUnderline()
+    {
+        Assertions.assertEquals("\\__Hello\\__", markdown.compute("__Hello__"));
+        Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
+    }
+
+    @Test
+    public void testStrike()
+    {
+        Assertions.assertEquals("\\~~Hello\\~~", markdown.compute("~~Hello~~"));
+        Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
+    }
+
+    @Test
+    public void testSpoiler()
+    {
+        Assertions.assertEquals("\\||Hello\\||", markdown.compute("||Hello||"));
+        Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
+    }
+
+    @Test
+    public void testMono()
+    {
+        Assertions.assertEquals("\\`Hello\\`", markdown.compute("`Hello`"));
+        Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
+
+        Assertions.assertEquals("\\`Hello **World**\\`", markdown.compute("`Hello **World**`"));
+        Assertions.assertEquals("`Hello \\**World\\**", markdown.compute("`Hello **World**"));
+    }
+
+    @Test
+    public void testMonoTwo()
+    {
+        Assertions.assertEquals("\\``Hello\\``", markdown.compute("``Hello``"));
+        Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
+
+        Assertions.assertEquals("\\``Hello **World**\\``", markdown.compute("``Hello **World**``"));
+        Assertions.assertEquals("``Hello \\**World\\**", markdown.compute("``Hello **World**"));
+
+        Assertions.assertEquals("\\``Hello `to` World\\``", markdown.compute("``Hello `to` World``"));
+        Assertions.assertEquals("``Hello \\`to\\` World", markdown.compute("``Hello `to` World"));
+    }
+
+    @Test
+    public void testBlock()
+    {
+        Assertions.assertEquals("\\```Hello\\```", markdown.compute("```Hello```"));
+        Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
+
+        Assertions.assertEquals("\\```Hello **World**\\```", markdown.compute("```Hello **World**```"));
+        Assertions.assertEquals("```Hello \\**World\\**", markdown.compute("```Hello **World**"));
+
+        Assertions.assertEquals("\\```Hello `to` World\\```", markdown.compute("```Hello `to` World```"));
+        Assertions.assertEquals("```Hello \\`to\\` World", markdown.compute("```Hello `to` World"));
+    }
+}

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -130,6 +130,8 @@ class MarkdownTest
         Assertions.assertEquals("Hello `to` World", markdown.compute("```Hello `to` World```"));
         Assertions.assertEquals("```Hello to World", markdown.compute("```Hello `to` World"));
         Assertions.assertEquals("\\```Hello to World```", markdown.compute("\\```Hello `to` World```"));
+
+        Assertions.assertEquals("Test", markdown.compute("```java\nTest```"));
     }
 }
 
@@ -229,6 +231,8 @@ class IgnoreMarkdownTest
 
         Assertions.assertEquals("```Hello `to` World```", markdown.compute("```Hello `to` World```"));
         Assertions.assertEquals("```Hello `to` World", markdown.compute("```Hello `to` World"));
+
+        Assertions.assertEquals("```java\nTest```", markdown.compute("```java\nTest```"));
     }
 }
 
@@ -344,5 +348,7 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\```Hello `to` World\\```", markdown.compute("```Hello `to` World```"));
         Assertions.assertEquals("```Hello \\`to\\` World", markdown.compute("```Hello `to` World"));
         Assertions.assertEquals("\\```Hello \\`to\\` World", markdown.compute("\\```Hello `to` World"));
+
+        Assertions.assertEquals("\\```java\nTest\\```", markdown.compute("```java\nTest```"));
     }
 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MarkdownTest
+{
+    private MarkdownSanitizer markdown;
+
+    @BeforeEach
+    public void setup()
+    {
+        markdown = new MarkdownSanitizer().withStrategy(MarkdownSanitizer.SanitizationStrategy.REMOVE);
+    }
+
+    @Test
+    public void testBold()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("**Hello**"));
+        Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
+    }
+
+    @Test
+    public void testItalics()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("*Hello*"));
+        Assertions.assertEquals("Hello", markdown.compute("_Hello_"));
+
+        Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
+        Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+    }
+
+    @Test
+    public void testUnderline()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("__Hello__"));
+        Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
+    }
+
+    @Test
+    public void testStrike()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("~~Hello~~"));
+        Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
+    }
+
+    @Test
+    public void testSpoiler()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("||Hello||"));
+        Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
+    }
+
+    @Test
+    public void testMono()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("`Hello`"));
+        Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
+
+        Assertions.assertEquals("Hello **World**", markdown.compute("`Hello **World**`"));
+        Assertions.assertEquals("`Hello World", markdown.compute("`Hello **World**"));
+    }
+
+    @Test
+    public void testMonoTwo()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("``Hello``"));
+        Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
+
+        Assertions.assertEquals("Hello **World**", markdown.compute("``Hello **World**``"));
+        Assertions.assertEquals("``Hello World", markdown.compute("``Hello **World**"));
+
+        Assertions.assertEquals("Hello `to` World", markdown.compute("``Hello `to` World``"));
+        Assertions.assertEquals("``Hello to World", markdown.compute("``Hello `to` World"));
+    }
+
+    @Test
+    public void testBlock()
+    {
+        Assertions.assertEquals("Hello", markdown.compute("```Hello```"));
+        Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
+
+        Assertions.assertEquals("Hello **World**", markdown.compute("```Hello **World**```"));
+        Assertions.assertEquals("```Hello World", markdown.compute("```Hello **World**"));
+
+        Assertions.assertEquals("Hello `to` World", markdown.compute("```Hello `to` World```"));
+        Assertions.assertEquals("```Hello to World", markdown.compute("```Hello `to` World"));
+    }
+}
+
+class IgnoreMarkdownTest
+{
+    private MarkdownSanitizer markdown;
+
+    @BeforeEach
+    public void setup()
+    {
+        markdown = new MarkdownSanitizer().withIgnored(0xFFFFFFFF);
+    }
+
+    @Test
+    public void testBold()
+    {
+        Assertions.assertEquals("**Hello**", markdown.compute("**Hello**"));
+        Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
+    }
+
+    @Test
+    public void testItalics()
+    {
+        Assertions.assertEquals("*Hello*", markdown.compute("*Hello*"));
+        Assertions.assertEquals("_Hello_", markdown.compute("_Hello_"));
+
+        Assertions.assertEquals("*Hello", markdown.compute("*Hello"));
+        Assertions.assertEquals("_Hello", markdown.compute("_Hello"));
+    }
+
+    @Test
+    public void testUnderline()
+    {
+        Assertions.assertEquals("__Hello__", markdown.compute("__Hello__"));
+        Assertions.assertEquals("__Hello", markdown.compute("__Hello"));
+    }
+
+    @Test
+    public void testStrike()
+    {
+        Assertions.assertEquals("~~Hello~~", markdown.compute("~~Hello~~"));
+        Assertions.assertEquals("~~Hello", markdown.compute("~~Hello"));
+    }
+
+    @Test
+    public void testSpoiler()
+    {
+        Assertions.assertEquals("||Hello||", markdown.compute("||Hello||"));
+        Assertions.assertEquals("||Hello", markdown.compute("||Hello"));
+    }
+
+    @Test
+    public void testMono()
+    {
+        Assertions.assertEquals("`Hello`", markdown.compute("`Hello`"));
+        Assertions.assertEquals("`Hello", markdown.compute("`Hello"));
+
+        Assertions.assertEquals("`Hello **World**`", markdown.compute("`Hello **World**`"));
+        Assertions.assertEquals("`Hello **World**", markdown.compute("`Hello **World**"));
+    }
+
+    @Test
+    public void testMonoTwo()
+    {
+        Assertions.assertEquals("``Hello``", markdown.compute("``Hello``"));
+        Assertions.assertEquals("``Hello", markdown.compute("``Hello"));
+
+        Assertions.assertEquals("``Hello **World**``", markdown.compute("``Hello **World**``"));
+        Assertions.assertEquals("``Hello **World**", markdown.compute("``Hello **World**"));
+
+        Assertions.assertEquals("``Hello `to` World``", markdown.compute("``Hello `to` World``"));
+        Assertions.assertEquals("``Hello `to` World", markdown.compute("``Hello `to` World"));
+    }
+
+    @Test
+    public void testBlock()
+    {
+        Assertions.assertEquals("```Hello```", markdown.compute("```Hello```"));
+        Assertions.assertEquals("```Hello", markdown.compute("```Hello"));
+
+        Assertions.assertEquals("```Hello **World**```", markdown.compute("```Hello **World**```"));
+        Assertions.assertEquals("```Hello **World**", markdown.compute("```Hello **World**"));
+
+        Assertions.assertEquals("```Hello `to` World```", markdown.compute("```Hello `to` World```"));
+        Assertions.assertEquals("```Hello `to` World", markdown.compute("```Hello `to` World"));
+    }
+}

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -30,6 +30,12 @@ class MarkdownTest
     }
 
     @Test
+    public void testComplex()
+    {
+        Assertions.assertEquals("ABCDEF", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+    }
+
+    @Test
     public void testBold()
     {
         Assertions.assertEquals("Hello", markdown.compute("**Hello**"));
@@ -115,6 +121,12 @@ class IgnoreMarkdownTest
     }
 
     @Test
+    public void testComplex()
+    {
+        Assertions.assertEquals("**A_B||C~~D__E`F`__~~||_**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+    }
+
+    @Test
     public void testBold()
     {
         Assertions.assertEquals("**Hello**", markdown.compute("**Hello**"));
@@ -197,6 +209,12 @@ class EscapeMarkdownTest
     public void setup()
     {
         markdown = new MarkdownSanitizer().withStrategy(MarkdownSanitizer.SanitizationStrategy.ESCAPE);
+    }
+
+    @Test
+    public void testComplex()
+    {
+        Assertions.assertEquals("\\**A\\_B\\||C\\~~D\\__E\\`F\\`\\__\\~~\\||\\_\\**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
     }
 
     @Test


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #838 

## Description

Add dedicated class for markdown sanitizing. This improves handling of `getContentStripped()` while also externalizing its logic, something I wanted to do for v4.

- [x] Handle all formats
- [x] Ignoring flags
- [x] Handle monospace mode ignoring formats within
- [x] Handle escaped markdown
- [x] Ability to choose whether to escape or remove format tokens

### Example 

```java
MarkdownSanitizer m = new MarkdownSanitizer();
m.withIgnored(MarkdownSanitizer.MONO | MarkdownSanitizer.UNDERLINE);
m.withStrategy(MarkdownSanitizer.SanitizationStrategy.ESCAPE);
String result = m.compute("Hello **world**!");
System.out.println(result);
```

```
Hello \**world\**!
```