### PR TITLE
Invite.Group#getUsers now returns usernames

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1157,7 +1157,7 @@ public class EntityBuilder
             if (usernameArray == null)
                 usernames = null;
             else
-                usernames = Collections.unmodifiableList(StreamSupport.stream(usernameArray.spliterator(), false).map(String::valueOf).collect(Collectors.toList()));
+                usernames = Collections.unmodifiableList(StreamSupport.stream(usernameArray.spliterator(), false).map(json -> new JSONObject(String.valueOf(json)).getString("username")).collect(Collectors.toList()));
 
             group = new InviteImpl.GroupImpl(groupIconId, groupName, groupId, usernames);
         }

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1152,9 +1152,8 @@ public class EntityBuilder
             final long groupId = channelObject.getLong("id");
             final String groupIconId = channelObject.optString("icon", null);
 
-            final JSONArray usernameArray = channelObject.optJSONArray("recipients");
             final List<String> usernames;
-            if (usernameArray == null)
+            if (channelObject.isNull("recipients"))
                 usernames = null;
             else
                 usernames = map(channelObject, "recipients", (json) -> json.getString("username"));

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1157,7 +1157,7 @@ public class EntityBuilder
             if (usernameArray == null)
                 usernames = null;
             else
-                usernames = Collections.unmodifiableList(StreamSupport.stream(usernameArray.spliterator(), false).map(json -> new JSONObject(String.valueOf(json)).getString("username")).collect(Collectors.toList()));
+                usernames = map(channelObject, "recipients", (json) -> json.getString("username"));
 
             group = new InviteImpl.GroupImpl(groupIconId, groupName, groupId, usernames);
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #965 

## Description

EntityBuilder#createInvite now parses the username JSON instead of passing the list of JSON strings to the constructor of Invite.Group.
