### PR TITLE
Initialize SelfUser from token verification

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -338,6 +338,7 @@ public class JDAImpl implements JDA
             if (userResponse != null)
             {
                 verifyAccountType(userResponse);
+                getEntityBuilder().createSelfUser(userResponse);
                 return;
             }
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This allows us to initialize the `SelfUser` before the ready event is received. Some events are fired before this gateway dispatch happens and they might find it useful to access the self user.
