### PR TITLE
Document exception in JDA#getSelfUser and expose JDA#hasSelfUser

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1678,9 +1678,19 @@ public interface JDA
     IEventManager getEventManager();
 
     /**
+     * Check whether the {@link net.dv8tion.jda.api.entities.SelfUser} of this JDA instance has been set.
+     *
+     * @return true if the {@link net.dv8tion.jda.api.entities.SelfUser} of this JDA instance has been set, false otherwise.
+     */
+    boolean hasSelfUser();
+
+    /**
      * Returns the currently logged in account represented by {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
      * <br>Account settings <b>cannot</b> be modified using this object. If you wish to modify account settings please
      * use the AccountManager which is accessible by {@link net.dv8tion.jda.api.entities.SelfUser#getManager()}.
+     *
+     * @throws IllegalStateException if the session is not ready yet so there is no {@link net.dv8tion.jda.api.entities.SelfUser}.
+     *         Use {@link JDA#hasSelfUser()} to check if the {@link net.dv8tion.jda.api.entities.SelfUser} is present.
      *
      * @return The currently logged in account.
      */

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -656,6 +656,7 @@ public class JDAImpl implements JDA
         return userCache;
     }
 
+    @Override
     public boolean hasSelfUser()
     {
         return selfUser != null;

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1325,7 +1325,7 @@ public class GuildImpl implements Guild
     public GuildImpl setOwner(Member owner)
     {
         // Only cache owner if user cache is enabled
-        if (!owner.isFake())
+        if (owner != null && !owner.isFake())
             this.owner = owner;
         return this;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [ ] I have checked the PRs for upcoming features/bug fixes.
- [ ] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Noticed that getSelfUser() throws an exception. That should be documented at least. It would also be nice for us enduser to be able to check it beforehand to avoid exception-driven control flow.