### PR TITLE
Deprecate GuildUpdateBannerEvent#getNewBannerIdUrl

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBannerEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBannerEvent.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.api.events.guild.update;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 
@@ -55,9 +57,25 @@ public class GuildUpdateBannerEvent extends GenericGuildUpdateEvent<String>
      * @return The new banner url, or null if the banner was removed
      */
     @Nullable
-    public String getNewBannerIdUrl()
+    public String getNewBannerUrl()
     {
         return next == null ? null : String.format(Guild.BANNER_URL, guild.getId(), next);
+    }
+
+    /**
+     * The new banner url
+     *
+     * @return The new banner url, or null if the banner was removed
+     *
+     * @deprecated This will be replaced by {@link #getNewBannerUrl()}
+     */
+    @Nullable
+    @Deprecated
+    @DeprecatedSince("4.1.1")
+    @ReplaceWith("getNewBannerUrl()")
+    public String getNewBannerIdUrl()
+    {
+        return getNewBannerUrl();
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBannerEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBannerEvent.java
@@ -71,7 +71,7 @@ public class GuildUpdateBannerEvent extends GenericGuildUpdateEvent<String>
      */
     @Nullable
     @Deprecated
-    @DeprecatedSince("4.1.1")
+    @DeprecatedSince("4.2.0")
     @ReplaceWith("getNewBannerUrl()")
     public String getNewBannerIdUrl()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The method `GuildUpdateBannerEvent#getNewBannerIdUrl` is a typo for `getNewBannerUrl` and it is corrected in this PR.