### PR TITLE
Mark getShardInfo() nonnull

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -113,6 +113,9 @@ public interface JDA
      */
     class ShardInfo
     {
+        /** Default sharding config with one shard */
+        public static final ShardInfo SINGLE = new ShardInfo(0, 1);
+
         int shardId;
         int shardTotal;
 
@@ -1479,9 +1482,9 @@ public interface JDA
      * The shard information used when creating this instance of JDA.
      * <br>Represents the information provided to {@link net.dv8tion.jda.api.JDABuilder#useSharding(int, int)}.
      *
-     * @return The shard information for this shard or {@code null} if this JDA instance isn't sharding.
+     * @return The shard information for this shard
      */
-    @Nullable
+    @Nonnull
     ShardInfo getShardInfo();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -331,10 +331,6 @@ public interface ShardManager
      * Unified {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView} of
      * all cached {@link net.dv8tion.jda.api.entities.Emote Emotes} visible to this ShardManager instance.
      *
-     * <p>This copies the backing store into a list. This means every call
-     * creates a new list with O(n) complexity. It is recommended to store this into
-     * a local variable or use {@link #getEmoteCache()} and use its more efficient
-     * versions of handling these values.
      *
      * @return Unified {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
@@ -352,6 +348,11 @@ public interface ShardManager
      * Emote#canInteract(net.dv8tion.jda.api.entities.User, net.dv8tion.jda.api.entities.MessageChannel)}
      *
      * <p><b>Unicode emojis are not included as {@link net.dv8tion.jda.api.entities.Emote Emote}!</b>
+     *
+     * <p>This copies the backing store into a list. This means every call
+     * creates a new list with O(n) complexity. It is recommended to store this into
+     * a local variable or use {@link #getEmoteCache()} and use its more efficient
+     * versions of handling these values.
      *
      * @return An immutable list of Emotes (which may or may not be available to usage).
      */

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
@@ -20,7 +20,6 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Controls states and behaviour of one or multiple {@link net.dv8tion.jda.api.JDA JDA} instances.
@@ -178,7 +177,7 @@ public interface SessionController
          *
          * @return The ShardInfo
          */
-        @Nullable
+        @Nonnull
         JDA.ShardInfo getShardInfo();
 
         /**

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -666,10 +666,11 @@ public class JDAImpl implements JDA
         return sessionConfig.getMaxReconnectDelay();
     }
 
+    @Nonnull
     @Override
     public ShardInfo getShardInfo()
     {
-        return shardInfo;
+        return shardInfo == null ? ShardInfo.SINGLE : shardInfo;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -51,6 +51,7 @@ import net.dv8tion.jda.internal.utils.compress.ZlibDecompressor;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
+import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
@@ -1219,12 +1220,14 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected abstract class ConnectNode implements SessionController.SessionConnectNode
     {
+        @Nonnull
         @Override
         public JDA getJDA()
         {
             return api;
         }
 
+        @Nonnull
         @Override
         public JDA.ShardInfo getShardInfo()
         {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The shard info indicates which shard id and shard total the current JDA session uses. If sharding is disabled this is equivalent to [0 / 1]. The identification string used for thread names is unchanged and will not report shard details unless explicitly set through `useSharding` or the shard manager.

- This is not a breaking change in java because it only changes an annotation.
- This is not a breaking change in kotlin because you can also store nonnull types in nullable typed variables. Safe-call operators should just emit a warning similar to unnecessary null checks.

