### PR TITLE
Deprecate Invite#getCreationTime in favor of Invite#getTimeCreated

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Invite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Invite.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild.VerificationLevel;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -188,8 +190,14 @@ public interface Invite
      *
      * @see    #expand()
      * @see    #isExpanded()
+     *
+     * @deprecated
+     *         Use {@link #getTimeCreated()} instead
      */
     @Nonnull
+    @Deprecated
+    @DeprecatedSince("4.BETA.0")
+    @ReplaceWith("getTimeCreated()")
     OffsetDateTime getCreationTime();
 
     /**
@@ -248,6 +256,22 @@ public interface Invite
     * @see    #isExpanded()
     */
     int getMaxUses();
+
+    /**
+     * Returns creation date of this invite.
+     *
+     * <p>This works only for expanded invites and will throw a {@link IllegalStateException} otherwise!
+     *
+     * @throws IllegalStateException
+     *         if this invite is not expanded
+     *
+     * @return The creation date of this invite
+     *
+     * @see    #expand()
+     * @see    #isExpanded()
+     */
+    @Nonnull
+    OffsetDateTime getTimeCreated();
 
     /**
      * How often this invite has been used.

--- a/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.internal.entities;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
@@ -170,11 +172,12 @@ public class InviteImpl implements Invite
 
     @Nonnull
     @Override
+    @Deprecated
+    @DeprecatedSince("4.BETA.0")
+    @ReplaceWith("getTimeCreated()")
     public OffsetDateTime getCreationTime()
     {
-        if (!this.expanded)
-            throw new IllegalStateException("Only valid for expanded invites");
-        return this.timeCreated;
+        return getTimeCreated();
     }
 
     @Override
@@ -216,6 +219,14 @@ public class InviteImpl implements Invite
         if (!this.expanded)
             throw new IllegalStateException("Only valid for expanded invites");
         return this.maxUses;
+    }
+
+    @Nonnull
+    @Override
+    public OffsetDateTime getTimeCreated() {
+        if (!this.expanded)
+            throw new IllegalStateException("Only valid for expanded invites");
+        return this.timeCreated;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
@@ -223,7 +223,8 @@ public class InviteImpl implements Invite
 
     @Nonnull
     @Override
-    public OffsetDateTime getTimeCreated() {
+    public OffsetDateTime getTimeCreated()
+    {
         if (!this.expanded)
             throw new IllegalStateException("Only valid for expanded invites");
         return this.timeCreated;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Invite was overlooked when refactoring time methods.