### PR TITLE
Rename LURKABLE feature and fix usage of VIP_REGIONS

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -212,10 +212,10 @@ public interface Guild extends ISnowflake
      *     <li>COMMERCE - Guild can sell software through a store channel</li>
      *     <li>DISCOVERABLE - Guild shows up in discovery tab</li>
      *     <li>INVITE_SPLASH - Guild has custom invite splash. See {@link #getSplashId()} and {@link #getSplashUrl()}</li>
-     *     <li>LURKABLE - Guild allows users to lurk</li>
      *     <li>MORE_EMOJI - Guild is able to use more than 50 emoji</li>
      *     <li>NEWS - Guild can create news channels</li>
      *     <li>PARTNERED - Guild is "partnered"</li>
+     *     <li>PUBLIC - Guild is public</li>
      *     <li>VANITY_URL - Guild a vanity URL (custom invite link). See {@link #getVanityUrl()}</li>
      *     <li>VERIFIED - Guild is "verified"</li>
      *     <li>VIP_REGIONS - Guild has VIP voice regions</li>

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -405,7 +405,7 @@ public interface Guild extends ISnowflake
      */
     default int getMaxBitrate()
     {
-        int maxBitrate = getFeatures().contains("VIP_REGIONS") ? 96000 : 128000;
+        int maxBitrate = getFeatures().contains("VIP_REGIONS") ? 384000 : 96000;
         return Math.max(maxBitrate, getBoostTier().getMaxBitrate());
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The ternary for `getMaxBitrate` was reversed causing incorrect results, additionally vip regions have tier 3 bitrate. Also LURKABLE was deprecated and replaced by PUBLIC.
