### PR TITLE
Add getPermissionHolder method to PermissionOverride

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.util.EnumSet;
 
 /**
@@ -99,6 +100,63 @@ public interface PermissionOverride extends ISnowflake
      */
     @Nonnull
     JDA getJDA();
+
+    /**
+     * This method will return the {@link net.dv8tion.jda.api.entities.IPermissionHolder PermissionHolder} of this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}.
+     * It can be used to e. g. get the general permissions of that PermissionHolder no matter if it is a {@link net.dv8tion.jda.api.entities.Member Member} or a {@link net.dv8tion.jda.api.entities.Role Role}.
+     *
+     * <p><b>To get the concrete Member or Role, use {@link PermissionOverride#getMember()} or {@link PermissionOverride#getRole()}!</b>
+     *
+     * <h2>Example</h2>
+     * <pre><code>
+     * private static final List{@literal <}Permission{@literal >} HIGH_PERMISSIONS = Arrays.asList(Permission.ADMINISTRATOR, Permission.BAN_MEMBERS,
+     *      Permission.MANAGE_SERVER, Permission.KICK_MEMBERS);  // list because the order matters
+     *
+     * guild.getTextChannelCache().stream().filter(tc -{@literal >}
+     * {
+     *     List{@literal <}PermissionOverride{@literal >} permissionOverrides = tc.getPermissionOverrides();
+     *
+     *     // OLD
+     *     for (Permission perm : HIGH_PERMISSIONS)
+     *     {
+     *         // Any member with an override has a high permission?
+     *         boolean highMemberOverride = permissionOverrides.stream()
+     *             .filter(PermissionOverride::isMemberOverride)
+     *             .anyMatch(po -{@literal >} po.getMember().hasPermission(perm));
+     *         if (highMemberOverride)
+     *             return true;
+     *
+     *         // Any role with an override has a high permission?
+     *         boolean highRoleOverride = permissionOverrides.stream()
+     *             .filter(PermissionOverride::isRoleOverride)
+     *             .anyMatch(po -{@literal >} po.getRole().hasPermission(perm));
+     *         if (highRoleOverride)
+     *           return true;
+     *     }
+     *
+     *     // NEW
+     *     for (Permission perm : HIGH_PERMISSIONS)
+     *     {
+     *         // Any permission holder with an override has a high permission?
+     *         boolean highOverride = permissionOverrides.stream()
+     *             .anyMatch(po -{@literal >} po.getPermissionHolder().hasPermission(perm));
+     *         if (highOverride)
+     *             return true;
+     *     }
+     *
+     *     return false;
+     * });
+     * </code></pre>
+     *
+     * @return Never-null {@link net.dv8tion.jda.api.entities.IPermissionHolder PermissionHolder} of this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}.
+     *
+     * @see    PermissionOverride#getRole()
+     * @see    PermissionOverride#getMember()
+     * @see    net.dv8tion.jda.api.entities.IPermissionHolder#getPermissions() IPermissionHolder#getPermissions
+     * @see    net.dv8tion.jda.api.entities.IPermissionHolder#hasPermission(Permission... permissions) IPermissionHolder#hasPermission
+     */
+    @Nonnull
+    IPermissionHolder getPermissionHolder();
 
     /**
      * If this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} is an override dealing with

--- a/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
@@ -93,8 +93,7 @@ public interface PermissionOverride extends ISnowflake
     EnumSet<Permission> getDenied();
 
     /**
-     * The {@link net.dv8tion.jda.api.JDA JDA} instance that this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}
-     * is related to.
+     * The {@link net.dv8tion.jda.api.JDA JDA} instance that this PermissionOverride is related to.
      *
      * @return Never-null {@link net.dv8tion.jda.api.JDA JDA} instance.
      */
@@ -102,67 +101,24 @@ public interface PermissionOverride extends ISnowflake
     JDA getJDA();
 
     /**
-     * This method will return the {@link net.dv8tion.jda.api.entities.IPermissionHolder PermissionHolder} of this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}.
+     * This method will return the {@link net.dv8tion.jda.api.entities.IPermissionHolder PermissionHolder} of this PermissionOverride.
      * It can be used to e. g. get the general permissions of that PermissionHolder no matter if it is a {@link net.dv8tion.jda.api.entities.Member Member} or a {@link net.dv8tion.jda.api.entities.Role Role}.
      *
      * <p><b>To get the concrete Member or Role, use {@link PermissionOverride#getMember()} or {@link PermissionOverride#getRole()}!</b>
      *
-     * <h2>Example</h2>
-     * <pre><code>
-     * private static final {@literal List<Permission>} HIGH_PERMISSIONS = Arrays.asList(Permission.ADMINISTRATOR, Permission.BAN_MEMBERS,
-     *      Permission.MANAGE_SERVER, Permission.KICK_MEMBERS);  // list because the order matters
-     *
-     * guild.getTextChannelCache().stream().filter(tc -{@literal >}
-     * {
-     *     {@literal List<PermissionOverride>} permissionOverrides = tc.getPermissionOverrides();
-     *
-     *     // OLD
-     *     for (Permission perm : HIGH_PERMISSIONS)
-     *     {
-     *         // Any member with an override has a high permission?
-     *         boolean highMemberOverride = permissionOverrides.stream()
-     *             .filter(PermissionOverride::isMemberOverride)
-     *             .anyMatch(po -{@literal >} po.getMember().hasPermission(perm));
-     *         if (highMemberOverride)
-     *             return true;
-     *
-     *         // Any role with an override has a high permission?
-     *         boolean highRoleOverride = permissionOverrides.stream()
-     *             .filter(PermissionOverride::isRoleOverride)
-     *             .anyMatch(po -{@literal >} po.getRole().hasPermission(perm));
-     *         if (highRoleOverride)
-     *           return true;
-     *     }
-     *
-     *     // NEW
-     *     for (Permission perm : HIGH_PERMISSIONS)
-     *     {
-     *         // Any permission holder with an override has a high permission?
-     *         boolean highOverride = permissionOverrides.stream()
-     *             .anyMatch(po -{@literal >} po.getPermissionHolder().hasPermission(perm));
-     *         if (highOverride)
-     *             return true;
-     *     }
-     *
-     *     return false;
-     * });
-     * </code></pre>
-     *
-     * @return Never-null {@link net.dv8tion.jda.api.entities.IPermissionHolder PermissionHolder} of this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}.
+     * @return Possibly-null {@link net.dv8tion.jda.api.entities.IPermissionHolder PermissionHolder} of this PermissionOverride.
      *
      * @see    PermissionOverride#getRole()
      * @see    PermissionOverride#getMember()
-     * @see    net.dv8tion.jda.api.entities.IPermissionHolder#getPermissions() IPermissionHolder#getPermissions
-     * @see    net.dv8tion.jda.api.entities.IPermissionHolder#hasPermission(Permission... permissions) IPermissionHolder#hasPermission
      */
-    @Nonnull
+    @Nullable
     IPermissionHolder getPermissionHolder();
 
     /**
-     * If this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} is an override dealing with
-     * a {@link net.dv8tion.jda.api.entities.Member Member}, then this method will return the related {@link net.dv8tion.jda.api.entities.Member Member}.
+     * If this PermissionOverride is an override dealing with a {@link net.dv8tion.jda.api.entities.Member Member}, then
+     * this method will return the related {@link net.dv8tion.jda.api.entities.Member Member}.
      * <br>Otherwise, this method returns {@code null}.
-     * <br>Basically: if {@link net.dv8tion.jda.api.entities.PermissionOverride#isMemberOverride()}
+     * <br>Basically: if {@link PermissionOverride#isMemberOverride()}
      * returns {@code false}, this returns {@code null}.
      *
      * @return Possibly-null related {@link net.dv8tion.jda.api.entities.Member Member}.
@@ -171,10 +127,10 @@ public interface PermissionOverride extends ISnowflake
     Member getMember();
 
     /**
-     * If this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} is an override dealing with
-     * a {@link net.dv8tion.jda.api.entities.Role Role}, then this method will return the related {@link net.dv8tion.jda.api.entities.Role Role}.
+     * If this PermissionOverride is an override dealing with a {@link net.dv8tion.jda.api.entities.Role Role}, then
+     * this method will return the related {@link net.dv8tion.jda.api.entities.Role Role}.
      * <br>Otherwise, this method returns {@code null}.
-     * Basically: if {@link net.dv8tion.jda.api.entities.PermissionOverride#isRoleOverride()}
+     * <br>Basically: if {@link PermissionOverride#isRoleOverride()}
      * returns {@code false}, this returns {@code null}.
      *
      * @return Possibly-null related {@link net.dv8tion.jda.api.entities.Role}.
@@ -183,18 +139,17 @@ public interface PermissionOverride extends ISnowflake
     Role getRole();
 
     /**
-     * The {@link GuildChannel GuildChannel} that this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} affects.
+     * The {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} that this PermissionOverride affects.
      *
-     * @return Never-null related {@link GuildChannel GuildChannel} that this override is part of.
+     * @return Never-null related {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} that this override is part of.
      */
     @Nonnull
     GuildChannel getChannel();
 
     /**
-     * The {@link net.dv8tion.jda.api.entities.Guild Guild} that the {@link GuildChannel GuildChannel}
+     * The {@link net.dv8tion.jda.api.entities.Guild Guild} that the {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}
      * returned from {@link net.dv8tion.jda.api.entities.PermissionOverride#getChannel()} is a part of.
-     * By inference, this is the {@link net.dv8tion.jda.api.entities.Guild Guild} that this
-     * {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} is part of.
+     * By inference, this is the {@link net.dv8tion.jda.api.entities.Guild Guild} that this PermissionOverride is part of.
      *
      * @return Never-null related {@link net.dv8tion.jda.api.entities.Guild Guild}.
      */
@@ -202,7 +157,7 @@ public interface PermissionOverride extends ISnowflake
     Guild getGuild();
 
     /**
-     * Used to determine if this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} relates to
+     * Used to determine if this PermissionOverride relates to
      * a specific {@link net.dv8tion.jda.api.entities.Member Member}.
      *
      * @return True if this override is a user override.
@@ -210,7 +165,7 @@ public interface PermissionOverride extends ISnowflake
     boolean isMemberOverride();
 
     /**
-     * Used to determine if this {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} relates to
+     * Used to determine if this PermissionOverride relates to
      * a specific {@link net.dv8tion.jda.api.entities.Role Role}.
      *
      * @return True if this override is a role override.

--- a/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
@@ -109,12 +109,12 @@ public interface PermissionOverride extends ISnowflake
      *
      * <h2>Example</h2>
      * <pre><code>
-     * private static final List{@literal <}Permission{@literal >} HIGH_PERMISSIONS = Arrays.asList(Permission.ADMINISTRATOR, Permission.BAN_MEMBERS,
+     * private static final {@literal List<Permission>} HIGH_PERMISSIONS = Arrays.asList(Permission.ADMINISTRATOR, Permission.BAN_MEMBERS,
      *      Permission.MANAGE_SERVER, Permission.KICK_MEMBERS);  // list because the order matters
      *
      * guild.getTextChannelCache().stream().filter(tc -{@literal >}
      * {
-     *     List{@literal <}PermissionOverride{@literal >} permissionOverrides = tc.getPermissionOverrides();
+     *     {@literal List<PermissionOverride>} permissionOverrides = tc.getPermissionOverrides();
      *
      *     // OLD
      *     for (Permission perm : HIGH_PERMISSIONS)

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -30,6 +30,8 @@ import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl
 import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
@@ -103,12 +105,21 @@ public class PermissionOverrideImpl implements PermissionOverride
         return api;
     }
 
+    @Nonnull
+    @Override
+    public IPermissionHolder getPermissionHolder()
+    {
+        return (IPermissionHolder) (role ? getRole() : getMember());  // permissionHolder is no longer a field
+    }
+
+    @Nullable
     @Override
     public Member getMember()
     {
         return getGuild().getMemberById(id);
     }
 
+    @Nullable
     @Override
     public Role getRole()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -30,7 +30,6 @@ import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl
 import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.EnumSet;
 import java.util.Objects;
@@ -105,21 +104,18 @@ public class PermissionOverrideImpl implements PermissionOverride
         return api;
     }
 
-    @Nonnull
     @Override
     public IPermissionHolder getPermissionHolder()
     {
         return (IPermissionHolder) (role ? getRole() : getMember());  // permissionHolder is no longer a field
     }
 
-    @Nullable
     @Override
     public Member getMember()
     {
         return getGuild().getMemberById(id);
     }
 
-    @Nullable
     @Override
     public Role getRole()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

Adds a function `PermissionOverride#getPermissionHolder` to get the `IPermissionHolder`. It can be used to e. g. get the general permissions of that PermissionHolder no matter if it is a Member or a Role.

Also adds missing `@Nullable` annotations in the `PermissionOverrideImpl` class for consistency.

### Example Use Case
Check if a GuildChannel has a an override for a Member / Role which itself has a high permission (like Administrator, Manage Messages, etc.).

```java
     for (Permission perm : HIGH_PERMISSIONS)
     {
         // Any member with an override has a high permission?
         boolean highMemberOverride = permissionOverrides.stream()
             .filter(PermissionOverride::isMemberOverride)
             .anyMatch(po -> po.getMember().hasPermission(perm));
         if (highMemberOverride)
             return true;

         // Any role with an override has a high permission?
         boolean highRoleOverride = permissionOverrides.stream()
             .filter(PermissionOverride::isRoleOverride)
             .anyMatch(po -> po.getRole().hasPermission(perm));
         if (highRoleOverride)
           return true;
     }
```
With that new method:
```java
     for (Permission perm : HIGH_PERMISSIONS)
     {
         // Any permission holder with an override has a high permission?
         boolean highOverride = permissionOverrides.stream()
             .anyMatch(po -> po.getPermissionHolder().hasPermission(perm));
         if (highOverride)
             return true;
     }
```