### PR TITLE
Cleanup udp discovery code

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -600,9 +600,12 @@ class AudioWebSocket extends WebSocketAdapter
             //Example string:"   121.83.253.66                                                   ��"
             //You'll notice that there are 4 leading nulls and a large amount of nulls between the the ip and
             // the last 2 bytes. Not sure why these exist.  The last 2 bytes are the port. More info below.
-            String ourIP = new String(received);//Puts the entire byte array in. nulls are converted to spaces.
-            ourIP = ourIP.substring(4, ourIP.length() - 2); //Removes the SSRC of the answer package and the port that is stuck on the end of this string. (last 2 bytes are the port)
-            ourIP = ourIP.trim();  //Removes the extra whitespace(nulls) attached to both sides of the IP
+
+            //Take bytes between SSRC and PORT and put them into a string
+            // null bytes at the beginning are skipped and the rest are appended to the end of the string
+            String ourIP = new String(received, 4, received.length - 6);
+            // Removes the extra nulls attached to the end of the IP string
+            ourIP = ourIP.trim();
 
             //The port exists as the last 2 bytes in the packet data, and is encoded as an UNSIGNED short.
             //Furthermore, it is stored in Little Endian instead of normal Big Endian.

--- a/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
@@ -161,6 +161,13 @@ public class IOUtil
                        | arr[offset + 1] & 0xff);
     }
 
+    public static short getShortLittleEndian(byte[] arr, int offset)
+    {
+        // Same as big endian but reversed order of bytes (java uses big endian)
+        return (short) ((arr[offset    ] & 0xff)
+                      | (arr[offset + 1] & 0xff) << 8);
+    }
+
     public static int getIntBigEndian(byte[] arr, int offset)
     {
         return arr[offset + 3] & 0xFF


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Close previously opened UDP client when the NAT hole punch is retried. I also moved the logic for retrieving the short endian port to the IOUtil where all the other related methods are located, this also removes  pointless allocation.
