### PR TITLE
Fix incorrect size check for MessageChannel#sendFile

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -770,8 +770,7 @@ public interface MessageChannel extends ISnowflake, Formattable
     {
         Checks.notNull(data, "data");
         Checks.notNull(fileName, "fileName");
-        final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
-        Checks.check(data.length <= maxSize, "File is too big! Max file-size is %d bytes", maxSize);
+
         return sendFile(new ByteArrayInputStream(data), fileName, options);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -166,6 +166,16 @@ public class PrivateChannelImpl implements PrivateChannel
         return PrivateChannel.super.sendFile(file, fileName, options);
     }
 
+    @Nonnull
+    @Override
+    public MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    {
+        checkBot();
+        final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
+        Checks.check(data == null || data.length <= maxSize, "File is too big! Max file-size is %d bytes", maxSize);
+        return PrivateChannel.super.sendFile(data, fileName, options);
+    }
+
     public PrivateChannelImpl setLastMessageId(long id)
     {
         this.lastMessageId = id;

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -388,6 +388,21 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
 
     @Nonnull
     @Override
+    public MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    {
+        checkPermission(Permission.MESSAGE_READ);
+        checkPermission(Permission.MESSAGE_WRITE);
+        checkPermission(Permission.MESSAGE_ATTACH_FILES);
+
+        final long maxSize = getGuild().getMaxFileSize();
+        Checks.check(data == null || data.length <= maxSize, "File is too big! Max file-size is %d bytes", maxSize);
+
+        //Call MessageChannel's default method
+        return TextChannel.super.sendFile(data, fileName, options);
+    }
+
+    @Nonnull
+    @Override
     public RestAction<Message> retrieveMessageById(@Nonnull String messageId)
     {
         checkPermission(Permission.MESSAGE_READ);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes an issue where the `byte[]` overload of `MessageChannel#sendFile` 
does not check permissions and ignores guild boosts in the max allowed size check.
