### PR TITLE
Fix BOLD | ITALICS_A not getting escaped properly in MarkdownSanitizer (#1086)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ val javadoc: Javadoc by tasks
 val jar: Jar by tasks
 val build: Task by tasks
 val clean: Task by tasks
-val test: Task by tasks
+val test: Test by tasks
 val check: Task by tasks
 
 shadowJar.classifier = "withDependencies"
@@ -257,6 +257,11 @@ bintrayUpload.apply {
     onlyIf { getProjectProperty("bintrayUsername").isNotEmpty() }
     onlyIf { getProjectProperty("bintrayApiKey").isNotEmpty() }
     onlyIf { System.getenv("BUILD_NUMBER") != null }
+}
+
+test.apply {
+    useJUnitPlatform()
+    failFast = true
 }
 
 publishing {

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -416,6 +416,8 @@ public class MarkdownSanitizer
             throw new IllegalStateException("Found illegal region for strategy ESCAPE '" + region + "' with no known format token!");
         if (region == UNDERLINE)
             token = "_\\_"; // UNDERLINE needs special handling because the client thinks its ITALICS_U if you only escape once
+        else if (region == BOLD)
+            token = "*\\*"; // BOLD needs special handling because the client thinks its ITALICS_A if you only escape once
         else if (region == (BOLD | ITALICS_A))
             token = "*\\*\\*"; // BOLD | ITALICS_A needs special handling because the client thinks its BOLD if you only escape once
         builder.append("\\").append(token)

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -416,6 +416,8 @@ public class MarkdownSanitizer
             throw new IllegalStateException("Found illegal region for strategy ESCAPE '" + region + "' with no known format token!");
         if (region == UNDERLINE)
             token = "_\\_"; // UNDERLINE needs special handling because the client thinks its ITALICS_U if you only escape once
+        else if (region == (BOLD | ITALICS_A))
+            token = "*\\*\\*"; // BOLD | ITALICS_A needs special handling because the client thinks its BOLD if you only escape once
         builder.append("\\").append(token)
                .append(seq)
                .append("\\").append(token);

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -277,13 +277,13 @@ class EscapeMarkdownTest
     @Test
     public void testComplex()
     {
-        Assertions.assertEquals("\\**A\\_B\\||C\\~~D\\_\\_E\\`F\\`\\_\\_\\~~\\||\\_\\**", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
+        Assertions.assertEquals("\\*\\*A\\_B\\||C\\~~D\\_\\_E\\`F\\`\\_\\_\\~~\\||\\_\\*\\*", markdown.compute("**A_B||C~~D__E`F`__~~||_**"));
     }
 
     @Test
     public void testBold()
     {
-        Assertions.assertEquals("\\**Hello\\**", markdown.compute("**Hello**"));
+        Assertions.assertEquals("\\*\\*Hello\\*\\*", markdown.compute("**Hello**"));
         Assertions.assertEquals("**Hello", markdown.compute("**Hello"));
         Assertions.assertEquals("\\**Hello**", markdown.compute("\\**Hello**"));
     }
@@ -341,8 +341,8 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\`Hello`", markdown.compute("\\`Hello`"));
 
         Assertions.assertEquals("\\`Hello **World**\\`", markdown.compute("`Hello **World**`"));
-        Assertions.assertEquals("`Hello \\**World\\**", markdown.compute("`Hello **World**"));
-        Assertions.assertEquals("\\`Hello \\**World\\**`", markdown.compute("\\`Hello **World**`"));
+        Assertions.assertEquals("`Hello \\*\\*World\\*\\*", markdown.compute("`Hello **World**"));
+        Assertions.assertEquals("\\`Hello \\*\\*World\\*\\*`", markdown.compute("\\`Hello **World**`"));
 
     }
 
@@ -354,8 +354,8 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\``Hello``", markdown.compute("\\``Hello``"));
 
         Assertions.assertEquals("\\``Hello **World**\\``", markdown.compute("``Hello **World**``"));
-        Assertions.assertEquals("``Hello \\**World\\**", markdown.compute("``Hello **World**"));
-        Assertions.assertEquals("\\``Hello \\**World\\**``", markdown.compute("\\``Hello **World**``"));
+        Assertions.assertEquals("``Hello \\*\\*World\\*\\*", markdown.compute("``Hello **World**"));
+        Assertions.assertEquals("\\``Hello \\*\\*World\\*\\*``", markdown.compute("\\``Hello **World**``"));
 
         Assertions.assertEquals("\\``Hello `to` World\\``", markdown.compute("``Hello `to` World``"));
         Assertions.assertEquals("``Hello \\`to\\` World", markdown.compute("``Hello `to` World"));
@@ -370,8 +370,8 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\```Hello", markdown.compute("\\```Hello"));
 
         Assertions.assertEquals("\\```Hello **World**\\```", markdown.compute("```Hello **World**```"));
-        Assertions.assertEquals("```Hello \\**World\\**", markdown.compute("```Hello **World**"));
-        Assertions.assertEquals("\\```Hello \\**World\\**", markdown.compute("\\```Hello **World**"));
+        Assertions.assertEquals("```Hello \\*\\*World\\*\\*", markdown.compute("```Hello **World**"));
+        Assertions.assertEquals("\\```Hello \\*\\*World\\*\\*", markdown.compute("\\```Hello **World**"));
 
         Assertions.assertEquals("\\```Hello `to` World\\```", markdown.compute("```Hello `to` World```"));
         Assertions.assertEquals("```Hello \\`to\\` World", markdown.compute("```Hello `to` World"));

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -304,7 +304,7 @@ class EscapeMarkdownTest
     @Test
     public void testBoldItalics()
     {
-        Assertions.assertEquals("\\***Hello\\***", markdown.compute("***Hello***"));
+        Assertions.assertEquals("\\*\\*\\*Hello\\*\\*\\*", markdown.compute("***Hello***"));
         Assertions.assertEquals("***Hello", markdown.compute("***Hello"));
         Assertions.assertEquals("\\***Hello***", markdown.compute("\\***Hello***"));
     }

--- a/src/test/java/MarkdownUtilTest.java
+++ b/src/test/java/MarkdownUtilTest.java
@@ -25,7 +25,7 @@ public class MarkdownUtilTest
     public void testBold()
     {
         Assertions.assertEquals("**Hello World**", bold("Hello World"));
-        Assertions.assertEquals("**Hello \\**Test\\** World**", bold("Hello **Test** World"));
+        Assertions.assertEquals("**Hello \\*\\*Test\\*\\* World**", bold("Hello **Test** World"));
         Assertions.assertEquals("**Hello *Test* World**", bold("Hello *Test* World"));
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1086

## Description

Fixes the `MarkdownSanitizer`'s `escape` method not properly escaping BOLD | ITALICS_A mixture of text (ie: `***text***`).

~~I did not test the changes, I will look how can I test later today.~~ 

~~I also plan to fix a very similar issue that I think might happen with code blocks, I will look into that later today too, making this PR a WIP one. I will therefore create a new commit, which I could squash them if preferable on any maintainer's request.~~ 

_Also, there might be a need to change the README's Contributing guidelines, as there is no `v4` branch anymore... :_ 
```
If you want to contribute to JDA, make sure to base your branch off of our v4 branch (or a feature-branch) and create your PR into that same branch. We will be rejecting any PRs between branches or into release branches!
```
 