### PR TITLE
Fix for removing an emoji reaction in codepoint style

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1773,11 +1773,8 @@ public interface MessageChannel extends ISnowflake, Formattable
         unicode = unicode.trim();
         Checks.notEmpty(unicode, "Provided Unicode");
 
-        String encoded;
-        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
-            encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
-        else
-            encoded = EncodingUtil.encodeUTF8(unicode);
+        final String encoded = EncodingUtil.encodeReaction(unicode);
+
         Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, encoded, "@me");
         return new RestActionImpl<>(getJDA(), route);
     }
@@ -2044,11 +2041,7 @@ public interface MessageChannel extends ISnowflake, Formattable
         unicode = unicode.trim();
         Checks.notEmpty(unicode, "Provided Unicode");
 
-        String encoded;
-        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
-            encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
-        else
-            encoded = EncodingUtil.encodeUTF8(unicode);
+        final String encoded = EncodingUtil.encodeReaction(unicode);
 
         final Route.CompiledRoute route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, encoded, "@me");
         return new RestActionImpl<>(getJDA(), route);

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -1772,10 +1772,9 @@ public interface MessageChannel extends ISnowflake, Formattable
         Checks.notNull(unicode, "Provided Unicode");
         unicode = unicode.trim();
         Checks.notEmpty(unicode, "Provided Unicode");
-        // TODO Maybe checking for Checks.noWhitespace(unicode, "Unicode emoji") instead (in terms of consistency / making it uniform)
 
         String encoded;
-        if (unicode.startsWith("U+"))
+        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
             encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
         else
             encoded = EncodingUtil.encodeUTF8(unicode);
@@ -2040,8 +2039,19 @@ public interface MessageChannel extends ISnowflake, Formattable
     @CheckReturnValue
     default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode)
     {
-        // removes code redundancy but kind of bad design
-        return ((TextChannel) this).removeReactionById(messageId, unicode, getJDA().getSelfUser());
+        Checks.isSnowflake(messageId, "Message ID");
+        Checks.notNull(unicode, "Provided Unicode");
+        unicode = unicode.trim();
+        Checks.notEmpty(unicode, "Provided Unicode");
+
+        String encoded;
+        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
+            encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
+        else
+            encoded = EncodingUtil.encodeUTF8(unicode);
+
+        final Route.CompiledRoute route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, encoded, "@me");
+        return new RestActionImpl<>(getJDA(), route);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -458,14 +458,23 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         Checks.isSnowflake(messageId, "Message ID");
         Checks.noWhitespace(unicode, "Unicode emoji");
         Checks.notNull(user, "User");
+
         if (!getJDA().getSelfUser().equals(user))
             checkPermission(Permission.MESSAGE_MANAGE);
-        final String code = EncodingUtil.encodeUTF8(unicode);
-        Route.CompiledRoute route;
-        if (user.equals(getJDA().getSelfUser()))
-            route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, code, "@me");
+
+        String encoded;
+        if (unicode.startsWith("U+"))
+            encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
         else
-            route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, code, user.getId());
+            encoded = EncodingUtil.encodeUTF8(unicode);
+
+        String targetUser;
+        if (user.equals(getJDA().getSelfUser()))
+            targetUser = "@me";
+        else
+            targetUser = user.getId();
+
+        final Route.CompiledRoute route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, encoded, targetUser);
         return new RestActionImpl<>(getJDA(), route);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -464,11 +464,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         if (!getJDA().getSelfUser().equals(user))
             checkPermission(Permission.MESSAGE_MANAGE);
 
-        String encoded;
-        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
-            encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
-        else
-            encoded = EncodingUtil.encodeUTF8(unicode);
+        final String encoded = EncodingUtil.encodeReaction(unicode);
 
         String targetUser;
         if (user.equals(getJDA().getSelfUser()))

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -456,14 +456,16 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
     public RestActionImpl<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode, @Nonnull User user)
     {
         Checks.isSnowflake(messageId, "Message ID");
-        Checks.noWhitespace(unicode, "Unicode emoji");
+        Checks.notNull(unicode, "Provided Unicode");
+        unicode = unicode.trim();
+        Checks.notEmpty(unicode, "Provided Unicode");
         Checks.notNull(user, "User");
 
         if (!getJDA().getSelfUser().equals(user))
             checkPermission(Permission.MESSAGE_MANAGE);
 
         String encoded;
-        if (unicode.startsWith("U+"))
+        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
             encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
         else
             encoded = EncodingUtil.encodeUTF8(unicode);

--- a/src/main/java/net/dv8tion/jda/internal/utils/EncodingUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/EncodingUtil.java
@@ -68,4 +68,17 @@ public class EncodingUtil
         int codePoint = Integer.parseUnsignedInt(hex, radix);
         return String.valueOf(Character.toChars(codePoint));
     }
+
+    /**
+     * Encodes a unicode correctly based on being in codepoint notation or not.
+     * @param  unicode Provided unicode in the form of <code>\​uXXXX</code> or <code>U+XXXX</code>
+     * @return Never-null String containing the encoded unicode
+     */
+    public static String encodeReaction(String unicode)
+    {
+        if (unicode.startsWith("U+") || unicode.startsWith("u+"))
+            return encodeCodepointsUTF8(unicode);
+        else
+            return encodeUTF8(unicode);
+    }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds a missing ("breaking") check on the codepoint variant in `MessageChannel#removeReactionById` which lead to an `ErrorResponseException: 10014: Unknown Emoji` experienced by MarRue#3658 first. It also makes the code more uniform in terms of `addReactionById` and `removeReactionById`.

#### The Problem
```JAVA
default RestAction<Void> addReactionById(@Nonnull String messageId, @Nonnull String unicode)
{
	Checks.isSnowflake(messageId, "Message ID");
	Checks.notNull(unicode, "Provided Unicode");
	unicode = unicode.trim();
	Checks.notEmpty(unicode, "Provided Unicode");

	String encoded;
	if (unicode.startsWith("U+"))  // checking for codepoint style
		encoded = EncodingUtil.encodeCodepointsUTF8(unicode);
	else
		encoded = EncodingUtil.encodeUTF8(unicode);
	Route.CompiledRoute route = Route.Messages.ADD_REACTION.compile(getId(), messageId, encoded, "@me");
	// ...
}
```
```JAVA
default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode)
{
	Checks.isSnowflake(messageId, "Message ID");
	Checks.noWhitespace(unicode, "Emoji");

	final String code = EncodingUtil.encodeUTF8(unicode);  // missing check if (unicode.startsWith("U+"))
	final Route.CompiledRoute route = Route.Messages.REMOVE_REACTION.compile(getId(), messageId, code, "@me");
	// ...
}
```

#### Removing Code Redundancy
Before, the `removeReactionById` logic was both in the `MessageChannel` and the `TextChannelImpl` leading to code redundancy. Now the method in the `MessageChannel` calls the method in the `TextChannelImpl`. **This is imo a bad design and I would like to get feedback on that because within 3 hours, I couldn't come up with a better approach.**

#### Making the code more uniform
Before, all four methods of `MessageChannel#removeReactionById` were leading to one implementation. However for adding reactions, there were two (or three) small implementations. For this PR, I also made it that all four methods are leading to one implementation as well.

With removing the code redundancy, there is now **just one implementation for both adding and removing reactions** making it more maintainable. 

**Also a point to discuss would be if `noWhitespace` or `notNull` with `notEmpty` should be used for adding and removing** since `addReaction("\uXXXX ")` will work currently but `removeReaction("\uXXXX ")` won't (approved by Kantenkugel). **I'm unsure what is better (where I am preferring `noWhitespace`) and so is Kantenkugel so I would like to hear your opinions on that.**

(Nearly) all of this has already been discussed in the JDA-Server with Kantenkugel starting [here](https://discordapp.com/channels/125227483518861312/125227483518861312/628315511654055959).