### PR TITLE
EmoteManagerImpl#finalizeData resets the role list before serializing

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
@@ -154,9 +154,8 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         withLock(this.roles, (list) ->
         {
             if (shouldUpdate(ROLES))
-                object.put("roles", list);
+                object.put("roles", new ArrayList<>(list));
         });
-
         reset();
         return getRequestBody(object);
     }

--- a/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.EmoteManager;
+import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EmoteImpl;
 import net.dv8tion.jda.internal.requests.Route;
@@ -154,7 +155,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         withLock(this.roles, (list) ->
         {
             if (shouldUpdate(ROLES))
-                object.put("roles", new ArrayList<>(list));
+                object.put("roles", DataArray.fromCollection(list));
         });
         reset();
         return getRequestBody(object);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

When the `EmoteManager` is reset in `EmoteManagerImpl#finalizeData`, the role list is still referenced by the `DataObject`, clearing it before the rest action serializes it. This means that an empty list is always sent to Discord no matter the contents provided in `EmoteManager#setRoles(Set<Role>)`.

State before `reset()` is called:

![before-reset](https://cdn.discordapp.com/attachments/554542479525806090/647232966602391563/unknown.png)

State after `reset()` is called:

![after-reset](https://cdn.discordapp.com/attachments/554542479525806090/647233024328728585/unknown.png)