### PR TITLE
Use enqueue instead of execute for HTTP requests

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/FunctionalCallback.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/FunctionalCallback.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.requests;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.function.BiConsumer;
+
+public class FunctionalCallback implements Callback
+{
+    private final BiConsumer<Call, IOException> failure;
+    private final BiConsumer<Call, Response> success;
+
+    public FunctionalCallback(BiConsumer<Call, IOException> failure, BiConsumer<Call, Response> success)
+    {
+        this.failure = failure;
+        this.success = success;
+    }
+
+    public static Builder onSuccess(BiConsumer<Call, Response> callback)
+    {
+        return new Builder().onSuccess(callback);
+    }
+
+    public static Builder onFailure(BiConsumer<Call, IOException> callback)
+    {
+        return new Builder().onFailure(callback);
+    }
+
+    @Override
+    public void onFailure(@Nonnull Call call, @Nonnull IOException e)
+    {
+        if (failure != null)
+            failure.accept(call, e);
+    }
+
+    @Override
+    public void onResponse(@Nonnull Call call, @Nonnull Response response)
+    {
+        if (success != null)
+            success.accept(call, response);
+    }
+
+    public static class Builder
+    {
+        private BiConsumer<Call, IOException> failure;
+        private BiConsumer<Call, Response> success;
+
+        public Builder onSuccess(BiConsumer<Call, Response> callback)
+        {
+            this.success = callback;
+            return this;
+        }
+
+        public Builder onFailure(BiConsumer<Call, IOException> callback)
+        {
+            this.failure = callback;
+            return this;
+        }
+
+        public FunctionalCallback build()
+        {
+            return new FunctionalCallback(failure, success);
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -234,6 +234,10 @@ public class Requester
         Set<String> rays = new LinkedHashSet<>();
         List<okhttp3.Response> responses = new ArrayList<>(4);
         CompletableFuture<Long> task = new CompletableFuture<>();
+        task.whenComplete((i1, i2) -> {
+            for (okhttp3.Response r : responses)
+                r.close();
+        });
         // Initialize state-machine
         attemptRequest(task, request, responses, rays, apiRequest, url, handleOnRatelimit, false, 0);
         return task;

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -27,24 +27,22 @@ import net.dv8tion.jda.internal.requests.ratelimit.ClientRateLimiter;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
-import okhttp3.Call;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.RequestBody;
+import okhttp3.*;
 import okhttp3.internal.http.HttpMethod;
 import org.jetbrains.annotations.Async;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
+import javax.annotation.Nonnull;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
@@ -122,7 +120,85 @@ public class Requester
             execute(apiRequest, true);
     }
 
-    public Long execute(Request<?> apiRequest)
+    private void attemptRequest(CompletableFuture<Long> task, okhttp3.Request request,
+                                List<okhttp3.Response> responses, Set<String> rays,
+                                Request apiRequest, String url,
+                                boolean handleOnRatelimit, int attempt)
+    {
+        Route.CompiledRoute route = apiRequest.getRoute();
+        okhttp3.Response lastResponse = responses.isEmpty() ? null : responses.get(responses.size() - 1);
+        // If the request has been canceled via the Future, don't execute.
+        if (apiRequest.isCanceled())
+        {
+            apiRequest.onFailure(new CancellationException("RestAction has been cancelled"));
+            task.complete(null);
+            return;
+        }
+
+        if (attempt >= 4)
+        {
+            //Epic failure from other end. Attempted 4 times.
+            Response response = new Response(Objects.requireNonNull(lastResponse), -1, rays);
+            apiRequest.handleResponse(response);
+            task.complete(null);
+            return;
+        }
+        Call call = httpClient.newCall(request);
+        call.enqueue(new Callback()
+        {
+            @Override
+            public void onFailure(@Nonnull Call call, @Nonnull IOException e)
+            {
+                if (e instanceof SocketException || e instanceof SocketTimeoutException)
+                {
+                    if (retryOnTimeout)
+                    {
+                        attemptRequest(task, request, responses, rays, apiRequest, url, true, 3);
+                    }
+                    else
+                    {
+                        LOG.error("Requester timed out while executing a request", e);
+                        apiRequest.handleResponse(new Response(null, e, rays));
+                        task.complete(null);
+                    }
+                    return;
+                }
+                LOG.error("There was an exception while executing a REST request", e); //This originally only printed on DEBUG in 2.x
+                apiRequest.handleResponse(new Response(null, e, rays));
+                task.complete(null);
+            }
+
+            @Override
+            public void onResponse(@Nonnull Call call, @Nonnull okhttp3.Response response)
+            {
+                responses.add(response);
+                String cfRay = response.header("CF-RAY");
+                if (cfRay != null)
+                    rays.add(cfRay);
+
+                if (response.code() >= 500)
+                {
+                    LOG.debug("Requesting {} -> {} returned status {}... retrying (attempt {})",
+                              route.getMethod(), url, response.code(), attempt);
+                    attemptRequest(task, request, responses, rays, apiRequest, url, true, attempt + 1);
+                    return;
+                }
+
+                Long retryAfter = rateLimiter.handleResponse(route, response);
+                if (!rays.isEmpty())
+                    LOG.debug("Received response with following cf-rays: {}", rays);
+
+                if (retryAfter == null)
+                    apiRequest.handleResponse(new Response(response, -1, rays));
+                else if (handleOnRatelimit)
+                    apiRequest.handleResponse(new Response(response, retryAfter, rays));
+
+                task.complete(retryAfter);
+            }
+        });
+    }
+
+    public CompletableFuture<Long> execute(Request<?> apiRequest)
     {
         return execute(apiRequest, false);
     }
@@ -139,12 +215,12 @@ public class Requester
      *         the request can be made again. This could either be for the Per-Route ratelimit or the Global ratelimit.
      *         <br>Check if globalCooldown is {@code null} to determine if it was Per-Route or Global.
      */
-    public Long execute(Request<?> apiRequest, boolean handleOnRateLimit)
+    public CompletableFuture<Long> execute(Request<?> apiRequest, boolean handleOnRateLimit)
     {
         return execute(apiRequest, false, handleOnRateLimit);
     }
 
-    public Long execute(@Async.Execute Request<?> apiRequest, boolean retried, boolean handleOnRatelimit)
+    public CompletableFuture<Long> execute(@Async.Execute Request<?> apiRequest, boolean retried, boolean handleOnRatelimit)
     {
         Route.CompiledRoute route = apiRequest.getRoute();
         Long retryAfter = rateLimiter.getRateLimit(route);
@@ -152,7 +228,7 @@ public class Requester
         {
             if (handleOnRatelimit)
                 apiRequest.handleResponse(new Response(retryAfter, Collections.emptySet()));
-            return retryAfter;
+            return CompletableFuture.completedFuture(retryAfter);
         }
 
         okhttp3.Request.Builder builder = new okhttp3.Request.Builder();
@@ -186,82 +262,10 @@ public class Requester
         okhttp3.Request request = builder.build();
 
         Set<String> rays = new LinkedHashSet<>();
-        okhttp3.Response[] responses = new okhttp3.Response[4];
-        // we have an array of all responses to later close them all at once
-        //the response below this comment is used as the first successful response from the server
-        okhttp3.Response lastResponse = null;
-        try
-        {
-            int attempt = 0;
-            do
-            {
-                //If the request has been canceled via the Future, don't execute.
-                //if (apiRequest.isCanceled())
-                //    return null;
-                Call call = httpClient.newCall(request);
-                lastResponse = call.execute();
-                responses[attempt] = lastResponse;
-                String cfRay = lastResponse.header("CF-RAY");
-                if (cfRay != null)
-                    rays.add(cfRay);
-
-                if (lastResponse.code() < 500)
-                    break; // break loop, got a successful response!
-
-                attempt++;
-                LOG.debug("Requesting {} -> {} returned status {}... retrying (attempt {})",
-                        apiRequest.getRoute().getMethod(),
-                        url, lastResponse.code(), attempt);
-                try
-                {
-                    Thread.sleep(50 * attempt);
-                }
-                catch (InterruptedException ignored) {}
-            }
-            while (attempt < 3 && lastResponse.code() >= 500);
-
-            if (lastResponse.code() >= 500)
-            {
-                //Epic failure from other end. Attempted 4 times.
-                Response response = new Response(lastResponse, -1, rays);
-                apiRequest.handleResponse(response);
-                return null;
-            }
-
-            retryAfter = rateLimiter.handleResponse(route, lastResponse);
-            if (!rays.isEmpty())
-                LOG.debug("Received response with following cf-rays: {}", rays);
-
-            if (retryAfter == null)
-                apiRequest.handleResponse(new Response(lastResponse, -1, rays));
-            else if (handleOnRatelimit)
-                apiRequest.handleResponse(new Response(lastResponse, retryAfter, rays));
-
-            return retryAfter;
-        }
-        catch (SocketException | SocketTimeoutException e)
-        {
-            if (retryOnTimeout && !retried)
-                return execute(apiRequest, true, handleOnRatelimit);
-            LOG.error("Requester timed out while executing a request", e);
-            apiRequest.handleResponse(new Response(lastResponse, e, rays));
-            return null;
-        }
-        catch (Exception e)
-        {
-            LOG.error("There was an exception while executing a REST request", e); //This originally only printed on DEBUG in 2.x
-            apiRequest.handleResponse(new Response(lastResponse, e, rays));
-            return null;
-        }
-        finally
-        {
-            for (okhttp3.Response r : responses)
-            {
-                if (r == null)
-                    break;
-                r.close();
-            }
-        }
+        List<okhttp3.Response> responses = new ArrayList<>(4);
+        CompletableFuture<Long> task = new CompletableFuture<>();
+        attemptRequest(task, request, responses, rays, apiRequest, url, handleOnRatelimit, 0);
+        return task;
     }
 
     public OkHttpClient getHttpClient()

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/ClientRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/ClientRateLimiter.java
@@ -206,7 +206,8 @@ public class ClientRateLimiter extends RateLimiter
                             request = it.next();
                             if (isSkipped(it, request))
                                 continue;
-                            Long retryAfter = requester.execute(request);
+                            // Blocking code because I'm lazy and client accounts are not priority
+                            Long retryAfter = requester.execute(request).get();
                             if (retryAfter != null)
                                 break;
                             else


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This removes the blocking execute() calls in favor of the async enqueue+callback system provided by OkHTTP. This should allow the requester to be more concurrent on lighter thread configuration.
