### PR TITLE
Remove two redundant checks

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -559,7 +559,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         if (!isFromType(ChannelType.PRIVATE))
             throw new IllegalStateException("This message was not sent in a private channel");
-        return isFromType(ChannelType.PRIVATE) ? (PrivateChannel) channel : null;
+        return (PrivateChannel) channel;
     }
 
     @Nonnull
@@ -568,7 +568,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         if (!isFromType(ChannelType.TEXT))
             throw new IllegalStateException("This message was not sent in a text channel");
-        return isFromType(ChannelType.TEXT) ? (TextChannel) channel : null;
+        return (TextChannel) channel;
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Removed two redundant checks of the channel type from `net.dv8tion.jda.internal.entities.ReceivedMessage` (one from `getPrivateChannel()` and one from `getTextChannel()`).