### PR TITLE
Only load member from voice state when connected

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -192,11 +192,9 @@ public class VoiceStateUpdateHandler extends SocketHandler
         boolean subscriptions = getJDA().isGuildSubscriptions();
         if (member == null)
         {
-            if (subscriptions || (connected && getJDA().isCacheFlagSet(CacheFlag.VOICE_STATE)))
+            if (connected && (subscriptions || getJDA().isCacheFlagSet(CacheFlag.VOICE_STATE)))
             {
-                // this means either:
-                // - the member just connected to a voice channel, otherwise we would know about it already!
-                // - the member is not connect to a voice channel but we can load it here because subscriptions are enabled
+                // the member just connected to a voice channel, otherwise we would know about it already!
                 member = loadMember(userId, guild, memberJson.get(), "Initializing");
             }
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1169 

## Description

We should only load members if they are connected to a voice channel when handling a voice state.