### PR TITLE
Forcibly request chunks again when caching too many events

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -125,7 +125,7 @@ public class GuildSetupController
     {
         setupNodes.remove(id);
         WebSocketClient client = getJDA().getClient();
-        if (!client.isReady() && --incompleteCount < 1)
+        if (--incompleteCount < 1 && !client.isReady())
             client.ready();
         else
             tryChunking();

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -333,7 +333,17 @@ public class GuildSetupController
 
     // Chunking
 
-    private void sendChunkRequest(Object obj)
+    int getIncompleteCount()
+    {
+        return incompleteCount;
+    }
+
+    int getChunkingCount()
+    {
+        return chunkingGuilds.size();
+    }
+
+    void sendChunkRequest(Object obj)
     {
         log.debug("Sending chunking requests for {} guilds", obj instanceof JSONArray ? ((JSONArray) obj).length() : 1);
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
@@ -326,10 +326,18 @@ public class GuildSetupNode
         int cacheSize = cachedEvents.size();
         if (cacheSize >= 2000 && cacheSize % 1000 == 0)
         {
+            GuildSetupController controller = getController();
             GuildSetupController.log.warn(
                 "Accumulating suspicious amounts of cached events during guild setup, " +
-                "something might be wrong. Cached: {} Members: {}/{} Status: {} GuildId: {}",
-                cacheSize, getCurrentMemberCount(), getExpectedMemberCount(), status, id);
+                "something might be wrong. Cached: {} Members: {}/{} Status: {} GuildId: {} Incomplete: {}/{}",
+                cacheSize, getCurrentMemberCount(), getExpectedMemberCount(),
+                status, id, controller.getChunkingCount(), controller.getIncompleteCount());
+
+            if (status == GuildSetupController.Status.CHUNKING)
+            {
+                GuildSetupController.log.debug("Forcing new chunk request for guild: {}", id);
+                controller.sendChunkRequest(id);
+            }
         }
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

If we know that the guild is waiting for member chunks we should just try asking for them again.