### PR TITLE
Add ability to set speaking delay in audio manager

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
@@ -147,7 +147,7 @@ public interface AudioManager
      * By default the delay is 200 milliseconds which is also the minimum delay.
      *
      * <p>If the delay is less than 200 milliseconds it will reset it the minimum delay. The provided delay
-     * will be aligned the audio frame length of 20 milliseconds by means of integer division. This means
+     * will be aligned to the audio frame length of 20 milliseconds by means of integer division. This means
      * it will be rounded down to the next biggest multiple of 20.
      *
      * <p>Note that this delay is not reliable and operates entirely based on the send system polling times

--- a/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
@@ -141,6 +141,21 @@ public interface AudioManager
     @Incubating
     EnumSet<SpeakingMode> getSpeakingMode();
 
+    /**
+     * Configures the delay between the last provided frame and removing the speaking indicator.
+     * <br>This can be useful for send systems that buffer a certain interval of audio frames that will be sent.
+     * By default the delay is 200 milliseconds which is also the minimum delay.
+     *
+     * <p>If the delay is less than 200 milliseconds it will reset it the minimum delay. The provided delay
+     * will be aligned the audio frame length of 20 milliseconds by means of integer division. This means
+     * it will be rounded down to the next biggest multiple of 20.
+     *
+     * <p>Note that this delay is not reliable and operates entirely based on the send system polling times
+     * which can cause it to be released earlier or later than the provided delay specifies.
+     *
+     * @param millis
+     *        The delay that should be used, in milliseconds
+     */
     void setSpeakingDelay(int millis);
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
@@ -141,6 +141,8 @@ public interface AudioManager
     @Incubating
     EnumSet<SpeakingMode> getSpeakingMode();
 
+    void setSpeakingDelay(int millis);
+
     /**
      * Gets the {@link net.dv8tion.jda.api.JDA JDA} instance that this AudioManager is a part of.
      *

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -59,6 +59,7 @@ public class AudioConnection
                                                         // to Left and Right mono (stereo that is the same on both sides)
     public static final long MAX_UINT_32 = 4294967295L;
 
+    private static final int NOT_SPEAKING = 0;
     private static final byte[] silenceBytes = new byte[] {(byte)0xF8, (byte)0xFF, (byte)0xFE};
     private static boolean printedError = false;
 
@@ -706,7 +707,7 @@ public class AudioConnection
                     if ((!sentSilenceOnConnect && silenceCounter > 10) || silenceCounter > speakingDelay)
                     {
                         if (sentSilenceOnConnect)
-                            setSpeaking(0);
+                            setSpeaking(NOT_SPEAKING);
                         silenceCounter = -1;
                         sentSilenceOnConnect = true;
                     }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -701,6 +701,8 @@ public class AudioConnection
                         seq++;
 
                     silenceCounter++;
+                    //If we have sent our 10 silent packets on initial connect, or if we have sent enough silent packets
+                    // to satisfy the speaking delay, stop transmitting silence.
                     if ((!sentSilenceOnConnect && silenceCounter > 10) || silenceCounter > speakingDelay)
                     {
                         if (sentSilenceOnConnect)

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -117,7 +117,7 @@ public class AudioConnection
 
     public void setSpeakingDelay(int millis)
     {
-        speakingDelay = (Math.max(0, millis) / 20) + 10; // millis / frame-length + minimum
+        speakingDelay = Math.max(millis / 20, 10); // max { millis / frame-length, 200 millis }
     }
 
     public void setSendingHandler(AudioSendHandler handler)

--- a/src/main/java/net/dv8tion/jda/internal/managers/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/AudioManagerImpl.java
@@ -64,6 +64,7 @@ public class AudioManagerImpl implements AudioManager
     protected boolean selfDeafened = false;
 
     protected long timeout = DEFAULT_CONNECTION_TIMEOUT;
+    protected int speakingDelay = 0;
 
     public AudioManagerImpl(GuildImpl guild)
     {
@@ -172,6 +173,14 @@ public class AudioManagerImpl implements AudioManager
     public EnumSet<SpeakingMode> getSpeakingMode()
     {
         return EnumSet.copyOf(this.speakingModes);
+    }
+
+    @Override
+    public void setSpeakingDelay(int millis)
+    {
+        this.speakingDelay = millis;
+        if (audioConnection != null)
+            audioConnection.setSpeakingDelay(millis);
     }
 
     @Override
@@ -334,6 +343,7 @@ public class AudioManagerImpl implements AudioManager
         audioConnection.setReceivingHandler(receiveHandler);
         audioConnection.setQueueTimeout(queueTimeout);
         audioConnection.setSpeakingMode(speakingModes);
+        audioConnection.setSpeakingDelay(speakingDelay);
     }
 
     public void prepareForRegionChange()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This can be helpful for song transitions that take longer than 200ms, or buffered systems.
The delay can be specified in ms but will be aligned with the frame length (20ms) through integer division (no rest). It is set to a minimum of 10 frames = 200ms.