### PR TITLE
Remove Voice channel from JDA cache on deletion

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
@@ -90,7 +90,7 @@ public class ChannelDeleteHandler extends SocketHandler
             case VOICE:
             {
                 GuildImpl guild = (GuildImpl) getJDA().getGuildsView().get(guildId);
-                VoiceChannel channel = guild.getVoiceChannelsView().remove(channelId);
+                VoiceChannel channel = getJDA().getVoiceChannelsView().remove(channelId);
                 if (channel == null)
                 {
                     WebSocketClient.LOG.debug("CHANNEL_DELETE attempted to delete a voice channel that is not yet cached. JSON: {}", content);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

When a voice channel is deleted on discord the handler only ever deleted it from the guild cache and not from the JDA cache. This caused an exception being thrown when getting the guild from a voice channel via the JDA cache because the guild was garbage collected.
This pull request fixes that by also deleting the voice channel from the JDA cache.