### PR TITLE
Adding a check in reaction methods before calling getTextChannel()

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1378,6 +1378,7 @@ public interface Message extends ISnowflake, Formattable
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} is fake {@link net.dv8tion.jda.api.entities.Emote#isFake() Emote.isFake()}.</li>
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} cannot be used in the current channel.
      *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *             <li>If the provided user is null</li>
      *         </ul>
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
@@ -1488,7 +1489,7 @@ public interface Message extends ISnowflake, Formattable
      *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}</li>
      *         </ul>
      * @throws java.lang.IllegalArgumentException
-     *         If the provided unicode emoji is null or empty.
+     *         If the provided unicode emoji is null or empty or if the provided user is null.
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
      *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1163,7 +1163,7 @@ public interface Message extends ISnowflake, Formattable
      * Removes all reactions from this Message.
      * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
      *
-     * <p>Please note that you <b>can't</b> clear reactions if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     * <p>Please note that you <b>can't</b> clear reactions if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
      *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
@@ -1191,7 +1191,7 @@ public interface Message extends ISnowflake, Formattable
      *         in the channel.
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -1202,7 +1202,7 @@ public interface Message extends ISnowflake, Formattable
     /**
      * Removes all reactions for the specified emoji.
      *
-     * <p>Please note that you <b>can't</b> clear reactions if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     * <p>Please note that you <b>can't</b> clear reactions if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
      *
      * <h2>Example</h2>
      * <pre><code>
@@ -1238,7 +1238,7 @@ public interface Message extends ISnowflake, Formattable
      *         If provided with null
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *
      * @return {@link RestAction}
      *
@@ -1251,7 +1251,7 @@ public interface Message extends ISnowflake, Formattable
     /**
      * Removes all reactions for the specified emote.
      *
-     * <p>Please note that you <b>can't</b> clear reactions if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     * <p>Please note that you <b>can't</b> clear reactions if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
      *
      * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
@@ -1277,7 +1277,7 @@ public interface Message extends ISnowflake, Formattable
      *         If provided with null
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *
      * @return {@link RestAction}
      *
@@ -1336,7 +1336,7 @@ public interface Message extends ISnowflake, Formattable
     /**
      * Removes a {@link net.dv8tion.jda.api.entities.User User's} reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emote Emote}.
      *
-     * <p>Please note that you <b>can't</b> remove reactions of other users if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     * <p>Please note that you <b>can't</b> remove reactions of other users if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
      *
      * <p>This message instance will not be updated by this operation.
      *
@@ -1382,7 +1382,7 @@ public interface Message extends ISnowflake, Formattable
      *         </ul>
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
      *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
@@ -1450,7 +1450,7 @@ public interface Message extends ISnowflake, Formattable
      * <br>A reference of unicode emojis can be found here:
      * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
      *
-     * <p>Please note that you <b>can't</b> remove reactions of other users if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     * <p>Please note that you <b>can't</b> remove reactions of other users if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
      *
      * <p>This message instance will not be updated by this operation.
      *
@@ -1492,7 +1492,7 @@ public interface Message extends ISnowflake, Formattable
      *         If the provided unicode emoji is null or empty or if the provided user is null.
      * @throws java.lang.IllegalStateException
      *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
      *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1163,6 +1163,8 @@ public interface Message extends ISnowflake, Formattable
      * Removes all reactions from this Message.
      * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
      *
+     * <p>Please note that you <b>can't</b> clear reactions if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     *
      * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
      *
      * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
@@ -1200,6 +1202,8 @@ public interface Message extends ISnowflake, Formattable
     /**
      * Removes all reactions for the specified emoji.
      *
+     * <p>Please note that you <b>can't</b> clear reactions if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     *
      * <h2>Example</h2>
      * <pre><code>
      * // custom
@@ -1232,6 +1236,9 @@ public interface Message extends ISnowflake, Formattable
      *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
      * @throws IllegalArgumentException
      *         If provided with null
+     * @throws java.lang.IllegalStateException
+     *         If this message was <b>not</b> sent in a
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
      *
      * @return {@link RestAction}
      *
@@ -1243,6 +1250,8 @@ public interface Message extends ISnowflake, Formattable
 
     /**
      * Removes all reactions for the specified emote.
+     *
+     * <p>Please note that you <b>can't</b> clear reactions if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
      *
      * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
      * <ul>
@@ -1266,6 +1275,9 @@ public interface Message extends ISnowflake, Formattable
      *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
      * @throws IllegalArgumentException
      *         If provided with null
+     * @throws java.lang.IllegalStateException
+     *         If this message was <b>not</b> sent in a
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
      *
      * @return {@link RestAction}
      *
@@ -1324,6 +1336,8 @@ public interface Message extends ISnowflake, Formattable
     /**
      * Removes a {@link net.dv8tion.jda.api.entities.User User's} reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emote Emote}.
      *
+     * <p>Please note that you <b>can't</b> remove reactions of other users if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     *
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
@@ -1365,6 +1379,10 @@ public interface Message extends ISnowflake, Formattable
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} cannot be used in the current channel.
      *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
      *         </ul>
+     * @throws java.lang.IllegalStateException
+     *         If this message was <b>not</b> sent in a
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      *
@@ -1431,6 +1449,8 @@ public interface Message extends ISnowflake, Formattable
      * <br>A reference of unicode emojis can be found here:
      * <a href="http://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a>.
      *
+     * <p>Please note that you <b>can't</b> remove reactions of other users if this is a private message / this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     *
      * <p>This message instance will not be updated by this operation.
      *
      * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
@@ -1469,6 +1489,10 @@ public interface Message extends ISnowflake, Formattable
      *         </ul>
      * @throws java.lang.IllegalArgumentException
      *         If the provided unicode emoji is null or empty.
+     * @throws java.lang.IllegalStateException
+     *         If this message was <b>not</b> sent in a
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      *

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -163,7 +163,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions()
     {
-        if (!isFromType(ChannelType.TEXT))
+        if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId());
     }
@@ -172,7 +172,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull String unicode)
     {
-        if (!isFromType(ChannelType.TEXT))
+        if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
     }
@@ -181,7 +181,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
     {
-        if (!isFromType(ChannelType.TEXT))
+        if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
     }
@@ -203,7 +203,7 @@ public class ReceivedMessage extends AbstractMessage
             // we can safely remove that
             return channel.removeReactionById(getIdLong(), emote);
 
-        if (!isFromType(ChannelType.TEXT))
+        if (!isFromGuild())
             throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getIdLong(), emote, user);
     }
@@ -223,7 +223,7 @@ public class ReceivedMessage extends AbstractMessage
         if (user.equals(getJDA().getSelfUser()))
             return channel.removeReactionById(getIdLong(), unicode);
 
-        if (!isFromType(ChannelType.TEXT))
+        if (!isFromGuild())
             throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
     }
@@ -408,7 +408,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public List<Member> getMentionedMembers()
     {
-        if (isFromType(ChannelType.TEXT))
+        if (isFromGuild())
             return getMentionedMembers(getGuild());
         else
             throw new IllegalStateException("You must specify a Guild for Messages which are not sent from a TextChannel!");
@@ -542,7 +542,7 @@ public class ReceivedMessage extends AbstractMessage
             final Member member = (Member) mentionable;
             return CollectionUtils.containsAny(getMentionedRoles(), member.getRoles());
         }
-        else if (isFromType(ChannelType.TEXT) && mentionable instanceof User)
+        else if (isFromGuild() && mentionable instanceof User)
         {
             final Member member = getGuild().getMember((User) mentionable);
             return member != null && CollectionUtils.containsAny(getMentionedRoles(), member.getRoles());
@@ -614,7 +614,7 @@ public class ReceivedMessage extends AbstractMessage
             for (User user : getMentionedUsers())
             {
                 String name;
-                if (isFromType(ChannelType.TEXT) && getGuild().isMember(user))
+                if (isFromGuild() && getGuild().isMember(user))
                     name = getGuild().getMember(user).getEffectiveName();
                 else
                     name = user.getName();
@@ -700,7 +700,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public TextChannel getTextChannel()
     {
-        if (!isFromType(ChannelType.TEXT))
+        // this is not really safe but at the moment this is the only guild channel with messages
+        // and a MessageChannel can just be Text or Private to this is assumable at the moment
+        if (!isFromGuild())
             throw new IllegalStateException("This message was not sent in a text channel");
         return (TextChannel) channel;
     }
@@ -708,7 +710,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public Category getCategory()
     {
-        return isFromType(ChannelType.TEXT) ? getTextChannel().getParent() : null;
+        return isFromGuild() ? getTextChannel().getParent() : null;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -163,7 +163,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions()
     {
-        Checks.check(isFromType(ChannelType.TEXT), "Cannot clear reactions from a message in a Group or PrivateChannel.");
+        if (!isFromType(ChannelType.TEXT))
+            throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId());
     }
 
@@ -171,7 +172,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull String unicode)
     {
-        Checks.check(isFromType(ChannelType.TEXT), "Cannot clear reactions from a message in a Group or PrivateChannel.");
+        if (!isFromType(ChannelType.TEXT))
+            throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
     }
 
@@ -179,7 +181,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
     {
-        Checks.check(isFromType(ChannelType.TEXT), "Cannot clear reactions from a message in a Group or PrivateChannel.");
+        if (!isFromType(ChannelType.TEXT))
+            throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
     }
 
@@ -194,7 +197,13 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
     {
-        Checks.check(isFromType(ChannelType.TEXT), "Cannot remove reactions of others from a message in a Group or PrivateChannel.");
+        // check if the passed user is the SelfUser, then the ChannelType doesn't matter
+        if (user.equals(getJDA().getSelfUser()))
+            // we can safely remove that
+            return channel.removeReactionById(getIdLong(), emote);
+
+        if (!isFromType(ChannelType.TEXT))
+            throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getIdLong(), emote, user);
     }
 
@@ -209,7 +218,11 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user)
     {
-        Checks.check(isFromType(ChannelType.TEXT), "Cannot remove reactions of others from a message in a Group or PrivateChannel.");
+        if (user.equals(getJDA().getSelfUser()))
+            return channel.removeReactionById(getIdLong(), unicode);
+
+        if (!isFromType(ChannelType.TEXT))
+            throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -700,9 +700,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public TextChannel getTextChannel()
     {
-        // this is not really safe but at the moment this is the only GuildChannel with messages
-        // and a MessageChannel can just be Text or Private so this is assumable as of now
-        if (!isFromGuild())
+        // might be the reason why other methods calling this throw that exception
+        // in case of other GuildChannels being able to receive messages in the future
+        if (!isFromType(ChannelType.TEXT))
             throw new IllegalStateException("This message was not sent in a text channel");
         return (TextChannel) channel;
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -197,6 +197,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
     {
+        Checks.notNull(user, "User");  // to prevent NPEs
         // check if the passed user is the SelfUser, then the ChannelType doesn't matter
         if (user.equals(getJDA().getSelfUser()))
             // we can safely remove that
@@ -218,6 +219,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user)
     {
+        Checks.notNull(user, "User");
         if (user.equals(getJDA().getSelfUser()))
             return channel.removeReactionById(getIdLong(), unicode);
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -198,9 +198,9 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
     {
         Checks.notNull(user, "User");  // to prevent NPEs
-        // check if the passed user is the SelfUser, then the ChannelType doesn't matter
+        // check if the passed user is the SelfUser, then the ChannelType doesn't matter and
+        // we can safely remove that
         if (user.equals(getJDA().getSelfUser()))
-            // we can safely remove that
             return channel.removeReactionById(getIdLong(), emote);
 
         if (!isFromGuild())

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -700,8 +700,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public TextChannel getTextChannel()
     {
-        // this is not really safe but at the moment this is the only guild channel with messages
-        // and a MessageChannel can just be Text or Private to this is assumable at the moment
+        // this is not really safe but at the moment this is the only GuildChannel with messages
+        // and a MessageChannel can just be Text or Private so this is assumable as of now
         if (!isFromGuild())
             throw new IllegalStateException("This message was not sent in a text channel");
         return (TextChannel) channel;

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -163,8 +163,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions()
     {
-        if (!isFromType(ChannelType.TEXT))
-            throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
+        Checks.check(isFromType(ChannelType.TEXT), "Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId());
     }
 
@@ -172,6 +171,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull String unicode)
     {
+        Checks.check(isFromType(ChannelType.TEXT), "Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
     }
 
@@ -179,6 +179,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
     {
+        Checks.check(isFromType(ChannelType.TEXT), "Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
     }
 
@@ -193,6 +194,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
     {
+        Checks.check(isFromType(ChannelType.TEXT), "Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getIdLong(), emote, user);
     }
 
@@ -207,6 +209,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user)
     {
+        Checks.check(isFromType(ChannelType.TEXT), "Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This PR adds a check in removing / clearing reaction methods, checking if the message was sent in a TextChannel and else tells the user that he is unable to remove reactions of others or clear them if the message is not from a TextChannel.

Before, `getTextChannel()` was called without a check throwing `This message was not sent in a text channel` if the message was from a PrivateChannel (or group) which could be misleading ([and actually was](https://discordapp.com/channels/81384788765712384/381889648827301889/684520138367827971) which is why I make that PR) in that context.

This also fixes a **bug** where if the SelfUser was passed to the function, it would still have thrown that exception even that would be allowed.