### PR TITLE
Disable presence and typing handlers when guild subs are off

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateOnlineStatusEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateOnlineStatusEvent.java
@@ -38,13 +38,13 @@ public class UserUpdateOnlineStatusEvent extends GenericUserUpdateEvent<OnlineSt
     public static final String IDENTIFIER = "status";
 
     private final Guild guild;
-    private Member member;
+    private final Member member;
 
-    public UserUpdateOnlineStatusEvent(@Nonnull JDA api, long responseNumber, User user, @Nonnull Guild guild, @Nonnull OnlineStatus oldOnlineStatus)
+    public UserUpdateOnlineStatusEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull OnlineStatus oldOnlineStatus)
     {
-        super(api, responseNumber, user, oldOnlineStatus, guild.getMember(user).getOnlineStatus(), IDENTIFIER);
-        this.guild = guild;
-        this.member = guild.getMember(getUser());
+        super(api, responseNumber, member.getUser(), oldOnlineStatus, member.getOnlineStatus(), IDENTIFIER);
+        this.guild = member.getGuild();
+        this.member = member;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/PresenceUpdateHandler.java
@@ -125,7 +125,7 @@ public class PresenceUpdateHandler extends SocketHandler
             getJDA().handleEvent(
                 new UserUpdateOnlineStatusEvent(
                     getJDA(), responseNumber,
-                    user, guild, oldStatus));
+                    member, oldStatus));
         }
         return null;
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -1214,12 +1214,22 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         handlers.put("MESSAGE_REACTION_REMOVE",     new MessageReactionHandler(api, false));
         handlers.put("MESSAGE_REACTION_REMOVE_ALL", new MessageReactionBulkRemoveHandler(api));
         handlers.put("MESSAGE_UPDATE",              new MessageUpdateHandler(api));
-        handlers.put("PRESENCE_UPDATE",             new PresenceUpdateHandler(api));
         handlers.put("READY",                       new ReadyHandler(api));
-        handlers.put("TYPING_START",                new TypingStartHandler(api));
         handlers.put("USER_UPDATE",                 new UserUpdateHandler(api));
         handlers.put("VOICE_SERVER_UPDATE",         new VoiceServerUpdateHandler(api));
         handlers.put("VOICE_STATE_UPDATE",          new VoiceStateUpdateHandler(api));
+
+        if (api.isGuildSubscriptions())
+        {
+            // These events are not expected if guild subscriptions are disabled
+            handlers.put("PRESENCE_UPDATE", new PresenceUpdateHandler(api));
+            handlers.put("TYPING_START",    new TypingStartHandler(api));
+        }
+        else
+        {
+            handlers.put("PRESENCE_UPDATE", nopHandler);
+            handlers.put("TYPING_START",    nopHandler);
+        }
 
         // Unused events
         handlers.put("CHANNEL_PINS_ACK",          nopHandler);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Both of these handlers should only be executed if guild subscriptions are enabled.
