### PR TITLE
Use buffer for file uploads to fix duplicated requests

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MiscUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MiscUtil.java
@@ -21,21 +21,12 @@ import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
-import okio.BufferedSink;
-import okio.Okio;
-import okio.Source;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Formatter;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class MiscUtil
 {
@@ -196,36 +187,5 @@ public class MiscUtil
         {
             throw new UncheckedIOException(e);
         }
-    }
-
-    /**
-     * Creates a new request body that transmits the provided {@link java.io.InputStream InputStream}.
-     *  
-     * @param  contentType
-     *         The {@link okhttp3.MediaType MediaType} of the data
-     * @param  stream
-     *         The {@link java.io.InputStream InputStream} to be transmitted
-     *
-     * @return RequestBody capable of transmitting the provided InputStream of data
-     */
-    public static RequestBody createRequestBody(final MediaType contentType, final InputStream stream)
-    {
-        return new RequestBody()
-        {
-            @Override
-            public MediaType contentType()
-            {
-                return contentType;
-            }
-
-            @Override
-            public void writeTo(BufferedSink sink) throws IOException
-            {
-                try (Source source = Okio.source(stream))
-                {
-                    sink.writeAll(source);
-                }
-            }
-        };
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -24,13 +24,13 @@ import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
-import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.requests.Method;
 import net.dv8tion.jda.internal.requests.Requester;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import org.json.JSONObject;
@@ -298,7 +298,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         int index = 0;
         for (Map.Entry<String, InputStream> entry : files.entrySet())
         {
-            final RequestBody body = MiscUtil.createRequestBody(Requester.MEDIA_TYPE_OCTET, entry.getValue());
+            final RequestBody body = IOUtil.createRequestBody(Requester.MEDIA_TYPE_OCTET, entry.getValue());
             builder.addFormDataPart("file" + index++, entry.getKey(), body);
         }
         if (!isEmpty())

--- a/src/main/java/net/dv8tion/jda/internal/utils/BufferedRequestBody.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/BufferedRequestBody.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils;
+
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Source;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class BufferedRequestBody extends RequestBody
+{
+    private final Source source;
+    private final MediaType type;
+    private byte[] data;
+
+    public BufferedRequestBody(Source source, MediaType type)
+    {
+        this.source = source;
+        this.type = type;
+    }
+
+    @Nullable
+    @Override
+    public MediaType contentType()
+    {
+        return type;
+    }
+
+    @Override
+    public void writeTo(@Nonnull BufferedSink sink) throws IOException
+    {
+        if (data != null)
+        {
+            sink.write(data);
+            return;
+        }
+
+        try (BufferedSource s = Okio.buffer(source))
+        {
+            data = s.readByteArray();
+            sink.write(data);
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
@@ -16,6 +16,10 @@
 
 package net.dv8tion.jda.internal.utils;
 
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.Okio;
+
 import java.io.*;
 
 public class IOUtil
@@ -127,5 +131,20 @@ public class IOUtil
             }
             return bos.toByteArray();
         }
+    }
+
+    /**
+     * Creates a new request body that transmits the provided {@link java.io.InputStream InputStream}.
+     *
+     * @param  contentType
+     *         The {@link okhttp3.MediaType MediaType} of the data
+     * @param  stream
+     *         The {@link java.io.InputStream InputStream} to be transmitted
+     *
+     * @return RequestBody capable of transmitting the provided InputStream of data
+     */
+    public static RequestBody createRequestBody(final MediaType contentType, final InputStream stream)
+    {
+        return new BufferedRequestBody(Okio.source(stream), contentType);
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #959 

## Description

When a request is retried we already have the stream exhausted and upload an empty file is sent
on retries instead. This is fixed by temporarily storing the data in a buffer.
