### PR TITLE
Correcting wrong information for Message#delete();

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -913,7 +913,7 @@ public interface Message extends ISnowflake, Formattable
      *         or lost {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE}.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
-     *         The message got already deleted at the time the request was send.</li>
+     *         The message was already deleted at the time the request was sent.</li>
      * </ul>
      *
      * @throws java.lang.UnsupportedOperationException

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -913,7 +913,7 @@ public interface Message extends ISnowflake, Formattable
      *         or lost {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE}.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
-     *         The pin was attempted after the Message had been deleted.</li>
+     *         The message got already deleted at the time the request was send.</li>
      * </ul>
      *
      * @throws java.lang.UnsupportedOperationException
@@ -1038,7 +1038,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
-     * showing how many users have reacted with same emoji/emote.
+     * showing how many users have reacted with the same emoji/emote.
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1100,7 +1100,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
-     * showing how many users have reacted with same emoji/emote.
+     * showing how many users have reacted with the same emoji/emote.
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1199,7 +1199,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
-     * showing how many users have reacted with same emoji/emote.
+     * showing how many users have reacted with the same emoji/emote.
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1245,7 +1245,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
-     * showing how many users have reacted with same emoji/emote.
+     * showing how many users have reacted with the same emoji/emote.
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1300,7 +1300,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
-     * showing how many users have reacted with same emoji/unicode.
+     * showing how many users have reacted with the same emoji/unicode.
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1352,7 +1352,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
-     * showing how many users have reacted with same emoji/unicode.
+     * showing how many users have reacted with the same emoji/unicode.
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1982,7 +1982,7 @@ public interface Message extends ISnowflake, Formattable
          * The height of the Attachment if this Attachment is an image/video.
          * <br>If this Attachment is neither an image, nor a video, this returns -1.
          *
-         * @return int containing image/video Attachment height.
+         * @return int containing image/video Attachment height, or -1 if attachment is neither image nor video.
          */
         public int getHeight()
         {
@@ -1993,7 +1993,7 @@ public interface Message extends ISnowflake, Formattable
          * The width of the Attachment if this Attachment is an image/video.
          * <br>If this Attachment is neither an image, nor a video, this returns -1.
          *
-         * @return int containing image/video Attachment width.
+         * @return int containing image/video Attachment width, or -1 if attachment is neither image nor video.
          */
         public int getWidth()
         {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

- Corrects a typo where the Javadoc says `The pin was attempted after the Message had been deleted.` for the method `Message#delete();` which should be about the message being already deleted, when the request was performed.
- Added additional mention of `Attachment#getWidth()` and `Attachment#getHeight()` returning -1 if Attachment is neither an image nor video.
- Smaller grammar correction about the description of what Reactions are.