### PR TITLE
Add clearReactions(String)

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -23,8 +23,9 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.awt.Color;
+import java.awt.*;
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -186,13 +187,17 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      * <br>The roles are ordered based on their position. The highest role being at index 0
      * and the lowest at the last index.
      *
-     * <p>A Member's roles can be changed using the <b>addRolesToMember</b>, <b>removeRolesFromMember</b>, and <b>modifyMemberRoles</b>
+     * <p>A Member's roles can be changed using the {@link Guild#addRoleToMember(Member, Role)}, {@link Guild#removeRoleFromMember(Member, Role)}, and {@link Guild#modifyMemberRoles(Member, Collection, Collection)}
      * methods in {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *
      * <p><b>The Public Role ({@code @everyone}) is not included in the returned immutable list of roles
      * <br>It is implicit that every member holds the Public Role in a Guild thus it is not listed here!</b>
      *
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.Role Roles} for this Member.
+     *
+     * @see    Guild#addRoleToMember(Member, Role)
+     * @see    Guild#removeRoleFromMember(Member, Role)
+     * @see    Guild#modifyMemberRoles(Member, Collection, Collection)
      */
     @Nonnull
     List<Role> getRoles();

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -16,7 +16,9 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.exceptions.HttpException;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
@@ -1188,16 +1190,83 @@ public interface Message extends ISnowflake, Formattable
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
      *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
+     *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
     @Nonnull
     @CheckReturnValue
     RestAction<Void> clearReactions();
 
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <h2>Example</h2>
+     * <pre><code>
+     * // custom
+     * message.clearReactions("minn:245267426227388416").queue();
+     * // unicode escape
+     * message.clearReactions("&#92;uD83D&#92;uDE02").queue();
+     * // codepoint notation
+     * message.clearReactions("U+1F602").queue();
+     * </code></pre>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided unicode emoji doesn't exist. Try using one of the example formats.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  unicode
+     *         The unicode emoji to remove reactions for
+     *
+     * @throws UnsupportedOperationException
+     *         If this reaction happened in a private channel
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     */
     @Nonnull
     @CheckReturnValue
     RestAction<Void> clearReactions(@Nonnull String unicode);
 
+    /**
+     * Removes all reactions for the specified emote.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emote was deleted or doesn't exist.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  emote
+     *         The {@link Emote} to remove reactions for
+     *
+     * @throws UnsupportedOperationException
+     *         If this reaction happened in a private channel
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     */
     @Nonnull
     @CheckReturnValue
     RestAction<Void> clearReactions(@Nonnull Emote emote);

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1194,6 +1194,14 @@ public interface Message extends ISnowflake, Formattable
     @CheckReturnValue
     RestAction<Void> clearReactions();
 
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Void> clearReactions(@Nonnull String unicode);
+
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Void> clearReactions(@Nonnull Emote emote);
+
     /**
      * Removes a reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emote Emote}.
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1234,6 +1234,8 @@ public interface Message extends ISnowflake, Formattable
      *         If provided with null
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue
@@ -1266,6 +1268,8 @@ public interface Message extends ISnowflake, Formattable
      *         If provided with null
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -470,9 +470,6 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The send request was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MESSAGE_WRITE Permission.MESSAGE_WRITE} in
      *         the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
      *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNAUTHORIZED UNAUTHORIZED}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} and the recipient User blocked you</li>
-     *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
      *     <br>If this is a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} and the currently logged in account
      *         does not share any Guilds with the recipient User</li>
@@ -619,9 +616,6 @@ public interface MessageChannel extends ISnowflake, Formattable
      *     <br>The send request was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MESSAGE_WRITE Permission.MESSAGE_WRITE} or
      *         {@link net.dv8tion.jda.api.Permission#MESSAGE_ATTACH_FILES Permission.MESSAGE_ATTACH_FILES}
      *         in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
-     *
-     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNAUTHORIZED UNAUTHORIZED}
-     *     <br>If this is a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} and the recipient User blocked you</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#CANNOT_SEND_TO_USER CANNOT_SEND_TO_USER}
      *     <br>If this is a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} and the currently logged in account

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -354,6 +354,31 @@ public class MessageReaction
         return new RestActionImpl<>(getJDA(), route);
     }
 
+    /**
+     * Removes this entire reaction from the message.
+     * <br>Unlike {@link #removeReaction(User)}, which removes the reaction of a single user, this will remove the reaction
+     * completely.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided unicode emoji doesn't exist. Try using one of the example formats.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @throws UnsupportedOperationException
+     *         If this reaction happened in a private channel
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     *
+     * @return {@link RestAction}
+     */
     @Nonnull
     @CheckReturnValue
     public RestAction<Void> clearReactions()

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -378,6 +378,8 @@ public class MessageReaction
      *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -391,7 +391,7 @@ public class MessageReaction
             throw new InsufficientPermissionException(guildChannel, Permission.MESSAGE_MANAGE);
 
         String code = getReactionCode();
-        Route.CompiledRoute route = Route.Messages.CLEAR_EMOTE_REACTIONS.compile(channel.getId(), code);
+        Route.CompiledRoute route = Route.Messages.CLEAR_EMOTE_REACTIONS.compile(channel.getId(), getMessageId(), code);
         return new RestActionImpl<>(getJDA(), route);
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -427,11 +427,81 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
     @CheckReturnValue
     RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote);
 
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <h2>Example</h2>
+     * <pre><code>
+     * // custom
+     * channel.clearReactions(messageId, "minn:245267426227388416").queue();
+     * // unicode escape
+     * channel.clearReactions(messageId, "&#92;uD83D&#92;uDE02").queue();
+     * // codepoint notation
+     * channel.clearReactions(messageId, "U+1F602").queue();
+     * </code></pre>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided unicode emoji doesn't exist. Try using one of the example formats.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id for the target message
+     * @param  unicode
+     *         The unicode emoji to remove reactions for
+     *
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
     default RestAction<Void> clearReactionsById(long messageId, @Nonnull String unicode)
     {
         return clearReactionsById(Long.toUnsignedString(messageId), unicode);
     }
 
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emote} was deleted or doesn't exist.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id for the target message
+     * @param  emote
+     *         The {@link Emote} to remove reactions for
+     *
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
     default RestAction<Void> clearReactionsById(long messageId, @Nonnull Emote emote)
     {
         return clearReactionsById(Long.toUnsignedString(messageId), emote);

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -390,6 +390,8 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
      *         If provided with null
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue
@@ -422,6 +424,8 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
      *         If provided with null
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue
@@ -464,6 +468,8 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
      *         If provided with null
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue
@@ -499,6 +505,8 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
      *         If provided with null
      *
      * @return {@link RestAction}
+     *
+     * @since  4.2.0
      */
     @Nonnull
     @CheckReturnValue

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -351,6 +351,19 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
         return clearReactionsById(Long.toUnsignedString(messageId));
     }
 
+    RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull String unicode);
+    RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote);
+
+    default RestAction<Void> clearReactionsById(long messageId, @Nonnull String unicode)
+    {
+        return clearReactionsById(Long.toUnsignedString(messageId), unicode);
+    }
+
+    default RestAction<Void> clearReactionsById(long messageId, @Nonnull Emote emote)
+    {
+        return clearReactionsById(Long.toUnsignedString(messageId), emote);
+    }
+
     /**
      * Attempts to remove the reaction from a message represented by the specified {@code messageId}
      * in this MessageChannel.

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -16,6 +16,8 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
@@ -67,12 +69,12 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
      */
     @Nullable
     String getTopic();
-    
+
     /**
-    * Whether or not this channel is considered as "NSFW" (Not-Safe-For-Work)
-    * 
-    * @return True, If this TextChannel is considered NSFW by the official Discord Client
-    */
+     * Whether or not this channel is considered as "NSFW" (Not-Safe-For-Work)
+     *
+     * @return True, If this TextChannel is considered NSFW by the official Discord Client
+     */
     boolean isNSFW();
 
     /**
@@ -351,7 +353,78 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
         return clearReactionsById(Long.toUnsignedString(messageId));
     }
 
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <h2>Example</h2>
+     * <pre><code>
+     * // custom
+     * channel.clearReactions(messageId, "minn:245267426227388416").queue();
+     * // unicode escape
+     * channel.clearReactions(messageId, "&#92;uD83D&#92;uDE02").queue();
+     * // codepoint notation
+     * channel.clearReactions(messageId, "U+1F602").queue();
+     * </code></pre>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided unicode emoji doesn't exist. Try using one of the example formats.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id for the target message
+     * @param  unicode
+     *         The unicode emoji to remove reactions for
+     *
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
     RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull String unicode);
+
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emote} was deleted or doesn't exist.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id for the target message
+     * @param  emote
+     *         The {@link Emote} to remove reactions for
+     *
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
     RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote);
 
     default RestAction<Void> clearReactionsById(long messageId, @Nonnull String unicode)
@@ -646,7 +719,7 @@ public interface TextChannel extends GuildChannel, MessageChannel, IMentionable
         String out;
 
         if (alt)
-            out = "#" + (upper ?  getName().toUpperCase(formatter.locale()) : getName());
+            out = "#" + (upper ? getName().toUpperCase(formatter.locale()) : getName());
         else
             out = getAsMention();
 

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -28,6 +28,8 @@ import javax.annotation.Nonnull;
  * Indicates that all reactions for a specific emoji/emote were removed by a moderator.
  *
  * <p>Can be used to detect which emoji/emote was removed.
+ *
+ * @since  4.2.0
  */
 public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.message.guild.react;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
+
+import javax.annotation.Nonnull;
+
+public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildEvent
+{
+    private final TextChannel channel;
+    private final MessageReaction reaction;
+    private final long messageId;
+
+    public GuildMessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull TextChannel channel, @Nonnull MessageReaction reaction, long messageId)
+    {
+        super(api, responseNumber, guild);
+
+        this.channel = channel;
+        this.reaction = reaction;
+        this.messageId = messageId;
+    }
+
+    @Nonnull
+    public TextChannel getChannel()
+    {
+        return channel;
+    }
+
+    @Nonnull
+    public MessageReaction getReaction()
+    {
+        return reaction;
+    }
+
+    @Nonnull
+    public MessageReaction.ReactionEmote getReactionEmote()
+    {
+        return reaction.getReactionEmote();
+    }
+
+    public long getMessageIdLong()
+    {
+        return messageId;
+    }
+
+    @Nonnull
+    public String getMessageId()
+    {
+        return Long.toUnsignedString(messageId);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -24,6 +24,11 @@ import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
 
 import javax.annotation.Nonnull;
 
+/**
+ * Indicates that all reactions for a specific emoji/emote were removed by a moderator.
+ *
+ * <p>Can be used to detect which emoji/emote was removed.
+ */
 public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildEvent
 {
     private final TextChannel channel;
@@ -39,29 +44,55 @@ public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildEvent
         this.messageId = messageId;
     }
 
+    /**
+     * The {@link TextChannel} where the reaction happened
+     *
+     * @return The TextChannel
+     */
     @Nonnull
     public TextChannel getChannel()
     {
         return channel;
     }
 
+    /**
+     * The {@link MessageReaction} that was removed.
+     *
+     * @return The removed MessageReaction
+     */
     @Nonnull
     public MessageReaction getReaction()
     {
         return reaction;
     }
 
+    /**
+     * The {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote ReactionEmote}.
+     * <br>Shortcut for {@code getReaction().getReactionEmote()}.
+     *
+     * @return The ReactionEmote
+     */
     @Nonnull
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();
     }
 
+    /**
+     * The id of the affected message
+     *
+     * @return The id of the message
+     */
     public long getMessageIdLong()
     {
         return messageId;
     }
 
+    /**
+     * The id of the affected message
+     *
+     * @return The id of the message
+     */
     @Nonnull
     public String getMessageId()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.message.react;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.MessageChannel;
+import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.events.message.GenericMessageEvent;
+
+import javax.annotation.Nonnull;
+
+public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
+{
+    private final MessageReaction reaction;
+
+    public MessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull MessageChannel channel, @Nonnull MessageReaction reaction)
+    {
+        super(api, responseNumber, messageId, channel);
+        this.reaction = reaction;
+    }
+
+    @Nonnull
+    public MessageReaction getReaction()
+    {
+        return reaction;
+    }
+
+    @Nonnull
+    public MessageReaction.ReactionEmote getReactionEmote()
+    {
+        return reaction.getReactionEmote();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
@@ -23,6 +23,11 @@ import net.dv8tion.jda.api.events.message.GenericMessageEvent;
 
 import javax.annotation.Nonnull;
 
+/**
+ * Indicates that all reactions for a specific emoji/emote were removed by a moderator.
+ *
+ * <p>Can be used to detect which emoji/emote was removed.
+ */
 public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
 {
     private final MessageReaction reaction;
@@ -33,12 +38,23 @@ public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
         this.reaction = reaction;
     }
 
+    /**
+     * The {@link MessageReaction} that was removed.
+     *
+     * @return The removed MessageReaction
+     */
     @Nonnull
     public MessageReaction getReaction()
     {
         return reaction;
     }
 
+    /**
+     * The {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote ReactionEmote}.
+     * <br>Shortcut for {@code getReaction().getReactionEmote()}.
+     *
+     * @return The ReactionEmote
+     */
     @Nonnull
     public MessageReaction.ReactionEmote getReactionEmote()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
@@ -27,6 +27,8 @@ import javax.annotation.Nonnull;
  * Indicates that all reactions for a specific emoji/emote were removed by a moderator.
  *
  * <p>Can be used to detect which emoji/emote was removed.
+ *
+ * @since  4.2.0
  */
 public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -56,18 +56,12 @@ import net.dv8tion.jda.api.events.guild.voice.*;
 import net.dv8tion.jda.api.events.http.HttpRequestEvent;
 import net.dv8tion.jda.api.events.message.*;
 import net.dv8tion.jda.api.events.message.guild.*;
-import net.dv8tion.jda.api.events.message.guild.react.GenericGuildMessageReactionEvent;
-import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent;
-import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionRemoveAllEvent;
-import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionRemoveEvent;
+import net.dv8tion.jda.api.events.message.guild.react.*;
 import net.dv8tion.jda.api.events.message.priv.*;
 import net.dv8tion.jda.api.events.message.priv.react.GenericPrivateMessageReactionEvent;
 import net.dv8tion.jda.api.events.message.priv.react.PrivateMessageReactionAddEvent;
 import net.dv8tion.jda.api.events.message.priv.react.PrivateMessageReactionRemoveEvent;
-import net.dv8tion.jda.api.events.message.react.GenericMessageReactionEvent;
-import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
-import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveAllEvent;
-import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEvent;
+import net.dv8tion.jda.api.events.message.react.*;
 import net.dv8tion.jda.api.events.role.GenericRoleEvent;
 import net.dv8tion.jda.api.events.role.RoleCreateEvent;
 import net.dv8tion.jda.api.events.role.RoleDeleteEvent;
@@ -148,6 +142,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildMessageReactionAdd(@Nonnull GuildMessageReactionAddEvent event) {}
     public void onGuildMessageReactionRemove(@Nonnull GuildMessageReactionRemoveEvent event) {}
     public void onGuildMessageReactionRemoveAll(@Nonnull GuildMessageReactionRemoveAllEvent event) {}
+    public void onGuildMessageReactionRemoveEmote(@Nonnull GuildMessageReactionRemoveEmoteEvent event) {}
 
     //Private Message Events
     public void onPrivateMessageReceived(@Nonnull PrivateMessageReceivedEvent event) {}
@@ -166,6 +161,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onMessageReactionAdd(@Nonnull MessageReactionAddEvent event) {}
     public void onMessageReactionRemove(@Nonnull MessageReactionRemoveEvent event) {}
     public void onMessageReactionRemoveAll(@Nonnull MessageReactionRemoveAllEvent event) {}
+    public void onMessageReactionRemoveEmote(@Nonnull MessageReactionRemoveEmoteEvent event) {}
 
     //StoreChannel Events
     public void onStoreChannelDelete(@Nonnull StoreChannelDeleteEvent event) {}
@@ -356,6 +352,8 @@ public abstract class ListenerAdapter implements EventListener
             onGuildMessageReactionRemove((GuildMessageReactionRemoveEvent) event);
         else if (event instanceof GuildMessageReactionRemoveAllEvent)
             onGuildMessageReactionRemoveAll((GuildMessageReactionRemoveAllEvent) event);
+        else if (event instanceof GuildMessageReactionRemoveEmoteEvent)
+            onGuildMessageReactionRemoveEmote((GuildMessageReactionRemoveEmoteEvent) event);
 
         //Private Message Events
         else if (event instanceof PrivateMessageReceivedEvent)
@@ -388,6 +386,8 @@ public abstract class ListenerAdapter implements EventListener
             onMessageReactionRemove((MessageReactionRemoveEvent) event);
         else if (event instanceof MessageReactionRemoveAllEvent)
             onMessageReactionRemoveAll((MessageReactionRemoveAllEvent) event);
+        else if (event instanceof MessageReactionRemoveEmoteEvent)
+            onMessageReactionRemoveEmote((MessageReactionRemoveEmoteEvent) event);
 
         //User Events
         else if (event instanceof UserUpdateNameEvent)

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -451,6 +451,22 @@ public abstract class AbstractMessage implements Message
 
     @Nonnull
     @Override
+    public RestAction<Void> clearReactions(@Nonnull String unicode)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> clearReactions(@Nonnull Emote emote)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Nonnull
+    @Override
     public RestAction<Void> removeReaction(@Nonnull Emote emote)
     {
         unsupported();

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -170,6 +170,20 @@ public class ReceivedMessage extends AbstractMessage
 
     @Nonnull
     @Override
+    public RestAction<Void> clearReactions(@Nonnull String unicode)
+    {
+        return getTextChannel().clearReactionsById(getId(), unicode);
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> clearReactions(@Nonnull Emote emote)
+    {
+        return getTextChannel().clearReactionsById(getId(), emote);
+    }
+
+    @Nonnull
+    @Override
     public RestAction<Void> removeReaction(@Nonnull Emote emote)
     {
         return channel.removeReactionById(getId(), emote);

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -459,6 +459,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new RestActionImpl<>(getJDA(), route);
     }
 
+    @Nonnull
     @Override
     public RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull String unicode)
     {
@@ -471,6 +472,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new RestActionImpl<>(getJDA(), route);
     }
 
+    @Nonnull
     @Override
     public RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote)
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -459,6 +459,25 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new RestActionImpl<>(getJDA(), route);
     }
 
+    @Override
+    public RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull String unicode)
+    {
+        Checks.notNull(messageId, "Message ID");
+        Checks.notNull(unicode, "Emote Name");
+        checkPermission(Permission.MESSAGE_MANAGE);
+
+        String code = EncodingUtil.encodeReaction(unicode);
+        Route.CompiledRoute route = Route.Messages.CLEAR_EMOTE_REACTIONS.compile(getId(), messageId, unicode);
+        return new RestActionImpl<>(getJDA(), route);
+    }
+
+    @Override
+    public RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote)
+    {
+        Checks.notNull(emote, "Emote");
+        return clearReactionsById(messageId, emote.getName() + ":" + emote.getId());
+    }
+
     @Nonnull
     @Override
     public RestActionImpl<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode, @Nonnull User user)

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmoteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmoteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmoteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmoteHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.handle;
+
+import net.dv8tion.jda.api.entities.Emote;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageReaction;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionRemoveEmoteEvent;
+import net.dv8tion.jda.api.events.message.react.MessageReactionRemoveEmoteEvent;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.JDAImpl;
+import net.dv8tion.jda.internal.entities.EmoteImpl;
+
+public class MessageReactionClearEmoteHandler extends SocketHandler
+{
+    public MessageReactionClearEmoteHandler(JDAImpl api)
+    {
+        super(api);
+    }
+
+    @Override
+    protected Long handleInternally(DataObject content)
+    {
+        long guildId = content.getUnsignedLong("guild_id");
+        if (getJDA().getGuildSetupController().isLocked(guildId))
+            return guildId;
+        Guild guild = getJDA().getGuildById(guildId);
+        if (guild == null)
+        {
+            EventCache.LOG.debug("Caching MESSAGE_REACTION_REMOVE_EMOJI event for unknown guild {}", guildId);
+            getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);
+            return null;
+        }
+
+        long channelId = content.getUnsignedLong("channel_id");
+        TextChannel channel = guild.getTextChannelById(channelId);
+        if (channel == null)
+        {
+            EventCache.LOG.debug("Caching MESSAGE_REACTION_REMOVE_EMOJI event for unknown channel {}", channelId);
+            getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);
+            return null;
+        }
+
+        long messageId = content.getUnsignedInt("message_id");
+        DataObject emoji = content.getObject("emoji");
+        MessageReaction.ReactionEmote reactionEmote = null;
+        if (emoji.isNull("id"))
+        {
+            reactionEmote = MessageReaction.ReactionEmote.fromUnicode(emoji.getString("name"), getJDA());
+        }
+        else
+        {
+            long emoteId = emoji.getUnsignedLong("emoji");
+            Emote emote = getJDA().getEmoteById(emoteId);
+            if (emote == null)
+            {
+                emote = new EmoteImpl(emoteId, getJDA())
+                    .setAnimated(emoji.getBoolean("animated"))
+                    .setName(emoji.getString("name", ""));
+            }
+            reactionEmote = MessageReaction.ReactionEmote.fromCustom(emote);
+        }
+
+        MessageReaction reaction = new MessageReaction(channel, reactionEmote, messageId, false, 0);
+        getJDA().handleEvent(new GuildMessageReactionRemoveEmoteEvent(getJDA(), responseNumber, guild, channel, reaction, messageId));
+        getJDA().handleEvent(new MessageReactionRemoveEmoteEvent(getJDA(), responseNumber, messageId, channel, reaction));
+        return null;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -200,10 +200,11 @@ public class Route
         public static final Route ADD_PINNED_MESSAGE =    new Route(PUT,    "channels/{channel_id}/pins/{message_id}");
         public static final Route REMOVE_PINNED_MESSAGE = new Route(DELETE, "channels/{channel_id}/pins/{message_id}");
 
-        public static final Route ADD_REACTION =             new Route(PUT,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}");
-        public static final Route REMOVE_REACTION =          new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}");
-        public static final Route REMOVE_ALL_REACTIONS =     new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions");
-        public static final Route GET_REACTION_USERS =       new Route(GET,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}");
+        public static final Route ADD_REACTION =          new Route(PUT,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}");
+        public static final Route REMOVE_REACTION =       new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}/{user_id}");
+        public static final Route REMOVE_ALL_REACTIONS =  new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions");
+        public static final Route GET_REACTION_USERS =    new Route(GET,    "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}");
+        public static final Route CLEAR_EMOTE_REACTIONS = new Route(DELETE, "channels/{channel_id}/messages/{message_id}/reactions/{reaction_code}");
 
         public static final Route DELETE_MESSAGE =      new Route(DELETE, "channels/{channel_id}/messages/{message_id}");
         public static final Route GET_MESSAGE_HISTORY = new Route(GET,    "channels/{channel_id}/messages");

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -1199,35 +1199,36 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected void setupHandlers()
     {
-        final SocketHandler.NOPHandler nopHandler = new SocketHandler.NOPHandler(api);
-        handlers.put("CHANNEL_CREATE",              new ChannelCreateHandler(api));
-        handlers.put("CHANNEL_DELETE",              new ChannelDeleteHandler(api));
-        handlers.put("CHANNEL_UPDATE",              new ChannelUpdateHandler(api));
-        handlers.put("GUILD_BAN_ADD",               new GuildBanHandler(api, true));
-        handlers.put("GUILD_BAN_REMOVE",            new GuildBanHandler(api, false));
-        handlers.put("GUILD_CREATE",                new GuildCreateHandler(api));
-        handlers.put("GUILD_DELETE",                new GuildDeleteHandler(api));
-        handlers.put("GUILD_EMOJIS_UPDATE",         new GuildEmojisUpdateHandler(api));
-        handlers.put("GUILD_MEMBER_ADD",            new GuildMemberAddHandler(api));
-        handlers.put("GUILD_MEMBER_REMOVE",         new GuildMemberRemoveHandler(api));
-        handlers.put("GUILD_MEMBER_UPDATE",         new GuildMemberUpdateHandler(api));
-        handlers.put("GUILD_MEMBERS_CHUNK",         new GuildMembersChunkHandler(api));
-        handlers.put("GUILD_ROLE_CREATE",           new GuildRoleCreateHandler(api));
-        handlers.put("GUILD_ROLE_DELETE",           new GuildRoleDeleteHandler(api));
-        handlers.put("GUILD_ROLE_UPDATE",           new GuildRoleUpdateHandler(api));
-        handlers.put("GUILD_SYNC",                  new GuildSyncHandler(api));
-        handlers.put("GUILD_UPDATE",                new GuildUpdateHandler(api));
-        handlers.put("MESSAGE_CREATE",              new MessageCreateHandler(api));
-        handlers.put("MESSAGE_DELETE",              new MessageDeleteHandler(api));
-        handlers.put("MESSAGE_DELETE_BULK",         new MessageBulkDeleteHandler(api));
-        handlers.put("MESSAGE_REACTION_ADD",        new MessageReactionHandler(api, true));
-        handlers.put("MESSAGE_REACTION_REMOVE",     new MessageReactionHandler(api, false));
-        handlers.put("MESSAGE_REACTION_REMOVE_ALL", new MessageReactionBulkRemoveHandler(api));
-        handlers.put("MESSAGE_UPDATE",              new MessageUpdateHandler(api));
-        handlers.put("READY",                       new ReadyHandler(api));
-        handlers.put("USER_UPDATE",                 new UserUpdateHandler(api));
-        handlers.put("VOICE_SERVER_UPDATE",         new VoiceServerUpdateHandler(api));
-        handlers.put("VOICE_STATE_UPDATE",          new VoiceStateUpdateHandler(api));
+        final SocketHandler.NOPHandler nopHandler =   new SocketHandler.NOPHandler(api);
+        handlers.put("CHANNEL_CREATE",                new ChannelCreateHandler(api));
+        handlers.put("CHANNEL_DELETE",                new ChannelDeleteHandler(api));
+        handlers.put("CHANNEL_UPDATE",                new ChannelUpdateHandler(api));
+        handlers.put("GUILD_BAN_ADD",                 new GuildBanHandler(api, true));
+        handlers.put("GUILD_BAN_REMOVE",              new GuildBanHandler(api, false));
+        handlers.put("GUILD_CREATE",                  new GuildCreateHandler(api));
+        handlers.put("GUILD_DELETE",                  new GuildDeleteHandler(api));
+        handlers.put("GUILD_EMOJIS_UPDATE",           new GuildEmojisUpdateHandler(api));
+        handlers.put("GUILD_MEMBER_ADD",              new GuildMemberAddHandler(api));
+        handlers.put("GUILD_MEMBER_REMOVE",           new GuildMemberRemoveHandler(api));
+        handlers.put("GUILD_MEMBER_UPDATE",           new GuildMemberUpdateHandler(api));
+        handlers.put("GUILD_MEMBERS_CHUNK",           new GuildMembersChunkHandler(api));
+        handlers.put("GUILD_ROLE_CREATE",             new GuildRoleCreateHandler(api));
+        handlers.put("GUILD_ROLE_DELETE",             new GuildRoleDeleteHandler(api));
+        handlers.put("GUILD_ROLE_UPDATE",             new GuildRoleUpdateHandler(api));
+        handlers.put("GUILD_SYNC",                    new GuildSyncHandler(api));
+        handlers.put("GUILD_UPDATE",                  new GuildUpdateHandler(api));
+        handlers.put("MESSAGE_CREATE",                new MessageCreateHandler(api));
+        handlers.put("MESSAGE_DELETE",                new MessageDeleteHandler(api));
+        handlers.put("MESSAGE_DELETE_BULK",           new MessageBulkDeleteHandler(api));
+        handlers.put("MESSAGE_REACTION_ADD",          new MessageReactionHandler(api, true));
+        handlers.put("MESSAGE_REACTION_REMOVE",       new MessageReactionHandler(api, false));
+        handlers.put("MESSAGE_REACTION_REMOVE_ALL",   new MessageReactionBulkRemoveHandler(api));
+        handlers.put("MESSAGE_REACTION_REMOVE_EMOTE", new MessageReactionClearEmoteHandler(api));
+        handlers.put("MESSAGE_UPDATE",                new MessageUpdateHandler(api));
+        handlers.put("READY",                         new ReadyHandler(api));
+        handlers.put("USER_UPDATE",                   new UserUpdateHandler(api));
+        handlers.put("VOICE_SERVER_UPDATE",           new VoiceServerUpdateHandler(api));
+        handlers.put("VOICE_STATE_UPDATE",            new VoiceStateUpdateHandler(api));
 
         if (api.isGuildSubscriptions())
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -415,9 +415,11 @@ public class BotRateLimiter extends RateLimiter
                     // The request went through so we can remove it
                     iterator.remove();
                 }
-                catch (Exception ex)
+                catch (Throwable ex)
                 {
                     log.error("Encountered exception trying to execute request", ex);
+                    if (ex instanceof Error)
+                        throw (Error) ex;
                     break;
                 }
             }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This can be used to remove the entire reaction from a message. Previously you could only remove reactions from individual users or remove all reactions on the message, now you can delete all reactions with a specific emoji. We also need to add the related event **MESSAGE_REACTION_REMOVE_EMOJI**.

Reference: discordapp/discord-api-docs#1309
