### PR TITLE
Replace disconnect handling to recover from strange thread states

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -395,10 +395,17 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     public void onDisconnected(WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer)
     {
         // Use a new thread to avoid issues with sleep interruption
-        Thread thread = new Thread(() ->
-                handleDisconnect(websocket, serverCloseFrame, clientCloseFrame, closedByServer));
-        thread.setName(api.getIdentifierString() + " MainWS-ReconnectThread");
-        thread.start();
+        if (Thread.currentThread().isInterrupted())
+        {
+            Thread thread = new Thread(() ->
+                    handleDisconnect(websocket, serverCloseFrame, clientCloseFrame, closedByServer));
+            thread.setName(api.getIdentifierString() + " MainWS-ReconnectThread");
+            thread.start();
+        }
+        else
+        {
+            handleDisconnect(websocket, serverCloseFrame, clientCloseFrame, closedByServer);
+        }
     }
 
     private void handleDisconnect(WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer)

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -281,19 +281,19 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     public void close()
     {
         if (socket != null)
-            socket.sendClose(1000);
+            socket.disconnect(1000);
     }
 
     public void close(int code)
     {
         if (socket != null)
-            socket.sendClose(code);
+            socket.disconnect(code);
     }
 
     public void close(int code, String reason)
     {
         if (socket != null)
-            socket.sendClose(code, reason);
+            socket.disconnect(code, reason);
     }
 
     public synchronized void shutdown()

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -394,6 +394,15 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     @Override
     public void onDisconnected(WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer)
     {
+        // Use a new thread to avoid issues with sleep interruption
+        Thread thread = new Thread(() ->
+                handleDisconnect(websocket, serverCloseFrame, clientCloseFrame, closedByServer));
+        thread.setName(api.getIdentifierString() + " MainWS-ReconnectThread");
+        thread.start();
+    }
+
+    private void handleDisconnect(WebSocket websocket, WebSocketFrame serverCloseFrame, WebSocketFrame clientCloseFrame, boolean closedByServer)
+    {
         sentAuthInfo = false;
         connected = false;
         api.setStatus(JDA.Status.DISCONNECTED);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

The `disconnect` method will work regardless of the `WriteThread`. However, it interrupts the thread so we have to create a new thread to handle the sleeping. There isn't a good thread-pool we could use for this and I don't wanna add another one just for this small code. This should in theory have marginal performance cost.
