### PR TITLE
Add an upper limit to prune and retrievePrunableMemberCount

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1736,7 +1736,7 @@ public interface Guild extends ISnowflake
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
      * @throws IllegalArgumentException
-     *         If the provided days are less than {@code 1}
+     *         If the provided days are less than {@code 1} or more than {@code 30}
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Integer
      *         <br>The amount of Members that would be affected.
@@ -2165,7 +2165,7 @@ public interface Guild extends ISnowflake
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
      * @throws IllegalArgumentException
-     *         If the provided days are less than {@code 1}
+     *         If the provided days are less than {@code 1} or more than {@code 30}
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: Integer
      *         <br>The amount of Members that were pruned from the Guild.

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -545,7 +545,7 @@ public class GuildImpl implements Guild
         if (!getSelfMember().hasPermission(Permission.KICK_MEMBERS))
             throw new InsufficientPermissionException(this, Permission.KICK_MEMBERS);
 
-        Checks.check(days >= 1 && days <= 30, "Days amount must be at between 1 and 30 days.");
+        Checks.check(days >= 1 && days <= 30, "Days amount must be between 1 and 30 days.");
 
         Route.CompiledRoute route = Route.Guilds.PRUNABLE_COUNT.compile(getId()).withQueryParams("days", Integer.toString(days));
         return new RestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));
@@ -839,7 +839,7 @@ public class GuildImpl implements Guild
     {
         checkPermission(Permission.KICK_MEMBERS);
 
-        Checks.check(days >= 1 && days <= 30, "Days amount must be at between 1 and 30 days.");
+        Checks.check(days >= 1 && days <= 30, "Days amount must be between 1 and 30 days.");
 
         Route.CompiledRoute route = Route.Guilds.PRUNE_MEMBERS.compile(getId()).withQueryParams("days", Integer.toString(days));
         return new AuditableRestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -545,7 +545,7 @@ public class GuildImpl implements Guild
         if (!getSelfMember().hasPermission(Permission.KICK_MEMBERS))
             throw new InsufficientPermissionException(this, Permission.KICK_MEMBERS);
 
-        Checks.check(days >= 1 && days <= 30, "Days amount must be between 1 and 30 days.");
+        Checks.check(days >= 1 && days <= 30, "Provided %d days must be between 1 and 30.", days);
 
         Route.CompiledRoute route = Route.Guilds.PRUNABLE_COUNT.compile(getId()).withQueryParams("days", Integer.toString(days));
         return new RestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));
@@ -839,7 +839,7 @@ public class GuildImpl implements Guild
     {
         checkPermission(Permission.KICK_MEMBERS);
 
-        Checks.check(days >= 1 && days <= 30, "Days amount must be between 1 and 30 days.");
+        Checks.check(days >= 1 && days <= 30, "Provided %d days must be between 1 and 30.", days);
 
         Route.CompiledRoute route = Route.Guilds.PRUNE_MEMBERS.compile(getId()).withQueryParams("days", Integer.toString(days));
         return new AuditableRestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -840,7 +840,7 @@ public class GuildImpl implements Guild
     {
         checkPermission(Permission.KICK_MEMBERS);
 
-        Checks.check(days >= 1, "Days amount must be at minimum 1 day.");
+        Checks.check(days >= 1 && days <= 30, "Days amount must be at between 1 and 30 days.");
 
         Route.CompiledRoute route = Route.Guilds.PRUNE_MEMBERS.compile(getId()).withQueryParams("days", Integer.toString(days));
         return new AuditableRestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -545,8 +545,7 @@ public class GuildImpl implements Guild
         if (!getSelfMember().hasPermission(Permission.KICK_MEMBERS))
             throw new InsufficientPermissionException(this, Permission.KICK_MEMBERS);
 
-        if (days < 1)
-            throw new IllegalArgumentException("Days amount must be at minimum 1 day.");
+        Checks.check(days >= 1 && days <= 30, "Days amount must be at between 1 and 30 days.");
 
         Route.CompiledRoute route = Route.Guilds.PRUNABLE_COUNT.compile(getId()).withQueryParams("days", Integer.toString(days));
         return new RestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds an upper limit to Guild#prune's and Guild#retrievePrunableMemberCount's `days` according to Discord API's upper limit of thirty days. This prevents illegal amounts causing 400s by checking if the upper limit is met and throwing if it's not before a REST request can be made.