### PR TITLE
Add voice kick handling that stops JDA from reconnecting

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/audio/hooks/ConnectionStatus.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/hooks/ConnectionStatus.java
@@ -58,6 +58,8 @@ public enum ConnectionStatus
      * that this audio connection was connected to, thus the connection was severed.
      */
     DISCONNECTED_REMOVED_FROM_GUILD(false),
+    /** Indicates that we were kicked from a channel by a moderator */
+    DISCONNECTED_KICKED_FROM_CHANNEL(false),
     /**
      * Indicates that the logged in account was removed from the {@link net.dv8tion.jda.api.entities.Guild Guild}
      * while reconnecting to the gateway

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -160,10 +160,10 @@ class AudioWebSocket extends WebSocketAdapter
 
             //Verify that it is actually a lost of connection and not due the connected channel being deleted.
             JDAImpl api = getJDA();
-            if (status == ConnectionStatus.ERROR_LOST_CONNECTION)
+            if (status == ConnectionStatus.ERROR_LOST_CONNECTION || status == ConnectionStatus.DISCONNECTED_KICKED_FROM_CHANNEL)
             {
                 //Get guild from JDA, don't use [guild] field to make sure that we don't have
-               // a problem of an out of date guild stored in [guild] during a possible mWS invalidate.
+                // a problem of an out of date guild stored in [guild] during a possible mWS invalidate.
                 Guild connGuild = api.getGuildById(guild.getIdLong());
                 if (connGuild != null)
                 {

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -297,6 +297,9 @@ class AudioWebSocket extends WebSocketAdapter
                 case AUTHENTICATION_FAILED:
                     this.close(ConnectionStatus.DISCONNECTED_AUTHENTICATION_FAILURE);
                     break;
+                case DISCONNECTED:
+                    this.close(ConnectionStatus.DISCONNECTED_KICKED_FROM_CHANNEL);
+                    break;
                 default:
                     this.reconnect();
             }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -192,7 +192,7 @@ class AudioWebSocket extends WebSocketAdapter
                 //Remove audio manager as we are no longer in the guild
                 api.getAudioManagersView().remove(guild.getIdLong());
             }
-            else if (status != ConnectionStatus.AUDIO_REGION_CHANGE)
+            else if (status != ConnectionStatus.AUDIO_REGION_CHANGE && status != ConnectionStatus.DISCONNECTED_KICKED_FROM_CHANNEL)
             {
                 api.getDirectAudioController().disconnect(guild);
             }

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.handle;
 
-import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.channel.category.CategoryDeleteEvent;
 import net.dv8tion.jda.api.events.channel.priv.PrivateChannelDeleteEvent;
@@ -26,7 +25,6 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.UserImpl;
-import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 
@@ -81,13 +79,14 @@ public class ChannelDeleteHandler extends SocketHandler
                     return null;
                 }
 
-                //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
-                AudioManagerImpl manager = (AudioManagerImpl) getJDA().getAudioManagersView().get(guild.getIdLong());
-                if (manager != null && manager.isConnected()
-                        && manager.getConnectedChannel().getIdLong() == channel.getIdLong())
-                {
-                    manager.closeAudioConnection(ConnectionStatus.DISCONNECTED_CHANNEL_DELETED);
-                }
+                // This is done in the AudioWebSocket already
+//                //We use this instead of getAudioManager(Guild) so we don't create a new instance. Efficiency!
+//                AudioManagerImpl manager = (AudioManagerImpl) getJDA().getAudioManagersView().get(guild.getIdLong());
+//                if (manager != null && manager.isConnected()
+//                        && manager.getConnectedChannel().getIdLong() == channel.getIdLong())
+//                {
+//                    manager.closeAudioConnection(ConnectionStatus.DISCONNECTED_CHANNEL_DELETED);
+//                }
                 guild.getVoiceChannelsView().remove(channel.getIdLong());
                 getJDA().getEventManager().handle(
                     new VoiceChannelDeleteEvent(

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -16,7 +16,6 @@
 
 package net.dv8tion.jda.internal.handle;
 
-import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.guild.voice.*;
 import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor;
@@ -139,7 +138,6 @@ public class VoiceStateUpdateHandler extends SocketHandler
         {
             VoiceChannelImpl oldChannel = (VoiceChannelImpl) vState.getChannel();
             vState.setConnectedChannel(channel);
-            AudioManagerImpl mng = (AudioManagerImpl) getJDA().getAudioManagersView().get(guildId);
 
             if (oldChannel == null)
             {
@@ -153,12 +151,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
             {
                 oldChannel.getConnectedMembersMap().remove(userId);
                 if (isSelf)
-                {
-                    // Tell the audio manager that we were kicked from the channel
-                    if (mng != null)
-                        mng.closeAudioConnection(ConnectionStatus.DISCONNECTED_KICKED_FROM_CHANNEL);
                     getJDA().getDirectAudioController().update(guild, null);
-                }
                 getJDA().getEventManager().handle(
                         new GuildVoiceLeaveEvent(
                                 getJDA(), responseNumber,
@@ -166,6 +159,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
             }
             else
             {
+                AudioManagerImpl mng = (AudioManagerImpl) getJDA().getAudioManagersView().get(guildId);
                 //If the currently connected account is the one that is being moved
                 if (isSelf && mng != null && voiceInterceptor == null)
                 {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Since voice kick was not a thing before, we were not aware that we can be removed from a channel by a moderator. Due to the auto-reconnect logic we then simply reconnect right away. This is changed by this PR which will not attempt to reconnect if we were kicked from the channel.