### PR TITLE
Improve handling of webhooks without tokens

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
@@ -132,8 +132,22 @@ public interface Webhook extends ISnowflake, IFakeable
     /**
      * Deletes this Webhook.
      *
-     * @throws IllegalStateException 
-     *         if the Webhook is fake, such as the Webhooks retrieved from Audit Logs
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The delete was attempted after the account lost permission to view the channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The delete was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MANAGE_WEBHOOKS Permission.MANAGE_WEBHOOKS} in
+     *         the channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_WEBHOOK UNKNOWN_WEBHOOK}
+     *     <br>The delete was attempted after the Webhook had already been deleted.</li>
+     * </ul>
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the Webhook is fake, such as the Webhooks retrieved from Audit Logs and the currently
+     *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_WEBHOOKS} in this channel.
      * 
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *         <br>The rest action to delete this Webhook.
@@ -141,6 +155,37 @@ public interface Webhook extends ISnowflake, IFakeable
     @Nonnull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
+
+    /**
+     * Deletes this Webhook.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The delete was attempted after the account lost permission to view the channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The delete was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MANAGE_WEBHOOKS Permission.MANAGE_WEBHOOKS} in
+     *         the channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_WEBHOOK UNKNOWN_WEBHOOK}
+     *     <br>The delete was attempted after the Webhook had already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#INVALID_WEBHOOK_TOKEN INVALID_WEBHOOK_TOKEN}
+     *     <br>If the provided webhook token is not valid.</li>
+     * </ul>
+     *
+     * @throws IllegalArgumentException
+     *         If the provided token is null
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     *         <br>The rest action to delete this Webhook.
+     *
+     * @since  4.0.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    AuditableRestAction<Void> delete(@Nonnull String token);
 
     /**
      * The {@link WebhookManager WebhookManager} for this Webhook.

--- a/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
@@ -175,6 +175,9 @@ public interface Webhook extends ISnowflake, IFakeable
      *     <br>If the provided webhook token is not valid.</li>
      * </ul>
      *
+     * @param  token
+     *         The webhook token (this is not the bot authorization token!)
+     *
      * @throws IllegalArgumentException
      *         If the provided token is null
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
@@ -192,14 +192,11 @@ public interface Webhook extends ISnowflake, IFakeable
 
     /**
      * The {@link WebhookManager WebhookManager} for this Webhook.
-     * <br>You modify multiple fields in one request by chaining setters before calling {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction.queue()}.
+     * <br>You can modify multiple fields in one request by chaining setters before calling {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction.queue()}.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_WEBHOOKS Permission.MANAGE_WEBHOOKS}
      *
-     * @throws IllegalStateException 
-     *         if the Webhook is fake, such as the Webhooks retrieved from Audit Logs
-     * 
      * @return The {@link WebhookManager WebhookManager} for this Webhook
      */
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
@@ -72,6 +72,7 @@ public enum ErrorResponse
     INVITE_CODE_INVALID(            50020, "Invite code is either invalid or taken"),
     INVALID_MESSAGE_TARGET(         50021, "Cannot execute action on a system message"),
     INVALID_OAUTH_ACCESS_TOKEN(     50025, "Invalid OAuth2 access token"),
+    INVALID_WEBHOOK_TOKEN(          50027, "Invalid Webhook Token"),
     INVALID_BULK_DELETE_MESSAGE_AGE(50034, "A Message provided to bulk_delete was older than 2 weeks"),
     INVALID_FORM_BODY(              50035, "Invalid Form Body"),
     INVITE_FOR_UNKNOWN_GUILD(       50036, "An invite was accepted to a guild the application's bot is not in"),

--- a/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
@@ -136,9 +136,6 @@ public class WebhookImpl implements Webhook
     @Override
     public WebhookManager getManager()
     {
-        if (isFake())
-            throw new IllegalStateException("Fake Webhooks (such as those retrieved from Audit Logs) "
-                    + "cannot provide a WebhookManager!");
         WebhookManager mng = manager;
         if (mng == null)
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.requests.ratelimit;
 
 import net.dv8tion.jda.api.events.ExceptionEvent;
 import net.dv8tion.jda.api.requests.Request;
+import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.RateLimiter;
@@ -402,11 +403,10 @@ public class BotRateLimiter extends RateLimiter
         private void finishProcess()
         {
             // We are done with processing
-            requestLock.lock();
-            try (UnlockHook hook = new UnlockHook(requestLock))
+            MiscUtil.locked(requestLock, () ->
             {
                 processing = false;
-            }
+            });
             // Re-submit if new requests were added or rate-limit was hit
             synchronized (submittedBuckets)
             {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Now you can delete webhooks without knowing the token if you have permissions.
