### PR TITLE
Change reconnect code to 4900 to avoid confusion

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/CloseCode.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/CloseCode.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
  */
 public enum CloseCode
 {
+    RECONNECT(            4900, "The connection has been closed to reconnect."),
     GRACEFUL_CLOSE(       1000, "The connection was closed gracefully or your heartbeats timed out."),
     CLOUD_FLARE_LOAD(     1001, "The connection was closed due to CloudFlare load balancing."),
     INTERNAL_SERVER_ERROR(1006, "Something broke on the remote's end, sorry 'bout that... Try reconnecting!"),

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -203,7 +203,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         else
         {
-            JDAImpl.LOG.info("Successfully resumed Session!");
+            JDAImpl.LOG.debug("Successfully resumed Session!");
             api.handleEvent(new ResumedEvent(api, api.getResponseTotal()));
         }
         api.setStatus(JDA.Status.CONNECTED);
@@ -494,7 +494,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         else // if resume is possible
         {
-            LOG.warn("Got disconnected from WebSocket. Attempting to resume session");
+            LOG.debug("Got disconnected from WebSocket. Attempting to resume session");
             reconnect();
         }
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -406,6 +406,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             closeCode = CloseCode.from(rawCloseCode);
             if (closeCode == CloseCode.RATE_LIMITED)
                 LOG.error("WebSocket connection closed due to ratelimit! Sent more than 120 websocket messages in under 60 seconds!");
+            else if (closeCode == CloseCode.UNKNOWN_ERROR)
+                LOG.error("WebSocket connection closed due to server error! {}: {}", rawCloseCode, rawCloseReason);
             else if (closeCode != null)
                 LOG.debug("WebSocket connection closed with code {}", closeCode);
             else if (rawCloseReason != null)

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
@@ -132,6 +132,15 @@ class WebSocketSendingThread implements Runnable
         {
             LOG.debug("Main WS send thread interrupted. Most likely JDA is disconnecting the websocket.");
         }
+        catch (Throwable ex)
+        {
+            // Log error
+            LOG.error("Encountered error in gateway worker", ex);
+            if (ex instanceof RuntimeException)
+                throw (RuntimeException) ex;
+            else
+                throw (Error) ex;
+        }
         finally
         {
             // on any exception that might cause this lock to not release


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The reconnect close codes we use shouldn't overlap with the disconnect close codes that discord uses. This will make it a lot easier to identify an issue with the connection. If we close with 4000 it can be confusing because discord also uses this code for various other reasons, such as gateway timeout for large bots.

I chose code 4900 for reconnects since it should be way out of the normal code range that discord uses but is still RFC compliant. The fallback code has been changed to 1005 which is the correct code to indicate a missing close code.
