### PR TITLE
Allow to open private channel with user id

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1575,6 +1575,8 @@ public interface JDA
 
     /**
      * Opens a {@link PrivateChannel} with the provided user by id.
+     * <br>This will fail with {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_USER UNKNOWN_USER}
+     * if the user does not exist.
      *
      * <h2>Example</h2>
      * <pre>{@code
@@ -1602,6 +1604,8 @@ public interface JDA
 
     /**
      * Opens a {@link PrivateChannel} with the provided user by id.
+     * <br>This will fail with {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_USER UNKNOWN_USER}
+     * if the user does not exist.
      *
      * <h2>Example</h2>
      * <pre>{@code

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -308,17 +308,6 @@ public interface JDA
         return awaitStatus(status, new JDA.Status[0]);
     }
 
-    @Nonnull
-    @CheckReturnValue
-    RestAction<PrivateChannel> openPrivateChannelById(long userId);
-
-    @Nonnull
-    @CheckReturnValue
-    default RestAction<PrivateChannel> openPrivateChannelById(@Nonnull String userId)
-    {
-        return openPrivateChannelById(MiscUtil.parseSnowflake(userId));
-    }
-
     /**
      * This method will block until JDA has reached the specified connection status.
      *
@@ -1582,6 +1571,17 @@ public interface JDA
     default PrivateChannel getPrivateChannelById(long id)
     {
         return getPrivateChannelCache().getElementById(id);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    RestAction<PrivateChannel> openPrivateChannelById(long userId);
+
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<PrivateChannel> openPrivateChannelById(@Nonnull String userId)
+    {
+        return openPrivateChannelById(MiscUtil.parseSnowflake(userId));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -308,6 +308,17 @@ public interface JDA
         return awaitStatus(status, new JDA.Status[0]);
     }
 
+    @Nonnull
+    @CheckReturnValue
+    RestAction<PrivateChannel> openPrivateChannelById(long userId);
+
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<PrivateChannel> openPrivateChannelById(@Nonnull String userId)
+    {
+        return openPrivateChannelById(MiscUtil.parseSnowflake(userId));
+    }
+
     /**
      * This method will block until JDA has reached the specified connection status.
      *

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1573,10 +1573,58 @@ public interface JDA
         return getPrivateChannelCache().getElementById(id);
     }
 
+    /**
+     * Opens a {@link PrivateChannel} with the provided user by id.
+     *
+     * <h2>Example</h2>
+     * <pre>{@code
+     * public void sendMessage(User user, String content) {
+     *     JDA jda = user.getJDA();
+     *     jda.openPrivateChannelById(user.getIdLong())
+     *        .flatMap(channel -> channel.sendMessage(content))
+     *        .queue();
+     * }
+     * }</pre>
+     *
+     * @param  userId
+     *         The id of the target user
+     *
+     * @throws UnsupportedOperationException
+     *         If the target user is the currently logged in account
+     *
+     * @return {@link RestAction} - Type: {@link PrivateChannel}
+     *
+     * @see    User#openPrivateChannel()
+     */
     @Nonnull
     @CheckReturnValue
     RestAction<PrivateChannel> openPrivateChannelById(long userId);
 
+    /**
+     * Opens a {@link PrivateChannel} with the provided user by id.
+     *
+     * <h2>Example</h2>
+     * <pre>{@code
+     * public void sendMessage(User user, String content) {
+     *     JDA jda = user.getJDA();
+     *     jda.openPrivateChannelById(user.getId())
+     *        .flatMap(channel -> channel.sendMessage(content))
+     *        .queue();
+     * }
+     * }</pre>
+     *
+     * @param  userId
+     *         The id of the target user
+     *
+     * @throws UnsupportedOperationException
+     *         If the target user is the currently logged in account
+     * @throws IllegalArgumentException
+     *         If the provided id is not a valid snowflake
+     *
+     * @return {@link RestAction} - Type: {@link PrivateChannel}
+     *
+     * @see    User#openPrivateChannel()
+     */
     @Nonnull
     @CheckReturnValue
     default RestAction<PrivateChannel> openPrivateChannelById(@Nonnull String userId)

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1580,9 +1580,8 @@ public interface JDA
      *
      * <h2>Example</h2>
      * <pre>{@code
-     * public void sendMessage(User user, String content) {
-     *     JDA jda = user.getJDA();
-     *     jda.openPrivateChannelById(user.getIdLong())
+     * public void sendMessage(JDA jda, long userId, String content) {
+     *     jda.openPrivateChannelById(userId)
      *        .flatMap(channel -> channel.sendMessage(content))
      *        .queue();
      * }
@@ -1609,9 +1608,8 @@ public interface JDA
      *
      * <h2>Example</h2>
      * <pre>{@code
-     * public void sendMessage(User user, String content) {
-     *     JDA jda = user.getJDA();
-     *     jda.openPrivateChannelById(user.getId())
+     * public void sendMessage(JDA jda, String userId, String content) {
+     *     jda.openPrivateChannelById(userId)
      *        .flatMap(channel -> channel.sendMessage(content))
      *        .queue();
      * }

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -195,6 +195,8 @@ public interface User extends IMentionable, IFakeable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}
      *         <br>Retrieves the PrivateChannel to use to directly message this User.
+     *
+     * @see    JDA#openPrivateChannelById(long)
      */
     @Nonnull
     @CheckReturnValue

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -658,7 +658,7 @@ public class JDAImpl implements JDA
             throw new UnsupportedOperationException("Cannot open private channel with yourself!");
         return new DeferredRestAction<>(this, PrivateChannel.class, () -> {
             User user = getUserById(userId);
-            if (user != null && user.hasPrivateChannel())
+            if (user instanceof UserImpl)
                 return ((UserImpl) user).getPrivateChannel();
             return null;
         }, () -> {

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -654,6 +654,8 @@ public class JDAImpl implements JDA
     @Override
     public RestAction<PrivateChannel> openPrivateChannelById(long userId)
     {
+        if (selfUser != null && userId == selfUser.getIdLong())
+            throw new UnsupportedOperationException("Cannot open private channel with yourself!");
         return new DeferredRestAction<>(this, PrivateChannel.class, () -> {
             User user = getUserById(userId);
             if (user != null && user.hasPrivateChannel())

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -50,6 +50,7 @@ import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.handle.EventCache;
 import net.dv8tion.jda.internal.handle.GuildSetupController;
 import net.dv8tion.jda.internal.hooks.EventManagerProxy;
@@ -647,6 +648,23 @@ public class JDAImpl implements JDA
     public SnowflakeCacheView<PrivateChannel> getPrivateChannelCache()
     {
         return privateChannelCache;
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<PrivateChannel> openPrivateChannelById(long userId)
+    {
+        return new DeferredRestAction<>(this, PrivateChannel.class, () -> {
+            User user = getUserById(userId);
+            if (user != null && user.hasPrivateChannel())
+                return ((UserImpl) user).getPrivateChannel();
+            return null;
+        }, () -> {
+            Route.CompiledRoute route = Route.Self.CREATE_PRIVATE_CHANNEL.compile();
+            DataObject body = DataObject.empty().put("recipient_id", userId);
+            return new RestActionImpl<>(this, route, body,
+                (response, request) -> getEntityBuilder().createPrivateChannel(response.getObject()));
+        });
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -121,6 +121,8 @@ public class UserImpl implements User
             throw new IllegalStateException("There is no PrivateChannel for this user yet! Use User#openPrivateChannel() first!");
 
         PrivateChannel channel = getJDA().getPrivateChannelById(privateChannel);
+        if (channel == null)
+            channel = getJDA().getFakePrivateChannelMap().get(privateChannel);
         return channel != null ? channel : new PrivateChannelImpl(privateChannel, this);
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This enables users to open a private channel directly using the user id instead of first retrieving the user. Additionally, we now always keep the channel id in the user object once it has been resolved.
