### PR TITLE
Fix "malformed HTML" javadoc task compilation error

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
@@ -255,7 +255,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * Sets the bitrate for the new VoiceChannel
      *
      * @param  bitrate
-     *         The bitrate for the new VoiceChannel in {@code bps} (limits 8000 <= bitrate <= {@link Guild#getMaxBitrate()})
+     *         The bitrate for the new VoiceChannel in {@code bps} (limits 8000 {@literal <}= bitrate {@literal <}= {@link Guild#getMaxBitrate()})
      *         or {@code null} to use the default 64kbps.
      *
      * @throws UnsupportedOperationException


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

I've forked the `hacktoberfest` branch and tried to build it, but the `javadoc` task failed with message `malformed HTML`. This should fix it.