### PR TITLE
Implement config.yml for Template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/0hMr4ce0tIk3pSjp
+    about: The JDA Discord is the best place to receive fast support for your questions.
+  - name: Javadoc
+    url: https://ci.dv8tion.net/job/JDA/javadoc/
+    about: The Javadoc is the perfect place to retrieve information about various methods within JDA.
+  - name: Jenkins
+    url: https://ci.dv8tion.net/job/JDA/
+    about: You can find the latest Dev Builds on the Jenkins CI Server.
+  - name: Wiki
+    url: https://github.com/DV8FromTheWorld/JDA/wiki
+    about: You can find answers to common questions on our Wiki. Make sure to read the FAQ page!
+  - name: Releases
+    url: https://github.com/DV8FromTheWorld/JDA/releases
+    about: You can find the latest releases here on GitHub and on Bintray.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Use this Template to ask a question regarding JDA (Joining the Discord is recommendet)
+about: Use this template to ask a question regarding JDA (Joining the Discord first is highly recommended)
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,42 @@
+---
+name: Question
+about: Use this Template to ask a question regarding JDA (Joining the Discord is recommendet)
+---
+
+<!--
+  We suggest to join the JDA Discord server for faster responses: https://discord.gg/0hMr4ce0tIl3SLv5
+-->
+
+[download]: https://bintray.com/dv8fromtheworld/maven/JDA/_latestVersion
+[guild]: https://discord.gg/0hMr4ce0tIk3pSjp
+[wiki]: https://github.com/DV8FromTheWorld/JDA/wiki
+[FAQ]: https://github.com/DV8FromTheWorld/JDA/wiki/10%29-FAQ
+
+## General Troubleshooting
+
+<!--
+  Hey there! Before you ask your question, please make sure
+  to follow these steps first!
+-->
+
+- [ ] I have checked for similar issues.
+- [ ] I have updated to the [latest JDA version][download]
+- [ ] I have checked the [wiki] and especially the [FAQ] section for similar questions.
+
+<!--
+  This is not the place to learn Java. Please refer to StackOverflow for your
+  general programming questions: https://stackoverflow.com/questions/tagged/java
+-->
+
+## Question
+
+<!--
+Ask your question here and provide as much information as possible.
+-->
+
+## Example Code
+
+<!--
+Provide some example code regarding your question here.
+Make sure to put it in a code block.
+-->


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Issue-system (template chooser) of GitHub <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1252 

## Description
This PR implements a `config.yml` within the `.github/ISSUE_TEMPLATE` directory.
Having this file allows for the addition of external links to sources like the wiki, javadoc, or releases.
It also allows disabling of the option to skip choosing a template.

Current Settings are as follows:
- Creating of blank issues is __disabled__
- Following Links where added:
  - Discord: https://discord.gg/0hMr4ce0tIk3pSjp
  - Javadoc: https://ci.dv8tion.net/job/JDA/javadoc/
  - Jenkins: https://ci.dv8tion.net/job/JDA/
  - Wiki: https://github.com/DV8FromTheWorld/JDA/wiki
  - Releases: https://github.com/DV8FromTheWorld/JDA/releases
