### PR TITLE
Handle split zlib messages with Z_SYNC_FLUSH suffix

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -43,7 +43,6 @@ import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.handle.*;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.managers.PresenceImpl;
-import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
@@ -858,7 +857,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         {
             json = handleBinary(binary);
         }
-        handleEvent(json);
+        if (json != null)
+            handleEvent(json);
     }
 
     protected DataObject handleBinary(byte[] binary) throws DataFormatException
@@ -870,6 +870,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         try
         {
             jsonString = decompressor.decompress(binary);
+            if (jsonString == null)
+                return null;
         }
         catch (DataFormatException e)
         {

--- a/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
@@ -21,6 +21,7 @@ import okhttp3.RequestBody;
 import okio.Okio;
 
 import java.io.*;
+import java.nio.ByteBuffer;
 
 public class IOUtil
 {
@@ -168,5 +169,12 @@ public class IOUtil
         arr[offset + 1] = (byte) ((it >>> 16) & 0xFF);
         arr[offset + 2] = (byte) ((it >>> 8)  & 0xFF);
         arr[offset + 3] = (byte) ( it         & 0xFF);
+    }
+
+    public static ByteBuffer reallocate(ByteBuffer original, int length)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(length);
+        buffer.put(original);
+        return buffer;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/Decompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/Decompressor.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.utils.Compression;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import java.util.zip.DataFormatException;
 
 public interface Decompressor
@@ -32,5 +33,6 @@ public interface Decompressor
 
     void shutdown();
 
+    @Nullable // returns null when the decompression isn't done, for example when no Z_SYNC_FLUSH was present
     String decompress(byte[] data) throws DataFormatException;
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
@@ -67,12 +67,13 @@ public class ZlibDecompressor implements Decompressor
         if (flushBuffer == null)
             flushBuffer = ByteBuffer.allocate(data.length * 2);
 
+        //Ensure the capacity can hold the new data, ByteBuffer doesn't grow automatically
         if (flushBuffer.capacity() < data.length + flushBuffer.position())
         {
-            ByteBuffer buffer = ByteBuffer.allocate((flushBuffer.capacity() + data.length) * 2);
+            //Flip to make it a read buffer
             flushBuffer.flip();
-            buffer.put(flushBuffer);
-            flushBuffer = buffer;
+            //Reallocate for the new capacity
+            flushBuffer = IOUtil.reallocate(flushBuffer, (flushBuffer.capacity() + data.length) * 2);
         }
 
         flushBuffer.put(data);

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
@@ -17,11 +17,13 @@
 package net.dv8tion.jda.internal.utils.compress;
 
 import net.dv8tion.jda.api.utils.Compression;
+import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.JDALogger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -29,7 +31,10 @@ import java.util.zip.InflaterOutputStream;
 
 public class ZlibDecompressor implements Decompressor
 {
+    private static final int Z_SYNC_FLUSH = 0x0000FFFF;
+
     private final Inflater inflater = new Inflater();
+    private ByteBuffer flushBuffer = null;
     private SoftReference<ByteArrayOutputStream> decompressBuffer = null;
 
     private SoftReference<ByteArrayOutputStream> newDecompressBuffer()
@@ -47,6 +52,35 @@ public class ZlibDecompressor implements Decompressor
         if (buffer == null) // create a ne buffer because the GC got it
             decompressBuffer = new SoftReference<>(buffer = new ByteArrayOutputStream(1024));
         return buffer;
+    }
+
+    private boolean isFlush(byte[] data)
+    {
+        if (data.length < 4)
+            return false;
+        int suffix = IOUtil.getIntBigEndian(data, data.length - 4);
+        return suffix == Z_SYNC_FLUSH;
+    }
+
+    private void buffer(byte[] data)
+    {
+        if (flushBuffer == null)
+            flushBuffer = ByteBuffer.allocate(data.length * 2);
+
+        if (flushBuffer.capacity() < data.length + flushBuffer.position())
+        {
+            ByteBuffer buffer = ByteBuffer.allocate((flushBuffer.capacity() + data.length) * 2);
+            flushBuffer.flip();
+            buffer.put(flushBuffer);
+            flushBuffer = buffer;
+        }
+
+        flushBuffer.put(data);
+    }
+
+    private Object lazy(byte[] data)
+    {
+        return JDALogger.getLazyString(() -> Arrays.toString(data));
     }
 
     @Override
@@ -71,7 +105,26 @@ public class ZlibDecompressor implements Decompressor
     @SuppressWarnings("CharsetObjectCanBeUsed")
     public String decompress(byte[] data) throws DataFormatException
     {
-        LOG.trace("Decompressing data {}", JDALogger.getLazyString(() -> Arrays.toString(data)));
+        //Handle split messages
+        if (!isFlush(data))
+        {
+            //There is no flush suffix so this is not the end of the message
+            LOG.debug("Received incomplete data, writing to buffer. Length: {}", data.length);
+            buffer(data);
+            return null; // signal failure to decompress
+        }
+        else if (flushBuffer != null)
+        {
+            //This has a flush suffix and we have an incomplete package buffered
+            //concatenate the package with the new data and decompress it below
+            LOG.debug("Received final part of incomplete data");
+            buffer(data);
+            byte[] arr = flushBuffer.array();
+            data = new byte[flushBuffer.position()];
+            System.arraycopy(arr, 0, data, 0, data.length);
+            flushBuffer = null;
+        }
+        LOG.trace("Decompressing data {}", lazy(data));
         //Get the compressed message and inflate it
         //We use the same buffer here to optimize gc use
         ByteArrayOutputStream buffer = getDecompressBuffer();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This handles the Z_SYNC_FLUSH suffix. I don't believe this will ever be used but its part of the protocol so we should support it. Currently discord doesn't use this but they might use it in the future.
