### PR TITLE
Deprecate IFakeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,27 +319,16 @@ public static void main(String[] args) throws Exception
 
 ## Entity Lifetimes
 
-An **Entity** is the term used to describe types such as **GuildChannel**/**Message**/**User** and other entities
-that Discord provides.
-Instances of these entities are created and deleted by JDA when Discord instructs it. This means
-the lifetime depends on signals provided by the Discord API which are used to create/update/delete entities.
+An **Entity** is the term used to describe types such as **GuildChannel**/**Message**/**User** and other entities that Discord provides.
+Instances of these entities are created and deleted by JDA when Discord instructs it. This means the lifetime depends on signals provided by the Discord API which are used to create/update/delete entities.
 This is done through Gateway Events known as "dispatches" that are handled by the JDA WebSocket handlers.
 When Discord instructs JDA to delete entities, they are simply removed from the JDA cache and lose their references.
-Once that happens, nothing in JDA interacts or updates the instances of those entities, and they become useless. Discord
-may instruct to delete these entities randomly for cache synchronization with the API.
+Once that happens, nothing in JDA interacts or updates the instances of those entities, and they become useless.
+Discord may instruct to delete these entities randomly for cache synchronization with the API.
 
 **It is not recommended to store _any_ of these entities for a longer period of time!**
 Instead of keeping (e.g.) a `User` instance in some field, an ID should be used. With the ID of a user,
 you can use `getUserById(id)` to get and keep the user reference in a local variable (see below).
-
-### Fake Entities
-
-Some entities in JDA are marked through an interface called `IFakeable`. These entities can exist outside
-of the JDA cache and are inaccessible through the common `get...ById(id)` methods.
-Fake entities are essentially instances that are not directly referenced by the JDA cache and are only
-temporarily created for a specific usage. It may be used for the author of a message that has left the guild
-when requesting the history of a `MessageChannel` or for `Emote` instances used in a `Message` that are not part
-of any of the guilds available to the bot.
 
 ### Entity Updates
 

--- a/src/main/java/net/dv8tion/jda/annotations/ForRemoval.java
+++ b/src/main/java/net/dv8tion/jda/annotations/ForRemoval.java
@@ -27,4 +27,10 @@ import java.lang.annotation.*;
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
 public @interface ForRemoval
 {
+    /**
+     * Version which will most likely remove this feature.
+     *
+     * @return The deadline version or N/A if this isn't known yet
+     */
+    String deadline() default "N/A";
 }

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1510,8 +1510,8 @@ public interface JDA
      */
     @Nonnull
     @Deprecated
-    @ForRemoval
     @DeprecatedSince("4.0.0")
+    @ForRemoval(deadline="4.3.0")
     @ReplaceWith("jda.getVoiceChannelsByName(name, ignoreCase)")
     default List<VoiceChannel> getVoiceChannelByName(@Nonnull String name, boolean ignoreCase)
     {

--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -1123,8 +1123,8 @@ public class MessageBuilder implements Appendable
      */
     @Nonnull
     @Deprecated
-    @ForRemoval
     @DeprecatedSince("4.2.1")
+    @ForRemoval(deadline="4.3.0")
     @ReplaceWith("channel.sendMessage(builder.build())")
     public MessageAction sendTo(@Nonnull MessageChannel channel)
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -222,7 +222,7 @@ public interface ApplicationInfo extends ISnowflake
     String getName();
 
     /**
-     * The owner of the bot's application. This may be a fake user.
+     * The owner of the bot's application.
      * 
      * @return The owner of the bot's application
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -155,8 +155,6 @@ public interface Emote extends IMentionable, IFakeable
      *     <br>If we were removed from the Guild</li>
      * </ul>
      *
-     * @throws IllegalStateException
-     *         if this Emote is fake ({@link #isFake()})
      * @throws java.lang.UnsupportedOperationException
      *         If this emote is managed by discord ({@link #isManaged()})
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -36,13 +36,6 @@ import java.util.List;
  *
  * <p><b>This does not represent unicode emojis like they are used in the official client! (:smiley: is not a custom emoji)</b>
  *
- * <h2>Fake Emote</h2>
- * When an emote is declared as fake it cannot be updated by JDA. That means it will not be accessible
- * through cache such as {@link Guild#getEmoteCache()} and similar.
- * <br>Fake emotes may or may not have an attached {@link Guild Guild} and thus might not be manageable though
- * {@link #getManager()} or {@link #delete()}. They also might lack attached roles for {@link #getRoles()}.
- *
- *
  * @since  2.2
  *
  * @see    net.dv8tion.jda.api.entities.ListedEmote ListedEmote
@@ -65,9 +58,9 @@ public interface Emote extends IMentionable, IFakeable
     /**
      * The {@link net.dv8tion.jda.api.entities.Guild Guild} this emote is attached to.
      *
-     * <p><b>This is null if the emote is fake (retrieved from a Message)</b>
+     * <p><b>This is null if the emote is created from a message</b>
      *
-     * @return Guild of this emote or null if it is a fake entity
+     * @return Guild of this emote or null if it is created from a message
      */
     @Nullable
     Guild getGuild();
@@ -173,7 +166,7 @@ public interface Emote extends IMentionable, IFakeable
      * <br>You modify multiple fields in one request by chaining setters before calling {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction.queue()}.
      *
      * @throws IllegalStateException
-     *         if this emote is fake
+     *         if this emote is created from a message or the bot does not have access to the emote
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_EMOTES Permission.MANAGE_EMOTES}
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1755,7 +1755,7 @@ public interface Guild extends ISnowflake
         JDA jda = getJDA();
         return new DeferredRestAction<>(jda, ListedEmote.class,
         () -> {
-            if (emote instanceof ListedEmote && !emote.isFake())
+            if (emote instanceof ListedEmote)
             {
                 ListedEmote listedEmote = (ListedEmote) emote;
                 if (listedEmote.hasUser() || !getSelfMember().hasPermission(Permission.MANAGE_EMOTES))

--- a/src/main/java/net/dv8tion/jda/api/entities/IFakeable.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/IFakeable.java
@@ -36,9 +36,9 @@ import net.dv8tion.jda.annotations.ForRemoval;
  *
  * @since 3.0
  */
-@ForRemoval
 @Deprecated
 @DeprecatedSince("4.2.1")
+@ForRemoval(deadline="4.3.0")
 @SuppressWarnings("DeprecatedIsStillUsed")
 public interface IFakeable
 {
@@ -47,8 +47,8 @@ public interface IFakeable
      *
      * @return False, if this is an actual JDA entity.
      */
-    @ForRemoval
     @Deprecated
     @DeprecatedSince("4.2.1")
+    @ForRemoval(deadline="4.3.0")
     boolean isFake();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/IFakeable.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/IFakeable.java
@@ -36,6 +36,10 @@ import net.dv8tion.jda.annotations.ForRemoval;
  *
  * @since 3.0
  */
+@ForRemoval
+@Deprecated
+@DeprecatedSince("4.2.1")
+@SuppressWarnings("DeprecatedIsStillUsed")
 public interface IFakeable
 {
     /**
@@ -45,6 +49,6 @@ public interface IFakeable
      */
     @ForRemoval
     @Deprecated
-    @DeprecatedSince("4.2.0")
+    @DeprecatedSince("4.2.1")
     boolean isFake();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/IFakeable.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/IFakeable.java
@@ -16,6 +16,9 @@
 
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ForRemoval;
+
 /**
  * Marks a fakeable entity.
  * <br>A fake entity ({@link #isFake()} is true) is an entity which is not directly related to this instance of JDA or
@@ -40,5 +43,8 @@ public interface IFakeable
      *
      * @return False, if this is an actual JDA entity.
      */
+    @ForRemoval
+    @Deprecated
+    @DeprecatedSince("4.2.0")
     boolean isFake();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/Invite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Invite.java
@@ -218,7 +218,7 @@ public interface Invite
     Guild getGuild();
 
     /**
-     * The user who created this invite. This may be a fake user. For not expanded invites this may be null.
+     * The user who created this invite. For not expanded invites this may be null.
      *
      * @return The user who created this invite
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -668,9 +668,6 @@ public interface Message extends ISnowflake, Formattable
      * <br><b>This only includes Custom Emotes, not unicode Emojis.</b> JDA classifies Emotes as the Custom Emojis uploaded
      * to a Guild and retrievable with {@link net.dv8tion.jda.api.entities.Guild#getEmotes()}. These are not the same
      * as the unicode emojis that Discord also supports. Elements are sorted in order of appearance.
-     * <p>
-     * <b>This may or may not contain fake Emotes which means they can be displayed but not used by the logged in account.</b>
-     * To check whether an Emote is fake you can test if {@link Emote#isFake()} returns true.
      *
      * <p><b><u>Unicode emojis are not included as {@link net.dv8tion.jda.api.entities.Emote Emote}!</u></b>
      *
@@ -1089,7 +1086,6 @@ public interface Message extends ISnowflake, Formattable
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} is null.</li>
-     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} is fake {@link net.dv8tion.jda.api.entities.Emote#isFake() Emote.isFake()}.</li>
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} cannot be used in the current channel.
      *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
      *         </ul>
@@ -1393,7 +1389,6 @@ public interface Message extends ISnowflake, Formattable
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} is null.</li>
-     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} is fake {@link net.dv8tion.jda.api.entities.Emote#isFake() Emote.isFake()}.</li>
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} cannot be used in the current channel.
      *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
      *             <li>If the provided user is null</li>

--- a/src/main/java/net/dv8tion/jda/api/entities/TeamMember.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TeamMember.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
 public interface TeamMember
 {
     /**
-     * Possibly-fake user for the team member.
+     * User for the team member.
      *
      * @return The user
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
@@ -72,7 +72,7 @@ public interface Webhook extends ISnowflake, IFakeable
     TextChannel getChannel();
 
     /**
-     * The owner of this Webhook. This will be null for fake Webhooks, such as those retrieved from Audit Logs.
+     * The owner of this Webhook. This will be null for some Webhooks, such as those retrieved from Audit Logs.
      *
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Member Member} instance
      *         representing the owner of this Webhook.
@@ -83,7 +83,7 @@ public interface Webhook extends ISnowflake, IFakeable
     /**
      * The default User for this Webhook.
      *
-     * <p>The {@link net.dv8tion.jda.api.entities.User User} returned is always {@code fake}.
+     * <p>The {@link net.dv8tion.jda.api.entities.User User} returned is always fake and cannot be interacted with.
      * <br>This User is used for all messages posted to the Webhook route (found in {@link #getUrl()}),
      * it holds the default references for the message authors of messages by this Webhook.
      *
@@ -115,7 +115,7 @@ public interface Webhook extends ISnowflake, IFakeable
      * <br>This can be used to modify/delete/execute
      * this Webhook.
      * 
-     * <p><b>Note: Fake Webhooks, such as those retrieved from Audit Logs, do not contain a token</b>
+     * <p><b>Note: Some Webhooks, such as those retrieved from Audit Logs, do not contain a token</b>
      *
      * @return The execute token for this Webhook
      */
@@ -125,7 +125,7 @@ public interface Webhook extends ISnowflake, IFakeable
     /**
      * The {@code POST} route for this Webhook.
      * <br>This contains the {@link #getToken() token} and {@link #getId() id}
-     * of this Webhook. Fake Webhooks without tokens (such as those retrieved from Audit Logs)
+     * of this Webhook. Some Webhooks without tokens (such as those retrieved from Audit Logs)
      * will return a URL without a token.
      *
      * <p>The route returned by this method does not need permission checks
@@ -159,7 +159,7 @@ public interface Webhook extends ISnowflake, IFakeable
      * </ul>
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the Webhook is fake, such as the Webhooks retrieved from Audit Logs and the currently
+     *         If the Webhook does not have a token, such as the Webhooks retrieved from Audit Logs and the currently
      *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_WEBHOOKS} in this channel.
      * 
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildBanEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildBanEvent.java
@@ -41,7 +41,6 @@ public class GuildBanEvent extends GenericGuildEvent
 
     /**
      * The banned {@link net.dv8tion.jda.api.entities.User User}
-     * <br>Possibly fake user.
      *
      * @return The banned user
      */

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildUnbanEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildUnbanEvent.java
@@ -38,7 +38,6 @@ public class GuildUnbanEvent extends GenericGuildEvent
 
     /**
      * The {@link net.dv8tion.jda.api.entities.User User} who was unbanned
-     * <br>Possibly fake user.
      *
      * @return The unbanned user
      */

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageReceivedEvent.java
@@ -57,7 +57,6 @@ public class MessageReceivedEvent extends GenericMessageEvent
      * @return The Author of the Message.
      *
      * @see #isWebhookMessage()
-     * @see net.dv8tion.jda.api.entities.User#isFake()
      */
     @Nonnull
     public User getAuthor()

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageReceivedEvent.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.Webhook;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -53,6 +54,7 @@ public class MessageReceivedEvent extends GenericMessageEvent
     /**
      * The Author of the Message received as {@link net.dv8tion.jda.api.entities.User User} object.
      * <br>This will be never-null but might be a fake user if Message was sent via Webhook (Guild only).
+     * See {@link Webhook#getDefaultUser()}.
      *
      * @return The Author of the Message.
      *

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageReceivedEvent.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.Webhook;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,7 +52,8 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
 
     /**
      * The Author of the Message received as {@link net.dv8tion.jda.api.entities.User User} object.
-     * <br>This will be never-null but might be a fake User if Message was sent via Webhook
+     * <br>This will be never-null but might be a fake User if Message was sent via Webhook.
+     * See {@link Webhook#getDefaultUser()}.
      *
      * @return The Author of the Message.
      *

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageReceivedEvent.java
@@ -56,7 +56,6 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
      * @return The Author of the Message.
      *
      * @see    #isWebhookMessage()
-     * @see    net.dv8tion.jda.api.entities.User#isFake()
      */
     @Nonnull
     public User getAuthor()

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -582,7 +582,7 @@ public interface ShardManager
 
         JDAImpl jda = (JDAImpl) api;
         Route.CompiledRoute route = Route.Users.GET_USER.compile(Long.toUnsignedString(id));
-        return new RestActionImpl<>(jda, route, (response, request) -> jda.getEntityBuilder().createFakeUser(response.getObject()));
+        return new RestActionImpl<>(jda, route, (response, request) -> jda.getEntityBuilder().createUser(response.getObject()));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -93,9 +93,6 @@ public class JDAImpl implements JDA
     protected final SnowflakeCacheViewImpl<VoiceChannel> voiceChannelCache = new SnowflakeCacheViewImpl<>(VoiceChannel.class, GuildChannel::getName);
     protected final SnowflakeCacheViewImpl<PrivateChannel> privateChannelCache = new SnowflakeCacheViewImpl<>(PrivateChannel.class, MessageChannel::getName);
 
-    protected final TLongObjectMap<User> fakeUsers = MiscUtil.newLongMap();
-    protected final TLongObjectMap<PrivateChannel> fakePrivateChannels = MiscUtil.newLongMap();
-
     protected final AbstractCacheView<AudioManager> audioManagers = new CacheView.SimpleCacheView<>(AudioManager.class, m -> m.getGuild().getName());
 
     protected final PresenceImpl presence;
@@ -574,7 +571,7 @@ public class JDAImpl implements JDA
                 () -> {
                     Route.CompiledRoute route = Route.Users.GET_USER.compile(Long.toUnsignedString(id));
                     return new RestActionImpl<>(this, route,
-                            (response, request) -> getEntityBuilder().createFakeUser(response.getObject()));
+                            (response, request) -> getEntityBuilder().createUser(response.getObject()));
                 });
     }
 
@@ -996,16 +993,6 @@ public class JDAImpl implements JDA
     public AbstractCacheView<AudioManager> getAudioManagersView()
     {
         return audioManagers;
-    }
-
-    public TLongObjectMap<User> getFakeUserMap()
-    {
-        return fakeUsers;
-    }
-
-    public TLongObjectMap<PrivateChannel> getFakePrivateChannelMap()
-    {
-        return fakePrivateChannels;
     }
 
     public void setSelfUser(SelfUser selfUser)

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -686,11 +686,7 @@ class AudioWebSocket extends WebSocketAdapter
 
     private User getUser(final long userId)
     {
-        JDAImpl api = getJDA();
-        User user = api.getUserById(userId);
-        if (user != null)
-            return user;
-        return api.getFakeUserMap().get(userId);
+        return getJDA().getUserById(userId);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -50,7 +50,6 @@ public class EmoteImpl implements ListedEmote
     private final SnowflakeReference<Guild> guild;
     private final JDAImpl api;
     private final Set<Role> roles;
-    private final boolean fake;
 
     private final ReentrantLock mngLock = new ReentrantLock();
     private volatile EmoteManager manager = null;
@@ -71,7 +70,6 @@ public class EmoteImpl implements ListedEmote
         this.api = guild.getJDA();
         this.guild = new SnowflakeReference<>(guild, api::getGuildById);
         this.roles = ConcurrentHashMap.newKeySet();
-        this.fake = fake;
     }
 
     public EmoteImpl(long id, JDAImpl api)
@@ -80,7 +78,6 @@ public class EmoteImpl implements ListedEmote
         this.api = api;
         this.guild = null;
         this.roles = null;
-        this.fake = true;
     }
 
     @Override
@@ -118,9 +115,10 @@ public class EmoteImpl implements ListedEmote
     }
 
     @Override
+    @Deprecated
     public boolean isFake()
     {
-        return fake;
+        return false;
     }
 
     @Override
@@ -252,7 +250,6 @@ public class EmoteImpl implements ListedEmote
     @Override
     public EmoteImpl clone()
     {
-        if (isFake()) return null;
         EmoteImpl copy = new EmoteImpl(id, getGuild()).setUser(user).setManaged(managed).setAnimated(animated).setName(name);
         copy.roles.addAll(roles);
         return copy;

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -91,7 +91,7 @@ public class EmoteImpl implements ListedEmote
     public List<Role> getRoles()
     {
         if (!canProvideRoles())
-            throw new IllegalStateException("Unable to return roles because this emote is fake. (We do not know the origin Guild of this emote)");
+            throw new IllegalStateException("Unable to return roles because this emote is from a message. (We do not know the origin Guild of this emote)");
         return Collections.unmodifiableList(new LinkedList<>(roles));
     }
 
@@ -177,7 +177,7 @@ public class EmoteImpl implements ListedEmote
     public AuditableRestAction<Void> delete()
     {
         if (getGuild() == null)
-            throw new IllegalStateException("The emote you are trying to delete is not an actual emote we have access to (it is fake)!");
+            throw new IllegalStateException("The emote you are trying to delete is not an actual emote we have access to (it is from a message)!");
         if (managed)
             throw new UnsupportedOperationException("You cannot delete a managed emote!");
         if (!getGuild().getSelfMember().hasPermission(Permission.MANAGE_EMOTES))

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -391,17 +391,11 @@ public class EntityBuilder
             if (membersView.remove(member.getIdLong()) == null)
                 return false;
             LOG.trace("Unloading member {}", member);
-            if (user.getMutualGuilds().isEmpty()
-                    && (!user.hasPrivateChannel() || api.getPrivateChannelById(user.getPrivateChannel().getIdLong()) == null))
+            if (user.getMutualGuilds().isEmpty())
             {
                 // we no longer share any guilds/channels with this user so remove it from cache
                 user.setFake(true);
                 getJDA().getUsersView().remove(user.getIdLong());
-                if (user.hasPrivateChannel())
-                {
-                    PrivateChannel channel = user.getPrivateChannel();
-                    getJDA().getPrivateChannelsView().remove(channel.getIdLong());
-                }
             }
 
             GuildVoiceStateImpl voiceState = (GuildVoiceStateImpl) member.getVoiceState();
@@ -426,16 +420,9 @@ public class EntityBuilder
         if (getJDA().getUserById(user.getIdLong()) == null)
         {
             SnowflakeCacheViewImpl<User> usersView = getJDA().getUsersView();
-            SnowflakeCacheViewImpl<PrivateChannel> privateChannels = getJDA().getPrivateChannelsView();
-            try (UnlockHook hook1 = usersView.writeLock();
-                 UnlockHook hook2 = privateChannels.writeLock())
+            try (UnlockHook hook1 = usersView.writeLock())
             {
                 usersView.getMap().put(user.getIdLong(), user);
-                if (user.hasPrivateChannel())
-                {
-                    PrivateChannel channel = user.getPrivateChannel();
-                    privateChannels.getMap().put(channel.getIdLong(), channel);
-                }
             }
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -579,7 +579,7 @@ public class GuildImpl implements Guild
             {
                 final DataObject object = bannedArr.getObject(i);
                 DataObject user = object.getObject("user");
-                bans.add(new Ban(builder.createFakeUser(user), object.getString("reason", null)));
+                bans.add(new Ban(builder.createUser(user), object.getString("reason", null)));
             }
             return Collections.unmodifiableList(bans);
         });
@@ -601,7 +601,7 @@ public class GuildImpl implements Guild
             EntityBuilder builder = api.getEntityBuilder();
             DataObject bannedObj = response.getObject();
             DataObject user = bannedObj.getObject("user");
-            return new Ban(builder.createFakeUser(user), bannedObj.getString("reason", null));
+            return new Ban(builder.createUser(user), bannedObj.getString("reason", null));
         });
     }
 
@@ -1384,7 +1384,7 @@ public class GuildImpl implements Guild
     public GuildImpl setOwner(Member owner)
     {
         // Only cache owner if user cache is enabled
-        if (owner != null && !owner.isFake())
+        if (owner != null && getMemberById(owner.getIdLong()) != null)
             this.owner = owner;
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -274,6 +274,7 @@ public class MemberImpl implements Member
     }
 
     @Override
+    @Deprecated
     public boolean isFake()
     {
         return getGuild().getMemberById(getIdLong()) == null;

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
 public class PrivateChannelImpl implements PrivateChannel
 {
     private final long id;
-    private final User user;
+    private User user;
     private long lastMessageId;
 
     public PrivateChannelImpl(long id, User user)
@@ -45,10 +45,19 @@ public class PrivateChannelImpl implements PrivateChannel
         this.user = user;
     }
 
+    private void updateUser()
+    {
+        // Load user from cache if one exists, otherwise we might have an outdated user instance
+        User realUser = getJDA().getUserById(user.getIdLong());
+        if (realUser != null)
+            this.user = realUser;
+    }
+
     @Nonnull
     @Override
     public User getUser()
     {
+        updateUser();
         return user;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -118,6 +118,7 @@ public class PrivateChannelImpl implements PrivateChannel
     }
 
     @Override
+    @Deprecated
     public boolean isFake()
     {
         return user.isFake();

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -293,8 +293,6 @@ public class ReceivedMessage extends AbstractMessage
         if (!mentionedUsers.contains(userId))
             return null;
         User user = getJDA().getUserById(userId);
-        if (user == null)
-            user = api.getFakeUserMap().get(userId);
         if (user == null && userMentions != null)
             user = userMentions.stream().filter(it -> it.getIdLong() == userId).findFirst().orElse(null);
         return user;

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -111,8 +111,6 @@ public class UserImpl implements User
         if (!hasPrivateChannel())
             return null;
         PrivateChannel channel = getJDA().getPrivateChannelById(privateChannel);
-        if (channel == null)
-            channel = getJDA().getFakePrivateChannelMap().get(privateChannel);
         return channel != null ? channel : new PrivateChannelImpl(privateChannel, this);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelCreateHandler.java
@@ -89,7 +89,7 @@ public class ChannelCreateHandler extends SocketHandler
                 jda.handleEvent(
                     new PrivateChannelCreateEvent(
                         jda, responseNumber,
-                        builder.createPrivateChannel(content)));
+                        builder.createPrivateChannel(content, true)));
                 break;
             }
             case GROUP:

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
@@ -25,7 +25,6 @@ import net.dv8tion.jda.api.events.channel.voice.VoiceChannelDeleteEvent;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
-import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 
@@ -132,8 +131,6 @@ public class ChannelDeleteHandler extends SocketHandler
                 PrivateChannel channel = privateView.remove(channelId);
 
                 if (channel == null)
-                    channel = getJDA().getFakePrivateChannelMap().remove(channelId);
-                if (channel == null)
                 {
 //                    getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, () -> handle(responseNumber, allContent));
                     WebSocketClient.LOG.debug(
@@ -143,9 +140,14 @@ public class ChannelDeleteHandler extends SocketHandler
                     return null;
                 }
 
-                if (channel.getUser().isFake())
-                    getJDA().getFakeUserMap().remove(channel.getUser().getIdLong());
-                ((UserImpl) channel.getUser()).setPrivateChannel(null);
+                if (channel.getUser().getMutualGuilds().isEmpty())
+                {
+                    // Remove user from cache, we no longer share any guilds/channels
+                    long userId = channel.getUser().getIdLong();
+                    getJDA().getUsersView().remove(userId);
+                    getJDA().getEventCache().clear(EventCache.Type.USER, userId);
+                }
+
                 getJDA().handleEvent(
                     new PrivateChannelDeleteEvent(
                         getJDA(), responseNumber,

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelDeleteHandler.java
@@ -140,14 +140,6 @@ public class ChannelDeleteHandler extends SocketHandler
                     return null;
                 }
 
-                if (channel.getUser().getMutualGuilds().isEmpty())
-                {
-                    // Remove user from cache, we no longer share any guilds/channels
-                    long userId = channel.getUser().getIdLong();
-                    getJDA().getUsersView().remove(userId);
-                    getJDA().getEventCache().clear(EventCache.Type.USER, userId);
-                }
-
                 getJDA().handleEvent(
                     new PrivateChannelDeleteEvent(
                         getJDA(), responseNumber,

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildBanHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildBanHandler.java
@@ -49,7 +49,7 @@ public class GuildBanHandler extends SocketHandler
             return null;
         }
 
-        User user = getJDA().getEntityBuilder().createFakeUser(userJson);
+        User user = getJDA().getEntityBuilder().createUser(userJson);
 
         if (banned)
         {

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
@@ -25,7 +25,6 @@ import net.dv8tion.jda.api.managers.AudioManager;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
-import net.dv8tion.jda.internal.entities.PrivateChannelImpl;
 import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
@@ -115,15 +114,12 @@ public class GuildDeleteHandler extends SocketHandler
             memberIds.forEach(memberId -> {
                 if (memberId == selfId)
                     return true; // don't remove selfUser from cache
-                UserImpl user = (UserImpl) userView.getMap().remove(memberId);
-                if (user.hasPrivateChannel())
+                UserImpl user = (UserImpl) userView.getMap().get(memberId);
+                if (!user.hasPrivateChannel() || getJDA().getPrivateChannelById(user.getPrivateChannel().getIdLong()) == null)
                 {
-                    PrivateChannelImpl priv = (PrivateChannelImpl) user.getPrivateChannel();
-                    user.setFake(true);
-                    getJDA().getFakeUserMap().put(user.getIdLong(), user);
-                    getJDA().getFakePrivateChannelMap().put(priv.getIdLong(), priv);
+                    userView.remove(memberId);
+                    getJDA().getEventCache().clear(EventCache.Type.USER, memberId);
                 }
-                getJDA().getEventCache().clear(EventCache.Type.USER, memberId);
                 return true;
             });
         }

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
@@ -25,7 +25,6 @@ import net.dv8tion.jda.api.managers.AudioManager;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
-import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.UnlockHook;
@@ -114,12 +113,8 @@ public class GuildDeleteHandler extends SocketHandler
             memberIds.forEach(memberId -> {
                 if (memberId == selfId)
                     return true; // don't remove selfUser from cache
-                UserImpl user = (UserImpl) userView.getMap().get(memberId);
-                if (!user.hasPrivateChannel() || getJDA().getPrivateChannelById(user.getPrivateChannel().getIdLong()) == null)
-                {
-                    userView.remove(memberId);
-                    getJDA().getEventCache().clear(EventCache.Type.USER, memberId);
-                }
+                userView.remove(memberId);
+                getJDA().getEventCache().clear(EventCache.Type.USER, memberId);
                 return true;
             });
         }

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
@@ -23,7 +23,10 @@ import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
-import net.dv8tion.jda.internal.entities.*;
+import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.entities.GuildVoiceStateImpl;
+import net.dv8tion.jda.internal.entities.MemberImpl;
+import net.dv8tion.jda.internal.entities.VoiceChannelImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
@@ -107,15 +110,10 @@ public class GuildMemberRemoveHandler extends SocketHandler
         {
             if (userId != getJDA().getSelfUser().getIdLong() // don't remove selfUser from cache
                     && getJDA().getGuildsView().stream()
-                               .map(GuildImpl.class::cast)
-                               .noneMatch(g -> g.getMembersView().get(userId) != null))
+                               .noneMatch(g -> g.getMemberById(userId) != null))
             {
-                UserImpl removedUser = (UserImpl) userView.getMap().get(userId);
-                if (!removedUser.hasPrivateChannel() || getJDA().getPrivateChannelById(removedUser.getPrivateChannel().getIdLong()) == null)
-                {
-                    userView.remove(userId);
-                    getJDA().getEventCache().clear(EventCache.Type.USER, userId);
-                }
+                userView.remove(userId);
+                getJDA().getEventCache().clear(EventCache.Type.USER, userId);
             }
         }
         // Cache dependent event

--- a/src/main/java/net/dv8tion/jda/internal/handle/InviteCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InviteCreateHandler.java
@@ -70,7 +70,7 @@ public class InviteCreateHandler extends SocketHandler
         Optional<DataObject> inviterJson = content.optObject("inviter");
         boolean expanded = maxUses != -1;
 
-        User inviter = inviterJson.map(json -> getJDA().getEntityBuilder().createFakeUser(json)).orElse(null);
+        User inviter = inviterJson.map(json -> getJDA().getEntityBuilder().createUser(json)).orElse(null);
         InviteImpl.ChannelImpl channel = new InviteImpl.ChannelImpl(realChannel);
         InviteImpl.GuildImpl guild = new InviteImpl.GuildImpl(realGuild);
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageDeleteHandler.java
@@ -46,10 +46,6 @@ public class MessageDeleteHandler extends SocketHandler
         }
         if (channel == null)
         {
-            channel = getJDA().getFakePrivateChannelMap().get(channelId);
-        }
-        if (channel == null)
-        {
             getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);
             EventCache.LOG.debug("Got message delete for a channel/group that is not yet cached. ChannelId: {}", channelId);
             return null;

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
@@ -95,8 +95,6 @@ public class MessageReactionHandler extends SocketHandler
         if (user == null && member != null)
             user = member.getUser(); // this happens when we have guild subscriptions disabled
         if (user == null)
-            user = getJDA().getFakeUserMap().get(userId);
-        if (user == null)
         {
             if (add && guild != null)
             {
@@ -109,13 +107,7 @@ public class MessageReactionHandler extends SocketHandler
 
         MessageChannel channel = getJDA().getTextChannelById(channelId);
         if (channel == null)
-        {
             channel = getJDA().getPrivateChannelById(channelId);
-        }
-        if (channel == null)
-        {
-            channel = getJDA().getFakePrivateChannelMap().get(channelId);
-        }
         if (channel == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageUpdateHandler.java
@@ -160,8 +160,6 @@ public class MessageUpdateHandler extends SocketHandler
         if (channel == null)
             channel = getJDA().getPrivateChannelsView().get(channelId);
         if (channel == null)
-            channel = getJDA().getFakePrivateChannelMap().get(channelId);
-        if (channel == null)
         {
             getJDA().getEventCache().cache(EventCache.Type.CHANNEL, channelId, responseNumber, allContent, this::handle);
             EventCache.LOG.debug("Received message update for embeds for a channel/group that JDA does not have cached yet.");

--- a/src/main/java/net/dv8tion/jda/internal/handle/TypingStartHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/TypingStartHandler.java
@@ -49,8 +49,6 @@ public class TypingStartHandler extends SocketHandler
         if (channel == null)
             channel = getJDA().getPrivateChannelsView().get(channelId);
         if (channel == null)
-            channel = getJDA().getFakePrivateChannelMap().get(channelId);
-        if (channel == null)
             return null;    //We don't have the channel cached yet. We chose not to cache this event
                             // because that happen very often and could easily fill up the EventCache if
                             // we, for some reason, never get the channel. Especially in an active channel.

--- a/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
@@ -47,9 +47,6 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
      *
      * @param  emote
      *         The target {@link net.dv8tion.jda.internal.entities.EmoteImpl EmoteImpl} to modify
-     *
-     * @throws java.lang.IllegalStateException
-     *         If the specified Emote is {@link net.dv8tion.jda.api.entities.Emote#isFake() fake} or {@link net.dv8tion.jda.api.entities.Emote#isManaged() managed}.
      */
     public EmoteManagerImpl(EmoteImpl emote)
     {
@@ -63,7 +60,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
     {
         Guild g = emote.getGuild();
         if (g == null)
-            throw new IllegalStateException("Cannot modify a fake emote");
+            throw new IllegalStateException("Cannot modify an emote without shared guild");
         return g;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -704,8 +704,6 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         api.getGuildsView().clear();
         api.getUsersView().clear();
         api.getPrivateChannelsView().clear();
-        api.getFakeUserMap().clear();
-        api.getFakePrivateChannelMap().clear();
         api.getEventCache().clear();
         api.getGuildSetupController().clearCache();
         chunkManager.clear();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
@@ -110,7 +110,7 @@ public class ReactionPaginationActionImpl
         {
             try
             {
-                final User user = builder.createFakeUser(array.getObject(i));
+                final User user = builder.createUser(array.getObject(i));
                 users.add(user);
                 if (useCache)
                     cached.add(user);

--- a/src/main/java/net/dv8tion/jda/internal/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/PermissionUtil.java
@@ -114,7 +114,7 @@ public class PermissionUtil
     /**
      * Check whether the provided {@link net.dv8tion.jda.api.entities.Member Member} can use the specified {@link net.dv8tion.jda.api.entities.Emote Emote}.
      *
-     * <p>If the specified Member is not in the emote's guild or the emote provided is fake this will return false.
+     * <p>If the specified Member is not in the emote's guild or the emote provided is from a message this will return false.
      * Otherwise it will check if the emote is restricted to any roles and if that is the case if the Member has one of these.
      *
      * <p>In the case of an {@link net.dv8tion.jda.api.entities.Emote#isAnimated() animated} Emote, this will


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This gets rid of the outdated "fake" terminology and interfaces. Almost every user can be considered "fake" and it just doesn't make sense to keep this design anymore.

We will not cache "fake" users for private channels. Instead, we simply keep the user reference in the private channel instance. That way we get a better cache structure that is easier to maintain.
