### PR TITLE
Add (Guild) Invite Events

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.invite;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
+
+import javax.annotation.Nonnull;
+
+public class GenericGuildInviteEvent extends GenericGuildEvent
+{
+    private final String code;
+    private final GuildChannel channel;
+
+    public GenericGuildInviteEvent(@Nonnull JDA api, long responseNumber, @Nonnull String code, @Nonnull GuildChannel channel)
+    {
+        super(api, responseNumber, channel.getGuild());
+        this.code = code;
+        this.channel = channel;
+    }
+
+    @Nonnull
+    public String getCode()
+    {
+        return code;
+    }
+
+    @Nonnull
+    public GuildChannel getChannel()
+    {
+        return channel;
+    }
+
+    @Nonnull
+    public ChannelType getChannelType()
+    {
+        return channel.getType();
+    }
+
+    @Nonnull
+    public TextChannel getTextChannel()
+    {
+        if (getChannelType() != ChannelType.TEXT)
+            throw new IllegalStateException("The channel is not of type TEXT");
+        return (TextChannel) getChannel();
+    }
+
+    @Nonnull
+    public VoiceChannel getVoiceChannel()
+    {
+        if (getChannelType() != ChannelType.VOICE)
+            throw new IllegalStateException("The channel is not of type VOICE");
+        return (VoiceChannel) getChannel();
+    }
+
+    @Nonnull
+    public StoreChannel getStoreChannel()
+    {
+        if (getChannelType() != ChannelType.STORE)
+            throw new IllegalStateException("The channel is not of type STORE");
+        return (StoreChannel) getChannel();
+    }
+
+    @Nonnull
+    public Category getCategory()
+    {
+        if (getChannelType() != ChannelType.CATEGORY)
+            throw new IllegalStateException("The channel is not of type CATEGORY");
+        return (Category) getChannel();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
@@ -22,6 +22,12 @@ import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
 
 import javax.annotation.Nonnull;
 
+/**
+ * Indicates that an {@link Invite} was created or deleted in a {@link Guild}.
+ * <br>Every GuildInviteEvent is derived from this event and can be casted.
+ *
+ * <p>Can be used to detect any GuildInviteEvent.
+ */
 public class GenericGuildInviteEvent extends GenericGuildEvent
 {
     private final String code;
@@ -34,24 +40,63 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
         this.channel = channel;
     }
 
+    /**
+     * The invite code.
+     * <br>This can be converted to a url with {@code discord.gg/<code>}.
+     *
+     * @return The invite code
+     */
     @Nonnull
     public String getCode()
     {
         return code;
     }
 
+    /**
+     * The invite url.
+     * <br>This uses the {@code https://discord.gg/<code>} format.
+     *
+     * @return The invite url
+     */
+    @Nonnull
+    public String getUrl()
+    {
+        return "https://discord.gg/" + code;
+    }
+
+    /**
+     * The {@link GuildChannel} this invite points to.
+     *
+     * @return {@link GuildChannel}
+     */
     @Nonnull
     public GuildChannel getChannel()
     {
         return channel;
     }
 
+    /**
+     * The {@link ChannelType} for of the {@link #getChannel() channel} this invite points to.
+     *
+     * @return {@link ChannelType}
+     */
     @Nonnull
     public ChannelType getChannelType()
     {
         return channel.getType();
     }
 
+    /**
+     * The {@link TextChannel} this invite points to.
+     *
+     * @throws IllegalStateException
+     *         If this did not happen in a channel of type {@link ChannelType#TEXT ChannelType.TEXT}
+     *
+     * @return {@link TextChannel}
+     *
+     * @see    #getChannel()
+     * @see    #getChannelType()
+     */
     @Nonnull
     public TextChannel getTextChannel()
     {
@@ -60,6 +105,17 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
         return (TextChannel) getChannel();
     }
 
+    /**
+     * The {@link VoiceChannel} this invite points to.
+     *
+     * @throws IllegalStateException
+     *         If this did not happen in a channel of type {@link ChannelType#VOICE ChannelType.VOICE}
+     *
+     * @return {@link VoiceChannel}
+     *
+     * @see    #getChannel()
+     * @see    #getChannelType()
+     */
     @Nonnull
     public VoiceChannel getVoiceChannel()
     {
@@ -68,6 +124,17 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
         return (VoiceChannel) getChannel();
     }
 
+    /**
+     * The {@link StoreChannel} this invite points to.
+     *
+     * @throws IllegalStateException
+     *         If this did not happen in a channel of type {@link ChannelType#STORE ChannelType.STORE}
+     *
+     * @return {@link StoreChannel}
+     *
+     * @see    #getChannel()
+     * @see    #getChannelType()
+     */
     @Nonnull
     public StoreChannel getStoreChannel()
     {
@@ -76,6 +143,17 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
         return (StoreChannel) getChannel();
     }
 
+    /**
+     * The {@link Category} this invite points to.
+     *
+     * @throws IllegalStateException
+     *         If this did not happen in a channel of type {@link ChannelType#CATEGORY ChannelType.CATEGORY}
+     *
+     * @return {@link Category}
+     *
+     * @see    #getChannel()
+     * @see    #getChannelType()
+     */
     @Nonnull
     public Category getCategory()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.invite;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Invite;
+
+import javax.annotation.Nonnull;
+
+public class GuildInviteCreateEvent extends GenericGuildInviteEvent
+{
+    private final Invite invite;
+
+    public GuildInviteCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Invite invite, @Nonnull GuildChannel channel)
+    {
+        super(api, responseNumber, invite.getCode(), channel);
+        this.invite = invite;
+    }
+
+    @Nonnull
+    public Invite getInvite()
+    {
+        return invite;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
@@ -22,6 +22,11 @@ import net.dv8tion.jda.api.entities.Invite;
 
 import javax.annotation.Nonnull;
 
+/**
+ * Indicates that an {@link Invite Invite} was created in a {@link net.dv8tion.jda.api.entities.Invite.Guild Guild}.
+ *
+ * <p>Can be used to track invites for moderation purposes.
+ */
 public class GuildInviteCreateEvent extends GenericGuildInviteEvent
 {
     private final Invite invite;
@@ -32,6 +37,11 @@ public class GuildInviteCreateEvent extends GenericGuildInviteEvent
         this.invite = invite;
     }
 
+    /**
+     * The invite which was created.
+     *
+     * @return {@link Invite}
+     */
     @Nonnull
     public Invite getInvite()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.invite;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.GuildChannel;
+
+import javax.annotation.Nonnull;
+
+public class GuildInviteDeleteEvent extends GenericGuildInviteEvent
+{
+    public GuildInviteDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull String code, @Nonnull GuildChannel channel)
+    {
+        super(api, responseNumber, code, channel);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
@@ -17,10 +17,17 @@
 package net.dv8tion.jda.api.events.guild.invite;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Invite;
 
 import javax.annotation.Nonnull;
 
+/**
+ * Indicates than an {@link Invite} was deleted from a {@link Guild}.
+ *
+ * <p>Can be used to track invite deletion for moderation purposes.
+ */
 public class GuildInviteDeleteEvent extends GenericGuildInviteEvent
 {
     public GuildInviteDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull String code, @Nonnull GuildChannel channel)

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -47,6 +47,9 @@ import net.dv8tion.jda.api.events.emote.update.EmoteUpdateNameEvent;
 import net.dv8tion.jda.api.events.emote.update.EmoteUpdateRolesEvent;
 import net.dv8tion.jda.api.events.emote.update.GenericEmoteUpdateEvent;
 import net.dv8tion.jda.api.events.guild.*;
+import net.dv8tion.jda.api.events.guild.invite.GenericGuildInviteEvent;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteDeleteEvent;
 import net.dv8tion.jda.api.events.guild.member.*;
 import net.dv8tion.jda.api.events.guild.member.update.GenericGuildMemberUpdateEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateBoostTimeEvent;
@@ -239,6 +242,10 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildUpdateMaxMembers(@Nonnull GuildUpdateMaxMembersEvent event) {}
     public void onGuildUpdateMaxPresences(@Nonnull GuildUpdateMaxPresencesEvent event) {}
 
+    //Guild Invite Events
+    public void onGuildInviteCreate(@Nonnull GuildInviteCreateEvent event) {}
+    public void onGuildInviteDelete(@Nonnull GuildInviteDeleteEvent event) {}
+
     //Guild Member Events
     public void onGuildMemberJoin(@Nonnull GuildMemberJoinEvent event) {}
     public void onGuildMemberLeave(@Nonnull GuildMemberLeaveEvent event) {}
@@ -305,6 +312,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onGenericCategoryUpdate(@Nonnull GenericCategoryUpdateEvent event) {}
     public void onGenericGuild(@Nonnull GenericGuildEvent event) {}
     public void onGenericGuildUpdate(@Nonnull GenericGuildUpdateEvent event) {}
+    public void onGenericGuildInvite(@Nonnull GenericGuildInviteEvent event) {}
     public void onGenericGuildMember(@Nonnull GenericGuildMemberEvent event) {}
     public void onGenericGuildMemberUpdate(@Nonnull GenericGuildMemberUpdateEvent event) {}
     public void onGenericGuildVoice(@Nonnull GenericGuildVoiceEvent event) {}
@@ -549,6 +557,12 @@ public abstract class ListenerAdapter implements EventListener
         else if (event instanceof GuildUpdateMaxPresencesEvent)
             onGuildUpdateMaxPresences((GuildUpdateMaxPresencesEvent) event);
 
+        //Guild Invite Events
+        else if (event instanceof GuildInviteCreateEvent)
+            onGuildInviteCreate((GuildInviteCreateEvent) event);
+        else if (event instanceof GuildInviteDeleteEvent)
+            onGuildInviteDelete((GuildInviteDeleteEvent) event);
+
         //Guild Member Events
         else if (event instanceof GuildMemberJoinEvent)
             onGuildMemberJoin((GuildMemberJoinEvent) event);
@@ -663,6 +677,8 @@ public abstract class ListenerAdapter implements EventListener
             onGenericPrivateMessage((GenericPrivateMessageEvent) event);
         else if (event instanceof GenericGuildMessageEvent)
             onGenericGuildMessage((GenericGuildMessageEvent) event);
+        else if (event instanceof GenericGuildInviteEvent)
+            onGenericGuildInvite((GenericGuildInviteEvent) event);
         else if (event instanceof GenericGuildMemberEvent)
             onGenericGuildMember((GenericGuildMemberEvent) event);
         else if (event instanceof GenericUserEvent)

--- a/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
@@ -29,7 +29,6 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
-import net.dv8tion.jda.internal.requests.DeferredRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
@@ -289,6 +288,11 @@ public class InviteImpl implements Invite
             this.type = type;
         }
 
+        public ChannelImpl(final GuildChannel channel)
+        {
+            this(channel.getIdLong(), channel.getName(), channel.getType());
+        }
+
         @Override
         public long getIdLong()
         {
@@ -330,6 +334,12 @@ public class InviteImpl implements Invite
             this.presenceCount = presenceCount;
             this.memberCount = memberCount;
             this.features = features;
+        }
+
+        public GuildImpl(final net.dv8tion.jda.api.entities.Guild guild)
+        {
+            this(guild.getIdLong(), guild.getIconId(), guild.getName(), guild.getSplashId(),
+                 guild.getVerificationLevel(), -1, -1, guild.getFeatures());
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/internal/handle/InviteCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InviteCreateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/internal/handle/InviteCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InviteCreateHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.handle;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Invite;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.JDAImpl;
+import net.dv8tion.jda.internal.entities.InviteImpl;
+
+import java.time.OffsetDateTime;
+
+public class InviteCreateHandler extends SocketHandler
+{
+    public InviteCreateHandler(JDAImpl api)
+    {
+        super(api);
+    }
+
+    @Override
+    protected Long handleInternally(DataObject content)
+    {
+        long guildId = content.getUnsignedLong("guild_id");
+        if (getJDA().getGuildSetupController().isLocked(guildId))
+            return guildId;
+        Guild realGuild = getJDA().getGuildById(guildId);
+        if (realGuild == null)
+        {
+            EventCache.LOG.debug("Caching INVITE_CREATE for unknown guild with id {}", guildId);
+            getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);
+            return null;
+        }
+
+        long channelId = content.getUnsignedLong("channel_id");
+        GuildChannel realChannel = realGuild.getGuildChannelById(channelId);
+        if (realChannel == null)
+        {
+            EventCache.LOG.debug("Caching INVITE_CREATE for unknown channel with id {} in guild with id {}", channelId, guildId);
+            getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);
+            return null;
+        }
+
+        String code = content.getString("code");
+        boolean temporary = content.getBoolean("temporary");
+        int maxAge = content.getInt("max_age");
+        int maxUses = content.getInt("max_uses");
+        OffsetDateTime creationTime = OffsetDateTime.parse(content.getString("created_at"));
+        DataObject inviterJson = content.getObject("inviter");
+
+        User inviter = getJDA().getEntityBuilder().createFakeUser(inviterJson, false);
+        InviteImpl.ChannelImpl channel = new InviteImpl.ChannelImpl(realChannel);
+        InviteImpl.GuildImpl guild = new InviteImpl.GuildImpl(realGuild);
+        Invite invite = new InviteImpl(getJDA(), code, true, inviter, maxAge, maxUses, temporary, creationTime, 0, channel, guild, null, Invite.InviteType.GUILD);
+        getJDA().handleEvent(
+            new GuildInviteCreateEvent(
+                getJDA(), responseNumber,
+                invite, realChannel));
+        return null;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/handle/InviteDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InviteDeleteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/internal/handle/InviteDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InviteDeleteHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2019 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.handle;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.events.guild.invite.GuildInviteDeleteEvent;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.JDAImpl;
+
+public class InviteDeleteHandler extends SocketHandler
+{
+    public InviteDeleteHandler(JDAImpl api)
+    {
+        super(api);
+    }
+
+    @Override
+    protected Long handleInternally(DataObject content)
+    {
+        long guildId = content.getUnsignedLong("guild_id");
+        if (getJDA().getGuildSetupController().isLocked(guildId))
+            return guildId;
+        Guild guild = getJDA().getGuildById(guildId);
+        if (guild == null)
+        {
+            EventCache.LOG.debug("Caching INVITE_DELETE for unknown guild {}", guildId);
+            getJDA().getEventCache().cache(EventCache.Type.GUILD, guildId, responseNumber, allContent, this::handle);
+            return null;
+        }
+        long channelId = content.getUnsignedLong("channel_id");
+        GuildChannel channel = guild.getGuildChannelById(channelId);
+        if (channel == null)
+        {
+            EventCache.LOG.debug("Caching INVITE_DELETE for unknown channel {} in guild {}", channelId, guildId);
+            getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);
+            return null;
+        }
+
+        String code = content.getString("code");
+        getJDA().handleEvent(
+            new GuildInviteDeleteEvent(
+                getJDA(), responseNumber,
+                code, channel));
+        return null;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -1217,6 +1217,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         handlers.put("GUILD_ROLE_UPDATE",           new GuildRoleUpdateHandler(api));
         handlers.put("GUILD_SYNC",                  new GuildSyncHandler(api));
         handlers.put("GUILD_UPDATE",                new GuildUpdateHandler(api));
+        handlers.put("INVITE_CREATE",                 new InviteCreateHandler(api));
+        handlers.put("INVITE_DELETE",                 new InviteDeleteHandler(api));
         handlers.put("MESSAGE_CREATE",              new MessageCreateHandler(api));
         handlers.put("MESSAGE_DELETE",              new MessageDeleteHandler(api));
         handlers.put("MESSAGE_DELETE_BULK",         new MessageBulkDeleteHandler(api));


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds the new invite events:

- Invite Create
- Invite Delete

Both of these events can only happen in guilds for now so I called them `GuildInvite{X}Event` for better backwards compatibility in case discord decides to also open this up to groups(?) or similar.

These events can be useful to track invites of guilds which are not cached by JDA. I don't think its reasonable to implement invite caching into JDA as its not possible to initialize from the gateway alone (no invites in GUILD_CREATE).
