### PR TITLE
Add Emote#isAvailable() method

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -133,8 +133,16 @@ public interface Emote extends IMentionable, IFakeable
     boolean isManaged();
 
     /**
-     * Whether this emote is available. A Emote is unavailable when the {@link net.dv8tion.jda.api.entities.Guild.BoostTier BoostTier}
-     * of the Guild is lower than required for this Emote.
+     * Whether this emote is available. When an emote becomes unavailable, it cannot be used in messages. An emote becomes
+     * unavailable when the {@link net.dv8tion.jda.api.entities.Guild.BoostTier BoostTier} of the guild drops such that
+     * the maximum allowed emotes is lower than the total amount of emotes added to the guild.
+     * 
+     * <p>If an emote is added to the guild when the boost tier allows for more than 50 normal and 50 animated emotes
+     * (BoostTier is at least {@link net.dv8tion.jda.api.entities.Guild.BoostTier#TIER_1 TIER_1}) and the emote is at least
+     * the 51st one added, then the emote becomes unavaiable when the BoostTier drops below a level that allows those emotes
+     * to be used.
+     * <br>Emotes that where added as part of a lower BoostTier (i.e. the 51st emote on BoostTier 2) will remain available,
+     * as long as the BoostTier stays about the required level.
      * 
      * @return True, if this emote is available
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -142,7 +142,7 @@ public interface Emote extends IMentionable, IFakeable
      * the 51st one added, then the emote becomes unavaiable when the BoostTier drops below a level that allows those emotes
      * to be used.
      * <br>Emotes that where added as part of a lower BoostTier (i.e. the 51st emote on BoostTier 2) will remain available,
-     * as long as the BoostTier stays about the required level.
+     * as long as the BoostTier stays above the required level.
      * 
      * @return True, if this emote is available
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -133,6 +133,14 @@ public interface Emote extends IMentionable, IFakeable
     boolean isManaged();
 
     /**
+     * Whether this emote is available. A Emote is unavailable when the {@link net.dv8tion.jda.api.entities.Guild.BoostTier BoostTier}
+     * of the Guild is lower than required for this Emote.
+     * 
+     * @return True, if this emote is available
+     */
+    boolean isAvailable();
+
+    /**
      * The {@link net.dv8tion.jda.api.JDA JDA} instance of this Emote
      *
      * @return The JDA instance of this Emote

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -56,6 +56,7 @@ public class EmoteImpl implements ListedEmote
     private volatile EmoteManager manager = null;
 
     private boolean managed = false;
+    private boolean available = true;
     private boolean animated = false;
     private String name;
     private User user;
@@ -115,6 +116,12 @@ public class EmoteImpl implements ListedEmote
     public boolean isManaged()
     {
         return managed;
+    }
+
+    @Override
+    public boolean isAvailable()
+    {
+        return available;
     }
 
     @Override
@@ -209,6 +216,12 @@ public class EmoteImpl implements ListedEmote
         return this;
     }
 
+    public EmoteImpl setAvailable(boolean available)
+    {
+        this.available = available;
+        return this;
+    }
+    
     public EmoteImpl setUser(User user)
     {
         this.user = user;

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -806,7 +806,7 @@ public class EntityBuilder
                 .setName(json.getString("name", ""))
                 .setAnimated(json.getBoolean("animated"))
                 .setManaged(json.getBoolean("managed"))
-                .setAvailable(json.getBoolean("available"));
+                .setAvailable(json.getBoolean("available", true));
     }
 
     public Category createCategory(DataObject json, long guildId)

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -805,7 +805,8 @@ public class EntityBuilder
         return emoteObj
                 .setName(json.getString("name", ""))
                 .setAnimated(json.getBoolean("animated"))
-                .setManaged(json.getBoolean("managed"));
+                .setManaged(json.getBoolean("managed"))
+                .setAvailable(json.getBoolean("available"));
     }
 
     public Category createCategory(DataObject json, long guildId)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
Adds `Emote#isAvailable()` method which tells if the emote is available or not.
The [Emoji structure](https://discord.com/developers/docs/resources/emoji#emoji-object-emoji-structure) has a `available` field that indicates if the emote is available for the users, depending on the current boost tier of the Guild.