### PR TITLE
Add specification to the default SplitPolicies of the MessageBuilder

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -944,17 +944,17 @@ public class MessageBuilder implements Appendable
     public interface SplitPolicy
     {
         /**
-         * Splits on newline chars {@code `\n`}.
+         * Splits on newline chars {@code `\n`} and removes the characters it splits on.
          */
         SplitPolicy NEWLINE = new CharSequenceSplitPolicy("\n", true);
 
         /**
-         * Splits on space chars {@code `\u0020`}.
+         * Splits on space chars {@code `\u0020`} and removes the characters it splits on.
          */
         SplitPolicy SPACE = new CharSequenceSplitPolicy(" ", true);
 
         /**
-         * Splits exactly after 2000 chars.
+         * Splits exactly after 2000 chars and doesn't remove the characters it splits on.
          */
         SplitPolicy ANYWHERE = (i, b) -> Math.min(i + 2000, b.length());
 


### PR DESCRIPTION
In the JavaDoc, it is now specified whether or not a certain default SplitPolicy removes the characters it splits on.

-  I have read the [contributing guidelines][contributing].

### Changes

- Documentation

## Description
Adds some JavaDoc that states whether NEWLINE, SPACE and ANYWHERE do or don't remove the characters they split on (one previously had to check the source code for that).