### PR TITLE
Add method to easily get the beginning history of a MessageChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -971,7 +971,7 @@ public interface MessageChannel extends ISnowflake, Formattable
     }
 
     /**
-     * Creates a new {@link MessageHistory MessageHistory} object for each call of this method.
+     * Creates a new {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object for each call of this method.
      * <br>MessageHistory is <b>NOT</b> an internal message cache, but rather it queries the Discord servers for previously sent messages.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
@@ -1031,7 +1031,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@code id} of a message as a marker and retrieves messages sent around
-     * the marker. The {@code limit} determines the amount of message retrieved near the marker. Discord will
+     * the marker. The {@code limit} determines the amount of messages retrieved near the marker. Discord will
      * attempt to evenly split the limit between before and after the marker, however in the case that the marker is set
      * near the beginning or near the end of the channel's history the amount of messages on each side of the marker may
      * be different, and their total count may not equal the provided {@code limit}.
@@ -1069,7 +1069,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param messageId
      *        The id of the message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved around the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1084,7 +1084,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message around the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages around the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAround(MessageChannel, String) MessageHistory.getHistoryAround(MessageChannel, String)
      */
@@ -1096,7 +1096,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@code id} of a message as a marker and retrieves messages around
-     * the marker. The {@code limit} determines the amount of message retrieved near the marker. Discord will
+     * the marker. The {@code limit} determines the amount of messages retrieved near the marker. Discord will
      * attempt to evenly split the limit between before and after the marker, however in the case that the marker is set
      * near the beginning or near the end of the channel's history the amount of messages on each side of the marker may
      * be different, and their total count may not equal the provided {@code limit}.
@@ -1134,7 +1134,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param messageId
      *        The id of the message that will act as a marker. The id must refer to a message from this MessageChannel.
      * @param limit
-     *        The amount of message to be retrieved around the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1149,7 +1149,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message around the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages around the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAround(MessageChannel, String) MessageHistory.getHistoryAround(MessageChannel, String)
      */
@@ -1161,7 +1161,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@link net.dv8tion.jda.api.entities.Message Message} as a marker and retrieves messages around
-     * the marker. The {@code limit} determines the amount of message retrieved near the marker. Discord will
+     * the marker. The {@code limit} determines the amount of messages retrieved near the marker. Discord will
      * attempt to evenly split the limit between before and after the marker, however in the case that the marker is set
      * near the beginning or near the end of the channel's history the amount of messages on each side of the marker may
      * be different, and their total count may not equal the provided {@code limit}.
@@ -1199,7 +1199,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *        The {@link net.dv8tion.jda.api.entities.Message Message} that will act as a marker. The provided Message
      *        must be from this MessageChannel.
      * @param limit
-     *        The amount of message to be retrieved around the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1214,7 +1214,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message around the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages around the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAround(MessageChannel, String) MessageHistory.getHistoryAround(MessageChannel, String)
      */
@@ -1227,7 +1227,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@code id} of a message as a marker and retrieves messages sent after
-     * the marker ID. The {@code limit} determines the amount of message retrieved near the marker.
+     * the marker ID. The {@code limit} determines the amount of messages retrieved near the marker.
      *
      * <p><b>Examples:</b>
      * <br>Retrieve 100 messages from the middle of history. {@literal >}100 message exist in history and the marker is {@literal >}50 messages
@@ -1257,7 +1257,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param messageId
      *        The id of the message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved after the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1272,7 +1272,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message after the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages after the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
@@ -1284,7 +1284,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@code id} of a message as a marker and retrieves messages sent after
-     * the marker ID. The {@code limit} determines the amount of message retrieved near the marker.
+     * the marker ID. The {@code limit} determines the amount of messages retrieved near the marker.
      *
      * <p><b>Examples:</b>
      * <br>Retrieve 100 messages from the middle of history. {@literal >}100 message exist in history and the marker is {@literal >}50 messages
@@ -1314,7 +1314,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param messageId
      *        The id of the message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved after the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         Provided {@code limit} is less than {@code 1} or greater than {@code 100}.
@@ -1326,7 +1326,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message after the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages after the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
@@ -1338,7 +1338,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided message as a marker and retrieves messages sent after
-     * the marker. The {@code limit} determines the amount of message retrieved near the marker.
+     * the marker. The {@code limit} determines the amount of messages retrieved near the marker.
      *
      * <p><b>Examples:</b>
      * <br>Retrieve 100 messages from the middle of history. {@literal >}100 message exist in history and the marker is {@literal >}50 messages
@@ -1368,7 +1368,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param message
      *        The message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved after the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1383,7 +1383,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message after the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages after the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
@@ -1396,7 +1396,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@code id} of a message as a marker and retrieves messages sent before
-     * the marker ID. The {@code limit} determines the amount of message retrieved near the marker.
+     * the marker ID. The {@code limit} determines the amount of messages retrieved near the marker.
      *
      * <p><b>Examples:</b>
      * <br>Retrieve 100 messages from the middle of history. {@literal >}100 message exist in history and the marker is {@literal >}50 messages
@@ -1426,7 +1426,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param messageId
      *        The id of the message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved after the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1441,7 +1441,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message before the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages before the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryBefore(MessageChannel, String) MessageHistory.getHistoryBefore(MessageChannel, String)
      */
@@ -1453,7 +1453,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided {@code id} of a message as a marker and retrieves messages sent before
-     * the marker ID. The {@code limit} determines the amount of message retrieved near the marker.
+     * the marker ID. The {@code limit} determines the amount of messages retrieved near the marker.
      *
      * <p><b>Examples:</b>
      * <br>Retrieve 100 messages from the middle of history. {@literal >}100 message exist in history and the marker is {@literal >}50 messages
@@ -1483,7 +1483,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param messageId
      *        The id of the message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved after the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1498,7 +1498,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message before the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages before the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryBefore(MessageChannel, String) MessageHistory.getHistoryBefore(MessageChannel, String)
      */
@@ -1510,7 +1510,7 @@ public interface MessageChannel extends ISnowflake, Formattable
 
     /**
      * Uses the provided message as a marker and retrieves messages sent before
-     * the marker. The {@code limit} determines the amount of message retrieved near the marker.
+     * the marker. The {@code limit} determines the amount of messages retrieved near the marker.
      *
      * <p><b>Examples:</b>
      * <br>Retrieve 100 messages from the middle of history. {@literal >}100 message exist in history and the marker is {@literal >}50 messages
@@ -1540,7 +1540,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @param message
      *        The message that will act as a marker.
      * @param limit
-     *        The amount of message to be retrieved after the marker. Minimum: 1, Max: 100.
+     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1555,7 +1555,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a MessageHistory object with message before the provided message loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages before the provided message loaded into it.
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryBefore(MessageChannel, String) MessageHistory.getHistoryBefore(MessageChannel, String)
      */
@@ -1565,7 +1565,68 @@ public interface MessageChannel extends ISnowflake, Formattable
         Checks.notNull(message, "Message");
         return getHistoryBefore(message.getId(), limit);
     }
-
+    
+    /**
+     * Retrieves messages from the beginning of this MessageChannel.
+     * The {@code limit} determines the amount of messages being retrieved.
+     * 
+     * <p><b>Example:</b>
+     * <pre><code>
+     * public void resendFirstMessage(MessageChannel channel)
+     * {
+     *     channel.getHistoryFromBeginning(1).queue(history ->
+     *     {
+     *         if (!history.isEmpty())
+     *         {
+     *             Message firstMsg = history.getRetrievedHistory().get(0);
+     *             channel.sendMessage(firstMsg).queue();
+     *         }
+     *         else
+     *             channel.sendMessage("No history for this channel!").queue();
+     *     });
+     * }
+     * </code></pre>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param limit
+     *        The amount of messages to be retrieved. Minimum: 1, Max: 100.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         Provided {@code limit} is less than {@code 1} or greater than {@code 100}.
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and the logged in account does not have
+     *         <ul>
+     *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}</li>
+     *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *         </ul>
+     *
+     * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages - beginning from the start - loaded into it.
+     *
+     * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryAfter(long, String) MessageChannel.getHistoryAfter(long, String)
+     * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
+     */
+    @CheckReturnValue
+    default MessageHistory.MessageRetrieveAction getHistoryFromBeginning(int limit)
+    {
+        return getHistoryAfter(0L, limit);
+    }
+    
     /**
      * Sends the typing status to discord. This is what is used to make the message "X is typing..." appear.
      * <br>The typing status only lasts for 10 seconds or until a message is sent.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1066,10 +1066,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param messageId
-     *        The id of the message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
+     * @param  messageId
+     *         The id of the message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1131,10 +1131,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param messageId
-     *        The id of the message that will act as a marker. The id must refer to a message from this MessageChannel.
-     * @param limit
-     *        The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
+     * @param  messageId
+     *         The id of the message that will act as a marker. The id must refer to a message from this MessageChannel.
+     * @param  limit
+     *         The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1195,11 +1195,11 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param message
-     *        The {@link net.dv8tion.jda.api.entities.Message Message} that will act as a marker. The provided Message
-     *        must be from this MessageChannel.
-     * @param limit
-     *        The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
+     * @param  message
+     *         The {@link net.dv8tion.jda.api.entities.Message Message} that will act as a marker. The provided Message
+     *         must be from this MessageChannel.
+     * @param  limit
+     *         The amount of messages to be retrieved around the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1254,10 +1254,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param messageId
-     *        The id of the message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
+     * @param  messageId
+     *         The id of the message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1311,10 +1311,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param messageId
-     *        The id of the message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
+     * @param  messageId
+     *         The id of the message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         Provided {@code limit} is less than {@code 1} or greater than {@code 100}.
@@ -1365,10 +1365,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param message
-     *        The message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
+     * @param  message
+     *         The message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1423,10 +1423,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param messageId
-     *        The id of the message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
+     * @param  messageId
+     *         The id of the message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1480,10 +1480,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param messageId
-     *        The id of the message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
+     * @param  messageId
+     *         The id of the message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1537,10 +1537,10 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param message
-     *        The message that will act as a marker.
-     * @param limit
-     *        The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
+     * @param  message
+     *         The message that will act as a marker.
+     * @param  limit
+     *         The amount of messages to be retrieved after the marker. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
@@ -1603,8 +1603,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The request was attempted after the channel was deleted.</li>
      * </ul>
      *
-     * @param limit
-     *        The amount of messages to be retrieved. Minimum: 1, Max: 100.
+     * @param  limit
+     *         The amount of messages to be retrieved. Minimum: 1, Max: 100.
      *
      * @throws java.lang.IllegalArgumentException
      *         Provided {@code limit} is less than {@code 1} or greater than {@code 100}.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -35,7 +35,9 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
 import org.json.JSONArray;
 
+import javax.annotation.Nonnull;
 import javax.annotation.CheckReturnValue;
+
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -1567,10 +1569,10 @@ public interface MessageChannel extends ISnowflake, Formattable
     }
     
     /**
-     * Retrieves messages from the beginning of this MessageChannel.
+     * Retrieves messages from the beginning of this {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
      * The {@code limit} determines the amount of messages being retrieved.
      * 
-     * <p><b>Example:</b>
+     * <h2>Example</h2>
      * <pre><code>
      * public void resendFirstMessage(MessageChannel channel)
      * {
@@ -1616,15 +1618,17 @@ public interface MessageChannel extends ISnowflake, Formattable
      *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageHistory.MessageRetrieveAction}
-     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with messages - beginning from the start - loaded into it.
+     *         <br>Provides a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} object with with the first messages of this channel loaded into it.
+     *         <br><b>Note: The messages are ordered from the most recent to oldest!</b>
      *
-     * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryAfter(long, String) MessageChannel.getHistoryAfter(long, String)
+     * @see    net.dv8tion.jda.api.entities.MessageHistory#retrieveFuture(int)                     MessageHistory.retrieveFuture(int)
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
+    @Nonnull
     @CheckReturnValue
     default MessageHistory.MessageRetrieveAction getHistoryFromBeginning(int limit)
     {
-        return getHistoryAfter(0L, limit);
+        return MessageHistory.getHistoryFromBeginning(this).limit(limit);
     }
     
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -35,6 +35,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 import java.util.*;
 
 /**
@@ -462,8 +464,7 @@ public class MessageHistory
      *         The {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}
      *
      * @throws java.lang.IllegalArgumentException
-     *         If any of the provided arguments is {@code null};
-     *         Or if the provided messageId contains whitespace
+     *         If the provided MessageChannel is {@code null};
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If this is a TextChannel and the currently logged in account does not
      *         have the permission {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
@@ -472,7 +473,9 @@ public class MessageHistory
      *
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryFromBeginning(int)  MessageChannel.getHistoryFromBeginning(int)
      */
-    public static MessageRetrieveAction getHistoryFromBeginning(MessageChannel channel)
+    @Nonnull
+    @CheckReturnValue
+    public static MessageRetrieveAction getHistoryFromBeginning(@Nonnull MessageChannel channel)
     {
         return getHistoryAfter(channel, "0L");
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -447,6 +447,36 @@ public class MessageHistory
         return new MessageRetrieveAction(route, channel);
     }
 
+    /**
+     * Constructs a {@link net.dv8tion.jda.api.entities.MessageHistory MessageHistory} with the initially retrieved history
+     * of messages sent.
+     *
+     * <p>Alternatively you can use {@link net.dv8tion.jda.api.entities.MessageChannel#getHistoryFromBeginning(int) MessageChannel.getHistoryFromBeginning(...)}
+     *
+     * <h2>Example</h2>
+     * <br>{@code MessageHistory history = MessageHistory.getHistoryFromBeginning(channel).limit(60).complete()}
+     * <br>Will return a MessageHistory instance with the first 60 messages of the given {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
+
+     *
+     * @param  channel
+     *         The {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If any of the provided arguments is {@code null};
+     *         Or if the provided messageId contains whitespace
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a TextChannel and the currently logged in account does not
+     *         have the permission {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
+     *
+     * @return {@link net.dv8tion.jda.api.entities.MessageHistory.MessageRetrieveAction MessageRetrieveAction}
+     *
+     * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryFromBeginning(int)  MessageChannel.getHistoryFromBeginning(int)
+     */
+    public static MessageRetrieveAction getHistoryFromBeginning(MessageChannel channel)
+    {
+        return getHistoryAfter(channel, "0L");
+    }
+
     private static void checkArguments(MessageChannel channel, String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -477,7 +477,7 @@ public class MessageHistory
     @CheckReturnValue
     public static MessageRetrieveAction getHistoryFromBeginning(@Nonnull MessageChannel channel)
     {
-        return getHistoryAfter(channel, "0L");
+        return getHistoryAfter(channel, "0");
     }
 
     private static void checkArguments(MessageChannel channel, String messageId)


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing).

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____

Closes Issue: #968

## Description

Adds a new method `getHistoryFromBeginning(int limit)` to the MessageChannel Interface that simply returns `getHistoryAfter(0L, limit)`. As @DV8FromTheWorld explained in the Issue mentioned above, most people don't know that this is the way to get the beginning history of a MessageChannel so I added it to make it easier for Users.

As I did that, I also made some minor fixes to the JavaDoc of some other functions in the Interface when I was at it (I spoke to @MinnDevelopment before doing so).

(It's my first real PR ever, I hope it's fine. I was spending more time in reading your guidelines and setting up this PR than writing the Code and the Documentation for it. If there is anything wrong, just tell me, I'll try to fix it asap.)