### PR TITLE
Add option to mute/deafen the owner of a guild

### DIFF
--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -207,7 +207,7 @@ public class MessageListenerExample extends ListenerAdapter
 
                         //Remember, due to the fact that we're using queue we will never have to deal with RateLimits.
                         // JDA will do it all for you so long as you are using queue!
-                        guild.getController().kick(member).queue(
+                        guild.kick(member).queue(
                             success -> channel.sendMessage("Kicked ").append(member.getEffectiveName()).append("! Cya!").queue(),
                             error ->
                             {

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2566,6 +2566,53 @@ public interface Guild extends ISnowflake
      *         The {@link net.dv8tion.jda.api.entities.Member Member} who's {@link GuildVoiceState VoiceState} is being changed.
      * @param  deafen
      *         Whether this {@link net.dv8tion.jda.api.entities.Member Member} should be deafened or undeafened.
+     * @param  protectOwner
+     *         Whether the owner should protected from being deafen.
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#VOICE_DEAF_OTHERS} permission.
+     * @throws net.dv8tion.jda.api.exceptions.HierarchyException
+     *         If the provided member is the Guild's owner. You cannot modify the owner of a Guild.
+     * @throws IllegalArgumentException
+     *         If the provided member is not from this Guild or null.
+     * @throws java.lang.IllegalStateException
+     *         If the provided member is not currently connected to a voice channel.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    AuditableRestAction<Void> deafen(@Nonnull Member member, boolean deafen, boolean protectOwner);
+
+    /**
+     * Sets the Guild Deafened state state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
+     * boolean.
+     *
+     * This method by default protects the owner to be deafen by this method. {@see deafen(Member, boolean, boolean)}
+     *
+     * <p><b>Note:</b> The Member's {@link net.dv8tion.jda.api.entities.GuildVoiceState#isGuildDeafened() GuildVoiceState.isGuildDeafened()} value won't change
+     * until JDA receives the {@link net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildDeafenEvent GuildVoiceGuildDeafenEvent} event related to this change.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The target Member cannot be deafened due to a permission discrepancy</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>We were removed from the Guild before finishing the task</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER}
+     *     <br>The specified Member was removed from the Guild before finishing the task</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#USER_NOT_CONNECTED USER_NOT_CONNECTED}
+     *     <br>The specified Member is not connected to a voice channel</li>
+     * </ul>
+     *
+     * @param  member
+     *         The {@link net.dv8tion.jda.api.entities.Member Member} who's {@link GuildVoiceState VoiceState} is being changed.
+     * @param  deafen
+     *         Whether this {@link net.dv8tion.jda.api.entities.Member Member} should be deafened or undeafened.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#VOICE_DEAF_OTHERS} permission.
@@ -2585,6 +2632,53 @@ public interface Guild extends ISnowflake
     /**
      * Sets the Guild Muted state state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
      * boolean.
+     *
+     * <p><b>Note:</b> The Member's {@link net.dv8tion.jda.api.entities.GuildVoiceState#isGuildMuted() GuildVoiceState.isGuildMuted()} value won't change
+     * until JDA receives the {@link net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildMuteEvent GuildVoiceGuildMuteEvent} event related to this change.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The target Member cannot be muted due to a permission discrepancy</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>We were removed from the Guild before finishing the task</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER}
+     *     <br>The specified Member was removed from the Guild before finishing the task</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#USER_NOT_CONNECTED USER_NOT_CONNECTED}
+     *     <br>The specified Member is not connected to a voice channel</li>
+     * </ul>
+     *
+     * @param  member
+     *         The {@link net.dv8tion.jda.api.entities.Member Member} who's {@link GuildVoiceState VoiceState} is being changed.
+     * @param  mute
+     *         Whether this {@link net.dv8tion.jda.api.entities.Member Member} should be muted or unmuted.
+     * @param  protectOwner
+     *         Whether the owner should protected from being muted.
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#VOICE_DEAF_OTHERS} permission.
+     * @throws net.dv8tion.jda.api.exceptions.HierarchyException
+     *         If the provided member is the Guild's owner. You cannot modify the owner of a Guild.
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided member is not from this Guild or null.
+     * @throws java.lang.IllegalStateException
+     *         If the provided member is not currently connected to a voice channel.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    AuditableRestAction<Void> mute(@Nonnull Member member, boolean mute, boolean protectOwner);
+
+    /**
+     * Sets the Guild Muted state state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
+     * boolean.
+     *
+     * This method by default protects the owner to be muted by this method. {@see mute(Member, boolean, boolean)}
      *
      * <p><b>Note:</b> The Member's {@link net.dv8tion.jda.api.entities.GuildVoiceState#isGuildMuted() GuildVoiceState.isGuildMuted()} value won't change
      * until JDA receives the {@link net.dv8tion.jda.api.events.guild.voice.GuildVoiceGuildMuteEvent GuildVoiceGuildMuteEvent} event related to this change.

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -874,7 +874,7 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
-    public AuditableRestAction<Void> deafen(@Nonnull Member member, boolean deafen)
+    public AuditableRestAction<Void> deafen(@Nonnull Member member, boolean deafen, boolean protectOwner)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -882,7 +882,7 @@ public class GuildImpl implements Guild
 
         //We check the owner instead of Position because, apparently, Discord doesn't care about position for
         // muting and deafening, only whether the affected Member is the owner.
-        if (member.equals(getOwner()))
+        if (protectOwner && member.equals(getOwner()))
             throw new HierarchyException("Cannot modify Guild Deafen status the Owner of the Guild");
 
         GuildVoiceState voiceState = member.getVoiceState();
@@ -901,7 +901,13 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
-    public AuditableRestAction<Void> mute(@Nonnull Member member, boolean mute)
+    public AuditableRestAction<Void> deafen(@Nonnull Member member, boolean mute) {
+        return mute(member, mute, true);
+    }
+
+    @Nonnull
+    @Override
+    public AuditableRestAction<Void> mute(@Nonnull Member member, boolean mute, boolean protectOwner)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -909,7 +915,7 @@ public class GuildImpl implements Guild
 
         //We check the owner instead of Position because, apparently, Discord doesn't care about position for
         // muting and deafening, only whether the affected Member is the owner.
-        if (member.equals(getOwner()))
+        if (protectOwner && member.equals(getOwner()))
             throw new HierarchyException("Cannot modify Guild Mute status the Owner of the Guild");
 
         GuildVoiceState voiceState = member.getVoiceState();
@@ -924,6 +930,12 @@ public class GuildImpl implements Guild
         DataObject body = DataObject.empty().put("mute", mute);
         Route.CompiledRoute route = Route.Guilds.MODIFY_MEMBER.compile(getId(), member.getUser().getId());
         return new AuditableRestActionImpl<>(getJDA(), route, body);
+    }
+
+    @Nonnull
+    @Override
+    public AuditableRestAction<Void> mute(@Nonnull Member member, boolean mute) {
+        return mute(member, mute, true);
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation

<!-- Replace "NaN" with an issue number if this is a response to an issue -->


## Description

I am working on a project where I need to be able to also mute/deafen the owner. Therefore my idae is to add a new parameter called protectOwner with a default value of true. This doesn't mess with exsisting end-user code but nevertheless adds this option.
