### PR TITLE
Use mark to get correct content of http response in getBody

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.ratelimit.BotRateLimiter;
 import net.dv8tion.jda.internal.requests.ratelimit.ClientRateLimiter;
+import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
 import okhttp3.Call;
@@ -35,6 +36,7 @@ import org.jetbrains.annotations.Async;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketTimeoutException;
@@ -169,7 +171,7 @@ public class Requester
 
         //adding token to all requests to the discord api or cdn pages
         //we can check for startsWith(DISCORD_API_PREFIX) because the cdn endpoints don't need any kind of authorization
-        if (url.startsWith(DISCORD_API_PREFIX) && authConfig.getToken() != null)
+        if (url.startsWith(DISCORD_API_PREFIX))
             builder.header("authorization", authConfig.getToken());
 
         // Apply custom headers like X-Audit-Log-Reason
@@ -296,22 +298,26 @@ public class Requester
      *
      * @return InputStream representing the body of this response
      */
+    @SuppressWarnings("ConstantConditions") // methods here don't return null despite the annotations on them, read the docs
     public static InputStream getBody(okhttp3.Response response) throws IOException
     {
         String encoding = response.header("content-encoding", "");
+        InputStream data = new BufferedInputStream(response.body().byteStream());
+        data.mark(256);
         try
         {
             if (encoding.equalsIgnoreCase("gzip"))
-                return new GZIPInputStream(response.body().byteStream());
+                return new GZIPInputStream(data);
             else if (encoding.equalsIgnoreCase("deflate"))
-                return new InflaterInputStream(response.body().byteStream(), new Inflater(true));
+                return new InflaterInputStream(data, new Inflater(true));
         }
         catch (ZipException ex)
         {
-            LOG.error("Failed to read gzip content for response. Header: 'content-encoding: {}' Content: '{}'",
-                     encoding, JDALogger.getLazyString(() -> new String(response.body().bytes())), ex);
+            data.reset(); // reset to get full content
+            LOG.error("Failed to read gzip content for response. Headers: {}\nContent: '{}'",
+                      response.headers(), JDALogger.getLazyString(() -> new String(IOUtil.readFully(data))), ex);
             return null;
         }
-        return response.body().byteStream();
+        return data;
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Without this the zip decompression will read the first few bytes and could potentially break the context of the content. This way we make sure to keep the actual content.