### PR TITLE
Fix xsalsa20_poly1305 encryption

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioPacket.java
@@ -168,7 +168,7 @@ public class AudioPacket
         // so we need to create a 24 byte array, and copy the nonce into it.
         // we will leave the extra bytes as nulls. (Java sets non-populated bytes as 0).
         byte[] extendedNonce = nonce;
-        if (nonce == null)
+        if (nlen == 0) // this means the header is the nonce!
             extendedNonce = getNoncePadded();
 
         //Create our SecretBox encoder with the secretKey provided by Discord.
@@ -182,7 +182,7 @@ public class AudioPacket
         if (capacity > buffer.remaining())
             buffer = ByteBuffer.allocate(capacity);
         populateBuffer(seq, timestamp, ssrc, ByteBuffer.wrap(encryptedAudio), buffer);
-        if (nonce != null)
+        if (nlen > 0) // this means we append the nonce to the payload
             buffer.put(nonce, 0, nlen);
 
         ((Buffer) buffer).flip();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This fixes the handling of nonces passed by the packet provider. The nonce array is never null but the length might be 0 which indicates that we use the legacy encryption. This shouldn't really matter since that encryption is never used.
