### PR TITLE
Change handling of GuildDeleteHandler to avoid deadlock

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/AudioManagerImpl.java
@@ -144,7 +144,7 @@ public class AudioManagerImpl implements AudioManager
             this.queuedAudioConnection = null;
             if (audioConnection != null)
                 this.audioConnection.close(reason);
-            else
+            else if (reason != ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD)
                 getJDA().getDirectAudioController().disconnect(getGuild());
             this.audioConnection = null;
         });


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1188 

## Description

This should fix a possible deadlock in `GuildDeleteHandler` which occurs because we are holding the write-lock while also trying to lock the audio connection. Holding a write-lock for this entire process is unnecessary so I rewrote it.
