### PR TITLE
Change defaults for requester to be non-daemon and have a shorter timeout

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -31,6 +31,7 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.PresenceImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
 import net.dv8tion.jda.internal.utils.config.MetaConfig;
 import net.dv8tion.jda.internal.utils.config.SessionConfig;
@@ -974,7 +975,7 @@ public class JDABuilder
         if (httpClient == null)
         {
             if (this.httpClientBuilder == null)
-                this.httpClientBuilder = new OkHttpClient.Builder();
+                this.httpClientBuilder = IOUtil.newHttpClientBuilder();
             httpClient = this.httpClientBuilder.build();
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -663,8 +663,8 @@ public class JDAImpl implements JDA
     @Override
     public synchronized void shutdownNow()
     {
-        shutdown();
         requester.shutdown(); // stop all requests
+        shutdown();
         threadConfig.shutdownNow();
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -664,8 +664,8 @@ public class JDAImpl implements JDA
     public synchronized void shutdownNow()
     {
         shutdown();
-        threadConfig.shutdownNow();
         requester.shutdown(); // stop all requests
+        threadConfig.shutdownNow();
     }
 
     @Override
@@ -691,7 +691,9 @@ public class JDAImpl implements JDA
         closeAudioConnections();
         guildSetupController.close();
 
-        requester.stop(); // stop accepting new requests
+        // stop accepting new requests
+        if (requester.stop()) // returns true if no more requests will be executed
+            shutdownRequester(); // in that case shutdown entirely
         if (audioLifeCyclePool != null)
             audioLifeCyclePool.shutdownNow();
         threadConfig.shutdown();
@@ -706,6 +708,13 @@ public class JDAImpl implements JDA
         }
 
         setStatus(Status.SHUTDOWN);
+    }
+
+    public synchronized void shutdownRequester()
+    {
+        // Stop all request processing
+        requester.shutdown();
+        threadConfig.shutdownRequester();
     }
 
     private void closeAudioConnections()

--- a/src/main/java/net/dv8tion/jda/internal/requests/RateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/RateLimiter.java
@@ -17,17 +17,11 @@
 package net.dv8tion.jda.internal.requests;
 
 import net.dv8tion.jda.api.requests.Request;
-import net.dv8tion.jda.internal.requests.ratelimit.IBucket;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 public abstract class RateLimiter
 {
@@ -35,8 +29,6 @@ public abstract class RateLimiter
     protected static final Logger log = JDALogger.getLog(RateLimiter.class);
     protected final Requester requester;
     protected volatile boolean isShutdown = false, isStopped = false;
-    protected final ConcurrentHashMap<String, IBucket> buckets = new ConcurrentHashMap<>();
-    protected final ConcurrentLinkedQueue<IBucket> submittedBuckets = new ConcurrentLinkedQueue<>();
 
     protected RateLimiter(Requester requester)
     {
@@ -80,32 +72,18 @@ public abstract class RateLimiter
         return getRateLimit(route) != null;
     }
 
-    public List<IBucket> getRouteBuckets()
-    {
-        synchronized (buckets)
-        {
-            return Collections.unmodifiableList(new ArrayList<>(buckets.values()));
-        }
-    }
-
-    public List<IBucket> getQueuedRouteBuckets()
-    {
-        synchronized (submittedBuckets)
-        {
-            return Collections.unmodifiableList(new ArrayList<>(submittedBuckets));
-        }
-    }
-
     public void init() {}
 
-    protected void stop()
+    // Return true if no more requests will be processed
+    protected boolean stop()
     {
         isStopped = true;
+        return true;
     }
 
     protected void shutdown()
     {
-        stop();
         isShutdown = true;
+        stop();
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.MDC;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
+import java.io.InterruptedIOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.Collections;
@@ -249,6 +250,11 @@ public class Requester
                 return execute(apiRequest, true, handleOnRatelimit);
             LOG.error("Requester timed out while executing a request", e);
             apiRequest.handleResponse(new Response(lastResponse, e, rays));
+            return null;
+        }
+        catch (InterruptedIOException e)
+        {
+            LOG.warn("Got interrupted while executing request", e);
             return null;
         }
         catch (Exception e)

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -316,9 +316,9 @@ public class Requester
         this.retryOnTimeout = retryOnTimeout;
     }
 
-    public void stop()
+    public boolean stop()
     {
-        rateLimiter.stop();
+        return rateLimiter.stop();
     }
 
     public void shutdown()

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -24,10 +24,7 @@ import net.dv8tion.jda.internal.requests.Route;
 import okhttp3.Headers;
 import org.jetbrains.annotations.Contract;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -82,9 +79,9 @@ public class BotRateLimiter extends RateLimiter
     // Route -> Should we print warning for 429? AKA did we already hit it once before
     private final Set<Route> hitRatelimit = ConcurrentHashMap.newKeySet(5);
     // Route -> Hash
-    private final Map<Route, String> hash = new ConcurrentHashMap<>();
+    private final Map<Route, String> hashes = new ConcurrentHashMap<>();
     // Hash + Major Parameter -> Bucket
-    private final Map<String, Bucket> bucket = new ConcurrentHashMap<>();
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
     // Bucket -> Rate-Limit Worker
     private final Map<Bucket, Future<?>> rateLimitQueue = new ConcurrentHashMap<>();
     private Future<?> cleanupWorker;
@@ -110,8 +107,8 @@ public class BotRateLimiter extends RateLimiter
         // This will remove buckets that are no longer needed every 30 seconds to avoid memory leakage
         // We will keep the hashes in memory since they are very limited (by the amount of possible routes)
         MiscUtil.locked(bucketLock, () -> {
-            int size = bucket.size();
-            Iterator<Map.Entry<String, Bucket>> entries = bucket.entrySet().iterator();
+            int size = buckets.size();
+            Iterator<Map.Entry<String, Bucket>> entries = buckets.entrySet().iterator();
 
             while (entries.hasNext())
             {
@@ -125,7 +122,7 @@ public class BotRateLimiter extends RateLimiter
                     entries.remove();
             }
             // Log how many buckets were removed
-            size -= bucket.size();
+            size -= buckets.size();
             if (size > 0)
                 log.debug("Removed {} expired buckets", size);
         });
@@ -133,16 +130,34 @@ public class BotRateLimiter extends RateLimiter
 
     private String getRouteHash(Route route)
     {
-        return hash.getOrDefault(route, UNLIMITED_BUCKET + "+" + route);
+        return hashes.getOrDefault(route, UNLIMITED_BUCKET + "+" + route);
     }
 
     @Override
-    protected void stop()
+    protected boolean stop()
     {
-        super.stop();
-        if (cleanupWorker != null)
-            cleanupWorker.cancel(false);
-        cleanup();
+        return MiscUtil.locked(bucketLock, () -> {
+            if (isStopped)
+                return false;
+            super.stop();
+            if (cleanupWorker != null)
+                cleanupWorker.cancel(false);
+            cleanup();
+            int size = buckets.size();
+            if (!isShutdown && size > 0) // Tell user about active buckets so they don't get confused by the longer shutdown
+            {
+                int average = (int) Math.ceil(
+                        buckets.values().stream()
+                            .map(Bucket::getRequests)
+                            .mapToInt(Collection::size)
+                            .average().orElse(0)
+                );
+
+                log.info("Waiting for {} bucket(s) to finish. Average queue size of {} requests", size, average);
+            }
+            // No more requests to process?
+            return size < 1;
+        });
     }
 
     @Override
@@ -199,9 +214,9 @@ public class BotRateLimiter extends RateLimiter
                 Route baseRoute = route.getBaseRoute();
                 if (hash != null)
                 {
-                    if (!this.hash.containsKey(baseRoute))
+                    if (!this.hashes.containsKey(baseRoute))
                     {
-                        this.hash.put(baseRoute, hash);
+                        this.hashes.put(baseRoute, hash);
                         log.debug("Caching bucket hash {} -> {}", baseRoute, hash);
                     }
 
@@ -271,9 +286,9 @@ public class BotRateLimiter extends RateLimiter
             String hash = getRouteHash(route.getBaseRoute());
             // Get or create a bucket for the hash + major parameters
             String bucketId = hash + ":" + route.getMajorParameters();
-            Bucket bucket = this.bucket.get(bucketId);
+            Bucket bucket = this.buckets.get(bucketId);
             if (bucket == null && create)
-                this.bucket.put(bucketId, bucket = new Bucket(bucketId));
+                this.buckets.put(bucketId, bucket = new Bucket(bucketId));
 
             return bucket;
         });
@@ -372,6 +387,10 @@ public class BotRateLimiter extends RateLimiter
                 rateLimitQueue.remove(this);
                 if (!requests.isEmpty())
                     runBucket(this);
+                else if (isStopped)
+                    buckets.remove(bucketId);
+                if (isStopped && buckets.isEmpty())
+                    requester.getJDA().shutdownRequester();
             });
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -182,19 +182,13 @@ public class BotRateLimiter extends RateLimiter
     @Override
     protected Long handleResponse(Route.CompiledRoute route, okhttp3.Response response)
     {
-        bucketLock.lock();
-        try
-        {
+        return MiscUtil.locked(bucketLock, () -> {
             long rateLimit = updateBucket(route, response).getRateLimit();
             if (response.code() == 429)
                 return rateLimit;
             else
                 return null;
-        }
-        finally
-        {
-            bucketLock.unlock();
-        }
+        });
     }
 
     private Bucket updateBucket(Route.CompiledRoute route, okhttp3.Response response)

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/ClientRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/ClientRateLimiter.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +38,8 @@ import java.util.concurrent.TimeUnit;
 public class ClientRateLimiter extends RateLimiter
 {
     volatile Long globalCooldown = null;
+    protected final ConcurrentHashMap<String, IBucket> buckets = new ConcurrentHashMap<>();
+    protected final ConcurrentLinkedQueue<IBucket> submittedBuckets = new ConcurrentLinkedQueue<>();
 
     public ClientRateLimiter(Requester requester)
     {

--- a/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/IOUtil.java
@@ -16,14 +16,14 @@
 
 package net.dv8tion.jda.internal.utils;
 
-import okhttp3.MediaType;
-import okhttp3.RequestBody;
+import okhttp3.*;
 import okio.Okio;
 import org.slf4j.Logger;
 
 import java.io.*;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
@@ -54,6 +54,18 @@ public class IOUtil
     public static String getHost(String uri)
     {
         return URI.create(uri).getHost();
+    }
+
+    public static OkHttpClient.Builder newHttpClientBuilder()
+    {
+        Dispatcher dispatcher = new Dispatcher();
+        // Allow 25 parallel requests to the same host (usually discordapp.com)
+        dispatcher.setMaxRequestsPerHost(25);
+        // Allow 5 idle threads with 10 seconds timeout for each
+        ConnectionPool connectionPool = new ConnectionPool(5, 10, TimeUnit.SECONDS);
+        return new OkHttpClient.Builder()
+                .connectionPool(connectionPool)
+                .dispatcher(dispatcher);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/utils/concurrent/CountingThreadFactory.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/concurrent/CountingThreadFactory.java
@@ -25,10 +25,17 @@ public class CountingThreadFactory implements ThreadFactory
 {
     private final Supplier<String> identifier;
     private final AtomicLong count = new AtomicLong(1);
+    private final boolean daemon;
 
     public CountingThreadFactory(@Nonnull Supplier<String> identifier, @Nonnull String specifier)
     {
+        this(identifier, specifier, true);
+    }
+
+    public CountingThreadFactory(@Nonnull Supplier<String> identifier, @Nonnull String specifier, boolean daemon)
+    {
         this.identifier = () -> identifier.get() + " " + specifier;
+        this.daemon = daemon;
     }
 
     @Nonnull
@@ -36,7 +43,7 @@ public class CountingThreadFactory implements ThreadFactory
     public Thread newThread(@Nonnull Runnable r)
     {
         final Thread thread = new Thread(r, identifier.get() + "-Worker " + count.getAndIncrement());
-        thread.setDaemon(true);
+        thread.setDaemon(daemon);
         return thread;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
@@ -63,7 +63,7 @@ public class ThreadingConfig
     public void init(@Nonnull Supplier<String> identifier)
     {
         if (this.rateLimitPool == null)
-            this.rateLimitPool = newScheduler(5, identifier, "RateLimit");
+            this.rateLimitPool = newScheduler(5, identifier, "RateLimit", false);
         if (this.gatewayPool == null)
             this.gatewayPool = newScheduler(1, identifier, "Gateway");
     }
@@ -87,6 +87,12 @@ public class ThreadingConfig
                 rateLimitPool.shutdown();
             }
         }
+    }
+
+    public void shutdownRequester()
+    {
+        if (shutdownRateLimitPool)
+            rateLimitPool.shutdown();
     }
 
     public void shutdownNow()
@@ -135,7 +141,13 @@ public class ThreadingConfig
     @Nonnull
     public static ScheduledThreadPoolExecutor newScheduler(int coreSize, Supplier<String> identifier, String baseName)
     {
-        return new ScheduledThreadPoolExecutor(coreSize, new CountingThreadFactory(identifier, baseName));
+        return newScheduler(coreSize, identifier, baseName, true);
+    }
+
+    @Nonnull
+    public static ScheduledThreadPoolExecutor newScheduler(int coreSize, Supplier<String> identifier, String baseName, boolean daemon)
+    {
+        return new ScheduledThreadPoolExecutor(coreSize, new CountingThreadFactory(identifier, baseName, daemon));
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingSessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingSessionConfig.java
@@ -20,6 +20,7 @@ import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.api.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor;
 import net.dv8tion.jda.api.utils.SessionController;
+import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.config.SessionConfig;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import net.dv8tion.jda.internal.utils.config.flags.ShardingConfigFlag;
@@ -44,7 +45,7 @@ public class ShardingSessionConfig extends SessionConfig
     {
         super(sessionController, httpClient, webSocketFactory, interceptor, flags, maxReconnectDelay, largeThreshold);
         if (httpClient == null)
-            this.builder = httpClientBuilder == null ? new OkHttpClient.Builder() : httpClientBuilder;
+            this.builder = httpClientBuilder == null ? IOUtil.newHttpClientBuilder() : httpClientBuilder;
         else
             this.builder = null;
         this.audioSendFactory = audioSendFactory;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Now the rate limit pool will keep doing requests until all requests are exhausted. I also decided to add an info log about this behavior so people know why the process doesn't stop immediately when calling `JDA#shutdown`.
