### PR TITLE
Added Server Insights permission

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -37,7 +37,7 @@ public enum Permission
     MESSAGE_ADD_REACTION( 6, true, true, "Add Reactions"),
     VIEW_AUDIT_LOGS(      7, true, false, "View Audit Logs"),
     PRIORITY_SPEAKER(     8, true, true, "Priority Speaker"),
-    VIEW_SERVER_INSIGHTS(19, true, false, "View Server Insights"),
+    VIEW_GUILD_INSIGHTS(19, true, false, "View Server Insights"),
 
     // Applicable to all channel types
     VIEW_CHANNEL(            10, true, true, "Read Text Channels & See Voice Channels"),

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -37,6 +37,7 @@ public enum Permission
     MESSAGE_ADD_REACTION( 6, true, true, "Add Reactions"),
     VIEW_AUDIT_LOGS(      7, true, false, "View Audit Logs"),
     PRIORITY_SPEAKER(     8, true, true, "Priority Speaker"),
+    VIEW_SERVER_INSIGHTS(19, true, false, "View Server Insights"),
 
     // Applicable to all channel types
     VIEW_CHANNEL(            10, true, true, "Read Text Channels & See Voice Channels"),


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

## Description

Since some months now, Discord has introduced a new feature called [Server Insights](https://support.discordapp.com/hc/en-us/articles/360032807371-Server-Insights-FAQ). For now, this feature - reserved to Verified or Partnered Discord - allows us to track members activities and more. Those statistics who were previously hide are used to determine if a server can be introduced in the server discovery.

Currently, this feature is experimental, but, since a little number of days, the *View Server Insights* permission has popped out on the developer portal, meaning Discord want's to *open* this feature (at least to developers).

The goal of this PR is therefore to implement the missing *View Server Insights* present on the developer portal. The permission integer is `524288` (as shown on the developer portal), which is exactly `1 << 19` (the offset is therefore 19).
