### PR TITLE
Update link to emoji documentation

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -54,7 +54,7 @@ public interface Emote extends IMentionable, IFakeable
     /**
      * The {@link net.dv8tion.jda.api.entities.Guild Guild} this emote is attached to.
      *
-     * <p><b>This is null if the emote is fake (retrieved from a Message)</b>
+     * <p><b>This is null if the emote is fake (retrieved from a Message) or when the attached Guild is on a separate Shard then the one this is called.</b>
      *
      * @return Guild of this emote or null if it is a fake entity
      */
@@ -62,8 +62,7 @@ public interface Emote extends IMentionable, IFakeable
     Guild getGuild();
 
     /**
-     * Roles this emote is active for
-     * <br><a href="https://discordapp.com/developers/docs/resources/guild#emoji-object" target="_blank">Learn More</a>
+     * Roles this emote is active for.
      *
      * @throws IllegalStateException
      *         If this Emote does not have attached roles according to {@link #canProvideRoles()}
@@ -114,7 +113,6 @@ public interface Emote extends IMentionable, IFakeable
     /**
      * Whether this emote is managed. A managed Emote is controlled by Discord, not the Guild administrator, typical
      * via a service like BBTV in conjunction with Twitch.
-     * <br><a href="https://discordapp.com/developers/docs/resources/guild#emoji-object" target="_blank">Learn More</a>
      *
      * @return True, if this emote is managed
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -54,7 +54,7 @@ public interface Emote extends IMentionable, IFakeable
     /**
      * The {@link net.dv8tion.jda.api.entities.Guild Guild} this emote is attached to.
      *
-     * <p><b>This is null if the emote is fake (retrieved from a Message) or when the attached Guild is on a separate Shard then the one this is called.</b>
+     * <p><b>This is null if the emote is fake (retrieved from a Message)</b>
      *
      * @return Guild of this emote or null if it is a fake entity
      */
@@ -63,6 +63,7 @@ public interface Emote extends IMentionable, IFakeable
 
     /**
      * Roles this emote is active for.
+     * <br><a href="https://discordapp.com/developers/docs/resources/emoji#emoji-object" target="_blank">Learn More</a>
      *
      * @throws IllegalStateException
      *         If this Emote does not have attached roles according to {@link #canProvideRoles()}
@@ -113,6 +114,7 @@ public interface Emote extends IMentionable, IFakeable
     /**
      * Whether this emote is managed. A managed Emote is controlled by Discord, not the Guild administrator, typical
      * via a service like BBTV in conjunction with Twitch.
+     * <br><a href="https://discordapp.com/developers/docs/resources/emoji#emoji-object" target="_blank">Learn More</a>
      *
      * @return True, if this emote is managed
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
I updated some descriptions in the Emotes.java
- `Emote#getGuild()` also returns null in the case that the Guild is in fact one the bot shares, but is on a different shard than where this method was called.
- https://discordapp.com/developers/docs/resources/guild#emoji-object is no longer a valid link (no longer exists) so it was removed. When the link changed, let me know so that I can update it.

This PR is from the feature/v4/new-guild-properties and should be pulled into this branch if it gets accepted.
