### PR TITLE
Shutdown the WebSocket connection after everything else

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -1859,6 +1859,8 @@ public interface JDA
      *
      * <p>If you want this instance to shutdown without executing, use {@link #shutdownNow() shutdownNow()}
      *
+     * <p>This will interrupt the default JDA event thread, due to the gateway connection being interrupted.
+     *
      * @see #shutdownNow()
      */
     void shutdown();
@@ -1869,6 +1871,8 @@ public interface JDA
      * This will also cancel all queued {@link net.dv8tion.jda.api.requests.RestAction RestActions}.
      *
      * <p>If you want this instance to shutdown without cancelling enqueued RestActions use {@link #shutdown() shutdown()}
+     *
+     * <p>This will interrupt the default JDA event thread, due to the gateway connection being interrupted.
      *
      * @see #shutdown()
      */

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -348,17 +348,22 @@ public class DefaultShardManager implements ShardManager
             catch (final Exception ignored) {}
         }
 
-        this.executor.shutdown();
-
         if (this.shards != null)
         {
-            this.shards.forEach(jda ->
-            {
-                if (shardingConfig.isUseShutdownNow())
-                    jda.shutdownNow();
-                else
-                    jda.shutdown();
+            executor.execute(() -> {
+                this.shards.forEach(jda ->
+                {
+                    if (shardingConfig.isUseShutdownNow())
+                        jda.shutdownNow();
+                    else
+                        jda.shutdown();
+                });
+                this.executor.shutdown();
             });
+        }
+        else
+        {
+            this.executor.shutdown();
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -1476,6 +1476,9 @@ public interface ShardManager
      * <br>This will shutdown the internal queue worker for (re-)starts of shards.
      * This means {@link #restart(int)}, {@link #restart()}, and {@link #start(int)} will throw
      * {@link java.util.concurrent.RejectedExecutionException}.
+     *
+     * <p>This will interrupt the default JDA event thread, due to the gateway connection being interrupted.
+     * It is recommended to call this from a different thread.
      */
     void shutdown();
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -1478,7 +1478,6 @@ public interface ShardManager
      * {@link java.util.concurrent.RejectedExecutionException}.
      *
      * <p>This will interrupt the default JDA event thread, due to the gateway connection being interrupted.
-     * It is recommended to call this from a different thread.
      */
     void shutdown();
 

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -712,15 +712,14 @@ public class JDAImpl implements JDA
             return;
 
         setStatus(Status.SHUTTING_DOWN);
+        shutdownInternals();
 
         WebSocketClient client = getClient();
         if (client != null)
         {
-            client.shutdown();
             client.getChunkManager().shutdown();
+            client.shutdown();
         }
-
-        shutdownInternals();
     }
 
     public synchronized void shutdownInternals()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Closing the gateway connection will interrupt the read thread. So, we should try doing that last.
