### PR TITLE
Add User#getFlags

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -223,7 +223,7 @@ public enum Permission
 
     /**
      * A set of all {@link net.dv8tion.jda.api.Permission Permissions} that are specified by this raw long representation of
-     * permissions. This is best used with the getRaw methods in {@link net.dv8tion.jda.api.entities.Role Role} or
+     * permissions. The is best used with the getRaw methods in {@link net.dv8tion.jda.api.entities.Role Role} or
      * {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}.
      *
      * <p>Example: {@link net.dv8tion.jda.api.entities.Role#getPermissionsRaw() Role.getPermissionsRaw()}

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -223,7 +223,7 @@ public enum Permission
 
     /**
      * A set of all {@link net.dv8tion.jda.api.Permission Permissions} that are specified by this raw long representation of
-     * permissions. The is best used with the getRaw methods in {@link net.dv8tion.jda.api.entities.Role Role} or
+     * permissions. This is best used with the getRaw methods in {@link net.dv8tion.jda.api.entities.Role Role} or
      * {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}.
      *
      * <p>Example: {@link net.dv8tion.jda.api.entities.Role#getPermissionsRaw() Role.getPermissionsRaw()}

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -225,4 +225,24 @@ public interface User extends IMentionable, IFakeable
      */
     @Nonnull
     JDA getJDA();
+    
+    public enum Flags{
+        NONE(0, "None"),
+        EMPLOYEE(1, "Discord Employee"),
+        PARTNER(2, "Discord Partner"),
+        HYPESQUAD(4, "HypeSquad Events"),
+        BUG_HUNTER_1(8, "Bug Hunter Level 1"),
+        BRAVERY(64, "HypeSquad House Bravery"),
+        BRILLIANCE(128, "HypeSquad House Brilliance"),
+        BALANCE(256, "HypeSquad House Balance"),
+        SYSTEM(4096, "System"),
+        BUG_HUNTER_2(16384, "Bug Hunter Level 2");
+        
+        private final int key;
+        private final String name;
+        
+        Flags(int key, String name){
+            this.key = key;
+            this.name = name;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -225,24 +225,63 @@ public interface User extends IMentionable, IFakeable
      */
     @Nonnull
     JDA getJDA();
-    
-    public enum Flags{
-        NONE(0, "None"),
-        EMPLOYEE(1, "Discord Employee"),
-        PARTNER(2, "Discord Partner"),
-        HYPESQUAD(4, "HypeSquad Events"),
-        BUG_HUNTER_1(8, "Bug Hunter Level 1"),
-        BRAVERY(64, "HypeSquad House Bravery"),
-        BRILLIANCE(128, "HypeSquad House Brilliance"),
-        BALANCE(256, "HypeSquad House Balance"),
-        SYSTEM(4096, "System"),
+
+    /**
+     * Represents the bit offsets used by Discord for public flags
+     */
+    enum Flags{
+        NONE(            0, "None"),
+        EMPLOYEE(        1, "Discord Employee"),
+        PARTNER(         2, "Discord Partner"),
+        HYPESQUAD(       4, "HypeSquad Events"),
+        BUG_HUNTER_1(    8, "Bug Hunter Level 1"),
+        BRAVERY(        64, "HypeSquad House Bravery"),
+        BRILLIANCE(    128, "HypeSquad House Brilliance"),
+        BALANCE(       256, "HypeSquad House Balance"),
+        SYSTEM(       4096, "System"),
         BUG_HUNTER_2(16384, "Bug Hunter Level 2");
         
-        private final int key;
+        private final int offset;
+        private final long raw;
         private final String name;
         
-        Flags(int key, String name){
-            this.key = key;
+        Flags(int offset, @Nonnull String name)
+        {
+            this.offset = offset;
+            this.raw = 1 << offset;
             this.name = name;
+        }
+
+        /**
+         * The readable name as used in the Discord Client.
+         * 
+         * @return The readable name of this {@link net.dv8tion.jda.api.entities.User.Flags Flag}.
+         */
+        @Nonnull
+        public String getName()
+        {
+            return this.name;
+        }
+
+        /**
+         * The binary offset of the flag.
+         * 
+         * @return The offset that represents this {@link net.dv8tion.jda.api.entities.User.Flags Flag}.
+         */
+        public int getOffset()
+        {
+            return offset;
+        }
+
+        /**
+         * The value of this flag when viewed as raw value.
+         * <br>This is equivalent to: <code>1 {@literal <<} {@link #getOffset()}</code>
+         * 
+         * @return The raw value of this specific flag.
+         */
+        public long getRawValue()
+        {
+            return raw;
+        }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -230,16 +230,23 @@ public interface User extends IMentionable, IFakeable
      * Represents the bit offsets used by Discord for public flags
      */
     enum Flags{
-        NONE(            0, "None"),
-        EMPLOYEE(        1, "Discord Employee"),
-        PARTNER(         2, "Discord Partner"),
-        HYPESQUAD(       4, "HypeSquad Events"),
-        BUG_HUNTER_1(    8, "Bug Hunter Level 1"),
-        BRAVERY(        64, "HypeSquad House Bravery"),
-        BRILLIANCE(    128, "HypeSquad House Brilliance"),
-        BALANCE(       256, "HypeSquad House Balance"),
-        SYSTEM(       4096, "System"),
-        BUG_HUNTER_2(16384, "Bug Hunter Level 2");
+        NONE(                      0, "None"),
+        STAFF(                     1, "Discord Employee"),
+        PARTNER(                   2, "Discord Partner"),
+        HYPESQUAD(                 4, "HypeSquad Events"),
+        BUG_HUNTER_LEVEL_1(        8, "Bug Hunter Level 1"),
+        // Bravery
+        HYPESQUAD_ONLINE_HOUSE_1( 64, "HypeSquad Online House Bravery"),
+        // Brilliance
+        HYPESQUAD_ONLINE_HOUSE_2(128, "HypeSquad Online House Brilliance"),
+        // Balance
+        HYPESQUAD_ONLINE_HOUSE_3(256, "HypeSquad Online House Balance"),
+        PREMIUM_EARLY_SUPPORTER( 512, "Early Supporter"),
+        TEAM_USER(              1024, "Team User"),
+        SYSTEM(                 4096, "System User"),
+        BUG_HUNTER_LEVEL_2(    16384, "Bug Hunter Level 2"),
+        VERIFIED_BOT(          65536, "Verified Bot"),
+        VERIFIED_DEVELOPER(   131072, "Verified Developer");
         
         private final int offset;
         private final long raw;

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -230,7 +230,7 @@ public interface User extends IMentionable, IFakeable
      * Represents the bit offsets used by Discord for public flags
      */
     enum Flags {
-        UNKOWN(                   -1, "Unknown"),
+        UNKNOWN(                   -1, "Unknown"),
         STAFF(                     0, "Discord Employee"),
         PARTNER(                   1, "Discord Partner"),
         HYPESQUAD(                 2, "HypeSquad Events"),

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -305,8 +306,39 @@ public interface User extends IMentionable, IFakeable
         {
             return raw;
         }
+
+        /**
+         * Gets the first {@link net.dv8tion.jda.api.entities.User.Flag Flag} relating to the provided offset.
+         * <br>If there is no {@link net.dv8tion.jda.api.entities.User.Flag Flag} that matches the provided offset,
+         * {@link net.dv8tion.jda.api.entities.User.Flag#UNKNOWN Flag.UNKNOWN} is returned.
+         * 
+         * @param  offset
+         *         The offset to match a {@link net.dv8tion.jda.api.entities.User.Flag Flag} to.
+         *         
+         * @return {@link net.dv8tion.jda.api.entities.User.Flag Flag} relating to the provided offset.
+         */
+        @Nonnull
+        public static Flag getFromOffset(int offset)
+        {
+            for (Flag flag : values())
+            {
+                if(flag.offset == offset)
+                    return flag;
+            }
+            return UNKNOWN;
+        }
         
-        public static EnumSet<Flag> getFlags(int flags)
+        /**
+         * A set of all {@link net.dv8tion.jda.api.entities.User.Flag Flags} that are specified by this raw long representation of
+         * flags.
+         * 
+         * @param  flags
+         *         The raw {@code long} representation if flags.
+         *         
+         * @return Possibly-empty EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+         */
+        @Nonnull
+        public static EnumSet<Flag> getFlags(long flags)
         {
             if(flags == 0)
                 return EnumSet.noneOf(Flag.class);
@@ -317,6 +349,45 @@ public interface User extends IMentionable, IFakeable
                     flagsSet.add(flag);
             }
             return flagsSet;
+        }
+
+        /**
+         * This is effectively the oposite of {@link #getFlags(long)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
+         * and returns the raw offset {@code long} representation of the flags.
+         * 
+         * @param  flags
+         *         The array of flags of which to form into the raw long representation.
+         *         
+         * @return Unsigned long representing the provided flags.
+         */
+        public static long getRaw(@Nonnull Flag... flags){
+            long raw = 0;
+            for (Flag flag : flags)
+            {
+                if (flag != null && flag != UNKNOWN)
+                    raw |= flag.raw;
+            }
+            
+            return raw;
+        }
+
+        /**
+         * This is effectively the oposite of {@link #getFlags(long)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
+         * and returns the raw offset {@code long} representation of the flags.
+         * <br>Example: {@code getRaw(EnumSet.of(Flag.STAFF, Flag.HYPESQUAD))}
+         *
+         * @param  flags
+         *         The Collection of flags of which to form into the raw long representation.
+         *
+         * @return Unsigned long representing the provided flags.
+         * 
+         * @see java.util.EnumSet EnumSet
+         */
+        public static long getRaw(@Nonnull Collection<Flag> flags)
+        {
+            Checks.notNull(flags, "Flag Collection");
+            
+            return getRaw(flags.toArray(EMPTY_FLAGS));
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -331,7 +331,7 @@ public interface User extends IMentionable, IFakeable
         }
         
         /**
-         * A set of all {@link net.dv8tion.jda.api.entities.User.UserFlag Flags} that are specified by this raw long representation of
+         * A set of all {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} that are specified by this raw long representation of
          * flags.
          * 
          * @param  flags

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -262,12 +262,12 @@ public interface User extends IMentionable, IFakeable
         UNKNOWN(                   -1, "Unknown");
 
         /**
-         * Empty array of Flag enum, useful for optimized use in {@link java.util.Collection#toArray(Object[])}.
+         * Empty array of UserFlag enum, useful for optimized use in {@link java.util.Collection#toArray(Object[])}.
          */
         public static final UserFlag[] EMPTY_FLAGS = new UserFlag[0];
         
         private final int offset;
-        private final long raw;
+        private final int raw;
         private final String name;
 
         UserFlag(int offset, @Nonnull String name)
@@ -304,7 +304,7 @@ public interface User extends IMentionable, IFakeable
          * 
          * @return The raw value of this specific flag.
          */
-        public long getRawValue()
+        public int getRawValue()
         {
             return raw;
         }
@@ -331,7 +331,7 @@ public interface User extends IMentionable, IFakeable
         }
         
         /**
-         * A set of all {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} that are specified by this raw long representation of
+         * A set of all {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} that are specified by this raw int representation of
          * flags.
          * 
          * @param  flags
@@ -356,7 +356,7 @@ public interface User extends IMentionable, IFakeable
 
         /**
          * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
-         * and returns the raw offset {@code long} representation of the flags.
+         * and returns the raw offset {@code int} representation of the flags.
          * 
          * @param  flags
          *         The array of flags of which to form into the raw long representation.
@@ -376,7 +376,7 @@ public interface User extends IMentionable, IFakeable
 
         /**
          * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
-         * and returns the raw offset {@code long} representation of the flags.
+         * and returns the raw offset {@code int} representation of the flags.
          * <br>Example: {@code getRaw(EnumSet.of(UserFlag.STAFF, UserFlag.HYPESQUAD))}
          *
          * @param  flags

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -342,15 +342,16 @@ public interface User extends IMentionable, IFakeable
         @Nonnull
         public static EnumSet<UserFlag> getFlags(int flags)
         {
-            if(flags == 0)
-                return EnumSet.noneOf(UserFlag.class);
-            EnumSet<UserFlag> userFlags = EnumSet.noneOf(UserFlag.class);
-            for (UserFlag flag : UserFlag.values())
-            {
+            final EnumSet<UserFlag> foundFlags = EnumSet.noneOf(UserFlag.class);
+            
+            if (flags == 0)
+                return foundFlags; //empty
+            
+            for (UserFlag flag : values())
                 if (flag != UNKNOWN && (flags & flag.raw) == flag.raw)
-                    userFlags.add(flag);
-            }
-            return userFlags;
+                    foundFlags.add(flag);
+                    
+            return foundFlags;
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -291,7 +291,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The binary offset of the flag.
          * 
-         * @return The offset that represents this {@link net.dv8tion.jda.api.entities.User.UserFlag Flag}.
+         * @return The offset that represents this {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}.
          */
         public int getOffset()
         {

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -238,9 +238,9 @@ public interface User extends IMentionable, IFakeable
     EnumSet<UserFlag> getFlags();
 
     /**
-     * Returns the raw {@code int} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of this user.
+     * Returns the bitmask representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of this user.
      * 
-     * @return Integer representing the raw value of the user's flags.
+     * @return bitmask representation of the user's flags.
      */
     int getFlagsRaw();
 

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -230,7 +230,7 @@ public interface User extends IMentionable, IFakeable
     JDA getJDA();
 
     /**
-     * Returns the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags} of this user.
+     * Returns the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of this user.
      * 
      * @return EnumSet containing the flags of the user.
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -280,7 +280,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The readable name as used in the Discord Client.
          * 
-         * @return The readable name of this {@link net.dv8tion.jda.api.entities.User.UserFlag Flag}.
+         * @return The readable name of this {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}.
          */
         @Nonnull
         public String getName()

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -238,6 +238,13 @@ public interface User extends IMentionable, IFakeable
     EnumSet<UserFlag> getFlags();
 
     /**
+     * Returns the raw {@code int} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of this user.
+     * 
+     * @return Integer representing the raw value of the user's flags.
+     */
+    int getFlagsRaw();
+
+    /**
      * Represents the bit offsets used by Discord for public flags
      */
     enum UserFlag
@@ -280,7 +287,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The readable name as used in the Discord Client.
          * 
-         * @return The readable name of this {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}.
+         * @return The readable name of this UserFlag.
          */
         @Nonnull
         public String getName()
@@ -291,7 +298,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The binary offset of the flag.
          * 
-         * @return The offset that represents this {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}.
+         * @return The offset that represents this UserFlag.
          */
         public int getOffset()
         {
@@ -310,14 +317,14 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * Gets the first {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} relating to the provided offset.
-         * <br>If there is no {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} that matches the provided offset,
+         * Gets the first UserFlag relating to the provided offset.
+         * <br>If there is no UserFlag that matches the provided offset,
          * {@link net.dv8tion.jda.api.entities.User.UserFlag#UNKNOWN UserFlag.UNKNOWN} is returned.
          * 
          * @param  offset
-         *         The offset to match a {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} to.
+         *         The offset to match a UserFlag to.
          *         
-         * @return {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} relating to the provided offset.
+         * @return UserFlag relating to the provided offset.
          */
         @Nonnull
         public static UserFlag getFromOffset(int offset)
@@ -331,13 +338,13 @@ public interface User extends IMentionable, IFakeable
         }
         
         /**
-         * A set of all {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} that are specified by this raw int representation of
+         * A set of all UserFlags that are specified by this raw int representation of
          * flags.
          * 
          * @param  flags
          *         The raw {@code int} representation if flags.
          *         
-         * @return Possibly-empty EnumSet of {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+         * @return Possibly-empty EnumSet of UserFlags.
          */
         @Nonnull
         public static EnumSet<UserFlag> getFlags(int flags)
@@ -357,15 +364,20 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
+         * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more UserFlags
          * and returns the raw offset {@code int} representation of the flags.
          * 
          * @param  flags
          *         The array of flags of which to form into the raw int representation.
          *         
-         * @return Unsigned int representing the provided flags.
+         * @return Unsigned bitmask representing the provided flags.
+         * 
+         * @throws java.lang.IllegalArgumentException
+         *         When the provided UsefLags are null.
          */
         public static int getRaw(@Nonnull UserFlag... flags){
+            Checks.noneNull(flags, "UserFlags");
+            
             int raw = 0;
             for (UserFlag flag : flags)
             {
@@ -384,7 +396,7 @@ public interface User extends IMentionable, IFakeable
          * @param  flags
          *         The Collection of flags of which to form into the raw int representation.
          *
-         * @return Unsigned int representing the provided flags.
+         * @return Unsigned bitmask representing the provided flags.
          * 
          * @see java.util.EnumSet EnumSet
          */

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -324,7 +324,7 @@ public interface User extends IMentionable, IFakeable
         {
             for (UserFlag flag : values())
             {
-                if(flag.offset == offset)
+                if (flag.offset == offset)
                     return flag;
             }
             return UNKNOWN;
@@ -348,8 +348,10 @@ public interface User extends IMentionable, IFakeable
                 return foundFlags; //empty
             
             for (UserFlag flag : values())
+            {
                 if (flag != UNKNOWN && (flags & flag.raw) == flag.raw)
                     foundFlags.add(flag);
+            }
                     
             return foundFlags;
         }

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -230,17 +230,17 @@ public interface User extends IMentionable, IFakeable
     JDA getJDA();
 
     /**
-     * Returns the {@link net.dv8tion.jda.api.entities.User.Flag Flags} of this user.
+     * Returns the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags} of this user.
      * 
      * @return EnumSet containing the flags of the user.
      */
     @Nonnull
-    EnumSet<Flag> getFlags();
+    EnumSet<UserFlag> getFlags();
 
     /**
      * Represents the bit offsets used by Discord for public flags
      */
-    enum Flag
+    enum UserFlag
     {
         STAFF(                     0, "Discord Employee"),
         PARTNER(                   1, "Discord Partner"),
@@ -262,15 +262,15 @@ public interface User extends IMentionable, IFakeable
         UNKNOWN(                   -1, "Unknown");
 
         /**
-         * Empty array of Flag enum, useful for optimized use in {@link Collection#toArray(Object[])}.
+         * Empty array of Flag enum, useful for optimized use in {@link java.util.Collection#toArray(Object[])}.
          */
-        public static final Flag[] EMPTY_FLAGS = new Flag[0];
+        public static final UserFlag[] EMPTY_FLAGS = new UserFlag[0];
         
         private final int offset;
         private final long raw;
         private final String name;
 
-        Flag(int offset, @Nonnull String name)
+        UserFlag(int offset, @Nonnull String name)
         {
             this.offset = offset;
             this.raw = 1 << offset;
@@ -280,7 +280,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The readable name as used in the Discord Client.
          * 
-         * @return The readable name of this {@link Flag Flag}.
+         * @return The readable name of this {@link net.dv8tion.jda.api.entities.User.UserFlag Flag}.
          */
         @Nonnull
         public String getName()
@@ -291,7 +291,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The binary offset of the flag.
          * 
-         * @return The offset that represents this {@link Flag Flag}.
+         * @return The offset that represents this {@link net.dv8tion.jda.api.entities.User.UserFlag Flag}.
          */
         public int getOffset()
         {
@@ -310,19 +310,19 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * Gets the first {@link net.dv8tion.jda.api.entities.User.Flag Flag} relating to the provided offset.
-         * <br>If there is no {@link net.dv8tion.jda.api.entities.User.Flag Flag} that matches the provided offset,
-         * {@link net.dv8tion.jda.api.entities.User.Flag#UNKNOWN Flag.UNKNOWN} is returned.
+         * Gets the first {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} relating to the provided offset.
+         * <br>If there is no {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} that matches the provided offset,
+         * {@link net.dv8tion.jda.api.entities.User.UserFlag#UNKNOWN Flag.UNKNOWN} is returned.
          * 
          * @param  offset
-         *         The offset to match a {@link net.dv8tion.jda.api.entities.User.Flag Flag} to.
+         *         The offset to match a {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} to.
          *         
-         * @return {@link net.dv8tion.jda.api.entities.User.Flag Flag} relating to the provided offset.
+         * @return {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} relating to the provided offset.
          */
         @Nonnull
-        public static Flag getFromOffset(int offset)
+        public static UserFlag getFromOffset(int offset)
         {
-            for (Flag flag : values())
+            for (UserFlag flag : values())
             {
                 if(flag.offset == offset)
                     return flag;
@@ -331,30 +331,30 @@ public interface User extends IMentionable, IFakeable
         }
         
         /**
-         * A set of all {@link net.dv8tion.jda.api.entities.User.Flag Flags} that are specified by this raw long representation of
+         * A set of all {@link net.dv8tion.jda.api.entities.User.UserFlag Flags} that are specified by this raw long representation of
          * flags.
          * 
          * @param  flags
          *         The raw {@code long} representation if flags.
          *         
-         * @return Possibly-empty EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+         * @return Possibly-empty EnumSet of {@link UserFlag Flags}.
          */
         @Nonnull
-        public static EnumSet<Flag> getFlags(int flags)
+        public static EnumSet<UserFlag> getFlags(int flags)
         {
             if(flags == 0)
-                return EnumSet.noneOf(Flag.class);
-            EnumSet<Flag> flagsSet = EnumSet.noneOf(Flag.class);
-            for (Flag flag : Flag.values())
+                return EnumSet.noneOf(UserFlag.class);
+            EnumSet<UserFlag> userFlags = EnumSet.noneOf(UserFlag.class);
+            for (UserFlag flag : UserFlag.values())
             {
                 if (flag != UNKNOWN && (flags & flag.raw) == flag.raw)
-                    flagsSet.add(flag);
+                    userFlags.add(flag);
             }
-            return flagsSet;
+            return userFlags;
         }
 
         /**
-         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
+         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}
          * and returns the raw offset {@code long} representation of the flags.
          * 
          * @param  flags
@@ -362,9 +362,9 @@ public interface User extends IMentionable, IFakeable
          *         
          * @return Unsigned long representing the provided flags.
          */
-        public static int getRaw(@Nonnull Flag... flags){
+        public static int getRaw(@Nonnull UserFlag... flags){
             int raw = 0;
-            for (Flag flag : flags)
+            for (UserFlag flag : flags)
             {
                 if (flag != null && flag != UNKNOWN)
                     raw |= flag.raw;
@@ -374,7 +374,7 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
+         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}
          * and returns the raw offset {@code long} representation of the flags.
          * <br>Example: {@code getRaw(EnumSet.of(Flag.STAFF, Flag.HYPESQUAD))}
          *
@@ -385,7 +385,7 @@ public interface User extends IMentionable, IFakeable
          * 
          * @see java.util.EnumSet EnumSet
          */
-        public static int getRaw(@Nonnull Collection<Flag> flags)
+        public static int getRaw(@Nonnull Collection<UserFlag> flags)
         {
             Checks.notNull(flags, "Flag Collection");
             

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -365,13 +365,13 @@ public interface User extends IMentionable, IFakeable
 
         /**
          * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more UserFlags
-         * and returns the raw offset {@code int} representation of the flags.
+         * and returns the bitmask representation of the flags.
          * 
          * @param  flags
          *         The array of flags of which to form into the raw int representation.
          *
          * @throws java.lang.IllegalArgumentException
-         *         When the provided UserFLags are null.
+         *         When the provided UserFlags are null.
          *         
          * @return bitmask representing the provided flags.
          */
@@ -390,11 +390,11 @@ public interface User extends IMentionable, IFakeable
 
         /**
          * This is effectively the opposite of {@link #getFlags(int)}. This takes a collection of UserFlags
-         * and returns the raw offset {@code int} representation of the flags.
+         * and returns the bitmask representation of the flags.
          * <br>Example: {@code getRaw(EnumSet.of(UserFlag.STAFF, UserFlag.HYPESQUAD))}
          *
          * @param  flags
-         *         The Collection of flags of which to form into the raw int representation.
+         *         The flags to convert
          *
          * @throws java.lang.IllegalArgumentException
          *         When the provided UserFLags are null.

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -377,7 +377,7 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
+         * This is effectively the opposite of {@link #getFlags(int)}. This takes a collection of UserFlags
          * and returns the raw offset {@code int} representation of the flags.
          * <br>Example: {@code getRaw(EnumSet.of(UserFlag.STAFF, UserFlag.HYPESQUAD))}
          *

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -319,7 +319,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * Gets the first UserFlag relating to the provided offset.
          * <br>If there is no UserFlag that matches the provided offset,
-         * {@link net.dv8tion.jda.api.entities.User.UserFlag#UNKNOWN UserFlag.UNKNOWN} is returned.
+         * {@link #UNKNOWN} is returned.
          * 
          * @param  offset
          *         The offset to match a UserFlag to.

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -370,7 +370,7 @@ public interface User extends IMentionable, IFakeable
          * @param  flags
          *         The array of flags of which to form into the raw int representation.
          *         
-         * @return Unsigned bitmask representing the provided flags.
+         * @return bitmask representing the provided flags.
          * 
          * @throws java.lang.IllegalArgumentException
          *         When the provided UsefLags are null.
@@ -396,7 +396,7 @@ public interface User extends IMentionable, IFakeable
          * @param  flags
          *         The Collection of flags of which to form into the raw int representation.
          *
-         * @return Unsigned bitmask representing the provided flags.
+         * @return bitmask representing the provided flags.
          * 
          * @see java.util.EnumSet EnumSet
          */

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -355,7 +355,7 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}
+         * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
          * and returns the raw offset {@code long} representation of the flags.
          * 
          * @param  flags
@@ -375,9 +375,9 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}
+         * This is effectively the opposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
          * and returns the raw offset {@code long} representation of the flags.
-         * <br>Example: {@code getRaw(EnumSet.of(Flag.STAFF, Flag.HYPESQUAD))}
+         * <br>Example: {@code getRaw(EnumSet.of(UserFlag.STAFF, UserFlag.HYPESQUAD))}
          *
          * @param  flags
          *         The Collection of flags of which to form into the raw long representation.

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -22,6 +22,8 @@ import net.dv8tion.jda.api.requests.RestAction;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -227,9 +229,17 @@ public interface User extends IMentionable, IFakeable
     JDA getJDA();
 
     /**
+     * Returns the {@link net.dv8tion.jda.api.entities.User.Flag Flags} of this user.
+     * 
+     * @return EnumSet containing the flags of the user.
+     */
+    EnumSet<Flag> getFlags();
+
+    /**
      * Represents the bit offsets used by Discord for public flags
      */
-    enum Flags {
+    enum Flag
+    {
         UNKNOWN(                   -1, "Unknown"),
         STAFF(                     0, "Discord Employee"),
         PARTNER(                   1, "Discord Partner"),
@@ -248,11 +258,16 @@ public interface User extends IMentionable, IFakeable
         VERIFIED_BOT(             16, "Verified Bot"),
         VERIFIED_DEVELOPER(       17, "Verified Bot Developer");
 
+        /**
+         * Empty array of Flag enum, useful for optimized use in {@link Collection#toArray(Object[])}.
+         */
+        public static final Flag[] EMPTY_FLAGS = new Flag[0];
+        
         private final int offset;
         private final long raw;
         private final String name;
 
-        Flags(int offset, @Nonnull String name)
+        Flag(int offset, @Nonnull String name)
         {
             this.offset = offset;
             this.raw = 1 << offset;
@@ -262,7 +277,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The readable name as used in the Discord Client.
          * 
-         * @return The readable name of this {@link net.dv8tion.jda.api.entities.User.Flags Flag}.
+         * @return The readable name of this {@link Flag Flag}.
          */
         @Nonnull
         public String getName()
@@ -273,7 +288,7 @@ public interface User extends IMentionable, IFakeable
         /**
          * The binary offset of the flag.
          * 
-         * @return The offset that represents this {@link net.dv8tion.jda.api.entities.User.Flags Flag}.
+         * @return The offset that represents this {@link Flag Flag}.
          */
         public int getOffset()
         {
@@ -289,6 +304,19 @@ public interface User extends IMentionable, IFakeable
         public long getRawValue()
         {
             return raw;
+        }
+        
+        public static EnumSet<Flag> getFlags(int flags)
+        {
+            if(flags == 0)
+                return EnumSet.noneOf(Flag.class);
+            EnumSet<Flag> flagsSet = EnumSet.noneOf(Flag.class);
+            for (Flag flag : Flag.values())
+            {
+                if (flag != UNKNOWN && (flags & flag.raw) == flag.raw)
+                    flagsSet.add(flag);
+            }
+            return flagsSet;
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -249,24 +249,24 @@ public interface User extends IMentionable, IFakeable
      */
     enum UserFlag
     {
-        STAFF(                     0, "Discord Employee"),
-        PARTNER(                   1, "Discord Partner"),
-        HYPESQUAD(                 2, "HypeSquad Events"),
-        BUG_HUNTER_LEVEL_1(        3, "Bug Hunter Level 1"),
+        STAFF(             0, "Discord Employee"),
+        PARTNER(           1, "Discord Partner"),
+        HYPESQUAD(         2, "HypeSquad Events"),
+        BUG_HUNTER_LEVEL_1(3, "Bug Hunter Level 1"),
 
         // HypeSquad
-        HYPESQUAD_BRAVERY(         6, "HypeSquad Bravery"),
-        HYPESQUAD_BRILLIANCE(      7, "HypeSquad Brilliance"),
-        HYPESQUAD_BALANCE(         8, "HypeSquad Balance"),
+        HYPESQUAD_BRAVERY(   6, "HypeSquad Bravery"),
+        HYPESQUAD_BRILLIANCE(7, "HypeSquad Brilliance"),
+        HYPESQUAD_BALANCE(   8, "HypeSquad Balance"),
 
-        EARLY_SUPPORTER(           9, "Early Supporter"),
-        TEAM_USER(                10, "Team User"),
-        SYSTEM(                   12, "System User"),
-        BUG_HUNTER_LEVEL_2(       14, "Bug Hunter Level 2"),
-        VERIFIED_BOT(             16, "Verified Bot"),
-        VERIFIED_DEVELOPER(       17, "Verified Bot Developer"),
+        EARLY_SUPPORTER(    9, "Early Supporter"),
+        TEAM_USER(         10, "Team User"),
+        SYSTEM(            12, "System User"),
+        BUG_HUNTER_LEVEL_2(14, "Bug Hunter Level 2"),
+        VERIFIED_BOT(      16, "Verified Bot"),
+        VERIFIED_DEVELOPER(17, "Verified Bot Developer"),
         
-        UNKNOWN(                   -1, "Unknown");
+        UNKNOWN(-1, "Unknown");
 
         /**
          * Empty array of UserFlag enum, useful for optimized use in {@link java.util.Collection#toArray(Object[])}.

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -310,14 +310,14 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * Gets the first {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} relating to the provided offset.
-         * <br>If there is no {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} that matches the provided offset,
-         * {@link net.dv8tion.jda.api.entities.User.UserFlag#UNKNOWN Flag.UNKNOWN} is returned.
+         * Gets the first {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} relating to the provided offset.
+         * <br>If there is no {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} that matches the provided offset,
+         * {@link net.dv8tion.jda.api.entities.User.UserFlag#UNKNOWN UserFlag.UNKNOWN} is returned.
          * 
          * @param  offset
-         *         The offset to match a {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} to.
+         *         The offset to match a {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} to.
          *         
-         * @return {@link net.dv8tion.jda.api.entities.User.UserFlag Flag} relating to the provided offset.
+         * @return {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag} relating to the provided offset.
          */
         @Nonnull
         public static UserFlag getFromOffset(int offset)
@@ -335,9 +335,9 @@ public interface User extends IMentionable, IFakeable
          * flags.
          * 
          * @param  flags
-         *         The raw {@code long} representation if flags.
+         *         The raw {@code int} representation if flags.
          *         
-         * @return Possibly-empty EnumSet of {@link UserFlag Flags}.
+         * @return Possibly-empty EnumSet of {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
          */
         @Nonnull
         public static EnumSet<UserFlag> getFlags(int flags)
@@ -359,9 +359,9 @@ public interface User extends IMentionable, IFakeable
          * and returns the raw offset {@code int} representation of the flags.
          * 
          * @param  flags
-         *         The array of flags of which to form into the raw long representation.
+         *         The array of flags of which to form into the raw int representation.
          *         
-         * @return Unsigned long representing the provided flags.
+         * @return Unsigned int representing the provided flags.
          */
         public static int getRaw(@Nonnull UserFlag... flags){
             int raw = 0;
@@ -380,9 +380,9 @@ public interface User extends IMentionable, IFakeable
          * <br>Example: {@code getRaw(EnumSet.of(UserFlag.STAFF, UserFlag.HYPESQUAD))}
          *
          * @param  flags
-         *         The Collection of flags of which to form into the raw long representation.
+         *         The Collection of flags of which to form into the raw int representation.
          *
-         * @return Unsigned long representing the provided flags.
+         * @return Unsigned int representing the provided flags.
          * 
          * @see java.util.EnumSet EnumSet
          */

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -369,11 +369,11 @@ public interface User extends IMentionable, IFakeable
          * 
          * @param  flags
          *         The array of flags of which to form into the raw int representation.
+         *
+         * @throws java.lang.IllegalArgumentException
+         *         When the provided UserFLags are null.
          *         
          * @return bitmask representing the provided flags.
-         * 
-         * @throws java.lang.IllegalArgumentException
-         *         When the provided UsefLags are null.
          */
         public static int getRaw(@Nonnull UserFlag... flags){
             Checks.noneNull(flags, "UserFlags");
@@ -395,6 +395,9 @@ public interface User extends IMentionable, IFakeable
          *
          * @param  flags
          *         The Collection of flags of which to form into the raw int representation.
+         *
+         * @throws java.lang.IllegalArgumentException
+         *         When the provided UserFLags are null.
          *
          * @return bitmask representing the provided flags.
          * 

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -234,6 +234,7 @@ public interface User extends IMentionable, IFakeable
      * 
      * @return EnumSet containing the flags of the user.
      */
+    @Nonnull
     EnumSet<Flag> getFlags();
 
     /**
@@ -241,7 +242,6 @@ public interface User extends IMentionable, IFakeable
      */
     enum Flag
     {
-        UNKNOWN(                   -1, "Unknown"),
         STAFF(                     0, "Discord Employee"),
         PARTNER(                   1, "Discord Partner"),
         HYPESQUAD(                 2, "HypeSquad Events"),
@@ -257,7 +257,9 @@ public interface User extends IMentionable, IFakeable
         SYSTEM(                   12, "System User"),
         BUG_HUNTER_LEVEL_2(       14, "Bug Hunter Level 2"),
         VERIFIED_BOT(             16, "Verified Bot"),
-        VERIFIED_DEVELOPER(       17, "Verified Bot Developer");
+        VERIFIED_DEVELOPER(       17, "Verified Bot Developer"),
+        
+        UNKNOWN(                   -1, "Unknown");
 
         /**
          * Empty array of Flag enum, useful for optimized use in {@link Collection#toArray(Object[])}.
@@ -338,7 +340,7 @@ public interface User extends IMentionable, IFakeable
          * @return Possibly-empty EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
          */
         @Nonnull
-        public static EnumSet<Flag> getFlags(long flags)
+        public static EnumSet<Flag> getFlags(int flags)
         {
             if(flags == 0)
                 return EnumSet.noneOf(Flag.class);
@@ -352,7 +354,7 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the oposite of {@link #getFlags(long)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
+         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
          * and returns the raw offset {@code long} representation of the flags.
          * 
          * @param  flags
@@ -372,7 +374,7 @@ public interface User extends IMentionable, IFakeable
         }
 
         /**
-         * This is effectively the oposite of {@link #getFlags(long)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
+         * This is effectively the oposite of {@link #getFlags(int)}, this takes 1 or more {@link net.dv8tion.jda.api.entities.User.Flag Flags}
          * and returns the raw offset {@code long} representation of the flags.
          * <br>Example: {@code getRaw(EnumSet.of(Flag.STAFF, Flag.HYPESQUAD))}
          *

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -362,8 +362,8 @@ public interface User extends IMentionable, IFakeable
          *         
          * @return Unsigned long representing the provided flags.
          */
-        public static long getRaw(@Nonnull Flag... flags){
-            long raw = 0;
+        public static int getRaw(@Nonnull Flag... flags){
+            int raw = 0;
             for (Flag flag : flags)
             {
                 if (flag != null && flag != UNKNOWN)
@@ -385,7 +385,7 @@ public interface User extends IMentionable, IFakeable
          * 
          * @see java.util.EnumSet EnumSet
          */
-        public static long getRaw(@Nonnull Collection<Flag> flags)
+        public static int getRaw(@Nonnull Collection<Flag> flags)
         {
             Checks.notNull(flags, "Flag Collection");
             

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.dv8tion.jda.api.events.user.update;
 
 import net.dv8tion.jda.api.JDA;
@@ -25,45 +40,45 @@ import java.util.EnumSet;
  * member was updated and gives us the updated member object. In order to fire a specific event like this we
  * need to have the old member cached to compare against.
  */
-public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
+public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.UserFlag>>
 {
     public static final String IDENTIFIER = "public_flags";
     
-    public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, int oldFlags)
+    public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, EnumSet<User.UserFlag> oldFlags)
     {
-        super(api, responseNumber, user, oldFlags, User.UserFlag.getRaw(user.getFlags()), IDENTIFIER);
+        super(api, responseNumber, user, oldFlags, user.getFlags(), IDENTIFIER);
     }
 
     /**
-     * @return The old {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * @return The old {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
      */
     @Nullable
-    public Integer getOldFlags()
+    public EnumSet<User.UserFlag> getOldFlags()
     {
         return getOldValue();
     }
 
     /**
-     * @return Possibly-null EnumSet of previous {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
-    public EnumSet<User.UserFlag> getOldFlagSet(){
-        return previous == null ? null : User.UserFlag.getFlags(previous);
+    public Integer getOldFlagsRaw(){
+        return User.UserFlag.getRaw(previous);
     }
 
     /**
-     * @return The new {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * @return The new {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
      */
     @Nullable
-    public Integer getNewFlags(){
+    public EnumSet<User.UserFlag> getNewFlags(){
         return getNewValue();
     }
 
     /**
-     * @return Possibly-null EnumSet of the new {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
-    public EnumSet<User.UserFlag> getNewFlagSet(){
-        return next == null ? null : User.UserFlag.getFlags(next);
+    public Integer getNewFlagsRaw(){
+        return User.UserFlag.getRaw(next);
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -84,7 +84,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     /**
      * Gets the new {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of the user and returns it as bitmask representation.
      *
-     * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * @return The old bitmask representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     public int getNewFlagsRaw()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -1,0 +1,77 @@
+package net.dv8tion.jda.api.events.user.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.User;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.EnumSet;
+
+/**
+ * Indicates that the {@link net.dv8tion.jda.api.entities.User.Flag Flags} of a {@link net.dv8tion.jda.api.entities.User User} changed.
+ * 
+ * <p>Can be used to retrieve the User who got their flags changed and their previous flags.
+ * 
+ * <p>Identifier: {@code public_flags}
+ *
+ * <h2>Requirements</h2>
+ *
+ * <p>This event requires the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent to be enabled.
+ * <br>{@link net.dv8tion.jda.api.JDABuilder#createDefault(String) createDefault(String)} and
+ * {@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disable this by default!
+ *
+ * <p>Additionally, this event also requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+ * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
+ * member was updated and gives us the updated member object. In order to fire a specific event like this we
+ * need to have the old member cached to compare against.
+ */
+public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
+{
+    public static final String IDENTIFIER = "public_flags";
+    
+    public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, int oldFlags)
+    {
+        super(api, responseNumber, user, oldFlags, User.Flag.getRaw(user.getFlags()), IDENTIFIER);
+    }
+
+    /**
+     * The previous raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * 
+     * @return The previous {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     */
+    @Nullable
+    public Integer getOldFlags()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The previous Set of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * 
+     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     */
+    @Nullable
+    public EnumSet<User.Flag> getOlfFlagSet(){
+        return previous == null ? null : User.Flag.getFlags(previous);
+    }
+
+    /**
+     * The new raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * 
+     * @return The new {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     */
+    @Nullable
+    public Integer getNewFlags(){
+        return getNewValue();
+    }
+
+    /**
+     * The new Set of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     *
+     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     */
+    @Nullable
+    public EnumSet<User.Flag> getNewFlagSet(){
+        return next == null ? null : User.Flag.getFlags(next);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 /**
- * Indicates that the {@link net.dv8tion.jda.api.entities.User.Flag Flags} of a {@link net.dv8tion.jda.api.entities.User User} changed.
+ * Indicates that the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags} of a {@link net.dv8tion.jda.api.entities.User User} changed.
  * 
  * <p>Can be used to retrieve the User who got their flags changed and their previous flags.
  * 
@@ -31,13 +31,13 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     
     public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, int oldFlags)
     {
-        super(api, responseNumber, user, oldFlags, User.Flag.getRaw(user.getFlags()), IDENTIFIER);
+        super(api, responseNumber, user, oldFlags, User.UserFlag.getRaw(user.getFlags()), IDENTIFIER);
     }
 
     /**
-     * The previous raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * The previous raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      * 
-     * @return The previous {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * @return The previous {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      */
     @Nullable
     public Integer getOldFlags()
@@ -46,19 +46,19 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     }
 
     /**
-     * The previous Set of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * The previous Set of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      * 
-     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      */
     @Nullable
-    public EnumSet<User.Flag> getOlfFlagSet(){
-        return previous == null ? null : User.Flag.getFlags(previous);
+    public EnumSet<User.UserFlag> getOlfFlagSet(){
+        return previous == null ? null : User.UserFlag.getFlags(previous);
     }
 
     /**
-     * The new raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * The new raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      * 
-     * @return The new {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * @return The new {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      */
     @Nullable
     public Integer getNewFlags(){
@@ -66,12 +66,12 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     }
 
     /**
-     * The new Set of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * The new Set of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      *
-     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.Flag Flags}.
+     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
      */
     @Nullable
-    public EnumSet<User.Flag> getNewFlagSet(){
-        return next == null ? null : User.Flag.getFlags(next);
+    public EnumSet<User.UserFlag> getNewFlagSet(){
+        return next == null ? null : User.UserFlag.getFlags(next);
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -35,9 +35,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     }
 
     /**
-     * The previous raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
-     * 
-     * @return The previous {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
+     * @return The old {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
     public Integer getOldFlags()
@@ -46,9 +44,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     }
 
     /**
-     * The previous Set of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
-     * 
-     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
+     * @return Possibly-null EnumSet of previous {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
     public EnumSet<User.UserFlag> getOlfFlagSet(){
@@ -56,9 +52,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     }
 
     /**
-     * The new raw {@code Integer} representation of the set {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
-     * 
-     * @return The new {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
+     * @return The new {@code Integer} representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
     public Integer getNewFlags(){
@@ -66,9 +60,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
     }
 
     /**
-     * The new Set of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
-     *
-     * @return The previous EnumSet of {@link net.dv8tion.jda.api.entities.User.UserFlag Flags}.
+     * @return Possibly-null EnumSet of the new {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
     public EnumSet<User.UserFlag> getNewFlagSet(){

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 /**
- * Indicates that the {@link net.dv8tion.jda.api.entities.User.UserFlag Flags} of a {@link net.dv8tion.jda.api.entities.User User} changed.
+ * Indicates that the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of a {@link net.dv8tion.jda.api.entities.User User} changed.
  * 
  * <p>Can be used to retrieve the User who got their flags changed and their previous flags.
  * 

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -84,7 +84,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     /**
      * Gets the new {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of the user and returns it as bitmask representation.
      *
-     * @return The old bitmask representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * @return The new bitmask representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     public int getNewFlagsRaw()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -50,6 +50,8 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     }
 
     /**
+     * Gets the old {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of the User as {@link EnumSet}.
+     * 
      * @return {@link EnumSet} of the old {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
      */
     @Nonnull
@@ -59,7 +61,9 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     }
 
     /**
-     * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
+     * Gets the old {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of the user and returns it as bitmask representation.
+     * 
+     * @return The old bitmask representation of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     public int getOldFlagsRaw()
     {
@@ -67,6 +71,8 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     }
 
     /**
+     * Gets the new {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of the User as {@link EnumSet}.
+     *
      * @return The new {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
      */
     @Nonnull
@@ -76,6 +82,8 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     }
 
     /**
+     * Gets the new {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags} of the user and returns it as bitmask representation.
+     *
      * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     public int getNewFlagsRaw()

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -52,7 +52,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     /**
      * @return The old {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
      */
-    @Nullable
+    @Nonnull
     public EnumSet<User.UserFlag> getOldFlags()
     {
         return getOldValue();
@@ -61,22 +61,25 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     /**
      * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
-    public int getOldFlagsRaw(){
+    public int getOldFlagsRaw()
+    {
         return User.UserFlag.getRaw(previous);
     }
 
     /**
      * @return The new {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
      */
-    @Nullable
-    public EnumSet<User.UserFlag> getNewFlags(){
+    @Nonnull
+    public EnumSet<User.UserFlag> getNewFlags()
+    {
         return getNewValue();
     }
 
     /**
      * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
-    public int getNewFlagsRaw(){
+    public int getNewFlagsRaw()
+    {
         return User.UserFlag.getRaw(next);
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -61,8 +61,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     /**
      * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
-    @Nullable
-    public Integer getOldFlagsRaw(){
+    public int getOldFlagsRaw(){
         return User.UserFlag.getRaw(previous);
     }
 
@@ -77,8 +76,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     /**
      * @return The old raw {@code Integer} value of the {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
-    @Nullable
-    public Integer getNewFlagsRaw(){
+    public int getNewFlagsRaw(){
         return User.UserFlag.getRaw(next);
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -44,7 +44,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
 {
     public static final String IDENTIFIER = "public_flags";
     
-    public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, EnumSet<User.UserFlag> oldFlags)
+    public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, @Nonnull EnumSet<User.UserFlag> oldFlags)
     {
         super(api, responseNumber, user, oldFlags, user.getFlags(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -47,7 +47,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<Integer>
      * @return Possibly-null EnumSet of previous {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}.
      */
     @Nullable
-    public EnumSet<User.UserFlag> getOlfFlagSet(){
+    public EnumSet<User.UserFlag> getOldFlagSet(){
         return previous == null ? null : User.UserFlag.getFlags(previous);
     }
 

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -50,7 +50,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
     }
 
     /**
-     * @return The old {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
+     * @return {@link EnumSet} of the old {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
      */
     @Nonnull
     public EnumSet<User.UserFlag> getOldFlags()

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -171,7 +171,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onUserTyping(@Nonnull UserTypingEvent event) {}
     public void onUserActivityStart(@Nonnull UserActivityStartEvent event) {}
     public void onUserActivityEnd(@Nonnull UserActivityEndEvent event) {}
-    public void onUserUpdateFlagsEvent(@Nonnull UserUpdateFlagsEvent event) {}
+    public void onUserUpdateFlags(@Nonnull UserUpdateFlagsEvent event) {}
 
     //Self Events. Fires only in relation to the currently logged in account.
     public void onSelfUpdateAvatar(@Nonnull SelfUpdateAvatarEvent event) {}
@@ -461,7 +461,7 @@ public abstract class ListenerAdapter implements EventListener
         else if (event instanceof UserActivityEndEvent)
             onUserActivityEnd((UserActivityEndEvent) event);
         else if (event instanceof UserUpdateFlagsEvent)
-            onUserUpdateFlagsEvent((UserUpdateFlagsEvent) event);
+            onUserUpdateFlags((UserUpdateFlagsEvent) event);
 
         //Self Events
         else if (event instanceof SelfUpdateAvatarEvent)

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -171,6 +171,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onUserTyping(@Nonnull UserTypingEvent event) {}
     public void onUserActivityStart(@Nonnull UserActivityStartEvent event) {}
     public void onUserActivityEnd(@Nonnull UserActivityEndEvent event) {}
+    public void onUserUpdateFlagsEvent(@Nonnull UserUpdateFlagsEvent event) {}
 
     //Self Events. Fires only in relation to the currently logged in account.
     public void onSelfUpdateAvatar(@Nonnull SelfUpdateAvatarEvent event) {}
@@ -459,6 +460,8 @@ public abstract class ListenerAdapter implements EventListener
             onUserActivityStart((UserActivityStartEvent) event);
         else if (event instanceof UserActivityEndEvent)
             onUserActivityEnd((UserActivityEndEvent) event);
+        else if (event instanceof UserUpdateFlagsEvent)
+            onUserUpdateFlagsEvent((UserUpdateFlagsEvent) event);
 
         //Self Events
         else if (event instanceof SelfUpdateAvatarEvent)

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -168,10 +168,10 @@ public abstract class ListenerAdapter implements EventListener
     public void onUserUpdateAvatar(@Nonnull UserUpdateAvatarEvent event) {}
     public void onUserUpdateOnlineStatus(@Nonnull UserUpdateOnlineStatusEvent event) {}
     public void onUserUpdateActivityOrder(@Nonnull UserUpdateActivityOrderEvent event) {}
+    public void onUserUpdateFlags(@Nonnull UserUpdateFlagsEvent event) {}
     public void onUserTyping(@Nonnull UserTypingEvent event) {}
     public void onUserActivityStart(@Nonnull UserActivityStartEvent event) {}
     public void onUserActivityEnd(@Nonnull UserActivityEndEvent event) {}
-    public void onUserUpdateFlags(@Nonnull UserUpdateFlagsEvent event) {}
 
     //Self Events. Fires only in relation to the currently logged in account.
     public void onSelfUpdateAvatar(@Nonnull SelfUpdateAvatarEvent event) {}

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -372,7 +372,7 @@ public class EntityBuilder
                     userObj, oldAvatar));
         }
         
-        if (!Objects.equals(oldFlags, newFlags))
+        if (oldFlags != newFlags)
         {
             userObj.setFlags(newFlags);
             jda.handleEvent(

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -319,7 +319,8 @@ public class EntityBuilder
             userObj.setName(user.getString("username"))
                    .setDiscriminator(user.get("discriminator").toString())
                    .setAvatarId(user.getString("avatar", null))
-                   .setBot(user.getBoolean("bot"));
+                   .setBot(user.getBoolean("bot"))
+                   .setFlags(user.getInt("public_flags", 0));
         }
         else if (!userObj.isFake())
         {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -378,7 +378,7 @@ public class EntityBuilder
             jda.handleEvent(
                     new UserUpdateFlagsEvent(
                         jda, responseNumber,
-                        userObj, oldFlags));
+                        userObj, User.UserFlag.getFlags(oldFlags)));
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -34,6 +34,7 @@ import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateBoostTime
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateAvatarEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateDiscriminatorEvent;
+import net.dv8tion.jda.api.events.user.update.UserUpdateFlagsEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateNameEvent;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.data.DataArray;
@@ -339,6 +340,8 @@ public class EntityBuilder
         String newDiscriminator = user.get("discriminator").toString();
         String oldAvatar = userObj.getAvatarId();
         String newAvatar = user.getString("avatar", null);
+        int oldFlags = userObj.getFlagsRaw();
+        int newFlags = user.getInt("public_flags", 0);
 
         JDAImpl jda = getJDA();
         long responseNumber = jda.getResponseTotal();
@@ -367,6 +370,15 @@ public class EntityBuilder
                 new UserUpdateAvatarEvent(
                     jda, responseNumber,
                     userObj, oldAvatar));
+        }
+        
+        if (!Objects.equals(oldFlags, newFlags))
+        {
+            userObj.setFlags(newFlags);
+            jda.handleEvent(
+                    new UserUpdateFlagsEvent(
+                        jda, responseNumber,
+                        userObj, oldFlags));
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -44,7 +44,7 @@ public class UserImpl implements User
     protected long privateChannel = 0L;
     protected boolean bot;
     protected boolean fake = false;
-    protected EnumSet<Flag> flagsSet;
+    protected EnumSet<UserFlag> flagsSet;
     protected int flagsRaw;
 
     public UserImpl(long id, JDAImpl api)
@@ -160,7 +160,7 @@ public class UserImpl implements User
 
     @Nonnull
     @Override
-    public EnumSet<Flag> getFlags()
+    public EnumSet<UserFlag> getFlags()
     {
         return flagsSet;
     }
@@ -235,7 +235,7 @@ public class UserImpl implements User
     public UserImpl setFlags(int flags)
     {
         this.flagsRaw = flags;
-        this.flagsSet = Flag.getFlags(flags);
+        this.flagsSet = UserFlag.getFlags(flags);
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -232,7 +232,8 @@ public class UserImpl implements User
         return this;
     }
     
-    public UserImpl setFlags(int flags){
+    public UserImpl setFlags(int flags)
+    {
         this.flags = flags;
         this.flagsSet = Flag.getFlags(flags);
         return this;

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 
 import javax.annotation.Nonnull;
+import java.util.EnumSet;
 import java.util.FormattableFlags;
 import java.util.Formatter;
 import java.util.List;
@@ -43,6 +44,8 @@ public class UserImpl implements User
     protected long privateChannel = 0L;
     protected boolean bot;
     protected boolean fake = false;
+    protected EnumSet<Flag> flagsEnum;
+    protected int flags;
 
     public UserImpl(long id, JDAImpl api)
     {
@@ -156,6 +159,17 @@ public class UserImpl implements User
     }
 
     @Override
+    public EnumSet<Flag> getFlags()
+    {
+        return flagsEnum;
+    }
+    
+    public int getFlagsValue()
+    {
+        return flags;
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (o == this)
@@ -214,6 +228,11 @@ public class UserImpl implements User
     public UserImpl setFake(boolean fake)
     {
         this.fake = fake;
+        return this;
+    }
+    
+    public UserImpl setFlags(int flags){
+        this.flags = flags;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -45,7 +45,7 @@ public class UserImpl implements User
     protected boolean bot;
     protected boolean fake = false;
     protected EnumSet<Flag> flagsSet;
-    protected int flags;
+    protected int flagsRaw;
 
     public UserImpl(long id, JDAImpl api)
     {
@@ -165,9 +165,9 @@ public class UserImpl implements User
         return flagsSet;
     }
     
-    public int getFlagsOffset()
+    public int getFlagsRaw()
     {
-        return flags;
+        return flagsRaw;
     }
 
     @Override
@@ -234,7 +234,7 @@ public class UserImpl implements User
     
     public UserImpl setFlags(int flags)
     {
-        this.flags = flags;
+        this.flagsRaw = flags;
         this.flagsSet = Flag.getFlags(flags);
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -44,7 +44,7 @@ public class UserImpl implements User
     protected long privateChannel = 0L;
     protected boolean bot;
     protected boolean fake = false;
-    protected EnumSet<Flag> flagsEnum;
+    protected EnumSet<Flag> flagsSet;
     protected int flags;
 
     public UserImpl(long id, JDAImpl api)
@@ -158,13 +158,14 @@ public class UserImpl implements User
         return fake;
     }
 
+    @Nonnull
     @Override
     public EnumSet<Flag> getFlags()
     {
-        return flagsEnum;
+        return flagsSet;
     }
     
-    public int getFlagsValue()
+    public int getFlagsOffset()
     {
         return flags;
     }
@@ -233,6 +234,7 @@ public class UserImpl implements User
     
     public UserImpl setFlags(int flags){
         this.flags = flags;
+        this.flagsSet = Flag.getFlags(flags);
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -44,8 +44,7 @@ public class UserImpl implements User
     protected long privateChannel = 0L;
     protected boolean bot;
     protected boolean fake = false;
-    protected EnumSet<UserFlag> flagsSet;
-    protected int flagsRaw;
+    protected int flags;
 
     public UserImpl(long id, JDAImpl api)
     {
@@ -162,12 +161,13 @@ public class UserImpl implements User
     @Override
     public EnumSet<UserFlag> getFlags()
     {
-        return flagsSet;
+        return UserFlag.getFlags(flags);
     }
     
+    @Override
     public int getFlagsRaw()
     {
-        return flagsRaw;
+        return flags;
     }
 
     @Override
@@ -234,8 +234,7 @@ public class UserImpl implements User
     
     public UserImpl setFlags(int flags)
     {
-        this.flagsRaw = flags;
-        this.flagsSet = UserFlag.getFlags(flags);
+        this.flags = flags;
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This implements the `public_flags` value for the User object, which essentially contains all [user flags](https://discord.com/developers/docs/resources/user#user-object-user-flags) with some exceptions like what type of nitro (or if they even have nitro) the user has and some other hidden flags.