### PR TITLE
Add ReactionEmote#getAsReactionCode method

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -399,7 +399,7 @@ public class MessageReaction
 
     private String getReactionCode()
     {
-        return emote.isEmote()
+        return emote != null
                 ? emote.getName() + ":" + emote.getId()
                 : EncodingUtil.encodeUTF8(emote.getName());
     }
@@ -539,7 +539,7 @@ public class MessageReaction
         @Nonnull
         public String getAsReactionCode()
         {
-            return emote != null
+            return isEmote()
                     ? name + ":" + id
                     : name;
         }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -528,6 +528,20 @@ public class MessageReaction
                 throw new IllegalStateException("Cannot get id for emoji reaction");
             return id;
         }
+        
+        /**
+         * The code for this Reaction.
+         * <br>For unicode emojis this will be the unicode of said emoji rather than an alias like {@code :smiley:}.
+         * <br>For custom emotes this will be the name and id of said emote in the format {@code <name>:<id>}.
+         *
+         * @return The unicode if it is an emoji, or the name and id in the format {@code <name>:<id>}
+         */
+        public String getAsReactionCode()
+        {
+            return isEmote()
+                    ? name + ":" + id
+                    : EncodingUtil.encodeUTF8(name);
+        }
 
         /**
          * The unicode representing the emoji used for reacting.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -539,7 +539,7 @@ public class MessageReaction
         @Nonnull
         public String getAsReactionCode()
         {
-            return isEmote()
+            return emote != null
                     ? name + ":" + id
                     : name;
         }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -536,6 +536,7 @@ public class MessageReaction
          *
          * @return The unicode if it is an emoji, or the name and id in the format {@code <name>:<id>}
          */
+        @Nonnull
         public String getAsReactionCode()
         {
             return isEmote()

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -540,7 +540,7 @@ public class MessageReaction
         {
             return isEmote()
                     ? name + ":" + id
-                    : EncodingUtil.encodeUTF8(name);
+                    : name;
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -399,7 +399,7 @@ public class MessageReaction
 
     private String getReactionCode()
     {
-        return emote != null
+        return emote.isEmote()
                 ? emote.getName() + ":" + emote.getId()
                 : EncodingUtil.encodeUTF8(emote.getName());
     }
@@ -539,7 +539,7 @@ public class MessageReaction
         @Nonnull
         public String getAsReactionCode()
         {
-            return isEmote()
+            return emote != null
                     ? name + ":" + id
                     : name;
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
Adds a `getAsReactionCode()` method to `MessageReaction.ReactionEmote` which would either return the UTF-8 code of the emoji, or the name and id of the Emote in the format `name:id` depending on what type it is.