### PR TITLE
Patch for isSelf returning incorrect values

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
@@ -125,7 +125,9 @@ public class MessageReactionHandler extends SocketHandler
         {
             rEmote = MessageReaction.ReactionEmote.fromUnicode(emojiName, getJDA());
         }
-        MessageReaction reaction = new MessageReaction(channel, rEmote, messageId, user.equals(getJDA().getSelfUser()), -1);
+        boolean self = channel.retrieveMessageById(messageId).complete().getReactions().stream()
+            .anyMatch(r -> r.getReactionEmote().equals(rEmote) && r.retrieveUsers().getCached().contains(getJDA().getSelfUser()));
+        MessageReaction reaction = new MessageReaction(channel, rEmote, messageId, self, -1);
 
         if (add)
             onAdd(reaction, user);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1094 

## Description

This is just a quick fix for the issue with the `MessageReaction#isSelf` method. Since the add/remove events don't supply the proper information directly, this is the only workaround I could think of.
