### PR TITLE
Add deprecated comment to GuildMemberLeaveEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberLeaveEvent.java
@@ -29,6 +29,8 @@ import javax.annotation.Nonnull;
  * You can use {@link GuildMemberRemoveEvent} to detect any member removes, regardless of cache state.
  *
  * <p>Can be used to retrieve members who leave a guild.
+ *
+ * @deprecated This was deprecated in favour of {@link GuildMemberRemoveEvent}
  */
 @Deprecated
 @DeprecatedSince("4.2.0")


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Added the missing `@deprecated` note about this method being deprecated in favour of the `GuildMemberRemoveEvent`