### PR TITLE
Swapped manage server and manage channel in Invite#isExpanded docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Invite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Invite.java
@@ -297,9 +297,9 @@ public interface Invite
     /**
      * Whether this Invite is expanded or not. Expanded invites contain more information, but they can only be
      * obtained be {@link net.dv8tion.jda.api.entities.Guild#retrieveInvites() Guild#retrieveInvites()} (requires
-     * {@link net.dv8tion.jda.api.Permission#MANAGE_CHANNEL Permission.MANAGE_CHANNEL}) or
+     * {@link net.dv8tion.jda.api.Permission#MANAGE_SERVER Permission.MANAGE_SERVER}) or
      * {@link GuildChannel#retrieveInvites() Channel#retrieveInvites()} (requires
-     * {@link net.dv8tion.jda.api.Permission#MANAGE_SERVER Permission.MANAGE_SERVER}).
+     * {@link net.dv8tion.jda.api.Permission#MANAGE_CHANNEL Permission.MANAGE_CHANNEL}).
      *
      * <p>There is a convenience method {@link #expand()} to get the expanded invite for an unexpanded one.
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Invite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Invite.java
@@ -296,9 +296,9 @@ public interface Invite
 
     /**
      * Whether this Invite is expanded or not. Expanded invites contain more information, but they can only be
-     * obtained be {@link net.dv8tion.jda.api.entities.Guild#retrieveInvites() Guild#retrieveInvites()} (requires
+     * obtained by {@link net.dv8tion.jda.api.entities.Guild#retrieveInvites() Guild#retrieveInvites()} (requires
      * {@link net.dv8tion.jda.api.Permission#MANAGE_SERVER Permission.MANAGE_SERVER}) or
-     * {@link GuildChannel#retrieveInvites() Channel#retrieveInvites()} (requires
+     * {@link net.dv8tion.jda.api.entities.GuildChannel#retrieveInvites() GuildChannel#retrieveInvites()} (requires
      * {@link net.dv8tion.jda.api.Permission#MANAGE_CHANNEL Permission.MANAGE_CHANNEL}).
      *
      * <p>There is a convenience method {@link #expand()} to get the expanded invite for an unexpanded one.


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Previously, the docs of [Invite#isExpanded](https://javadoc.io/static/net.dv8tion/JDA/4.1.1_109/net/dv8tion/jda/api/entities/Invite.html#isExpanded()) stated that `Channel#retrieveInvites` would require the `MANAGE_SERVER` Permission and that `Guild#retrieveInvites` would require the `MANAGE_CHANNEL` permission.

It should be swapped as described in the official discord developer docs [here](https://discordapp.com/developers/docs/resources/channel#get-channel-invites) and [here](https://discordapp.com/developers/docs/resources/guild#get-guild-invites)

Thanks to @byNoobiYT for finding this out.

As suggested by @DManstrator in the comments, this PR does also fix a typo (`can only be obtained be` to `can only be obtained by`), adds fully qualified class names to the `@link` reference in the docs and uses `GuildChannel` consistently.