### PR TITLE
Modified JDALogger SLF4J detection to be able to detect both pre-1.8.x and 1.8.x+ providers

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/utils/JDALogger.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/JDALogger.java
@@ -42,7 +42,7 @@ public class JDALogger
     public static final boolean SLF4J_ENABLED;
     static
     {
-        boolean tmp;
+        boolean tmp = false;
 
         try
         {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #580 

## Description

This pull request replaces the detection system in `JDALogger`, which currently is only able to detect an SLF4J provider via the SLF4J `1.7.x` `StaticLoggerBinder` mechanism with one which is able to detect both providers with the current mechanism as well as new `ServiceLoader`-based providers from SLF4J `1.8.x`.

This enables JDA to function correctly with any newer SLF4J API and provider version which may be present at runtime, even if the version it is compiled against is `1.7.x`. (`slf4j-api` has [always been binary compatible](https://www.slf4j.org/faq.html#compatibility) to previous versions, also see [this issue](https://github.com/DV8FromTheWorld/JDA/issues/580#issuecomment-479213460) for more information)
