### PR TITLE
Avoid losing entities skipped by forEachAsync iteration

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/AuditLogPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/AuditLogPaginationAction.java
@@ -24,6 +24,8 @@ import net.dv8tion.jda.api.entities.User;
 /**
  * {@link PaginationAction PaginationAction}
  * that paginates the endpoint {@link net.dv8tion.jda.internal.requests.Route.Guilds#GET_AUDIT_LOGS Route.Guilds.GET_AUDIT_LOGS}.
+ * <br>Note that this implementation is not considered thread-safe as modifications to the cache are not done
+ * with a lock. Calling methods on this class from multiple threads is not recommended.
  *
  * <p><b>Must provide not-null {@link net.dv8tion.jda.api.entities.Guild Guild} to compile a valid guild audit logs
  * pagination route</b>

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/MessagePaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/MessagePaginationAction.java
@@ -23,6 +23,8 @@ import net.dv8tion.jda.api.entities.MessageChannel;
 /**
  * {@link PaginationAction PaginationAction}
  * that paginates the endpoints {@link net.dv8tion.jda.internal.requests.Route.Messages#GET_MESSAGE_HISTORY Route.Messages.GET_MESSAGE_HISTORY}.
+ * <br>Note that this implementation is not considered thread-safe as modifications to the cache are not done
+ * with a lock. Calling methods on this class from multiple threads is not recommended.
  *
  * <p><b>Must provide not-null {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} to compile a valid
  * pagination route.</b>

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -34,6 +34,8 @@ import java.util.stream.StreamSupport;
 /**
  * {@link net.dv8tion.jda.api.requests.RestAction RestAction} specification used
  * to retrieve entities for paginated endpoints (before, after, limit).
+ * <br>Note that this implementation is not considered thread-safe as modifications to the cache are not done
+ * with a lock. Calling methods on this class from multiple threads is not recommended.
  *
  * <p><b>Examples</b>
  * <pre><code>

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/ReactionPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/ReactionPaginationAction.java
@@ -22,6 +22,8 @@ import net.dv8tion.jda.api.entities.User;
 /**
  * {@link PaginationAction PaginationAction}
  * that paginates the endpoint {@link net.dv8tion.jda.internal.requests.Route.Messages#GET_REACTION_USERS Route.Messages.GET_REACTION_USERS}.
+ * <br>Note that this implementation is not considered thread-safe as modifications to the cache are not done
+ * with a lock. Calling methods on this class from multiple threads is not recommended.
  *
  * <p><b>Must provide not-null {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} to compile a valid
  * pagination route.</b>

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
@@ -158,4 +158,10 @@ public class AuditLogPaginationActionImpl
 
         request.onSuccess(list);
     }
+
+    @Override
+    protected long getKey(AuditLogEntry it)
+    {
+        return it.getIdLong();
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/MessagePaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/MessagePaginationActionImpl.java
@@ -100,4 +100,10 @@ public class MessagePaginationActionImpl
 
         request.onSuccess(messages);
     }
+
+    @Override
+    protected long getKey(Message it)
+    {
+        return it.getIdLong();
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
@@ -361,17 +361,26 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
             }
             initial = false;
 
+            T previous = null;
             for (T it : list)
             {
                 if (task.isCancelled())
+                {
+                    if (previous != null)
+                        updateIndex(previous);
                     return;
+                }
                 if (action.execute(it))
+                {
+                    previous = it;
                     continue;
+                }
                 // set the iterator index for next call of remaining
                 updateIndex(it);
                 task.complete(null);
                 return;
             }
+
             final int currentLimit = limit.getAndSet(maxLimit);
             queue(this, throwableConsumer);
             limit.set(currentLimit);

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
@@ -108,4 +108,9 @@ public class ReactionPaginationActionImpl
         request.onSuccess(users);
     }
 
+    @Override
+    protected long getKey(User it)
+    {
+        return it.getIdLong();
+    }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Previously it was possible that entities of the current chunk
would be lost when the iteration of forEachAsync ends.
This means repeated uses of forEachRemainingAsync could
result in skipping significant sections of the data set.

I have also removed silly attempts of trying to make the class thread-safe that didn't actually make the class thread-safe to begin with. Instead I have added a note about thread-safety to the class documentation.