### PR TITLE
Add section to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,6 +49,15 @@ If you have a reproducible behavior, please provide some details for us.
 Otherwise just put N/A
 -->
 
+### Code for JDABuilder or DefaultShardManagerBuilder Used
+
+<!--
+Please provide the code you used to start your bot.
+This greatly impacts behavior due to the way cache and events are configured.
+
+Otherwise just put N/A
+-->
+
 ### Exception or Error
 
 <!--


### PR DESCRIPTION
This adds a new section to the bug report template. With the new changes to 4.2.0 we will need to always know how the user started the JDA session because of how things rely on intents and cache configuration.