### PR TITLE
Improve attachment retrieval by only offering async variants

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -303,7 +303,8 @@ public interface JDA
 
     /**
      * {@link ExecutorService} used to handle {@link RestAction} callbacks
-     * and completions.
+     * and completions. This is also used for handling {@link net.dv8tion.jda.api.entities.Message.Attachment} downloads
+     * when needed.
      * <br>By default this uses the {@link ForkJoinPool#commonPool() CommonPool} of the runtime.
      *
      * @return The {@link ExecutorService} used for callbacks

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -19,26 +19,16 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
-import net.dv8tion.jda.api.utils.IOConsumer;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.Requester;
-import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.IOUtil;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
+import okhttp3.*;
 
 import javax.annotation.CheckReturnValue;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.*;
 import java.time.OffsetDateTime;
 import java.util.Formattable;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
 /**
@@ -1113,114 +1103,95 @@ public interface Message extends ISnowflake, Formattable
             return fileName;
         }
 
-        /**
-         * Creates an {@link net.dv8tion.jda.api.entities.Icon Icon} instance for
-         * this attachment if {@link #isImage() isImage()} is {@code true}!
-         * <br>This is a convenience method that can be used to retrieve an Icon from an attachment image link which
-         * requires a set user-agent to be loaded.
-         *
-         * <p>When a global proxy was specified via {@link net.dv8tion.jda.api.JDABuilder JDABuilder} this will use the
-         * specified proxy to create an {@link java.io.InputStream InputStream} otherwise it will use a normal {@link java.net.URLConnection URLConnection}
-         * with the User-Agent for the currently logged in account.
-         *
-         * @throws IOException
-         *         If an IOError occurs while reading the image
-         * @throws java.lang.IllegalStateException
-         *         If this is not an image attachment
-         *
-         * @return {@link net.dv8tion.jda.api.entities.Icon Icon} for this image attachment
-         *
-         * @since  3.4.0
-         */
-        public Icon getAsIcon() throws IOException
+        public CompletableFuture<InputStream> retrieveData() // it is expected that the response is closed by the callback!
+        {
+            CompletableFuture<InputStream> future = new CompletableFuture<>();
+            Request req = getRequest();
+            OkHttpClient httpClient = getJDA().getHttpClient();
+            httpClient.newCall(req).enqueue(new Callback()
+            {
+                @Override
+                public void onFailure(Call call, IOException e)
+                {
+                    future.completeExceptionally(new IllegalStateException(e));
+                }
+
+                @Override
+                public void onResponse(Call call, Response response) throws IOException
+                {
+                    InputStream body = Requester.getBody(response);
+                    future.complete(body);
+                }
+            });
+            return future;
+        }
+
+        public CompletableFuture<File> downloadToFile() // using relative path
+        {
+            return downloadToFile(getFileName());
+        }
+
+        public CompletableFuture<File> downloadToFile(String path)
+        {
+            return retrieveData().thenApplyAsync((stream) -> {
+                try (FileOutputStream out = new FileOutputStream(path))
+                {
+                    byte[] buf = new byte[1024];
+                    int count;
+                    while ((count = stream.read(buf)) > 0)
+                    {
+                        out.write(buf, 0, count);
+                    }
+                    return new File(path);
+                }
+                catch (IOException e)
+                {
+                    throw new IllegalStateException(e);
+                }
+                finally
+                {
+                    silentClose(stream);
+                }
+            }, getJDA().getCallbackPool());
+        }
+
+        public CompletableFuture<Icon> retrieveAsIcon()
         {
             if (!isImage())
                 throw new IllegalStateException("Cannot create an Icon out of this attachment. This is not an image.");
-            AtomicReference<Icon> icon = new AtomicReference<>();
-            withInputStream((in) -> icon.set(Icon.from(in)));
-            return icon.get();
+            return retrieveData().thenApplyAsync((stream) ->
+            {
+                try
+                {
+                    return Icon.from(stream);
+                }
+                catch (IOException e)
+                {
+                    throw new IllegalStateException(e);
+                }
+                finally
+                {
+                    silentClose(stream);
+                }
+            }, getJDA().getCallbackPool());
         }
 
-        /**
-         * Downloads this attachment to given File
-         *
-         * @param  file
-         *         The file, where the attachment will get downloaded to
-         *
-         * @return boolean true, if successful, otherwise false
-         */
-        public boolean download(File file)
+        private void silentClose(Closeable closeable)
         {
             try
             {
-                withInputStream((in) -> Files.copy(in, Paths.get(file.getAbsolutePath())));
-                return true;
+                closeable.close();
             }
-            catch (Exception e)
-            {
-                JDAImpl.LOG.error("Error while downloading an attachment", e);
-            }
-            return false;
+            catch (IOException ignored) {}
         }
 
-        /**
-         * Creates a copy of the {@link java.io.InputStream InputStream} that is created using an {@link okhttp3.OkHttpClient OkHttpClient}.
-         *
-         * <p>You can access the input stream directly using {@link #withInputStream(net.dv8tion.jda.api.utils.IOConsumer) withInputStream(IOConsumer)}
-         * which will have an open input stream available within the consumer scope. The stream will be closed once that method returns.
-         *
-         * @throws java.io.IOException
-         *         If an IO error occurs trying to read from the opened HTTP channel
-         *
-         * @return InputStream copy of the response body for this Attachment
-         *
-         * @since  3.4.0
-         */
-        public InputStream getInputStream() throws IOException
+        protected Request getRequest()
         {
-            try (Response response = openConnection())
-            {
-                // creates a copy in order to properly close the response
-                InputStream in = Requester.getBody(response);
-                return new ByteArrayInputStream(IOUtil.readFully(in));
-            }
-        }
-
-        /**
-         * Allows to access the InputStream that is available from the HTTP {@link okhttp3.Response Response}
-         * to be used without having to copy it.
-         * <br>Unlike {@link #getInputStream()} this does not return a full copy of the input stream.
-         * Instead this method will provide the InputStream data in the specified consumer in which it is still accessible.
-         *
-         * <p><b>When this method returns the InputStream will be closed accordingly!</b>
-         *
-         * @param  then
-         *         Not-null {@link net.dv8tion.jda.api.utils.IOConsumer IOConsumer} to accept the InputStream
-         *
-         * @throws java.lang.IllegalArgumentException
-         *         If the provided IOConsumer is {@code null}
-         * @throws IOException
-         *         If an IOException occurs within the IOConsumer or while opening an HTTP channel
-         *
-         * @since  3.4.0
-         */
-        public void withInputStream(IOConsumer<InputStream> then) throws IOException
-        {
-            Checks.notNull(then, "Consumer");
-            try (Response response = openConnection())
-            {
-                then.accept(Requester.getBody(response));
-            }
-        }
-
-        protected Response openConnection() throws IOException
-        {
-            final OkHttpClient client = jda.getRequester().getHttpClient();
-            final Request request = new Request.Builder().url(getUrl())
-                        .addHeader("user-agent", Requester.USER_AGENT)
-                        .addHeader("accept-encoding", "gzip")
-                        .build();
-            return client.newCall(request).execute();
+            return new Request.Builder()
+                .url(getUrl())
+                .addHeader("user-agent", Requester.USER_AGENT)
+                .addHeader("accept-encoding", "gzip")
+                .build();
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1177,7 +1177,7 @@ public interface Message extends ISnowflake, Formattable
          * public void saveLocally(Message.Attachment attachment)
          * {
          *     attachment.downloadToFile()
-         *         .thenAccept(file -> System.out.println("Saved attachment to " + file.getName())
+         *         .thenAccept(file -> System.out.println("Saved attachment to " + file.getName()))
          *         .exceptionally(t ->
          *     { // handle failure
          *         t.printStackTrace();
@@ -1203,7 +1203,7 @@ public interface Message extends ISnowflake, Formattable
          * public void saveLocally(Message.Attachment attachment)
          * {
          *     attachment.downloadToFile("/tmp/" + attachment.getFileName())
-         *         .thenAccept(file -> System.out.println("Saved attachment to " + file.getName())
+         *         .thenAccept(file -> System.out.println("Saved attachment to " + file.getName()))
          *         .exceptionally(t ->
          *     { // handle failure
          *         t.printStackTrace();

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1165,7 +1165,7 @@ public interface Message extends ISnowflake, Formattable
         }
 
         /**
-         * Downloads the attachment to a file with the {@link #getFileName()} into the current working directory.
+         * Downloads the attachment into the current working directory using the file name provided by {@link #getFileName()}.
          * <br>This will download the file using the {@link net.dv8tion.jda.api.JDA#getCallbackPool() callback pool}.
          * Alternatively you can use {@link #retrieveData()} and use a continuation with a different executor.
          *

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1107,7 +1107,7 @@ public interface Message extends ISnowflake, Formattable
 
         /**
          * Enqueues a request to retrieve the contents of this Attachment.
-         * <br>The receiver is expected to close the retrieved {@link java.io.InputStream}.
+         * <br><b>The receiver is expected to close the retrieved {@link java.io.InputStream}.</b>
          *
          * <h2>Example</h2>
          * <pre>{@code

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -26,10 +26,7 @@ import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.*;
 
 import javax.annotation.CheckReturnValue;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.time.OffsetDateTime;
 import java.util.Formattable;
 import java.util.List;
@@ -1145,7 +1142,7 @@ public interface Message extends ISnowflake, Formattable
                 @Override
                 public void onFailure(Call call, IOException e)
                 {
-                    future.completeExceptionally(new IllegalStateException(e));
+                    future.completeExceptionally(new UncheckedIOException(e));
                 }
 
                 @Override
@@ -1232,7 +1229,7 @@ public interface Message extends ISnowflake, Formattable
                 }
                 catch (IOException e)
                 {
-                    throw new IllegalStateException(e);
+                    throw new UncheckedIOException(e);
                 }
                 finally
                 {
@@ -1279,7 +1276,7 @@ public interface Message extends ISnowflake, Formattable
                 }
                 catch (IOException e)
                 {
-                    throw new IllegalStateException(e);
+                    throw new UncheckedIOException(e);
                 }
                 finally
                 {
@@ -1293,7 +1290,7 @@ public interface Message extends ISnowflake, Formattable
             return new Request.Builder()
                 .url(getUrl())
                 .addHeader("user-agent", Requester.USER_AGENT)
-                .addHeader("accept-encoding", "gzip")
+                .addHeader("accept-encoding", "gzip, deflate")
                 .build();
         }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.exceptions.HttpException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
@@ -1119,8 +1120,16 @@ public interface Message extends ISnowflake, Formattable
                 @Override
                 public void onResponse(Call call, Response response) throws IOException
                 {
-                    InputStream body = Requester.getBody(response);
-                    future.complete(body);
+                    if (response.isSuccessful())
+                    {
+                        InputStream body = Requester.getBody(response);
+                        future.complete(body);
+                    }
+                    else
+                    {
+                        future.completeExceptionally(new HttpException(response.code() + ": " + response.message()));
+                        response.close();
+                    }
                 }
             });
             return future;

--- a/src/main/java/net/dv8tion/jda/api/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MiscUtil.java
@@ -29,6 +29,7 @@ import okio.Source;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Formatter;
@@ -228,7 +229,7 @@ public class MiscUtil
         }
         catch (IOException e)
         {
-            throw new AssertionError(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
@@ -37,6 +37,7 @@ import org.json.JSONTokener;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -184,6 +185,8 @@ public class WidgetUtil
      * @param  guildId
      *         The id of the Guild
      *
+     * @throws java.io.UncheckedIOException
+     *         If an I/O error occurs
      * @throws net.dv8tion.jda.api.exceptions.RateLimitedException
      *         If the request was rate limited, <b>respect the timeout</b>!
      *
@@ -222,7 +225,7 @@ public class WidgetUtil
                     }
                     catch (IOException e)
                     {
-                        throw new IllegalStateException(e);
+                        throw new UncheckedIOException(e);
                     }
                 }
                 case 400: // not valid snowflake
@@ -249,7 +252,7 @@ public class WidgetUtil
         }
         catch (IOException e)
         {
-            throw new IllegalStateException(e);
+            throw new UncheckedIOException(e);
         }
     }
     

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.internal.utils.Helpers;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.OffsetDateTime;
 import java.util.FormattableFlags;
 import java.util.Formatter;
@@ -96,7 +97,7 @@ public abstract class AbstractMessage implements Message
         }
         catch (IOException e)
         {
-            throw new AssertionError(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -29,6 +29,7 @@ import org.json.JSONTokener;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
@@ -93,7 +94,7 @@ public class BotRateLimiter extends RateLimiter
                     }
                     catch (IOException e)
                     {
-                        throw new IllegalStateException(e);
+                        throw new UncheckedIOException(e);
                     }
                 }
                 long retryAfter = Long.parseLong(retry);

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/ClientRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/ClientRateLimiter.java
@@ -28,6 +28,7 @@ import org.json.JSONTokener;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -87,7 +88,7 @@ public class ClientRateLimiter extends RateLimiter
                 }
                 catch (IOException e)
                 {
-                    throw new IllegalStateException(e);
+                    throw new UncheckedIOException(e);
                 }
             }
             else

--- a/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
@@ -20,6 +20,23 @@ import java.io.*;
 
 public class IOUtil
 {
+    public static void silentClose(AutoCloseable closeable)
+    {
+        try
+        {
+            closeable.close();
+        }
+        catch (Exception ignored) {}
+    }
+
+    public static void silentClose(Closeable closeable)
+    {
+        try
+        {
+            closeable.close();
+        }
+        catch (IOException ignored) {}
+    }
 
     /**
      * Used as an alternate to Java's nio Files.readAllBytes.


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This removes all blocking methods from `Message.Attachment` in favor of async variants. Downloading files should not happen on the event thread at any point in time.

- `download()` -> `downloadToFile()`
- `getAsIcon()` -> `retrieveAsIcon()`