### PR TITLE
Added EmbedBuilder#setFooter for convenience

### DIFF
--- a/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/core/EmbedBuilder.java
@@ -675,6 +675,22 @@ public class EmbedBuilder
     }
     
     /**
+     * Sets the Footer of the embed without icon.
+     * @param  text
+     *         the text of the footer of the embed. If this is not set, the footer will not appear in the embed.
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the length of {@code text} is longer than {@link net.dv8tion.jda.core.entities.MessageEmbed#TEXT_MAX_LENGTH}.</li>
+     *         </ul>
+     *
+     * @return the builder after the footer has been set
+     */
+    public EmbedBuilder setFooter(String text)
+    {
+        return setFooter(text, null);
+    }
+    
+    /**
      * Copies the provided Field into a new Field for this builder.
      * <br>For additional documentation, see {@link #addField(String, String, boolean)}
      * 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

I only added EmbedBuilder#setFooter without the icon url parameter for convenient use so that we wouldn't have to pass a null object when we don't want to use a footer icon.
