### PR TITLE
Add prune overload to disable wait parameter

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2608,6 +2608,9 @@ public interface Guild extends ISnowflake
      * <br>You can use {@link Guild#retrievePrunableMemberCount(int)} to determine how many Members would be pruned if you were to
      * call this method.
      *
+     * <p>This might timeout when pruning many members.
+     * You can use {@code prune(days, false)} to ignore the prune count and avoid a timeout.
+     *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
      * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
      * <ul>
@@ -2628,7 +2631,42 @@ public interface Guild extends ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    AuditableRestAction<Integer> prune(int days);
+    default AuditableRestAction<Integer> prune(int days)
+    {
+        return prune(days, true);
+    }
+
+    /**
+     * This method will prune (kick) all members who were offline for at least <i>days</i> days.
+     * <br>The RestAction returned from this method will return the amount of Members that were pruned.
+     * <br>You can use {@link Guild#retrievePrunableMemberCount(int)} to determine how many Members would be pruned if you were to
+     * call this method.
+     *
+     * <p>This might timeout when pruning many members with {@code wait=true}.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The prune cannot finished due to a permission discrepancy</li>
+     * </ul>
+     *
+     * @param  days
+     *         Minimum number of days since a member has been offline to get affected.
+     * @param  wait
+     *         Whether to calculate the number of pruned members and wait for the response (timeout for too many pruned)
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the account doesn't have {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS KICK_MEMBER} Permission.
+     * @throws IllegalArgumentException
+     *         If the provided days are less than {@code 1} or more than {@code 30}
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: Integer
+     *         <br>Provides the amount of Members that were pruned from the Guild, if wait is true.
+     */
+    @Nonnull
+    @CheckReturnValue
+    AuditableRestAction<Integer> prune(int days, boolean wait);
 
     /**
      * Kicks the {@link net.dv8tion.jda.api.entities.Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -905,14 +905,16 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
-    public AuditableRestAction<Integer> prune(int days)
+    public AuditableRestAction<Integer> prune(int days, boolean wait)
     {
         checkPermission(Permission.KICK_MEMBERS);
 
         Checks.check(days >= 1 && days <= 30, "Provided %d days must be between 1 and 30.", days);
 
         Route.CompiledRoute route = Route.Guilds.PRUNE_MEMBERS.compile(getId()).withQueryParams("days", Integer.toString(days));
-        return new AuditableRestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));
+        if (!wait)
+            route = route.withQueryParams("compute_prune_count", "false");
+        return new AuditableRestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned", 0));
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Add prune overload which allows to disable the `compute_member_count` parameter. This can be useful for prunes on large guilds where this computation may timeout the response.
