### PR TITLE
Fix SessionConnectNode#run typo

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
@@ -257,7 +257,7 @@ public interface SessionController
          *
          * @param  isLast
          *         True, if this is the last node in a queue worker.
-         *         When false this will not wait for the payload to be delivered.
+         *         When true this will not wait for the payload to be delivered.
          *
          * @throws InterruptedException
          *         If the calling thread is interrupted


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The `SessionConnectNode` implementation (`StartingNode`) does not wait if `isLast` is true, but the interface documentation says that it waits if it is true.
