### PR TITLE
Allow more configuration on data caching

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -19,6 +19,7 @@ import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.api.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.entities.bean.MutableGuildData;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import net.dv8tion.jda.api.hooks.IEventManager;
 import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor;
@@ -30,10 +31,7 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.PresenceImpl;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
-import net.dv8tion.jda.internal.utils.config.MetaConfig;
-import net.dv8tion.jda.internal.utils.config.SessionConfig;
-import net.dv8tion.jda.internal.utils.config.ThreadingConfig;
+import net.dv8tion.jda.internal.utils.config.*;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import okhttp3.OkHttpClient;
 
@@ -42,6 +40,7 @@ import javax.annotation.Nullable;
 import javax.security.auth.login.LoginException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.LongFunction;
 
 /**
  * Used to create new {@link net.dv8tion.jda.api.JDA} instances. This is also useful for making sure all of
@@ -57,6 +56,7 @@ public class JDABuilder
 {
     protected final List<Object> listeners;
     protected final AccountType accountType;
+    protected final DataProviderConfig dataProviderConfig = new DataProviderConfig();
 
     protected ScheduledExecutorService rateLimitPool = null;
     protected boolean shutdownRateLimitPool = true;
@@ -823,6 +823,13 @@ public class JDABuilder
         return this;
     }
 
+    @Nonnull
+    public JDABuilder setGuildDataProvider(@Nullable LongFunction<? extends MutableGuildData> provider)
+    {
+        this.dataProviderConfig.setGuildProvider(provider);
+        return this;
+    }
+
     /**
      * Builds a new {@link net.dv8tion.jda.api.JDA} instance and uses the provided token to start the login process.
      * <br>The login process runs in a different thread, so while this will return immediately, {@link net.dv8tion.jda.api.JDA} has not
@@ -869,7 +876,7 @@ public class JDABuilder
         SessionConfig sessionConfig = new SessionConfig(controller, httpClient, wsFactory, voiceDispatchInterceptor, flags, maxReconnectDelay);
         MetaConfig metaConfig = new MetaConfig(contextMap, cacheFlags, flags);
 
-        JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig);
+        JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig, dataProviderConfig);
 
         if (eventManager != null)
             jda.setEventManager(eventManager);

--- a/src/main/java/net/dv8tion/jda/api/entities/SelfUser.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/SelfUser.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
  */
 public interface SelfUser extends User
 {
-
     /**
      * The status of this account's verification.
      * (Have you accepted the verification email)

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/GuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/GuildData.java
@@ -20,6 +20,8 @@ import net.dv8tion.jda.api.entities.Guild;
 
 public interface GuildData
 {
+    GuildData copy();
+
     String getIconId();
     String getSplashId();
     String getDescription();

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/GuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/GuildData.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+import net.dv8tion.jda.api.entities.Guild;
+
+public interface GuildData
+{
+    String getIconId();
+    String getSplashId();
+    String getDescription();
+    String getBannerId();
+    Guild.BoostTier getBoostTier();
+    int getBoostCount();
+    int getMaxMembers();
+    int getMaxPresences();
+    long getAfkChannelId();
+    long getSystemChannelId();
+    Guild.Timeout getAfkTimeout();
+    Guild.VerificationLevel getVerificationLevel();
+    Guild.NotificationLevel getNotificationLevel();
+    Guild.MFALevel getMFALevel();
+    Guild.ExplicitContentLevel getExplicitContentLevel();
+    String getRegion();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MemberData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MemberData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.entities.ClientType;
+
+import java.util.List;
+
+public interface MemberData
+{
+    String getNickname();
+    long getTimeJoined();
+    long getTimeBoosted();
+    List<Activity> getActivities();
+    OnlineStatus getOnlineStatus();
+    OnlineStatus getOnlineStatus(ClientType type);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableGuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableGuildData.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+import net.dv8tion.jda.api.entities.Guild;
+
+public interface MutableGuildData extends GuildData
+{
+    // Returning old value, this can be useful for update events!
+    String setIconId(String id);
+    String setSplashId(String id);
+    String setDescription(String description);
+    String setBannerId(String id);
+    Guild.BoostTier setBoostTier(Guild.BoostTier tier);
+    int setBoostCount(int count);
+    int setMaxMembers(int members);
+    int setMaxPresences(int presences);
+    long setAfkChannelId(long id);
+    long setSystemChannelId(long id);
+    Guild.Timeout setAfkTimeout(Guild.Timeout timeout);
+    Guild.VerificationLevel setVerificationLevel(Guild.VerificationLevel level);
+    Guild.NotificationLevel setNotificationLevel(Guild.NotificationLevel level);
+    Guild.ExplicitContentLevel setExplicitContentLevel(Guild.ExplicitContentLevel level);
+    Guild.MFALevel setMFALevel(Guild.MFALevel level);
+    String setRegion(String region);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableGuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableGuildData.java
@@ -17,9 +17,16 @@
 package net.dv8tion.jda.api.entities.bean;
 
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.bean.light.LightGuildData;
+import net.dv8tion.jda.api.entities.bean.rich.RichGuildData;
+
+import java.util.function.LongFunction;
 
 public interface MutableGuildData extends GuildData
 {
+    LongFunction<MutableGuildData> LIGHT_PROVIDER = (id) -> new LightGuildData();
+    LongFunction<MutableGuildData> RICH_PROVIDER = (id) -> new RichGuildData();
+
     // Returning old value, this can be useful for update events!
     String setIconId(String id);
     String setSplashId(String id);

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableMemberData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableMemberData.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.entities.ClientType;
+
+import java.util.List;
+
+public interface MutableMemberData extends MemberData
+{
+    String setNickname(String nickname);
+    long setTimeJoined(long time);
+    long setTimeBoosted(long time);
+    List<Activity> setActivities(List<Activity> activities);
+    OnlineStatus setOnlineStatus(OnlineStatus status);
+    OnlineStatus setOnlineStatus(ClientType type, OnlineStatus status);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableRoleData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableRoleData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface MutableRoleData extends RoleData
+{
+    int setColor(int color);
+    String setName(String name);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableSelfUserData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableSelfUserData.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface MutableSelfUserData extends SelfUserData, MutableUserData
+{
+    boolean setVerified(boolean verified);
+    boolean setMfaEnabled(boolean enabled);
+    boolean setMobile(boolean mobile);
+    boolean setNitro(boolean nitro);
+    String setEmail(String email);
+    String setPhoneNumber(String number);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableTextChannelData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableTextChannelData.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface MutableTextChannelData extends TextChannelData
+{
+    String setTopic(String topic);
+    boolean setNSFW(boolean nsfw);
+    int setSlowmode(int slowmode);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableUserData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableUserData.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface MutableUserData extends UserData
+{
+    String setAvatarId(String id);
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/MutableVoiceChannelData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/MutableVoiceChannelData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface MutableVoiceChannelData extends VoiceChannelData
+{
+    int getUserLimit();
+    int getBitrate();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/RoleData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/RoleData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface RoleData
+{
+    int getColor();
+    String getName();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/SelfUserData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/SelfUserData.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface SelfUserData extends UserData
+{
+    boolean isVerified();
+    boolean isMfaEnabled();
+    boolean isMobile();
+    boolean isNitro();
+    String getEmail();
+    String getPhoneNumber();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/TextChannelData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/TextChannelData.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface TextChannelData
+{
+    String getTopic();
+    boolean isNSFW();
+    int getSlowmode();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/UserData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/UserData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface UserData
+{
+    String getAvatarId();
+    boolean isBot();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/VoiceChannelData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/VoiceChannelData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean;
+
+public interface VoiceChannelData
+{
+    int getUserLimit();
+    int getBitrate();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/light/LightGuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/light/LightGuildData.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean.light;
+
+import net.dv8tion.jda.api.Region;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.bean.MutableGuildData;
+
+public class LightGuildData implements MutableGuildData
+{
+    @Override
+    public String setIconId(String id)
+    {
+        return id;
+    }
+
+    @Override
+    public String setSplashId(String id)
+    {
+        return id;
+    }
+
+    @Override
+    public String setDescription(String description)
+    {
+        return description;
+    }
+
+    @Override
+    public String setBannerId(String id)
+    {
+        return id;
+    }
+
+    @Override
+    public Guild.BoostTier setBoostTier(Guild.BoostTier tier)
+    {
+        return tier;
+    }
+
+    @Override
+    public int setBoostCount(int count)
+    {
+        return count;
+    }
+
+    @Override
+    public int setMaxMembers(int members)
+    {
+        return members;
+    }
+
+    @Override
+    public int setMaxPresences(int presences)
+    {
+        return presences;
+    }
+
+    @Override
+    public long setAfkChannelId(long id)
+    {
+        return id;
+    }
+
+    @Override
+    public long setSystemChannelId(long id)
+    {
+        return id;
+    }
+
+    @Override
+    public Guild.Timeout setAfkTimeout(Guild.Timeout timeout)
+    {
+        return timeout;
+    }
+
+    @Override
+    public Guild.VerificationLevel setVerificationLevel(Guild.VerificationLevel level)
+    {
+        return level;
+    }
+
+    @Override
+    public Guild.NotificationLevel setNotificationLevel(Guild.NotificationLevel level)
+    {
+        return level;
+    }
+
+    @Override
+    public Guild.ExplicitContentLevel setExplicitContentLevel(Guild.ExplicitContentLevel level)
+    {
+        return level;
+    }
+
+    @Override
+    public Guild.MFALevel setMFALevel(Guild.MFALevel level)
+    {
+        return level;
+    }
+
+    @Override
+    public String setRegion(String region)
+    {
+        return region;
+    }
+
+    @Override
+    public String getIconId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getSplashId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "";
+    }
+
+    @Override
+    public String getBannerId()
+    {
+        return null;
+    }
+
+    @Override
+    public Guild.BoostTier getBoostTier()
+    {
+        return Guild.BoostTier.NONE;
+    }
+
+    @Override
+    public int getBoostCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getMaxMembers()
+    {
+        return 0;
+    }
+
+    @Override
+    public int getMaxPresences()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getAfkChannelId()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getSystemChannelId()
+    {
+        return 0;
+    }
+
+    @Override
+    public Guild.Timeout getAfkTimeout()
+    {
+        return Guild.Timeout.SECONDS_3600;
+    }
+
+    @Override
+    public Guild.VerificationLevel getVerificationLevel()
+    {
+        return Guild.VerificationLevel.UNKNOWN;
+    }
+
+    @Override
+    public Guild.NotificationLevel getNotificationLevel()
+    {
+        return Guild.NotificationLevel.UNKNOWN;
+    }
+
+    @Override
+    public Guild.MFALevel getMFALevel()
+    {
+        return Guild.MFALevel.UNKNOWN;
+    }
+
+    @Override
+    public Guild.ExplicitContentLevel getExplicitContentLevel()
+    {
+        return Guild.ExplicitContentLevel.UNKNOWN;
+    }
+
+    @Override
+    public String getRegion()
+    {
+        return Region.UNKNOWN.getKey();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/light/LightGuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/light/LightGuildData.java
@@ -18,10 +18,17 @@ package net.dv8tion.jda.api.entities.bean.light;
 
 import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.bean.GuildData;
 import net.dv8tion.jda.api.entities.bean.MutableGuildData;
 
 public class LightGuildData implements MutableGuildData
 {
+    @Override
+    public GuildData copy()
+    {
+        return new LightGuildData();
+    }
+
     @Override
     public String setIconId(String id)
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/rich/RichGuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/rich/RichGuildData.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.entities.bean.rich;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.bean.MutableGuildData;
+
+public class RichGuildData implements MutableGuildData
+{
+    private String iconId, splashId, bannerId;
+    private String description = "", region = "";
+    private int maxMembers, maxPresences, boostCount;
+    private Guild.BoostTier boostTier;
+    private Guild.NotificationLevel notificationLevel;
+    private Guild.ExplicitContentLevel explicitContentLevel;
+    private Guild.MFALevel mfaLevel;
+    private Guild.VerificationLevel verificationLevel;
+    private Guild.Timeout afkTimeout;
+    private long systemChannelId, afkChannelId;
+
+    @Override
+    public String setIconId(String id)
+    {
+        String oldIcon = this.iconId;
+        this.iconId = id;
+        return oldIcon;
+    }
+
+    @Override
+    public String setSplashId(String id)
+    {
+        String oldSplash = this.splashId;
+        this.splashId = id;
+        return oldSplash;
+    }
+
+    @Override
+    public String setDescription(String description)
+    {
+        String oldDescription = this.description;
+        this.description = description;
+        return oldDescription;
+    }
+
+    @Override
+    public String setBannerId(String id)
+    {
+        String oldBanner = this.bannerId;
+        this.bannerId = id;
+        return oldBanner;
+    }
+
+    @Override
+    public Guild.BoostTier setBoostTier(Guild.BoostTier tier)
+    {
+        Guild.BoostTier oldTier = this.boostTier;
+        this.boostTier = tier;
+        return oldTier;
+    }
+
+    @Override
+    public int setBoostCount(int count)
+    {
+        int oldCount = this.boostCount;
+        this.boostCount = count;
+        return count;
+    }
+
+    @Override
+    public int setMaxMembers(int members)
+    {
+        int oldMax = this.maxMembers;
+        this.maxMembers = members;
+        return oldMax;
+    }
+
+    @Override
+    public int setMaxPresences(int presences)
+    {
+        int oldMax = this.maxPresences;
+        this.maxPresences = presences;
+        return oldMax;
+    }
+
+    @Override
+    public long setAfkChannelId(long id)
+    {
+        long oldId = this.afkChannelId;
+        this.afkChannelId = id;
+        return oldId;
+    }
+
+    @Override
+    public long setSystemChannelId(long id)
+    {
+        long oldId = this.systemChannelId;
+        this.systemChannelId = id;
+        return oldId;
+    }
+
+    @Override
+    public Guild.Timeout setAfkTimeout(Guild.Timeout timeout)
+    {
+        Guild.Timeout oldTimeout = this.afkTimeout;
+        this.afkTimeout = timeout;
+        return oldTimeout;
+    }
+
+    @Override
+    public Guild.VerificationLevel setVerificationLevel(Guild.VerificationLevel level)
+    {
+        Guild.VerificationLevel oldLevel = this.verificationLevel;
+        this.verificationLevel = level;
+        return oldLevel;
+    }
+
+    @Override
+    public Guild.NotificationLevel setNotificationLevel(Guild.NotificationLevel level)
+    {
+        Guild.NotificationLevel oldLevel = this.notificationLevel;
+        this.notificationLevel = level;
+        return oldLevel;
+    }
+
+    @Override
+    public Guild.ExplicitContentLevel setExplicitContentLevel(Guild.ExplicitContentLevel level)
+    {
+        Guild.ExplicitContentLevel oldLevel = this.explicitContentLevel;
+        this.explicitContentLevel = level;
+        return oldLevel;
+    }
+
+    @Override
+    public Guild.MFALevel setMFALevel(Guild.MFALevel level)
+    {
+        Guild.MFALevel oldLevel = this.mfaLevel;
+        this.mfaLevel = level;
+        return oldLevel;
+    }
+
+    @Override
+    public String setRegion(String region)
+    {
+        String oldRegion = this.region;
+        this.region = region;
+        return oldRegion;
+    }
+
+    @Override
+    public String getIconId()
+    {
+        return iconId;
+    }
+
+    @Override
+    public String getSplashId()
+    {
+        return splashId;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return description;
+    }
+
+    @Override
+    public String getBannerId()
+    {
+        return bannerId;
+    }
+
+    @Override
+    public Guild.BoostTier getBoostTier()
+    {
+        return boostTier;
+    }
+
+    @Override
+    public int getBoostCount()
+    {
+        return boostCount;
+    }
+
+    @Override
+    public int getMaxMembers()
+    {
+        return maxMembers;
+    }
+
+    @Override
+    public int getMaxPresences()
+    {
+        return maxPresences;
+    }
+
+    @Override
+    public long getAfkChannelId()
+    {
+        return afkChannelId;
+    }
+
+    @Override
+    public long getSystemChannelId()
+    {
+        return systemChannelId;
+    }
+
+    @Override
+    public Guild.Timeout getAfkTimeout()
+    {
+        return afkTimeout;
+    }
+
+    @Override
+    public Guild.VerificationLevel getVerificationLevel()
+    {
+        return verificationLevel;
+    }
+
+    @Override
+    public Guild.NotificationLevel getNotificationLevel()
+    {
+        return notificationLevel;
+    }
+
+    @Override
+    public Guild.MFALevel getMFALevel()
+    {
+        return mfaLevel;
+    }
+
+    @Override
+    public Guild.ExplicitContentLevel getExplicitContentLevel()
+    {
+        return explicitContentLevel;
+    }
+
+    @Override
+    public String getRegion()
+    {
+        return region;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/bean/rich/RichGuildData.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/bean/rich/RichGuildData.java
@@ -33,6 +33,29 @@ public class RichGuildData implements MutableGuildData
     private long systemChannelId, afkChannelId;
 
     @Override
+    public RichGuildData copy()
+    {
+        RichGuildData data = new RichGuildData();
+        data.setIconId(iconId);
+        data.setSplashId(splashId);
+        data.setBannerId(bannerId);
+        data.setDescription(description);
+        data.setRegion(region);
+        data.setMaxMembers(maxMembers);
+        data.setMaxPresences(maxPresences);
+        data.setBoostCount(boostCount);
+        data.setBoostTier(boostTier);
+        data.setNotificationLevel(notificationLevel);
+        data.setExplicitContentLevel(explicitContentLevel);
+        data.setMFALevel(mfaLevel);
+        data.setVerificationLevel(verificationLevel);
+        data.setAfkTimeout(afkTimeout);
+        data.setSystemChannelId(systemChannelId);
+        data.setAfkChannelId(afkChannelId);
+        return data;
+    }
+
+    @Override
     public String setIconId(String id)
     {
         String oldIcon = this.iconId;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateDigestEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateDigestEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.bean.GuildData;
+import net.dv8tion.jda.internal.entities.GuildImpl;
+
+import javax.annotation.Nonnull;
+
+@SuppressWarnings("ConstantConditions")
+public class GuildUpdateDigestEvent extends GenericGuildUpdateEvent<GuildData>
+{
+    public static final String IDENTIFIER = "guild-data";
+
+    public GuildUpdateDigestEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull GuildData previous)
+    {
+        super(api, responseNumber, guild, previous, ((GuildImpl) guild).getMutableGuildData(), IDENTIFIER);
+    }
+
+    @Nonnull
+    @Override
+    public GuildData getOldValue()
+    {
+        return super.getOldValue();
+    }
+
+    @Nonnull
+    @Override
+    public GuildData getNewValue()
+    {
+        return super.getNewValue();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -216,6 +216,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildUnban(@Nonnull GuildUnbanEvent event) {}
 
     //Guild Update Events
+    public void onGuildUpdateDigest(@Nonnull GuildUpdateDigestEvent event) {}
     public void onGuildUpdateAfkChannel(@Nonnull GuildUpdateAfkChannelEvent event) {}
     public void onGuildUpdateSystemChannel(@Nonnull GuildUpdateSystemChannelEvent event) {}
     public void onGuildUpdateAfkTimeout(@Nonnull GuildUpdateAfkTimeoutEvent event) {}
@@ -502,6 +503,8 @@ public abstract class ListenerAdapter implements EventListener
             onGuildUnban((GuildUnbanEvent) event);
 
         //Guild Update Events
+        else if (event instanceof GuildUpdateDigestEvent)
+            onGuildUpdateDigest((GuildUpdateDigestEvent) event);
         else if (event instanceof GuildUpdateAfkChannelEvent)
             onGuildUpdateAfkChannel((GuildUpdateAfkChannelEvent) event);
         else if (event instanceof GuildUpdateSystemChannelEvent)

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -29,10 +29,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.ShardCacheViewImpl;
-import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
-import net.dv8tion.jda.internal.utils.config.MetaConfig;
-import net.dv8tion.jda.internal.utils.config.SessionConfig;
-import net.dv8tion.jda.internal.utils.config.ThreadingConfig;
+import net.dv8tion.jda.internal.utils.config.*;
 import net.dv8tion.jda.internal.utils.config.sharding.*;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 import okhttp3.OkHttpClient;
@@ -481,7 +478,7 @@ public class DefaultShardManager implements ShardManager
         threadingConfig.setGatewayPool(gatewayPool, shutdownGatewayPool);
         threadingConfig.setCallbackPool(callbackPool, shutdownCallbackPool);
         MetaConfig metaConfig = new MetaConfig(this.metaConfig.getContextMap(shardId), this.metaConfig.getCacheFlags(), this.sessionConfig.getFlags());
-        final JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig);
+        final JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig, DataProviderConfig.getDefault()); //TODO: Don't use default
         threadingConfig.init(jda::getIdentifierString);
 
         jda.setShardManager(this);

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.audio.factory.DefaultSendFactory;
 import net.dv8tion.jda.api.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.bean.MutableGuildData;
 import net.dv8tion.jda.api.events.StatusChangeEvent;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
@@ -58,10 +59,7 @@ import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.UpstreamReference;
-import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
-import net.dv8tion.jda.internal.utils.config.MetaConfig;
-import net.dv8tion.jda.internal.utils.config.SessionConfig;
-import net.dv8tion.jda.internal.utils.config.ThreadingConfig;
+import net.dv8tion.jda.internal.utils.config.*;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
@@ -105,6 +103,7 @@ public class JDAImpl implements JDA
     protected final ThreadingConfig threadConfig;
     protected final SessionConfig sessionConfig;
     protected final MetaConfig metaConfig;
+    protected final DataProviderConfig dataProviderConfig;
 
     protected UpstreamReference<WebSocketClient> client;
     protected Requester requester;
@@ -122,17 +121,19 @@ public class JDAImpl implements JDA
 
     public JDAImpl(AuthorizationConfig authConfig)
     {
-        this(authConfig, null, null, null);
+        this(authConfig, null, null, null, null);
     }
 
     public JDAImpl(
             AuthorizationConfig authConfig, SessionConfig sessionConfig,
-            ThreadingConfig threadConfig, MetaConfig metaConfig)
+            ThreadingConfig threadConfig, MetaConfig metaConfig,
+            DataProviderConfig dataProviderConfig)
     {
         this.authConfig = authConfig;
         this.threadConfig = threadConfig == null ? ThreadingConfig.getDefault() : threadConfig;
         this.sessionConfig = sessionConfig == null ? SessionConfig.getDefault() : sessionConfig;
         this.metaConfig = metaConfig == null ? MetaConfig.getDefault() : metaConfig;
+        this.dataProviderConfig = dataProviderConfig == null ? DataProviderConfig.getDefault() : dataProviderConfig;
         this.shutdownHook = this.metaConfig.isUseShutdownHook() ? new Thread(this::shutdown, "JDA Shutdown Hook") : null;
         this.presence = new PresenceImpl(this);
         this.requester = new Requester(this);
@@ -944,5 +945,13 @@ public class JDAImpl implements JDA
             }
         }
         return pool;
+    }
+
+    /* MutableData Providers */
+
+    public MutableGuildData provideGuildData(long id)
+    {
+        // TODO: Catch exceptions
+        return dataProviderConfig.provideGuildData(id);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -22,7 +22,6 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.bean.MutableGuildData;
-import net.dv8tion.jda.api.entities.bean.rich.RichGuildData;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.exceptions.PermissionException;
@@ -89,7 +88,7 @@ public class GuildImpl implements Guild
     private final ReentrantLock mngLock = new ReentrantLock();
     private volatile GuildManager manager;
 
-    private final MutableGuildData guildData = new RichGuildData();
+    private final MutableGuildData guildData;
     private Member owner;
     private String name;
     private String vanityCode;
@@ -103,6 +102,7 @@ public class GuildImpl implements Guild
     {
         this.id = id;
         this.api = new UpstreamReference<>(api);
+        this.guildData = api.provideGuildData(id);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -105,6 +105,11 @@ public class GuildImpl implements Guild
         this.guildData = api.provideGuildData(id);
     }
 
+    public MutableGuildData getMutableGuildData()
+    {
+        return guildData;
+    }
+
     @Nonnull
     @Override
     public RestAction<EnumSet<Region>> retrieveRegions(boolean includeDeprecated)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -21,6 +21,8 @@ import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.bean.MutableGuildData;
+import net.dv8tion.jda.api.entities.bean.rich.RichGuildData;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.exceptions.PermissionException;
@@ -87,25 +89,13 @@ public class GuildImpl implements Guild
     private final ReentrantLock mngLock = new ReentrantLock();
     private volatile GuildManager manager;
 
+    private final MutableGuildData guildData = new RichGuildData();
     private Member owner;
     private String name;
-    private String iconId, splashId;
-    private String region;
     private String vanityCode;
-    private String description, banner;
-    private int maxPresences, maxMembers;
-    private int boostCount;
     private long ownerId;
     private Set<String> features;
-    private VoiceChannel afkChannel;
-    private TextChannel systemChannel;
     private Role publicRole;
-    private VerificationLevel verificationLevel = VerificationLevel.UNKNOWN;
-    private NotificationLevel defaultNotificationLevel = NotificationLevel.UNKNOWN;
-    private MFALevel mfaLevel = MFALevel.UNKNOWN;
-    private ExplicitContentLevel explicitContentLevel = ExplicitContentLevel.UNKNOWN;
-    private Timeout afkTimeout;
-    private BoostTier boostTier = BoostTier.NONE;
     private boolean available;
     private boolean canSendVerification = false;
 
@@ -160,7 +150,7 @@ public class GuildImpl implements Guild
     @Override
     public String getIconId()
     {
-        return iconId;
+        return guildData.getIconId();
     }
 
     @Nonnull
@@ -173,7 +163,7 @@ public class GuildImpl implements Guild
     @Override
     public String getSplashId()
     {
-        return splashId;
+        return guildData.getSplashId();
     }
 
     @Nonnull
@@ -203,27 +193,27 @@ public class GuildImpl implements Guild
     @Override
     public String getDescription()
     {
-        return description;
+        return guildData.getDescription();
     }
 
     @Nullable
     @Override
     public String getBannerId()
     {
-        return banner;
+        return guildData.getBannerId();
     }
 
     @Nonnull
     @Override
     public BoostTier getBoostTier()
     {
-        return boostTier;
+        return guildData.getBoostTier();
     }
 
     @Override
     public int getBoostCount()
     {
-        return boostCount;
+        return guildData.getBoostCount();
     }
 
     @Nonnull
@@ -240,25 +230,25 @@ public class GuildImpl implements Guild
     @Override
     public int getMaxMembers()
     {
-        return maxMembers;
+        return guildData.getMaxMembers();
     }
 
     @Override
     public int getMaxPresences()
     {
-        return maxPresences;
+        return guildData.getMaxPresences();
     }
 
     @Override
     public VoiceChannel getAfkChannel()
     {
-        return afkChannel;
+        return getVoiceChannelById(guildData.getAfkChannelId());
     }
 
     @Override
     public TextChannel getSystemChannel()
     {
-        return systemChannel;
+        return getTextChannelById(guildData.getSystemChannelId());
     }
 
     @Nonnull
@@ -308,14 +298,14 @@ public class GuildImpl implements Guild
     @Override
     public Timeout getAfkTimeout()
     {
-        return afkTimeout;
+        return guildData.getAfkTimeout();
     }
 
     @Nonnull
     @Override
     public String getRegionRaw()
     {
-        return region;
+        return guildData.getRegion();
     }
 
     @Override
@@ -679,28 +669,28 @@ public class GuildImpl implements Guild
     @Override
     public VerificationLevel getVerificationLevel()
     {
-        return verificationLevel;
+        return guildData.getVerificationLevel();
     }
 
     @Nonnull
     @Override
     public NotificationLevel getDefaultNotificationLevel()
     {
-        return defaultNotificationLevel;
+        return guildData.getNotificationLevel();
     }
 
     @Nonnull
     @Override
     public MFALevel getRequiredMFALevel()
     {
-        return mfaLevel;
+        return guildData.getMFALevel();
     }
 
     @Nonnull
     @Override
     public ExplicitContentLevel getExplicitContentLevel()
     {
-        return explicitContentLevel;
+        return guildData.getExplicitContentLevel();
     }
 
     @Override
@@ -714,7 +704,7 @@ public class GuildImpl implements Guild
         if (getJDA().getSelfUser().getPhoneNumber() != null)
             return canSendVerification = true;
 
-        switch (verificationLevel)
+        switch (getVerificationLevel())
         {
             case VERY_HIGH:
                 break; // we already checked for a verified phone number
@@ -1260,7 +1250,7 @@ public class GuildImpl implements Guild
 
     public GuildImpl setIconId(String iconId)
     {
-        this.iconId = iconId;
+        guildData.setIconId(iconId);
         return this;
     }
 
@@ -1272,13 +1262,13 @@ public class GuildImpl implements Guild
 
     public GuildImpl setSplashId(String splashId)
     {
-        this.splashId = splashId;
+        guildData.setSplashId(splashId);
         return this;
     }
 
     public GuildImpl setRegion(String region)
     {
-        this.region = region;
+        guildData.setRegion(region);
         return this;
     }
 
@@ -1290,37 +1280,37 @@ public class GuildImpl implements Guild
 
     public GuildImpl setDescription(String description)
     {
-        this.description = description;
+        guildData.setDescription(description);
         return this;
     }
 
     public GuildImpl setBannerId(String bannerId)
     {
-        this.banner = bannerId;
+        guildData.setBannerId(bannerId);
         return this;
     }
 
     public GuildImpl setMaxPresences(int maxPresences)
     {
-        this.maxPresences = maxPresences;
+        guildData.setMaxPresences(maxPresences);
         return this;
     }
 
     public GuildImpl setMaxMembers(int maxMembers)
     {
-        this.maxMembers = maxMembers;
+        guildData.setMaxMembers(maxMembers);
         return this;
     }
 
     public GuildImpl setAfkChannel(VoiceChannel afkChannel)
     {
-        this.afkChannel = afkChannel;
+        guildData.setAfkChannelId(afkChannel == null ? 0 : afkChannel.getIdLong());
         return this;
     }
 
     public GuildImpl setSystemChannel(TextChannel systemChannel)
     {
-        this.systemChannel = systemChannel;
+        guildData.setSystemChannelId(systemChannel == null ? 0 : systemChannel.getIdLong());
         return this;
     }
 
@@ -1332,44 +1322,44 @@ public class GuildImpl implements Guild
 
     public GuildImpl setVerificationLevel(VerificationLevel level)
     {
-        this.verificationLevel = level;
+        guildData.setVerificationLevel(level);
         this.canSendVerification = false;   //recalc on next send
         return this;
     }
 
     public GuildImpl setDefaultNotificationLevel(NotificationLevel level)
     {
-        this.defaultNotificationLevel = level;
+        guildData.setNotificationLevel(level);
         return this;
     }
 
     public GuildImpl setRequiredMFALevel(MFALevel level)
     {
-        this.mfaLevel = level;
+        guildData.setMFALevel(level);
         return this;
     }
 
     public GuildImpl setExplicitContentLevel(ExplicitContentLevel level)
     {
-        this.explicitContentLevel = level;
+        guildData.setExplicitContentLevel(level);
         return this;
     }
 
     public GuildImpl setAfkTimeout(Timeout afkTimeout)
     {
-        this.afkTimeout = afkTimeout;
+        guildData.setAfkTimeout(afkTimeout);
         return this;
     }
 
     public GuildImpl setBoostTier(int tier)
     {
-        this.boostTier = BoostTier.fromKey(tier);
+        guildData.setBoostTier(BoostTier.fromKey(tier));
         return this;
     }
 
     public GuildImpl setBoostCount(int count)
     {
-        this.boostCount = count;
+        guildData.setBoostCount(count);
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/DataProviderConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/DataProviderConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils.config;
+
+import net.dv8tion.jda.api.entities.bean.MutableGuildData;
+
+import java.util.function.LongFunction;
+
+public class DataProviderConfig
+{
+    private static final DataProviderConfig DEFAULT = new DataProviderConfig();
+
+    private LongFunction<? extends MutableGuildData> guildProvider = MutableGuildData.RICH_PROVIDER;
+
+    public void setGuildProvider(LongFunction<? extends MutableGuildData> provider)
+    {
+        this.guildProvider = provider;
+    }
+
+    public MutableGuildData provideGuildData(long guildId)
+    {
+        return guildProvider.apply(guildId);
+    }
+
+    public static DataProviderConfig getDefault()
+    {
+        return DEFAULT;
+    }
+}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

With these changes I introduce `XData` and `MutableXData` interfaces which can be used to provide `XUpdateDigestEvent` rather than atomic events for each changed property. These interfaces can be implemented by the library user and provided using a callback.

```java
new JDABuilder(TOKEN)
    .setGuildDataProvider((id) -> new CustomGuildData());
```

We provide 2 implementations by default:

| Name | Description |
|-------|-------------|
| LIGHT | No data is stored, only default values (constants) |
| RICH | Everything is stored |

You could easily implement custom providers by extending the existing `LIGHT` configuration:

```java
public class CustomGuildData extends LightGuildData {
    private String description = "";
    private String bannerId = null;
    private String iconId = null;

    @Override
    public CustomGuildData copy() {
        // ...
    }

    // implement getters and setters
}
```

Example using rich and having digest events enabled:

```java
@Override
public void onGuildUpdateDigest(@Nonnull GuildUpdateDigestEvent event) {
    LOG.info("Received guild update digest for guild {}", event.getGuild().getName());
}

@Override
public void onGenericGuildUpdate(@Nonnull GenericGuildUpdateEvent event) {
    if (!(event instanceof GuildUpdateDigestEvent)) {
        LOG.info("Received atomic guild update ({}) for guild {}", event.getPropertyIdentifier(), event.getGuild().getName());
    }
}
```
Output:
```
13:29:01.931 JDA INFO   Received guild update digest for guild Testing Bacon
13:29:01.932 JDA INFO   Received atomic guild update (max_members) for guild Testing Bacon
13:29:01.933 JDA INFO   Received atomic guild update (region) for guild Testing Bacon
13:29:01.933 JDA INFO   Received atomic guild update (afk_timeout) for guild Testing Bacon
13:29:01.934 JDA INFO   Received atomic guild update (afk_channel) for guild Testing Bacon
13:29:01.934 JDA INFO   Received atomic guild update (system_channel) for guild Testing Bacon
```
