### PR TITLE
Improve handling of events for unavailable guilds

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -32,7 +32,6 @@ import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import net.dv8tion.jda.internal.requests.DeferredRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -813,6 +812,16 @@ public interface JDA
      */
     @Nonnull
     Set<String> getUnavailableGuilds();
+
+    /**
+     * Whether the guild is unavailable. If this returns true, the guild id should be in {@link #getUnavailableGuilds()}.
+     *
+     * @param  guildId
+     *         The guild id
+     *
+     * @return True, if this guild is unavailable
+     */
+    boolean isUnavailable(long guildId);
 
     /**
      * Unified {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView} of

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2034,17 +2034,19 @@ public interface Guild extends ISnowflake
     boolean checkVerification();
 
     /**
-     * Returns whether or not this Guild is available. A Guild can be unavailable, if the Discord server has problems.
-     * <br>If a Guild is unavailable, no actions on it can be performed (Messages, Manager,...)
+     * Whether or not this Guild is available. A Guild can be unavailable, if the Discord server has problems.
+     * <br>If a Guild is unavailable, it will be removed from the guild cache. You cannot receive events for unavailable guilds.
      *
      * @return If the Guild is available
      *
-     * @deprecated
-     *         This will be removed in a future version, unavailable guilds are now removed from cache
+     * @deprecated This will be removed in a future version,
+     *             unavailable guilds are now removed from cache.
+     *             Replace with {@link JDA#isUnavailable(long)}
      */
     @ForRemoval
     @Deprecated
     @DeprecatedSince("4.1.0")
+    @ReplaceWith("getJDA().isUnavailable(guild.getIdLong())")
     boolean isAvailable();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildJoinEvent.java
@@ -22,8 +22,11 @@ import javax.annotation.Nonnull;
 
 /**
  * Indicates that you joined a {@link net.dv8tion.jda.api.entities.Guild Guild}.
+ * <br>This requires that the guild is available when the guild leave happens. Otherwise a {@link UnavailableGuildJoinedEvent} is fired instead.
  *
  * <p><b>Warning: Discord already triggered a mass amount of these events due to a downtime. Be careful!</b>
+ *
+ * @see UnavailableGuildJoinedEvent
  */
 public class GuildJoinEvent extends GenericGuildEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildLeaveEvent.java
@@ -22,8 +22,11 @@ import javax.annotation.Nonnull;
 
 /**
  * Indicates that you left a {@link net.dv8tion.jda.api.entities.Guild Guild}.
+ * <br>This requires that the guild is available when the guild leave happens. Otherwise a {@link UnavailableGuildLeaveEvent} is fired instead.
  *
  * <p>Can be used to detect when you leave a Guild.
+ *
+ * @see UnavailableGuildLeaveEvent
  */
 public class GuildLeaveEvent extends GenericGuildEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildLeaveEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.events.Event;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Indicates that you left a {@link net.dv8tion.jda.api.entities.Guild Guild} that is not yet available.
+ * <b>This does not extend {@link net.dv8tion.jda.api.events.guild.GenericGuildEvent GenericGuildEvent}</b>
+ *
+ * <p>Can be used to retrieve id of the unavailable Guild.
+ */
+public class UnavailableGuildLeaveEvent extends Event
+{
+    private final long guildId;
+
+    public UnavailableGuildLeaveEvent(@Nonnull JDA api, long responseNumber, long guildId)
+    {
+        super(api, responseNumber);
+        this.guildId = guildId;
+    }
+
+    /**
+     * The id for the guild we left.
+     *
+     * @return The id for the guild
+     */
+    @Nonnull
+    public String getGuildId()
+    {
+        return Long.toUnsignedString(guildId);
+    }
+
+    /**
+     * The id for the guild we left.
+     *
+     * @return The id for the guild
+     */
+    public long getGuildIdLong()
+    {
+        return guildId;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -213,6 +213,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildAvailable(@Nonnull GuildAvailableEvent event) {}
     public void onGuildUnavailable(@Nonnull GuildUnavailableEvent event) {}
     public void onUnavailableGuildJoined(@Nonnull UnavailableGuildJoinedEvent event) {}
+    public void onUnavailableGuildLeave(@Nonnull UnavailableGuildLeaveEvent event) {}
     public void onGuildBan(@Nonnull GuildBanEvent event) {}
     public void onGuildUnban(@Nonnull GuildUnbanEvent event) {}
 
@@ -499,6 +500,8 @@ public abstract class ListenerAdapter implements EventListener
             onGuildUnavailable((GuildUnavailableEvent) event);
         else if (event instanceof UnavailableGuildJoinedEvent)
             onUnavailableGuildJoined((UnavailableGuildJoinedEvent) event);
+        else if (event instanceof UnavailableGuildLeaveEvent)
+            onUnavailableGuildLeave((UnavailableGuildLeaveEvent) event);
         else if (event instanceof GuildBanEvent)
             onGuildBan((GuildBanEvent) event);
         else if (event instanceof GuildUnbanEvent)

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -583,6 +583,12 @@ public class JDAImpl implements JDA
         return copy;
     }
 
+    @Override
+    public boolean isUnavailable(long guildId)
+    {
+        return guildSetupController.isUnavailable(guildId);
+    }
+
     @Nonnull
     @Override
     public SnowflakeCacheView<Role> getRoleCache()

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -326,7 +326,7 @@ public class EntityBuilder
             VoiceChannelImpl voiceChannel =
                     (VoiceChannelImpl) guildObj.getVoiceChannelsView().get(channelId);
             if (voiceChannel != null)
-                voiceChannel.getConnectedMembersMap().put(member.getUser().getIdLong(), member);
+                voiceChannel.getConnectedMembersMap().put(member.getIdLong(), member);
             else
                 LOG.error("Received a GuildVoiceState with a channel ID for a non-existent channel! ChannelId: {} GuildId: {} UserId: {}",
                     channelId, guildObj.getId(), userId);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -246,6 +246,7 @@ public class GuildSetupController
                 remove(id);
             else
                 ready(id);
+            api.getEventManager().handle(new UnavailableGuildLeaveEvent(api, api.getResponseTotal(), id));
         }
         log.debug("Updated incompleteCount to {} and syncCount to {}", incompleteCount, syncingCount);
         return true;

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -26,6 +26,7 @@ import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.api.AccountType;
+import net.dv8tion.jda.api.events.guild.UnavailableGuildLeaveEvent;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
@@ -205,6 +206,7 @@ public class GuildSetupController
         {
             log.debug("Leaving unavailable guild with id {}", id);
             remove(id);
+            api.getEventManager().handle(new UnavailableGuildLeaveEvent(api, api.getResponseTotal(), id));
             return true;
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -118,6 +118,7 @@ public class GuildSetupController
 
     void remove(long id)
     {
+        unavailableGuilds.remove(id);
         setupNodes.remove(id);
         chunkingGuilds.remove(id);
         synchronized (pendingChunks) { pendingChunks.remove(id); }
@@ -200,6 +201,13 @@ public class GuildSetupController
     public boolean onDelete(long id, DataObject obj)
     {
         boolean available = obj.isNull("unavailable") || !obj.getBoolean("unavailable");
+        if (isUnavailable(id) && available)
+        {
+            log.debug("Leaving unavailable guild with id {}", id);
+            remove(id);
+            return true;
+        }
+
         GuildSetupNode node = setupNodes.get(id);
         if (node == null)
             return false;

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -842,6 +842,12 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                     }
                     break;
                 default:
+                    long guildId = content.getLong("guild_id", 0L);
+                    if (api.isUnavailable(guildId) && !type.equals("GUILD_CREATE") && !type.equals("GUILD_DELETE"))
+                    {
+                        LOG.warn("Ignoring {} for unavailable guild with id {}. JSON: {}", type, guildId, content);
+                        break;
+                    }
                     SocketHandler handler = handlers.get(type);
                     if (handler != null)
                         handler.handle(responseTotal, raw);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This will now ignore events for unavailable guilds. We do expect discord to not send any events for unavailable guilds but if they do we should ignore them. Handling events for unavailable guilds could lead to unforseen consequences.
