### PR TITLE
Remove the overriden "GuildImpl#getIconUrl()" implementation

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -163,12 +163,6 @@ public class GuildImpl implements Guild
         return iconId;
     }
 
-    @Override
-    public String getIconUrl()
-    {
-        return iconId == null ? null : "https://cdn.discordapp.com/icons/" + id + "/" + iconId + ".png";
-    }
-
     @Nonnull
     @Override
     public Set<String> getFeatures()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

When #995 was merged, animated icon support for guilds was added as a default interface method on the `Guild` object.

However the original method implementation wasn't removed from `GuildImpl`, causing `getIconUrl()` to always use the overriden implementation that does not support animated icons.