### PR TITLE
Let ChannelUpdateHandler add overrides to cache

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -15,6 +15,7 @@
  */
 package net.dv8tion.jda.api.entities;
 
+import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
@@ -24,6 +25,8 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.entities.GuildImpl;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -363,7 +366,15 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
         if (!getGuild().getSelfMember().hasPermission(this, Permission.MANAGE_PERMISSIONS))
             throw new InsufficientPermissionException(this, Permission.MANAGE_PERMISSIONS);
         PermissionOverride override = getPermissionOverride(permissionHolder);
-        return override != null ? override.getManager() : putPermissionOverride(permissionHolder);
+        if (override != null)
+            return override.getManager();
+        PermissionOverrideAction action = putPermissionOverride(permissionHolder);
+        // Check if we have some information cached already
+        TLongObjectMap<DataObject> cache = ((GuildImpl) getGuild()).getOverrideMap(permissionHolder.getIdLong());
+        DataObject json = cache == null ? null : cache.get(getIdLong());
+        if (json != null)
+            action = action.setPermissions(json.getLong("allow"), json.getLong("deny"));
+        return action;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
@@ -24,7 +24,6 @@ import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import net.dv8tion.jda.internal.entities.AbstractChannelImpl;
 import net.dv8tion.jda.internal.entities.PermissionOverrideImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -219,9 +218,7 @@ public class PermissionOverrideActionImpl
         PermissionOverrideImpl override = new PermissionOverrideImpl(channel, permissionHolder);
         override.setAllow(object.getLong("allow"));
         override.setDeny(object.getLong("deny"));
-
-        ((AbstractChannelImpl<?,?>) channel).getOverrideMap().put(id, override);
-
+        //((AbstractChannelImpl<?,?>) channel).getOverrideMap().put(id, override); This is added by the event later
         request.onSuccess(override);
     }
 }


### PR DESCRIPTION


[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This is a bug since the override shouldn't be in the interface
if the member is not actually in the cache. With the current
implementation we have a cache inconsistency that could NPE.
