### PR TITLE
Improve handling of VOICE_SERVER_UPDATE

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.api.managers;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.audio.AudioReceiveHandler;
@@ -183,7 +185,12 @@ public interface AudioManager
      * {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} that JDA is attempting to setup an audio connection to.
      *
      * @return True, if JDA is currently attempting to create an audio connection.
+     *
+     * @deprecated The internals have changed and this is no longer used
      */
+    @Deprecated
+    @ForRemoval
+    @DeprecatedSince("4.2.0")
     boolean isAttemptingToConnect();
 
     /**
@@ -195,8 +202,13 @@ public interface AudioManager
      *
      * @return The {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} that JDA is attempting to create an
      *         audio connection with, or {@code null} if JDA isn't attempting to create a connection.
+     *
+     * @deprecated The internals have changed and this is no longer used
      */
     @Nullable
+    @Deprecated
+    @ForRemoval
+    @DeprecatedSince("4.2.0")
     VoiceChannel getQueuedAudioConnection();
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -758,15 +758,17 @@ public class JDAImpl implements JDA
 
     private void closeAudioConnections()
     {
+        List<AudioManagerImpl> managers;
         AbstractCacheView<AudioManager> view = getAudioManagersView();
         try (UnlockHook hook = view.writeLock())
         {
-            TLongObjectMap<AudioManager> map = view.getMap();
-            map.valueCollection().stream()
+            managers = view.stream()
                .map(AudioManagerImpl.class::cast)
-               .forEach(m -> m.closeAudioConnection(ConnectionStatus.SHUTTING_DOWN));
-            map.clear();
+               .collect(Collectors.toList());
+            view.clear();
         }
+
+        managers.forEach(m -> m.closeAudioConnection(ConnectionStatus.SHUTTING_DOWN));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -170,9 +170,6 @@ class AudioWebSocket extends WebSocketAdapter
             audioConnection.shutdown();
 
             VoiceChannel disconnectedChannel = manager.getConnectedChannel();
-            if (disconnectedChannel == null)
-                disconnectedChannel = manager.getQueuedAudioConnection();
-
             manager.setAudioConnection(null);
 
             //Verify that it is actually a lost of connection and not due the connected channel being deleted.
@@ -201,7 +198,6 @@ class AudioWebSocket extends WebSocketAdapter
                     LOG.debug("Cannot reconnect due to null voice channel");
                     return;
                 }
-                manager.setQueuedAudioConnection(disconnectedChannel);
                 api.getDirectAudioController().reconnect(disconnectedChannel);
             }
             else if (status == ConnectionStatus.DISCONNECTED_REMOVED_FROM_GUILD)

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
@@ -444,19 +444,15 @@ public class GuildSetupNode
             newMng.setConnectionListener(listener);
             newMng.setAutoReconnect(mng.isAutoReconnect());
 
-            if (mng.isConnected() || mng.isAttemptingToConnect())
+            if (mng.isConnected())
             {
-                final long channelId = mng.isConnected()
-                                       ? mng.getConnectedChannel().getIdLong()
-                                       : mng.getQueuedAudioConnection().getIdLong();
+                final long channelId = mng.getConnectedChannel().getIdLong();
 
                 final VoiceChannel channel = api.getVoiceChannelById(channelId);
                 if (channel != null)
                 {
                     if (mng.isConnected())
                         mng.closeAudioConnection(ConnectionStatus.ERROR_CANNOT_RESUME);
-                    //closing old connection in order to reconnect later
-                    newMng.setQueuedAudioConnection(channel);
                 }
                 else
                 {

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceServerUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceServerUpdateHandler.java
@@ -36,7 +36,6 @@ public class VoiceServerUpdateHandler extends SocketHandler
     @Override
     protected Long handleInternally(DataObject content)
     {
-        System.out.println("Handling " + content);
         final long guildId = content.getLong("guild_id");
         if (getJDA().getGuildSetupController().isLocked(guildId))
             return guildId;

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -166,7 +166,7 @@ public class VoiceStateUpdateHandler extends SocketHandler
                 {
                     //And this instance of JDA is connected or attempting to connect,
                     // then change the channel we expect to be connected to.
-                    if (mng.isConnected() || mng.isAttemptingToConnect())
+                    if (mng.isConnected())
                         mng.setConnectedChannel(channel);
 
                     //If we have connected (VOICE_SERVER_UPDATE received and AudioConnection created (actual connection might still be setting up)),

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
@@ -113,9 +113,10 @@ class WebSocketSendingThread implements Runnable
             api.setContext();
             attemptedToSend = false;
             needRateLimit = false;
+            // We do this outside of the lock because otherwise we could potentially deadlock here
+            audioRequest = client.getNextAudioConnectRequest();
             queueLock.lockInterruptibly();
 
-            audioRequest = client.getNextAudioConnectRequest();
             chunkRequest = chunkQueue.peek();
             if (chunkRequest != null)
                 handleChunkSync(chunkRequest);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adjusts the internals to properly handle disconnect -> voice region change. Discord seems to sometimes first disconnect our socket and then send the new voice region. This change now means that we will always establish a new connection when we get a VOICE_SERVER_UPDATE. According to testing, these are only sent to the session that requested the connection so that additional check is no longer present.
