### PR TITLE
Add methods to bulk retrieve members

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2484,8 +2484,9 @@ public interface Guild extends ISnowflake
      * <br>If the user does not resolve to a member of this guild, then it will not appear in the resulting list.
      * It is possible that none of the users resolve to a member, in which case an empty list will be the result.
      *
-     * <p>This will not load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
-     * of the members. You can use {@link #retrieveMembers(boolean, Collection)} to load presences.
+     * <p>If the {@link GatewayIntent#GUILD_PRESENCES GUILD_PRESENCES} intent is enabled,
+     * this will load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
+     * of the members. You can use {@link #retrieveMembers(boolean, Collection)} to disable presences.
      *
      * <p>The requests automatically timeout after {@code 10} seconds.
      * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
@@ -2521,8 +2522,9 @@ public interface Guild extends ISnowflake
      * <br>If the id does not resolve to a member of this guild, then it will not appear in the resulting list.
      * It is possible that none of the IDs resolve to a member, in which case an empty list will be the result.
      *
-     * <p>This will not load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
-     * of the members. You can use {@link #retrieveMembersByIds(boolean, Collection)} to load presences.
+     * <p>If the {@link GatewayIntent#GUILD_PRESENCES GUILD_PRESENCES} intent is enabled,
+     * this will load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
+     * of the members. You can use {@link #retrieveMembersByIds(boolean, Collection)} to disable presences.
      *
      * <p>The requests automatically timeout after {@code 10} seconds.
      * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
@@ -2558,8 +2560,9 @@ public interface Guild extends ISnowflake
      * <br>If the id does not resolve to a member of this guild, then it will not appear in the resulting list.
      * It is possible that none of the IDs resolve to a member, in which case an empty list will be the result.
      *
-     * <p>This will not load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
-     * of the members. You can use {@link #retrieveMembersByIds(boolean, String...)} to load presences.
+     * <p>If the {@link GatewayIntent#GUILD_PRESENCES GUILD_PRESENCES} intent is enabled,
+     * this will load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
+     * of the members. You can use {@link #retrieveMembersByIds(boolean, String...)} to disable presences.
      *
      * <p>The requests automatically timeout after {@code 10} seconds.
      * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
@@ -2597,8 +2600,9 @@ public interface Guild extends ISnowflake
      * <br>If the id does not resolve to a member of this guild, then it will not appear in the resulting list.
      * It is possible that none of the IDs resolve to a member, in which case an empty list will be the result.
      *
-     * <p>This will not load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
-     * of the members. You can use {@link #retrieveMembersByIds(boolean, long...)} to load presences.
+     * <p>If the {@link GatewayIntent#GUILD_PRESENCES GUILD_PRESENCES} intent is enabled,
+     * this will load the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} and {@link Activity Activities}
+     * of the members. You can use {@link #retrieveMembersByIds(boolean, long...)} to disable presences.
      *
      * <p>The requests automatically timeout after {@code 10} seconds.
      * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
@@ -2621,7 +2625,8 @@ public interface Guild extends ISnowflake
     @CheckReturnValue
     default Task<List<Member>> retrieveMembersByIds(@Nonnull long... ids)
     {
-        return retrieveMembersByIds(false, ids);
+        boolean presence = getJDA().getGatewayIntents().contains(GatewayIntent.GUILD_PRESENCES);
+        return retrieveMembersByIds(presence, ids);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -45,6 +45,7 @@ import net.dv8tion.jda.internal.requests.DeferredRestAction;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -2477,6 +2478,48 @@ public interface Guild extends ISnowflake
     {
         return retrieveMemberById(getOwnerIdLong(), update);
     }
+
+    @Nonnull
+    @CheckReturnValue
+    default Task<List<Member>> retrieveMembers(Collection<User> users)
+    {
+        Checks.noneNull(users, "Users");
+        if (users.isEmpty())
+            return new GatewayTask<>(CompletableFuture.completedFuture(Collections.emptyList()), () -> {});
+
+        long[] ids = users.stream().mapToLong(User::getIdLong).toArray();
+        return retrieveMembersByIds(ids);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    default Task<List<Member>> retrieveMembersByIds(Collection<Long> ids)
+    {
+        Checks.noneNull(ids, "IDs");
+        if (ids.isEmpty())
+            return new GatewayTask<>(CompletableFuture.completedFuture(Collections.emptyList()), () -> {});
+
+        long[] arr = ids.stream().mapToLong(Long::longValue).toArray();
+        return retrieveMembersByIds(arr);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    default Task<List<Member>> retrieveMembersByIds(String... ids)
+    {
+        Checks.notNull(ids, "Array");
+        if (ids.length == 0)
+            return new GatewayTask<>(CompletableFuture.completedFuture(Collections.emptyList()), () -> {});
+
+        long[] arr = new long[ids.length];
+        for (int i = 0; i < ids.length; i++)
+            arr[i] = MiscUtil.parseSnowflake(ids[i]);
+        return retrieveMembersByIds(arr);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    Task<List<Member>> retrieveMembersByIds(long... ids);
 
     /**
      * Queries a list of members using a radix tree based on the provided name prefix.

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2479,9 +2479,31 @@ public interface Guild extends ISnowflake
         return retrieveMemberById(getOwnerIdLong(), update);
     }
 
+    /**
+     * Retrieves a list of members.
+     * <br>If the user does not resolve to a member of this guild, then it will not appear in the resulting list.
+     * It is possible that none of the users resolve to a member, in which case an empty list will be the result.
+     *
+     * <p>The requests automatically timeout after {@code 10} seconds.
+     * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
+     *
+     * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
+     * The response handling happens on the event thread by default.
+     *
+     * @param  users
+     *         The users of the members (max 100)
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the input contains null</li>
+     *             <li>If the input is more than 100 IDs</li>
+     *         </ul>
+     *
+     * @return {@link Task} handle for the request
+     */
     @Nonnull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembers(Collection<User> users)
+    default Task<List<Member>> retrieveMembers(@Nonnull Collection<User> users)
     {
         Checks.noneNull(users, "Users");
         if (users.isEmpty())
@@ -2491,9 +2513,31 @@ public interface Guild extends ISnowflake
         return retrieveMembersByIds(ids);
     }
 
+    /**
+     * Retrieves a list of members by their user id.
+     * <br>If the id does not resolve to a member of this guild, then it will not appear in the resulting list.
+     * It is possible that none of the IDs resolve to a member, in which case an empty list will be the result.
+     *
+     * <p>The requests automatically timeout after {@code 10} seconds.
+     * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
+     *
+     * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
+     * The response handling happens on the event thread by default.
+     *
+     * @param  ids
+     *         The ids of the members (max 100)
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the input contains null</li>
+     *             <li>If the input is more than 100 IDs</li>
+     *         </ul>
+     *
+     * @return {@link Task} handle for the request
+     */
     @Nonnull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(Collection<Long> ids)
+    default Task<List<Member>> retrieveMembersByIds(@Nonnull Collection<Long> ids)
     {
         Checks.noneNull(ids, "IDs");
         if (ids.isEmpty())
@@ -2503,9 +2547,31 @@ public interface Guild extends ISnowflake
         return retrieveMembersByIds(arr);
     }
 
+    /**
+     * Retrieves a list of members by their user id.
+     * <br>If the id does not resolve to a member of this guild, then it will not appear in the resulting list.
+     * It is possible that none of the IDs resolve to a member, in which case an empty list will be the result.
+     *
+     * <p>The requests automatically timeout after {@code 10} seconds.
+     * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
+     *
+     * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
+     * The response handling happens on the event thread by default.
+     *
+     * @param  ids
+     *         The ids of the members (max 100)
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the input contains null</li>
+     *             <li>If the input is more than 100 IDs</li>
+     *         </ul>
+     *
+     * @return {@link Task} handle for the request
+     */
     @Nonnull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(String... ids)
+    default Task<List<Member>> retrieveMembersByIds(@Nonnull String... ids)
     {
         Checks.notNull(ids, "Array");
         if (ids.length == 0)
@@ -2517,9 +2583,31 @@ public interface Guild extends ISnowflake
         return retrieveMembersByIds(arr);
     }
 
+    /**
+     * Retrieves a list of members by their user id.
+     * <br>If the id does not resolve to a member of this guild, then it will not appear in the resulting list.
+     * It is possible that none of the IDs resolve to a member, in which case an empty list will be the result.
+     *
+     * <p>The requests automatically timeout after {@code 10} seconds.
+     * When the timeout occurs a {@link java.util.concurrent.TimeoutException TimeoutException} will be used to complete exceptionally.
+     *
+     * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
+     * The response handling happens on the event thread by default.
+     *
+     * @param  ids
+     *         The ids of the members (max 100)
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the input contains null</li>
+     *             <li>If the input is more than 100 IDs</li>
+     *         </ul>
+     *
+     * @return {@link Task} handle for the request
+     */
     @Nonnull
     @CheckReturnValue
-    Task<List<Member>> retrieveMembersByIds(long... ids);
+    Task<List<Member>> retrieveMembersByIds(@Nonnull long... ids);
 
     /**
      * Queries a list of members using a radix tree based on the provided name prefix.

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2660,7 +2660,7 @@ public interface Guild extends ISnowflake
             return new GatewayTask<>(CompletableFuture.completedFuture(Collections.emptyList()), () -> {});
 
         long[] ids = users.stream().mapToLong(User::getIdLong).toArray();
-        return retrieveMembersByIds(ids);
+        return retrieveMembersByIds(includePresence, ids);
     }
 
     /**
@@ -2699,7 +2699,7 @@ public interface Guild extends ISnowflake
             return new GatewayTask<>(CompletableFuture.completedFuture(Collections.emptyList()), () -> {});
 
         long[] arr = ids.stream().mapToLong(Long::longValue).toArray();
-        return retrieveMembersByIds(arr);
+        return retrieveMembersByIds(includePresence, arr);
     }
 
     /**
@@ -2740,7 +2740,7 @@ public interface Guild extends ISnowflake
         long[] arr = new long[ids.length];
         for (int i = 0; i < ids.length; i++)
             arr[i] = MiscUtil.parseSnowflake(ids[i]);
-        return retrieveMembersByIds(arr);
+        return retrieveMembersByIds(includePresence, arr);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/concurrent/Task.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/concurrent/Task.java
@@ -50,6 +50,7 @@ public interface Task<T>
      *
      * @return The current Task instance for chaining
      */
+    @Nonnull
     Task<T> onError(@Nonnull Consumer<? super Throwable> callback);
 
     /**
@@ -64,6 +65,7 @@ public interface Task<T>
      *
      * @return The current Task instance for chaining
      */
+    @Nonnull
     Task<T> onSuccess(@Nonnull Consumer<? super T> callback);
 
     /**
@@ -80,6 +82,7 @@ public interface Task<T>
      *
      * @return The result value
      */
+    @Nonnull
     T get();
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -147,7 +147,7 @@ public class EntityBuilder
         }
     }
 
-    private TLongObjectMap<DataObject> convertToUserMap(ToLongFunction<DataObject> getId, DataArray array)
+    public TLongObjectMap<DataObject> convertToUserMap(ToLongFunction<DataObject> getId, DataArray array)
     {
         TLongObjectMap<DataObject> map = new TLongObjectHashMap<>();
         for (int i = 0; i < array.length(); i++)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -844,7 +844,7 @@ public class GuildImpl implements Guild
     {
         Checks.notNull(ids, "ID Array");
         Checks.check(!includePresence || api.isIntent(GatewayIntent.GUILD_PRESENCES),
-                "Cannot retrieve persences of members without GUILD_PRESENCES intent!");
+                "Cannot retrieve presences of members without GUILD_PRESENCES intent!");
 
         if (ids.length == 0)
             return new GatewayTask<>(CompletableFuture.completedFuture(Collections.emptyList()), () -> {});

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -839,7 +839,7 @@ public class GuildImpl implements Guild
 
     @Nonnull
     @Override
-    public Task<List<Member>> retrieveMembersByIds(long... ids)
+    public Task<List<Member>> retrieveMembersByIds(@Nonnull long... ids)
     {
         Checks.notNull(ids, "ID Array");
         if (ids.length == 0)

--- a/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
@@ -77,6 +77,18 @@ public class MemberChunkManager
         return chunkRequest;
     }
 
+    public CompletableFuture<DataObject> chunkGuild(long guildId, long[] userIds)
+    {
+        init();
+        DataObject request = DataObject.empty()
+                .put("guild_id", guildId)
+                .put("user_ids", userIds);
+
+        ChunkRequest chunkRequest = new ChunkRequest(request);
+        makeRequest(chunkRequest);
+        return chunkRequest;
+    }
+
     public boolean handleChunk(long guildId, DataObject response)
     {
         return MiscUtil.locked(lock, () -> {

--- a/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
@@ -21,10 +21,7 @@ import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.data.DataObject;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class MemberChunkManager
@@ -133,7 +130,7 @@ public class MemberChunkManager
 
         public ChunkRequest(DataObject request)
         {
-            this.nonce = System.nanoTime() & ~1;
+            this.nonce = ThreadLocalRandom.current().nextLong() & ~1;
             this.request = request.put("nonce", getNonce());
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
@@ -77,11 +77,12 @@ public class MemberChunkManager
         return chunkRequest;
     }
 
-    public CompletableFuture<DataObject> chunkGuild(long guildId, long[] userIds)
+    public CompletableFuture<DataObject> chunkGuild(long guildId, boolean presence, long[] userIds)
     {
         init();
         DataObject request = DataObject.empty()
                 .put("guild_id", guildId)
+                .put("presences", presence)
                 .put("user_ids", userIds);
 
         ChunkRequest chunkRequest = new ChunkRequest(request);

--- a/src/main/java/net/dv8tion/jda/internal/utils/concurrent/task/GatewayTask.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/concurrent/task/GatewayTask.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class GatewayTask<T> implements Task<T>
 {
@@ -43,6 +44,7 @@ public class GatewayTask<T> implements Task<T>
         return true;
     }
 
+    @Nonnull
     @Override
     public Task<T> onError(@Nonnull Consumer<? super Throwable> callback)
     {
@@ -54,6 +56,7 @@ public class GatewayTask<T> implements Task<T>
         return this;
     }
 
+    @Nonnull
     @Override
     public Task<T> onSuccess(@Nonnull Consumer<? super T> callback)
     {
@@ -62,6 +65,7 @@ public class GatewayTask<T> implements Task<T>
         return this;
     }
 
+    @Nonnull
     @Override
     public T get()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds a method to retrieve a list of members, filtered by user IDs.

Note: We can't add a `retrieveMembersByIds(Collection<String>)` due to java type erasure.

### Example

```java
guild.retrieveMembersByIds(86699011792191488L, 107562988810027008L)
    .onSuccess((list) -> System.out.println("Found members: " + list));
```
