### PR TITLE
isImage fix, addition of hasImage (fixes #1071)

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1969,8 +1969,7 @@ public interface Message extends ISnowflake, Formattable
          * The height of the Attachment if this Attachment is an image/video.
          * <br>If this Attachment is neither an image, nor a video, this returns -1.
          *
-         * @return int containing image Attachment height.
-         * @see #hasImage()
+         * @return int containing image/video Attachment height.
          */
         public int getHeight()
         {
@@ -1981,8 +1980,7 @@ public interface Message extends ISnowflake, Formattable
          * The width of the Attachment if this Attachment is an image/video.
          * <br>If this Attachment is neither an image, nor a video, this returns -1.
          *
-         * @return int containing image Attachment width.
-         * @see #hasImage()
+         * @return int containing image/video Attachment width.
          */
         public int getWidth()
         {
@@ -1990,40 +1988,27 @@ public interface Message extends ISnowflake, Formattable
         }
 
         /**
-         * Whether or not this attachment is an Image.
-         * <br>Based on the values of {@link #getHeight()} and {@link #getWidth()} being larger than zero.
-         * <br>This method may return {@code true}, even when both
-         * {@link #isImage()} and {@link #isVideo()} return {@code false}.
-         *
-         * @return True if width and height are greater than zero.
-         */
-        public boolean hasImage()
-        {
-            return height > 0 && width > 0;
-        }
-
-        /**
          * Whether or not this attachment is an Image,
-         * based on {@link #hasImage()} and {@link #getFileExtension()}.
+         * based on {@link #getWidth()}, {@link #getHeight()} and {@link #getFileExtension()}.
          *
          * @return True if this attachment is an image
          */
         public boolean isImage()
         {
-            if (!hasImage()) return false;
+            if (width < 0) return false; //if width is -1, so is height
             String extension = getFileExtension();
             return extension != null && IMAGE_EXTENSIONS.contains(extension.toLowerCase());
         }
 
         /**
          * Whether or not this attachment is a video,
-         * based on {@link #hasImage()} and {@link #getFileExtension()}.
+         * based on {@link #getWidth()}, {@link #getHeight()} and {@link #getFileExtension()}.
          *
          * @return True if this attachment is a video
          */
         public boolean isVideo()
         {
-            if (!hasImage()) return false;
+            if (width < 0) return false; //if width is -1, so is height
             String extension = getFileExtension();
             return extension != null && VIDEO_EXTENSIONS.contains(extension.toLowerCase());
         }

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1642,9 +1642,9 @@ public interface Message extends ISnowflake, Formattable
     class Attachment implements ISnowflake
     {
         private static final Set<String> IMAGE_EXTENSIONS = new HashSet<>(Arrays.asList("jpg",
-                "jpeg", "png", "gif", "webp", "tiff", "svg"));
+                "jpeg", "png", "gif", "webp", "tiff", "svg", "apng"));
         private static final Set<String> VIDEO_EXTENSIONS = new HashSet<>(Arrays.asList("webm",
-                "flv", "vob", "avi", "mov", "wmv", "amv", "mp4", "mpg", "mpeg"));
+                "flv", "vob", "avi", "mov", "wmv", "amv", "mp4", "mpg", "mpeg", "gifv"));
         private final long id;
         private final String url;
         private final String proxyUrl;
@@ -1989,7 +1989,7 @@ public interface Message extends ISnowflake, Formattable
 
         /**
          * Whether or not this attachment is an Image,
-         * based on {@link #getWidth()}, {@link #getHeight()} and {@link #getFileExtension()}.
+         * based on {@link #getWidth()}, {@link #getHeight()}, and {@link #getFileExtension()}.
          *
          * @return True if this attachment is an image
          */
@@ -2002,7 +2002,7 @@ public interface Message extends ISnowflake, Formattable
 
         /**
          * Whether or not this attachment is a video,
-         * based on {@link #getWidth()}, {@link #getHeight()} and {@link #getFileExtension()}.
+         * based on {@link #getWidth()}, {@link #getHeight()}, and {@link #getFileExtension()}.
          *
          * @return True if this attachment is a video
          */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1071 

## Description

`Message.Attachment#isImage` has been renamed to `hasImage` and the `isImage`, `isVideo` methods have been added. This change was necessary because the previous `isImage` (now `hasImage`) returns `true` for videos as well (since it is based on the `width` and `height` properties). The new `isImage` and `isVideo` methods also depend on the `width` and `height` properties, but they do an additional check: they check the file extension of the uploaded attachment's name. For this reason as `getFileExtension` method has been added.

`isImage` is used internally once, in the `retrieveAsIcon` method.

Edit: the pointless, new `hasImage` method has been deleted, as per maintainer's request
