### PR TITLE
Add javadoc desc for the INVISIBLE const of the OnlineStatus enum

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/OnlineStatus.java
+++ b/src/main/java/net/dv8tion/jda/api/OnlineStatus.java
@@ -23,6 +23,10 @@ public enum OnlineStatus
     ONLINE("online"),
     IDLE("idle"),
     DO_NOT_DISTURB("dnd"),
+    /**
+     * Only available for the currently logged in account.
+     * <br>Other {@link net.dv8tion.jda.api.entities.Member Members} will show up as {@link net.dv8tion.jda.api.OnlineStatus#OFFLINE OFFLINE} even when they really are INVISIBLE.
+     */
     INVISIBLE("invisible"),
     OFFLINE("offline"),
     UNKNOWN("");


### PR DESCRIPTION
It is now specified that INVISIBLE is only used when the currently logged in account is INVISIBLE and that all other members will be shown as offline.

-  I have read the [contributing guidelines][contributing].

### Changes

- Documentation

## Description

Adds a JavaDoc description for the INVISIBLE value of the OnlineStatus enum.
It is now specified that INVISIBLE can only be used for the currently logged in account.
And that all other members are shown as OFFLINE, even if they really are INVISIBLE.
