### PR TITLE
Allow setting a maximum decompression buffer size

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -82,6 +82,7 @@ public class JDABuilder
     protected boolean idle = false;
     protected int maxReconnectDelay = 900;
     protected int largeThreshold = 250;
+    protected int maxBufferSize = 2048;
     protected EnumSet<ConfigFlag> flags = ConfigFlag.getDefault();
     protected ChunkingFilter chunkingFilter = ChunkingFilter.ALL;
 
@@ -921,6 +922,30 @@ public class JDABuilder
     }
 
     /**
+     * The maximum size, in bytes, of the buffer used for decompressing discord payloads.
+     * <br>If the maximum buffer size is exceeded a new buffer will be allocated instead.
+     * <br>Setting this to {@link Integer#MAX_VALUE} would imply the buffer will never be resized unless memory starvation is imminent.
+     * <br>Setting this to {@code 0} would imply the buffer would need to be allocated again for every payload (not recommended).
+     *
+     * <p>Default: {@code 2048}
+     *
+     * @param  bufferSize
+     *         The maximum size the buffer should allow to retain
+     *
+     * @throws IllegalArgumentException
+     *         If the provided buffer size is negative
+     *
+     * @return The JDABuilder instance. Useful for chaining.
+     */
+    @Nonnull
+    public JDABuilder setMaxBufferSize(int bufferSize)
+    {
+        Checks.notNegative(bufferSize, "The buffer size");
+        this.maxBufferSize = bufferSize;
+        return this;
+    }
+
+    /**
      * Builds a new {@link net.dv8tion.jda.api.JDA} instance and uses the provided token to start the login process.
      * <br>The login process runs in a different thread, so while this will return immediately, {@link net.dv8tion.jda.api.JDA} has not
      * finished loading, thus many {@link net.dv8tion.jda.api.JDA} methods have the chance to return incorrect information.
@@ -964,7 +989,7 @@ public class JDABuilder
         threadingConfig.setGatewayPool(mainWsPool, shutdownMainWsPool);
         threadingConfig.setRateLimitPool(rateLimitPool, shutdownRateLimitPool);
         SessionConfig sessionConfig = new SessionConfig(controller, httpClient, wsFactory, voiceDispatchInterceptor, flags, maxReconnectDelay, largeThreshold);
-        MetaConfig metaConfig = new MetaConfig(contextMap, cacheFlags, flags);
+        MetaConfig metaConfig = new MetaConfig(maxBufferSize, contextMap, cacheFlags, flags);
 
         JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig);
         jda.setChunkingFilter(chunkingFilter);

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -486,7 +486,7 @@ public class DefaultShardManager implements ShardManager
         threadingConfig.setRateLimitPool(rateLimitPool, shutdownRateLimitPool);
         threadingConfig.setGatewayPool(gatewayPool, shutdownGatewayPool);
         threadingConfig.setCallbackPool(callbackPool, shutdownCallbackPool);
-        MetaConfig metaConfig = new MetaConfig(this.metaConfig.getContextMap(shardId), this.metaConfig.getCacheFlags(), this.sessionConfig.getFlags());
+        MetaConfig metaConfig = new MetaConfig(this.metaConfig.getMaxBufferSize(), this.metaConfig.getContextMap(shardId), this.metaConfig.getCacheFlags(), this.sessionConfig.getFlags());
         final JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig);
         jda.setChunkingFilter(chunkingFilter);
         threadingConfig.init(jda::getIdentifierString);

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -177,6 +177,11 @@ public class JDAImpl implements JDA
         return sessionConfig.getLargeThreshold();
     }
 
+    public int getMaxBufferSize()
+    {
+        return metaConfig.getMaxBufferSize();
+    }
+
     public boolean chunkGuild(long id)
     {
         try

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -302,7 +302,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             {
                 case ZLIB:
                     if (decompressor == null || decompressor.getType() != Compression.ZLIB)
-                        decompressor = new ZlibDecompressor();
+                        decompressor = new ZlibDecompressor(api.getMaxBufferSize());
                     break;
                 default:
                     throw new IllegalStateException("Unknown compression");

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
@@ -33,13 +33,19 @@ public class ZlibDecompressor implements Decompressor
 {
     private static final int Z_SYNC_FLUSH = 0x0000FFFF;
 
+    private final int maxBufferSize;
     private final Inflater inflater = new Inflater();
     private ByteBuffer flushBuffer = null;
     private SoftReference<ByteArrayOutputStream> decompressBuffer = null;
 
+    public ZlibDecompressor(int maxBufferSize)
+    {
+        this.maxBufferSize = maxBufferSize;
+    }
+
     private SoftReference<ByteArrayOutputStream> newDecompressBuffer()
     {
-        return new SoftReference<>(new ByteArrayOutputStream(1024));
+        return new SoftReference<>(new ByteArrayOutputStream(Math.min(1024, maxBufferSize)));
     }
 
     private ByteArrayOutputStream getDecompressBuffer()
@@ -50,7 +56,7 @@ public class ZlibDecompressor implements Decompressor
         // Check if the buffer has been collected by the GC or not
         ByteArrayOutputStream buffer = decompressBuffer.get();
         if (buffer == null) // create a ne buffer because the GC got it
-            decompressBuffer = new SoftReference<>(buffer = new ByteArrayOutputStream(1024));
+            decompressBuffer = newDecompressBuffer();
         return buffer;
     }
 
@@ -103,7 +109,6 @@ public class ZlibDecompressor implements Decompressor
     }
 
     @Override
-    @SuppressWarnings("CharsetObjectCanBeUsed")
     public String decompress(byte[] data) throws DataFormatException
     {
         //Handle split messages
@@ -144,7 +149,10 @@ public class ZlibDecompressor implements Decompressor
         finally
         {
             // When done with decompression we want to reset the buffer so it can be used again later
-            buffer.reset();
+            if (buffer.size() > maxBufferSize)
+                decompressBuffer = newDecompressBuffer();
+            else
+                buffer.reset();
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/MetaConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/MetaConfig.java
@@ -27,17 +27,20 @@ import java.util.concurrent.ConcurrentMap;
 
 public class MetaConfig
 {
-    private static final MetaConfig defaultConfig = new MetaConfig(null, EnumSet.allOf(CacheFlag.class), ConfigFlag.getDefault());
+    private static final MetaConfig defaultConfig = new MetaConfig(2048, null, EnumSet.allOf(CacheFlag.class), ConfigFlag.getDefault());
     private final ConcurrentMap<String, String> mdcContextMap;
     private final EnumSet<CacheFlag> cacheFlags;
     private final boolean enableMDC;
     private final boolean useShutdownHook;
     private final boolean guildSubscriptions;
+    private final int maxBufferSize;
 
     public MetaConfig(
+            int maxBufferSize,
             @Nullable ConcurrentMap<String, String> mdcContextMap,
             @Nullable EnumSet<CacheFlag> cacheFlags, EnumSet<ConfigFlag> flags)
     {
+        this.maxBufferSize = maxBufferSize;
         this.cacheFlags = cacheFlags == null ? EnumSet.allOf(CacheFlag.class) : cacheFlags;
         this.enableMDC = flags.contains(ConfigFlag.MDC_CONTEXT);
         if (enableMDC)
@@ -73,6 +76,11 @@ public class MetaConfig
     public boolean isGuildSubscriptions()
     {
         return guildSubscriptions;
+    }
+
+    public int getMaxBufferSize()
+    {
+        return maxBufferSize;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingMetaConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingMetaConfig.java
@@ -29,15 +29,16 @@ import java.util.function.IntFunction;
 
 public class ShardingMetaConfig extends MetaConfig
 {
-    private static final ShardingMetaConfig defaultConfig = new ShardingMetaConfig(null, null, ConfigFlag.getDefault(), Compression.ZLIB);
+    private static final ShardingMetaConfig defaultConfig = new ShardingMetaConfig(2048, null, null, ConfigFlag.getDefault(), Compression.ZLIB);
     private final Compression compression;
     private final IntFunction<? extends ConcurrentMap<String, String>> contextProvider;
 
     public ShardingMetaConfig(
+        int maxBufferSize,
         @Nullable IntFunction<? extends ConcurrentMap<String, String>> contextProvider,
         @Nullable EnumSet<CacheFlag> cacheFlags, EnumSet<ConfigFlag> flags, Compression compression)
     {
-        super(null, cacheFlags, flags);
+        super(maxBufferSize, null, cacheFlags, flags);
 
         this.compression = compression;
         this.contextProvider = contextProvider;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This also changes the default behavior to re-allocate the decompression buffer when it exceeds 2048 bytes. That seems to be a reasonable default. To get the previous behavior you can do `setMaxBufferSize(Integer.MAX_VALUE)`.
