### PR TITLE
Disable owner caching when guild subs are off

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2139,7 +2139,7 @@ public interface Guild extends ISnowflake
     /**
      * Shortcut for {@code guild.retrieveMemberById(guild.getOwnerIdLong())}.
      * <br>This will retrieve the current owner of the guild.
-     * It is possible that the owner of a guild is no longer a registered disocrd user in which case this will fail.
+     * It is possible that the owner of a guild is no longer a registered discord user in which case this will fail.
      *
      * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
      * <ul>

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -500,11 +500,14 @@ public interface Guild extends ISnowflake
      * <br>This is null when the owner is no longer in this guild or not yet loaded (lazy loading).
      * Sometimes owners of guilds delete their account or get banned by Discord.
      *
+     * <p>If lazy-loading is used it is recommended to use {@link #retrieveOwner()} instead.
+     *
      * <p>Ownership can be transferred using {@link net.dv8tion.jda.api.entities.Guild#transferOwnership(Member)}.
      *
      * @return Possibly-null Member object for the Guild owner.
      *
      * @see    #getOwnerIdLong()
+     * @see    #retrieveOwner()
      */
     @Nullable
     Member getOwner();
@@ -2132,6 +2135,32 @@ public interface Guild extends ISnowflake
      */
     @Nonnull
     RestAction<Member> retrieveMemberById(long id);
+
+    /**
+     * Shortcut for {@code guild.retrieveMemberById(guild.getOwnerIdLong())}.
+     * <br>This will retrieve the current owner of the guild.
+     * It is possible that the owner of a guild is no longer a registered disocrd user in which case this will fail.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.exceptions.ErrorResponseException ErrorResponseExceptions} include:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER}
+     *     <br>The specified user is not a member of this guild</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_USER}
+     *     <br>The specified user does not exist</li>
+     * </ul>
+     *
+     * @return {@link RestAction} - Type: {@link Member}
+     *
+     * @see    #getOwner()
+     * @see    #getOwnerIdLong()
+     * @see    #retrieveMemberById(long)
+     */
+    @Nonnull
+    default RestAction<Member> retrieveOwner()
+    {
+        return retrieveMemberById(getOwnerIdLong());
+    }
 
     /* From GuildController */
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -768,6 +768,19 @@ public class GuildImpl implements Guild
         return chunkingCallback;
     }
 
+    @Nonnull
+    @Override
+    public RestAction<Member> retrieveMemberById(long id)
+    {
+        Member member = getMemberById(id);
+        if (member != null)
+            return new EmptyRestAction<>(getJDA(), member);
+
+        Route.CompiledRoute route = Route.Guilds.GET_MEMBER.compile(getId(), Long.toUnsignedString(id));
+        return new RestActionImpl<>(getJDA(), route, (resp, req) ->
+                getJDA().getEntityBuilder().createMember(this, resp.getObject()));
+    }
+
     @Override
     public long getIdLong()
     {
@@ -1528,20 +1541,6 @@ public class GuildImpl implements Guild
         });
         // remove all empty maps
         overrideMap.keySet().removeAll(toRemove);
-    }
-
-    @Nonnull
-    @Override
-    public RestAction<Member> retrieveMemberById(long id)
-    {
-        Member member = getMemberById(id);
-        // If guild subscriptions are disabled this member might not be up-to-date
-        if (member != null && getJDA().isGuildSubscriptions())
-            return new EmptyRestAction<>(getJDA(), member);
-
-        Route.CompiledRoute route = Route.Guilds.GET_MEMBER.compile(getId(), Long.toUnsignedString(id));
-        return new RestActionImpl<>(getJDA(), route, (resp, req) ->
-            getJDA().getEntityBuilder().createMember(this, resp.getObject()));
     }
 
     public void startChunking()

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1288,7 +1288,9 @@ public class GuildImpl implements Guild
 
     public GuildImpl setOwner(Member owner)
     {
-        this.owner = owner;
+        // Only cache owner if user cache is enabled
+        if (getJDA().isGuildSubscriptions())
+            this.owner = owner;
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The owner cache will be outdated when guild subscriptions are disabled thus we need to disable it as well.
