### PR TITLE
Fix rate-limits for reactions (undocumented behavior)

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1789,7 +1789,7 @@ public interface MessageChannel extends ISnowflake, Formattable
             encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
         else
             encoded = EncodingUtil.encodeUTF8(unicode);
-        Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, encoded);
+        Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, encoded, "@me");
         return new RestActionImpl<>(getJDA(), route);
     }
 
@@ -1930,7 +1930,7 @@ public interface MessageChannel extends ISnowflake, Formattable
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(emote, "Emote");
 
-        Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, String.format("%s:%s", emote.getName(), emote.getId()));
+        Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, String.format("%s:%s", emote.getName(), emote.getId()), "@me");
         return new RestActionImpl<Void>(getJDA(), route);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -106,7 +106,6 @@ public class Route
         public static final Route BAN =                new Route(PUT,    "guilds/{guild_id}/bans/{user_id}",    "guild_id");
         public static final Route KICK_MEMBER =        new Route(DELETE, "guilds/{guild_id}/members/{user_id}", "guild_id");
         public static final Route MODIFY_MEMBER =      new Route(PATCH,  "guilds/{guild_id}/members/{user_id}", "guild_id");
-        // TODO: no headers
         public static final Route ADD_MEMBER =         new Route(PUT,    "guilds/{guild_id}/members/{user_id}", "guild_id");
         public static final Route MODIFY_SELF_NICK =   new Route(PATCH,  "guilds/{guild_id}/members/@me/nick",  "guild_id");
         public static final Route PRUNABLE_COUNT =     new Route(GET,    "guilds/{guild_id}/prune",             "guild_id");
@@ -202,9 +201,8 @@ public class Route
         public static final Route ADD_PINNED_MESSAGE =    new Route(PUT,    "channels/{channel_id}/pins/{message_id}",     "channel_id");
         public static final Route REMOVE_PINNED_MESSAGE = new Route(DELETE, "channels/{channel_id}/pins/{message_id}",     "channel_id");
 
-        public static final Route ADD_REACTION =             new Route(PUT,    new RateLimit(1, 250),
-                                                                               "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/@me",       "channel_id");
-        public static final Route REMOVE_REACTION =          new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}", "channel_id");
+        public static final Route ADD_REACTION =             new ReactionRoute(PUT);
+        public static final Route REMOVE_REACTION =          new ReactionRoute(DELETE);
         public static final Route REMOVE_ALL_REACTIONS =     new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions",                           "channel_id");
         public static final Route GET_REACTION_USERS =       new Route(GET,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}",           "channel_id");
 
@@ -515,6 +513,21 @@ public class Route
         public String getRatelimitRoute()
         {
             return "channels/%s/messages/{message_id}/delete"; //the additional "/delete" forces a new bucket
+        }
+    }
+
+    // This endpoint shares the rate-limit bucket with REMOVE_ALL_REACTIONS
+    private static class ReactionRoute extends Route
+    {
+        private ReactionRoute(Method method)
+        {
+            super(method, new RateLimit(1, 250), "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}", "channel_id");
+        }
+
+        @Override
+        public String getRatelimitRoute()
+        {
+            return "channels/%s/messages/{message_id}/reactions";
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -203,7 +203,7 @@ public class Route
 
         public static final Route ADD_REACTION =             new ReactionRoute(PUT);
         public static final Route REMOVE_REACTION =          new ReactionRoute(DELETE);
-        public static final Route REMOVE_ALL_REACTIONS =     new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions",                           "channel_id");
+        public static final Route REMOVE_ALL_REACTIONS =     new Route(DELETE, new RateLimit(1, 250), "channels/{channel_id}/messages/{message_id}/reactions",    "channel_id");
         public static final Route GET_REACTION_USERS =       new Route(GET,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}",           "channel_id");
 
         public static final Route DELETE_MESSAGE =      new DeleteMessageRoute();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes rate-limits on reaction endpoints. All these endpoints seem to use the same bucket for rate-limiting. I've tested this before and after this change and it seems to resolve the issue.
