### PR TITLE
Implement max_concurrency in SessionController

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -1746,7 +1746,7 @@ public class JDABuilder
         WebSocketFactory wsFactory = this.wsFactory == null ? new WebSocketFactory() : this.wsFactory;
 
         if (controller == null && shardInfo != null)
-            controller = new SessionControllerAdapter();
+            controller = new ConcurrentSessionController();
 
         AuthorizationConfig authConfig = new AuthorizationConfig(token);
         ThreadingConfig threadingConfig = new ThreadingConfig();

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -538,6 +538,7 @@ public class DefaultShardManager implements ShardManager
             try
             {
                 SessionController.ShardedGateway gateway = jda.getShardedGateway();
+                this.sessionConfig.getSessionController().setConcurrency(gateway.getConcurrency());
                 this.gatewayURL = gateway.getUrl();
                 if (this.gatewayURL == null)
                     LOG.error("Acquired null gateway url from SessionController");

--- a/src/main/java/net/dv8tion/jda/api/utils/ConcurrentSessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/ConcurrentSessionController.java
@@ -62,7 +62,7 @@ public class ConcurrentSessionController extends SessionControllerAdapter implem
         return worker;
     }
 
-    private final class Worker extends Thread
+    private static class Worker extends Thread
     {
         private final Queue<SessionConnectNode> queue = new ConcurrentLinkedQueue<>();
 

--- a/src/main/java/net/dv8tion/jda/api/utils/ConcurrentSessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/ConcurrentSessionController.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils;
+
+import com.neovisionaries.ws.client.OpeningHandshakeException;
+import net.dv8tion.jda.api.JDA;
+
+import javax.annotation.Nonnull;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+
+public class ConcurrentSessionController extends SessionControllerAdapter implements SessionController
+{
+    private Worker[] workers = new Worker[1];
+
+    @Override
+    public void setConcurrency(int level)
+    {
+        // assertions are ignored at runtime by default, this is a sanity check
+        assert level > 0 && level < Integer.MAX_VALUE;
+        workers = new Worker[level];
+    }
+
+    @Override
+    public void appendSession(@Nonnull SessionConnectNode node)
+    {
+        getWorker(node).enqueue(node);
+    }
+
+    @Override
+    public void removeSession(@Nonnull SessionConnectNode node)
+    {
+        getWorker(node).dequeue(node);
+    }
+
+    private synchronized Worker getWorker(SessionConnectNode node)
+    {
+        // get or create worker (synchronously since this should be thread-safe)
+        int i = node.getShardInfo().getShardId() % workers.length;
+        Worker worker = workers[i];
+        if (worker == null)
+        {
+            log.debug("Creating new worker handle for shard pool {}", i);
+            workers[i] = worker = new Worker(i);
+        }
+        return worker;
+    }
+
+    private final class Worker extends Thread
+    {
+        private final Queue<SessionConnectNode> queue = new ConcurrentLinkedQueue<>();
+
+        public Worker(int id)
+        {
+            super("ConcurrentSessionController-Worker-" + id);
+        }
+
+        public void enqueue(SessionConnectNode node)
+        {
+            log.trace("Appending node to queue {}", node.getShardInfo());
+            queue.add(node);
+            execute();
+        }
+
+        public void dequeue(SessionConnectNode node)
+        {
+            log.trace("Removing node from queue {}", node.getShardInfo());
+            queue.remove(node);
+        }
+
+        public void execute()
+        {
+            if (!isAlive())
+            {
+                log.debug("Running worker");
+                start();
+            }
+        }
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                while (!queue.isEmpty())
+                {
+                    processQueue();
+                    // We always sleep here because its possible that we get a new session request before the rate limit expires
+                    TimeUnit.SECONDS.sleep(SessionController.IDENTIFY_DELAY);
+                }
+            }
+            catch (InterruptedException ex)
+            {
+                log.error("Worker failed to process queue", ex);
+            }
+        }
+
+        private void processQueue() throws InterruptedException
+        {
+            SessionConnectNode node = null;
+            try
+            {
+                node = queue.remove();
+                log.debug("Running connect node for shard {}", node.getShardInfo());
+                node.run(false); // we don't use isLast anymore because it can be a problem with many reconnecting shards
+            }
+            catch (NoSuchElementException ignored) {/* This means the node was removed before we started it */}
+            catch (IllegalStateException e)
+            {
+                Throwable t = e.getCause();
+                if (t instanceof OpeningHandshakeException)
+                    log.error("Failed opening handshake, appending to queue. Message: {}", e.getMessage());
+                else if (!JDA.Status.RECONNECT_QUEUED.name().equals(t.getMessage()))
+                    log.error("Failed to establish connection for a node, appending to queue", e);
+                if (node != null)
+                    appendSession(node);
+            }
+        }
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
@@ -86,6 +86,8 @@ public interface SessionController
      */
     int IDENTIFY_DELAY = 5;
 
+    default void setConcurrency(int level) {}
+
     /**
      * Called by a JDA session when a WebSocket should be started. (Connecting and Reconnecting)
      * <br>This should only add the node to a queue and execute the queue with respect to the {@link #IDENTIFY_DELAY}.
@@ -183,6 +185,7 @@ public interface SessionController
     {
         private final String url;
         private final int shardTotal;
+        private final int concurrency;
 
         /**
          * Creates a new GatewayBot instance with the provided properties
@@ -194,8 +197,14 @@ public interface SessionController
          */
         public ShardedGateway(String url, int shardTotal)
         {
+            this(url, shardTotal, 1);
+        }
+
+        public ShardedGateway(String url, int shardTotal, int concurrency)
+        {
             this.url = url;
             this.shardTotal = shardTotal;
+            this.concurrency = concurrency;
         }
 
         /**
@@ -216,6 +225,11 @@ public interface SessionController
         public int getShardTotal()
         {
             return shardTotal;
+        }
+
+        public int getConcurrency()
+        {
+            return concurrency;
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
@@ -248,7 +248,9 @@ public interface SessionController
         }
 
         /**
-         * The concurrency level for this bot
+         * The concurrency level for this bot.
+         * <br>This should not be a custom value as discord determines the eligible concurrency.
+         * Using a different concurrency value could result in issues and possibly a ban due to login spam.
          *
          * @return The concurrency level
          *

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
@@ -86,6 +86,26 @@ public interface SessionController
      */
     int IDENTIFY_DELAY = 5;
 
+    /**
+     * Apply the {@code max_concurrency} for this bot. This property is only useful for very large bots
+     * which get access to higher concurrency when starting their shards.
+     *
+     * <p>Currently, there are 3 different levels of concurrency 1, 16, and 64.
+     * The concurrency means the bot can connect multiple shards at once without hitting the IDENTIFY rate-limit.
+     * This works by applying the concurrency level as a modulo operand to the shard id: {@code shard_id % concurrency}.
+     * We use one thread per bucket in this implementation.
+     *
+     * <p>An implementation of this interface is not required to use this concurrency level.
+     * {@link SessionControllerAdapter} does not support this due to backwards compatibility.
+     *
+     * @param  level
+     *         The concurrency level
+     *
+     * @throws AssertionError
+     *         If the provided level is not a valid array length size
+     *
+     * @since  4.2.0
+     */
     default void setConcurrency(int level) {}
 
     /**
@@ -227,6 +247,13 @@ public interface SessionController
             return shardTotal;
         }
 
+        /**
+         * The concurrency level for this bot
+         *
+         * @return The concurrency level
+         *
+         * @see    #setConcurrency(int)
+         */
         public int getConcurrency()
         {
             return concurrency;

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionControllerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionControllerAdapter.java
@@ -232,8 +232,10 @@ public class SessionControllerAdapter implements SessionController
                     Throwable t = e.getCause();
                     if (t instanceof OpeningHandshakeException)
                         log.error("Failed opening handshake, appending to queue. Message: {}", e.getMessage());
-                    else if (!JDA.Status.RECONNECT_QUEUED.name().equals(t.getMessage()))
+                    else if (t != null && !JDA.Status.RECONNECT_QUEUED.name().equals(t.getMessage()))
                         log.error("Failed to establish connection for a node, appending to queue", e);
+                    else
+                        log.error("Unexpected exception when running connect node", e);
                     appendSession(node);
                 }
                 catch (InterruptedException e)

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionControllerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionControllerAdapter.java
@@ -17,6 +17,8 @@
 package net.dv8tion.jda.api.utils;
 
 import com.neovisionaries.ws.client.OpeningHandshakeException;
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
@@ -38,12 +40,25 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class SessionControllerAdapter implements SessionController
 {
+    @Deprecated
+    @ForRemoval
+    @DeprecatedSince("4.2.0")
+    protected Queue<SessionConnectNode> connectQueue;
+    @Deprecated
+    @ForRemoval
+    @DeprecatedSince("4.2.0")
+    protected Thread workerHandle;
+    @Deprecated
+    @ForRemoval
+    @DeprecatedSince("4.2.0")
+    protected long lastConnect = 0;
+
     protected static final Logger log = JDALogger.getLog(SessionControllerAdapter.class);
     protected final Object lock = new Object();
-    protected Queue<SessionConnectNode> connectQueue;
+
     protected AtomicLong globalRatelimit;
-    protected Thread workerHandle;
-    protected long lastConnect = 0;
+
+    protected QueueWorker[] workers = new QueueWorker[1];
 
     public SessionControllerAdapter()
     {
@@ -52,17 +67,39 @@ public class SessionControllerAdapter implements SessionController
     }
 
     @Override
+    public void setConcurrency(int level)
+    {
+        workers = new QueueWorker[Math.max(1, level)];
+    }
+
+    @Override
     public void appendSession(@Nonnull SessionConnectNode node)
     {
-        removeSession(node);
-        connectQueue.add(node);
-        runWorker();
+        synchronized (lock)
+        {
+            int shardId = node.getShardInfo().getShardId();
+            int bucket = shardId % workers.length;
+            QueueWorker worker = workers[bucket];
+            if (worker == null)
+                workers[bucket] = worker = new QueueWorker();
+            worker.connectQueue.add(node);
+
+            if (!worker.isAlive())
+                worker.start();
+        }
     }
 
     @Override
     public void removeSession(@Nonnull SessionConnectNode node)
     {
-        connectQueue.remove(node);
+        synchronized (lock)
+        {
+            int shardId = node.getShardInfo().getShardId();
+            int bucket = shardId % workers.length;
+            if (workers[bucket] == null)
+                return;
+            workers[bucket].connectQueue.remove(node);
+        }
     }
 
     @Override
@@ -104,8 +141,10 @@ public class SessionControllerAdapter implements SessionController
 
                         String url = object.getString("url");
                         int shards = object.getInt("shards");
+                        int concurrency = object.getObject("session_start_limit")
+                                                .getInt("max_concurrency", 1);
 
-                        request.onSuccess(new ShardedGateway(url, shards));
+                        request.onSuccess(new ShardedGateway(url, shards, concurrency));
                     }
                     else if (response.code == 401)
                     {
@@ -135,6 +174,9 @@ public class SessionControllerAdapter implements SessionController
         return Pair.of(bot.getUrl(), bot.getShardTotal());
     }
 
+    @Deprecated
+    @ForRemoval
+    @DeprecatedSince("4.2.0")
     protected void runWorker()
     {
         synchronized (lock)
@@ -151,6 +193,8 @@ public class SessionControllerAdapter implements SessionController
     {
         /** Delay (in milliseconds) to sleep between connecting sessions */
         protected final long delay;
+        protected final Queue<SessionConnectNode> connectQueue = new ConcurrentLinkedQueue<>();
+        protected long lastConnect = 0;
 
         public QueueWorker()
         {
@@ -201,13 +245,13 @@ public class SessionControllerAdapter implements SessionController
             catch (InterruptedException ex)
             {
                 log.error("Unable to backoff", ex);
+                return;
             }
             processQueue();
             synchronized (lock)
             {
-                workerHandle = null;
                 if (!connectQueue.isEmpty())
-                    runWorker();
+                    run();
             }
         }
 
@@ -217,6 +261,8 @@ public class SessionControllerAdapter implements SessionController
             while (!connectQueue.isEmpty())
             {
                 SessionConnectNode node = connectQueue.poll();
+                if (node == null)
+                    break;
                 try
                 {
                     node.run(isMultiple && connectQueue.isEmpty());
@@ -232,14 +278,16 @@ public class SessionControllerAdapter implements SessionController
                     Throwable t = e.getCause();
                     if (t instanceof OpeningHandshakeException)
                         log.error("Failed opening handshake, appending to queue. Message: {}", e.getMessage());
-                    else if (!JDA.Status.RECONNECT_QUEUED.name().equals(t.getMessage()))
+                    else if (t != null && !JDA.Status.RECONNECT_QUEUED.name().equals(t.getMessage()))
                         log.error("Failed to establish connection for a node, appending to queue", e);
-                    appendSession(node);
+                    else
+                        log.error("Unexpected exception in queue worker", e);
+                    connectQueue.add(node);
                 }
                 catch (InterruptedException e)
                 {
                     log.error("Failed to run node", e);
-                    appendSession(node);
+                    connectQueue.add(node);
                     return; // caller should start a new thread
                 }
             }

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.utils.config;
 
 import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor;
+import net.dv8tion.jda.api.utils.ConcurrentSessionController;
 import net.dv8tion.jda.api.utils.SessionController;
-import net.dv8tion.jda.api.utils.SessionControllerAdapter;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import okhttp3.OkHttpClient;
 
@@ -42,7 +42,7 @@ public class SessionConfig
         @Nullable WebSocketFactory webSocketFactory, @Nullable VoiceDispatchInterceptor interceptor,
         EnumSet<ConfigFlag> flags, int maxReconnectDelay, int largeThreshold)
     {
-        this.sessionController = sessionController == null ? new SessionControllerAdapter() : sessionController;
+        this.sessionController = sessionController == null ? new ConcurrentSessionController() : sessionController;
         this.httpClient = httpClient;
         this.webSocketFactory = webSocketFactory == null ? new WebSocketFactory() : webSocketFactory;
         this.interceptor = interceptor;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This implements the `max_concurrency` buckets in a new `ConcurrentSessionController` class (new default). The concurrency means that multiple shards can connect simultaneously, without hitting the identify rate limit. This is very important for larger bots which can connect 16 or 64 shards at once to reduce startup time.

The buckets work by using a modulo over the `shard_id`:

```
bucket = shard_id % concurrency
```
