### PR TITLE
AudioReceiveHandler#includeUserInCombinedAudio

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/audio/AudioReceiveHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/AudioReceiveHandler.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.api.audio;
 
+import net.dv8tion.jda.api.entities.User;
+
 import javax.sound.sampled.AudioFormat;
 
 /**
@@ -86,4 +88,26 @@ public interface AudioReceiveHandler
      *         The user audio data
      */
     void handleUserAudio(UserAudio userAudio);
+
+    /**
+     * This method is a filter predicate used by JDA to determine whether or not to include a
+     * {@link net.dv8tion.jda.api.entities.User User}'s audio when creating a CombinedAudio packet.
+     * <p>
+     * This method is especially useful in creating whitelist / blacklist functionality for receiving audio.
+     * <p>
+     * A few possible examples:
+     *  <li>Have this method always return false for Users that are bots.</li>
+     *  <li>Have this method return false for users who have been placed on a blacklist for abusing the bot's functionality.</li>
+     *  <li>Have this method only return true if the user is in a special whitelist of power users.</li>
+     *
+     * @param  user
+     *         The user whose audio was received
+     *
+     * @return If true, JDA will include the user's audio when merging audio sources when created packets
+     *         for {@link #handleCombinedAudio(CombinedAudio)}
+     */
+    default boolean includeUserInCombinedAudio(User user)
+    {
+        return true;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/audio/AudioReceiveHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/AudioReceiveHandler.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.audio;
 
 import net.dv8tion.jda.api.entities.User;
+import javax.annotation.Nonnull;
 
 import javax.sound.sampled.AudioFormat;
 
@@ -96,17 +97,18 @@ public interface AudioReceiveHandler
      * This method is especially useful in creating whitelist / blacklist functionality for receiving audio.
      * <p>
      * A few possible examples:
+     * <ul>
      *  <li>Have this method always return false for Users that are bots.</li>
      *  <li>Have this method return false for users who have been placed on a blacklist for abusing the bot's functionality.</li>
      *  <li>Have this method only return true if the user is in a special whitelist of power users.</li>
-     *
+     * </ul>
      * @param  user
      *         The user whose audio was received
      *
      * @return If true, JDA will include the user's audio when merging audio sources when created packets
      *         for {@link #handleCombinedAudio(CombinedAudio)}
      */
-    default boolean includeUserInCombinedAudio(User user)
+    default boolean includeUserInCombinedAudio(@Nonnull User user)
     {
         return true;
     }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -427,7 +427,7 @@ public class AudioConnection
                             {
                                 receiveHandler.handleUserAudio(new UserAudio(user, decodedAudio));
                             }
-                            if (receiveHandler.canReceiveCombined())
+                            if (receiveHandler.canReceiveCombined() && receiveHandler.includeUserInCombinedAudio(user))
                             {
                                 Queue<AudioData> queue = combinedQueue.get(user);
                                 if (queue == null)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #967

## Description
Adds support for filtering what users are included in in the packet created for `handleCombinedAudio(CombinedAudio)`

Example: Only include audio from users that are not bots.
```
public MyHandler implements AudioReceiveHandler {
  canReceiveCombined() {
    return true;
  }

  handleCombinedAudio(CombinedAudio audio) {
    //Handle audio
  }

  includeUserInCombinedAudio(User user) {
    return !user.isBot();
  }
}
```
