### PR TITLE
Fix Javadoc reference error

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -112,7 +112,7 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
      *     <br>The webhook could not be created due to a permission discrepancy</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
-     *     <br>The {@link net.dv8tion.jda.api.Permission.VIEW_CHANNEL VIEW_CHANNEL} permission was removed</li>
+     *     <br>The {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission was removed</li>
      * </ul>
      *
      * @param  name


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [ ] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes this ugly thing during the build:

```
> Task :javadoc
/home/napster/10/JDA/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java:115: error: reference not found
     *     <br>The {@link net.dv8tion.jda.api.Permission.VIEW_CHANNEL VIEW_CHANNEL} permission was removed</li>
                          ^
1 error

```
