### PR TITLE
Add permission STREAM to Permission enum.

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -37,6 +37,7 @@ public enum Permission
     MESSAGE_ADD_REACTION( 6, true, true, "Add Reactions"),
     VIEW_AUDIT_LOGS(      7, true, false, "View Audit Logs"),
     PRIORITY_SPEAKER(     8, true, true, "Priority Speaker"),
+    STREAM(               9, true, true, "Stream"),
 
     // Applicable to all channel types
     VIEW_CHANNEL(            10, true, true, "Read Text Channels & See Voice Channels"),


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing]

### Changes

- [x] Library interface (affecting end-user code) 
- [x] Documentation

Closes Issue: NaN

## Description

This is mentioned in discordapp/discord-api-docs#918. `Permissions#STREAM` is for Discord's guild video feature.

Previously, there was no permission set to 9.

I considered adding it to ALL_VOICE_PERMISSIONS but it didn't seem right.