### PR TITLE
Add getGuildChannelById methods

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -842,7 +842,7 @@ public interface JDA
      * <br>To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(String)}</li>
-     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getVoiceChannelById(String)}</li>
      *     <li>{@link #getStoreChannelById(String)}</li>
      *     <li>{@link #getCategoryById(String)}</li>
      * </ul>
@@ -870,7 +870,7 @@ public interface JDA
      * <br>To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(long)}</li>
-     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getVoiceChannelById(long)}</li>
      *     <li>{@link #getStoreChannelById(long)}</li>
      *     <li>{@link #getCategoryById(long)}</li>
      * </ul>
@@ -901,7 +901,7 @@ public interface JDA
      * To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(String)}</li>
-     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getVoiceChannelById(String)}</li>
      *     <li>{@link #getStoreChannelById(String)}</li>
      *     <li>{@link #getCategoryById(String)}</li>
      * </ul>
@@ -932,7 +932,7 @@ public interface JDA
      * To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(long)}</li>
-     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getVoiceChannelById(long)}</li>
      *     <li>{@link #getStoreChannelById(long)}</li>
      *     <li>{@link #getCategoryById(long)}</li>
      * </ul>

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -837,6 +837,15 @@ public interface JDA
 
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     * <br>This checks if any of the channel types in this guild have the provided ID and returns the first match.
+     *
+     * <br>To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(String)}</li>
+     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getStoreChannelById(String)}</li>
+     *     <li>{@link #getCategoryById(String)}</li>
+     * </ul>
      *
      * @param  id
      *         The ID of the channel
@@ -856,6 +865,15 @@ public interface JDA
 
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     * <br>This checks if any of the channel types in this guild have the provided ID and returns the first match.
+     *
+     * <br>To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(long)}</li>
+     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getStoreChannelById(long)}</li>
+     *     <li>{@link #getCategoryById(long)}</li>
+     * </ul>
      *
      * @param  id
      *         The ID of the channel
@@ -878,6 +896,16 @@ public interface JDA
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
      *
+     * <br>This is meant for systems that use a dynamic {@link net.dv8tion.jda.api.entities.ChannelType} and can
+     * profit from a simple function to get the channel instance.
+     * To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(String)}</li>
+     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getStoreChannelById(String)}</li>
+     *     <li>{@link #getCategoryById(String)}</li>
+     * </ul>
+     *
      * @param  type
      *         The {@link net.dv8tion.jda.api.entities.ChannelType}
      * @param  id
@@ -898,6 +926,16 @@ public interface JDA
 
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * <br>This is meant for systems that use a dynamic {@link net.dv8tion.jda.api.entities.ChannelType} and can
+     * profit from a simple function to get the channel instance.
+     * To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(long)}</li>
+     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getStoreChannelById(long)}</li>
+     *     <li>{@link #getCategoryById(long)}</li>
+     * </ul>
      *
      * @param  type
      *         The {@link net.dv8tion.jda.api.entities.ChannelType}

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.managers.Presence;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.GuildAction;
 import net.dv8tion.jda.api.sharding.ShardManager;
+import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
@@ -832,6 +833,95 @@ public interface JDA
     default List<Role> getRolesByName(@Nonnull String name, boolean ignoreCase)
     {
         return getRoleCache().getElementsByName(name, ignoreCase);
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  id
+     *         The ID of the channel
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided ID is null
+     * @throws java.lang.NumberFormatException
+     *         If the provided ID is not a snowflake
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(@Nonnull String id)
+    {
+        return getGuildChannelById(MiscUtil.parseSnowflake(id));
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  id
+     *         The ID of the channel
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(long id)
+    {
+        GuildChannel channel = getTextChannelById(id);
+        if (channel == null)
+            channel = getVoiceChannelById(id);
+        if (channel == null)
+            channel = getStoreChannelById(id);
+        if (channel == null)
+            channel = getCategoryById(id);
+        return channel;
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  type
+     *         The {@link net.dv8tion.jda.api.entities.ChannelType}
+     * @param  id
+     *         The ID of the channel
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided ID is null
+     * @throws java.lang.NumberFormatException
+     *         If the provided ID is not a snowflake
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, @Nonnull String id)
+    {
+        return getGuildChannelById(type, MiscUtil.parseSnowflake(id));
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  type
+     *         The {@link net.dv8tion.jda.api.entities.ChannelType}
+     * @param  id
+     *         The ID of the channel
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, long id)
+    {
+        Checks.notNull(type, "ChannelType");
+        switch (type)
+        {
+            case TEXT:
+                return getTextChannelById(id);
+            case VOICE:
+                return getVoiceChannelById(id);
+            case STORE:
+                return getStoreChannelById(id);
+            case CATEGORY:
+                return getCategoryById(id);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -621,7 +621,7 @@ public interface Guild extends ISnowflake
      * <br>To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(String)}</li>
-     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getVoiceChannelById(String)}</li>
      *     <li>{@link #getStoreChannelById(String)}</li>
      *     <li>{@link #getCategoryById(String)}</li>
      * </ul>
@@ -649,7 +649,7 @@ public interface Guild extends ISnowflake
      * <br>To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(long)}</li>
-     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getVoiceChannelById(long)}</li>
      *     <li>{@link #getStoreChannelById(long)}</li>
      *     <li>{@link #getCategoryById(long)}</li>
      * </ul>
@@ -680,7 +680,7 @@ public interface Guild extends ISnowflake
      * To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(String)}</li>
-     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getVoiceChannelById(String)}</li>
      *     <li>{@link #getStoreChannelById(String)}</li>
      *     <li>{@link #getCategoryById(String)}</li>
      * </ul>
@@ -711,7 +711,7 @@ public interface Guild extends ISnowflake
      * To get more specific channel types you can use one of the following:
      * <ul>
      *     <li>{@link #getTextChannelById(long)}</li>
-     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getVoiceChannelById(long)}</li>
      *     <li>{@link #getStoreChannelById(long)}</li>
      *     <li>{@link #getCategoryById(long)}</li>
      * </ul>

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -616,6 +616,15 @@ public interface Guild extends ISnowflake
 
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     * <br>This checks if any of the channel types in this guild have the provided ID and returns the first match.
+     *
+     * <br>To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(String)}</li>
+     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getStoreChannelById(String)}</li>
+     *     <li>{@link #getCategoryById(String)}</li>
+     * </ul>
      *
      * @param  id
      *         The ID of the channel
@@ -635,6 +644,15 @@ public interface Guild extends ISnowflake
 
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     * <br>This checks if any of the channel types in this guild have the provided ID and returns the first match.
+     *
+     * <br>To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(long)}</li>
+     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getStoreChannelById(long)}</li>
+     *     <li>{@link #getCategoryById(long)}</li>
+     * </ul>
      *
      * @param  id
      *         The ID of the channel
@@ -657,6 +675,16 @@ public interface Guild extends ISnowflake
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
      *
+     * <br>This is meant for systems that use a dynamic {@link net.dv8tion.jda.api.entities.ChannelType} and can
+     * profit from a simple function to get the channel instance.
+     * To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(String)}</li>
+     *     <lI>{@link #getVoiceChannelById(String)}</lI>
+     *     <li>{@link #getStoreChannelById(String)}</li>
+     *     <li>{@link #getCategoryById(String)}</li>
+     * </ul>
+     *
      * @param  type
      *         The {@link net.dv8tion.jda.api.entities.ChannelType}
      * @param  id
@@ -677,6 +705,16 @@ public interface Guild extends ISnowflake
 
     /**
      * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * <br>This is meant for systems that use a dynamic {@link net.dv8tion.jda.api.entities.ChannelType} and can
+     * profit from a simple function to get the channel instance.
+     * To get more specific channel types you can use one of the following:
+     * <ul>
+     *     <li>{@link #getTextChannelById(long)}</li>
+     *     <lI>{@link #getVoiceChannelById(long)}</lI>
+     *     <li>{@link #getStoreChannelById(long)}</li>
+     *     <li>{@link #getCategoryById(long)}</li>
+     * </ul>
      *
      * @param  type
      *         The {@link net.dv8tion.jda.api.entities.ChannelType}

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MemberAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction;
+import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.cache.MemberCacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView;
@@ -612,6 +613,95 @@ public interface Guild extends ISnowflake
      */
     @Nonnull
     MemberCacheView getMemberCache();
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  id
+     *         The ID of the channel
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided ID is null
+     * @throws java.lang.NumberFormatException
+     *         If the provided ID is not a snowflake
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(@Nonnull String id)
+    {
+        return getGuildChannelById(MiscUtil.parseSnowflake(id));
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  id
+     *         The ID of the channel
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(long id)
+    {
+        GuildChannel channel = getTextChannelById(id);
+        if (channel == null)
+            channel = getVoiceChannelById(id);
+        if (channel == null)
+            channel = getStoreChannelById(id);
+        if (channel == null)
+            channel = getCategoryById(id);
+        return channel;
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  type
+     *         The {@link net.dv8tion.jda.api.entities.ChannelType}
+     * @param  id
+     *         The ID of the channel
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided ID is null
+     * @throws java.lang.NumberFormatException
+     *         If the provided ID is not a snowflake
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, @Nonnull String id)
+    {
+        return getGuildChannelById(type, MiscUtil.parseSnowflake(id));
+    }
+
+    /**
+     * Get {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} for the provided ID.
+     *
+     * @param  type
+     *         The {@link net.dv8tion.jda.api.entities.ChannelType}
+     * @param  id
+     *         The ID of the channel
+     *
+     * @return The GuildChannel or null
+     */
+    @Nullable
+    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, long id)
+    {
+        Checks.notNull(type, "ChannelType");
+        switch (type)
+        {
+            case TEXT:
+                return getTextChannelById(id);
+            case VOICE:
+                return getVoiceChannelById(id);
+            case STORE:
+                return getStoreChannelById(id);
+            case CATEGORY:
+                return getCategoryById(id);
+        }
+        return null;
+    }
 
     /**
      * Gets the {@link net.dv8tion.jda.api.entities.Category Category} from this guild that matches the provided id.


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds a consistent way to retrieve a guild-channel by its ID. Otherwise we have to always update multiple switches for this behavior when a new type is introduced.

### Example


**Before**
```java
@Nullable
public GuildChannel getChannel(@Nonnull JDA api)
{
    Checks.notNull(api, "JDA");
    GuildChannel channel;
    switch (getChannelType())
    {
        case TEXT:
            return api.getTextChannelById(channelId);
        case CATEGORY:
            return api.getCategoryById(channelId);
        case VOICE:
            return api.getVoiceChannelById(channelId);
        case STORE:
            return api.getStoreChannelById(channelId);
    }
    return null;
}
```

**After**
```java
@Nullable
public GuildChannel getChannel(@Nonnull JDA api)
{
    Checks.notNull(api, "JDA");
    return api.getGuildChannelById(getChannelType(), channelId);
}
```