### PR TITLE
Use single UDP socket for all audio connections

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -61,8 +61,6 @@ public class AudioConnection
     private static final ByteBuffer silenceBytes = ByteBuffer.wrap(new byte[] {(byte)0xF8, (byte)0xFF, (byte)0xFE});
     private static boolean printedError = false;
 
-    protected volatile DatagramSocket udpSocket;
-
     private final TIntLongMap ssrcMap = new TIntLongHashMap();
     private final TIntObjectMap<Decoder> opusDecoders = new TIntObjectHashMap<>();
     private final HashMap<User, Queue<AudioData>> combinedQueue = new HashMap<>();
@@ -295,7 +293,7 @@ public class AudioConnection
 
     private synchronized void setupSendSystem()
     {
-        if (udpSocket != null && !udpSocket.isClosed() && sendHandler != null && sendSystem == null)
+        if (!getJDA().getUdpSocket().isClosed() && sendHandler != null && sendSystem == null)
         {
             IAudioSendFactory factory = getJDA().getAudioSendFactory();
             sendSystem = factory.createSendSystem(new PacketProvider(new TweetNaclFast.SecretBox(webSocket.getSecretKey())));
@@ -317,7 +315,7 @@ public class AudioConnection
 
     private synchronized void setupReceiveSystem()
     {
-        if (udpSocket != null && !udpSocket.isClosed() && receiveHandler != null && receiveThread == null)
+        if (!getJDA().getUdpSocket().isClosed() && receiveHandler != null && receiveThread == null)
         {
             setupReceiveThread();
         }
@@ -349,6 +347,7 @@ public class AudioConnection
             receiveThread = new Thread(() ->
             {
                 getJDA().setContext();
+                DatagramSocket udpSocket = getJDA().getUdpSocket();
                 try
                 {
                     udpSocket.setSoTimeout(1000);
@@ -648,7 +647,7 @@ public class AudioConnection
         @Override
         public DatagramSocket getUdpSocket()
         {
-            return udpSocket;
+            return getJDA().getUdpSocket();
         }
 
         @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

UDP is a connection-less protocol so we can just use a single socket for any amount of audio connections. The socket is created on first use and closed by JDA#shutdown.
