### PR TITLE
Json Parsing Optimizations

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -600,6 +601,25 @@ public class DataArray implements Iterable<Object>
     {
         data.remove(value);
         return this;
+    }
+
+    /**
+     * Serialize this object as JSON.
+     *
+     * @return a byte array containing the JSON representation of this object.
+     */
+    public byte[] toJson()
+    {
+        try
+        {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            mapper.writeValue(outputStream, data);
+            return outputStream.toByteArray();
+        }
+        catch (IOException e)
+        {
+            throw new IllegalStateException(e);
+        }
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -618,7 +619,7 @@ public class DataArray implements Iterable<Object>
         }
         catch (IOException e)
         {
-            throw new IllegalStateException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -631,7 +632,7 @@ public class DataArray implements Iterable<Object>
         }
         catch (JsonProcessingException e)
         {
-            throw new IllegalStateException(e);
+            throw new ParsingException(e);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -643,6 +644,25 @@ public class DataObject implements SerializableData
     public Set<String> keys()
     {
         return data.keySet();
+    }
+
+    /**
+     * Serialize this object as JSON.
+     *
+     * @return a byte array containing the JSON representation of this object.
+     */
+    public byte[] toJson()
+    {
+        try
+        {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            mapper.writeValue(outputStream, data);
+            return outputStream.toByteArray();
+        }
+        catch (IOException e)
+        {
+            throw new ParsingException(e);
+        }
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -82,6 +82,31 @@ public class DataObject implements SerializableData
     /**
      * Parses a JSON payload into a DataObject instance.
      *
+     * @param  data
+     *         The correctly formatted JSON payload to parse
+     *
+     * @throws net.dv8tion.jda.api.exceptions.ParsingException
+     *         If the provided json is incorrectly formatted
+     *
+     * @return A DataObject instance for the provided payload
+     */
+    @Nonnull
+    public static DataObject fromJson(@Nonnull byte[] data)
+    {
+        try
+        {
+            Map<String, Object> map = mapper.readValue(data, mapType);
+            return new DataObject(map);
+        }
+        catch (IOException ex)
+        {
+            throw new ParsingException(ex);
+        }
+    }
+
+    /**
+     * Parses a JSON payload into a DataObject instance.
+     *
      * @param  json
      *         The correctly formatted JSON payload to parse
      *

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -661,7 +662,7 @@ public class DataObject implements SerializableData
         }
         catch (IOException e)
         {
-            throw new ParsingException(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -134,8 +134,8 @@ class AudioWebSocket extends WebSocketAdapter
                 else // practically should never happen
                     socketFactory.setServerNames(null);
                 socket = socketFactory.createSocket(wssEndpoint);
-                socket.setDirectTextMessage(true);
             }
+            socket.setDirectTextMessage(true);
             socket.addListener(this);
             changeStatus(ConnectionStatus.CONNECTING_AWAITING_WEBSOCKET_CONNECT);
             socket.connectAsynchronously();

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -40,6 +40,7 @@ import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.NoRouteToHostException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,7 @@ class AudioWebSocket extends WebSocketAdapter
                 else // practically should never happen
                     socketFactory.setServerNames(null);
                 socket = socketFactory.createSocket(wssEndpoint);
+                socket.setDirectTextMessage(true);
             }
             socket.addListener(this);
             changeStatus(ConnectionStatus.CONNECTING_AWAITING_WEBSOCKET_CONNECT);
@@ -279,14 +281,20 @@ class AudioWebSocket extends WebSocketAdapter
     }
 
     @Override
-    public void onTextMessage(WebSocket websocket, String message)
+    public void onTextMessage(WebSocket websocket, byte[] data)
     {
         try
         {
-            handleEvent(DataObject.fromJson(message));
+            handleEvent(DataObject.fromJson(data));
         }
         catch (Exception ex)
         {
+            String message = "malformed";
+            try
+            {
+                message = new String(data, StandardCharsets.UTF_8);
+            }
+            catch (Exception ignored) {}
             LOG.error("Encountered exception trying to handle an event message: {}", message, ex);
         }
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/RestActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/RestActionImpl.java
@@ -133,7 +133,7 @@ public class RestActionImpl<T> implements RestAction<T>
 
     public RestActionImpl(JDA api, Route.CompiledRoute route, DataObject data, BiFunction<Response, Request<T>, T> handler)
     {
-        this(api, route, data == null ? null : RequestBody.create(Requester.MEDIA_TYPE_JSON, data.toString()), handler);
+        this(api, route, data == null ? null : RequestBody.create(Requester.MEDIA_TYPE_JSON, data.toJson()), handler);
         this.rawData = data;
     }
 
@@ -236,14 +236,14 @@ public class RestActionImpl<T> implements RestAction<T>
     {
         this.rawData = object;
 
-        return object == null ? null : RequestBody.create(Requester.MEDIA_TYPE_JSON, object.toString());
+        return object == null ? null : RequestBody.create(Requester.MEDIA_TYPE_JSON, object.toJson());
     }
 
     protected RequestBody getRequestBody(DataArray array)
     {
         this.rawData = array;
 
-        return array == null ? null : RequestBody.create(Requester.MEDIA_TYPE_JSON, array.toString());
+        return array == null ? null : RequestBody.create(Requester.MEDIA_TYPE_JSON, array.toJson());
     }
 
     private CheckWrapper getFinisher()

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -57,6 +57,7 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.*;
@@ -925,11 +926,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         if (decompressor == null)
             throw new IllegalStateException("Cannot decompress binary message due to unknown compression algorithm: " + compression);
         // Scoping allows us to print the json that possibly failed parsing
-        String jsonString;
+        byte[] jsonData;
         try
         {
-            jsonString = decompressor.decompress(binary);
-            if (jsonString == null)
+            jsonData = decompressor.decompress(binary);
+            if (jsonData == null)
                 return null;
         }
         catch (DataFormatException e)
@@ -940,12 +941,18 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
         try
         {
-            return DataObject.fromJson(jsonString);
+            return DataObject.fromJson(jsonData);
         }
         catch (ParsingException e)
         {
+            String jsonString = "malformed";
+            try
+            {
+                jsonString = new String(jsonData, StandardCharsets.UTF_8);
+            }
+            catch (Exception ignored) {}
             // Print the string that could not be parsed and re-throw the exception
-            LOG.error("Failed to parse json {}", jsonString);
+            LOG.error("Failed to parse json: {}", jsonString);
             throw e;
         }
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -336,6 +336,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 else // practically should never happen
                     socketFactory.setServerNames(null);
                 socket = socketFactory.createSocket(url);
+                socket.setDirectTextMessage(true);
             }
             socket.addHeader("Accept-Encoding", "gzip")
                   .addListener(this)
@@ -901,9 +902,9 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     }
 
     @Override
-    public void onTextMessage(WebSocket websocket, String message)
+    public void onTextMessage(WebSocket websocket, byte[] data)
     {
-        handleEvent(DataObject.fromJson(message));
+        handleEvent(DataObject.fromJson(data));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -337,8 +337,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 else // practically should never happen
                     socketFactory.setServerNames(null);
                 socket = socketFactory.createSocket(url);
-                socket.setDirectTextMessage(true);
             }
+            socket.setDirectTextMessage(true);
             socket.addHeader("Accept-Encoding", "gzip")
                   .addListener(this)
                   .connect();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -349,7 +349,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
 
     protected RequestBody asJSON()
     {
-        return RequestBody.create(Requester.MEDIA_TYPE_JSON, getJSON().toString());
+        return RequestBody.create(Requester.MEDIA_TYPE_JSON, getJSON().toJson());
     }
 
     protected DataObject getJSON()

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/Decompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/Decompressor.java
@@ -34,5 +34,5 @@ public interface Decompressor
     void shutdown();
 
     @Nullable // returns null when the decompression isn't done, for example when no Z_SYNC_FLUSH was present
-    String decompress(byte[] data) throws DataFormatException;
+    byte[] decompress(byte[] data) throws DataFormatException;
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/ZlibDecompressor.java
@@ -109,7 +109,7 @@ public class ZlibDecompressor implements Decompressor
     }
 
     @Override
-    public String decompress(byte[] data) throws DataFormatException
+    public byte[] decompress(byte[] data) throws DataFormatException
     {
         //Handle split messages
         if (!isFlush(data))
@@ -139,7 +139,7 @@ public class ZlibDecompressor implements Decompressor
             // This decompressor writes the received data and inflates it
             decompressor.write(data);
             // Once decompressed we re-interpret the data as a String which can be used for JSON parsing
-            return buffer.toString("UTF-8");
+            return buffer.toByteArray();
         }
         catch (IOException e)
         {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

## Description

I finally had some time to deep dive into some performance optimizations. The wins are not huge here, but still around a solid 5 % on a bot that has most intents turned off. I can imagine that number to look better the more events are received, as well as bot that have high REST requests (I did not do any).

This PR has 3 areas of improvement:
A. Uses the binary representation of websocket text messages
B. Avoid intermediate string representation of JSON payloads received on the websocket
C. Avoid intermediate string representation of JSON request bodies for rest actions

These are based on the official recommendations from Jackson, see https://github.com/FasterXML/jackson-docs/wiki/Presentation:-Jackson-Performance#basics-things-you-should-do-anyway

### Test Environment
- 100 shards fully loaded
- Enabled intents: GUILD_MESSAGES, DIRECT_MESSAGES, GUILD_MESSAGE_REACTIONS, GUILD_EMOJIS, GUILD_MEMBERS, GUILD_VOICE_STATES
- No commands being executed

Unfortunately the measurements are not as clean as they could be, as I was in parallel working on performance improvements of my metrics. Nevertheless, I have a direct comparison of the most important changes (change B) of this PR to vanilla JDA v4.1.1_133:

Vanilla 4.1.1_133:

![string](https://user-images.githubusercontent.com/6048348/79645333-f7359d00-81ae-11ea-8a0a-87ab4c4eb895.png)

Including change A and change B:
![bytearrays](https://user-images.githubusercontent.com/6048348/79645323-eab14480-81ae-11ea-8959-80e91e809b3c.png)