### PR TITLE
Add some convenience methods to reaction events

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -457,10 +457,13 @@ public interface Message extends ISnowflake, Formattable
 
     /**
      * Returns the author of this Message as a {@link net.dv8tion.jda.api.entities.Member member}.
-     * <br>This is just a shortcut to {@link #getGuild()}{@link net.dv8tion.jda.api.entities.Guild#getMember(User) .getMember(getAuthor())}.
      * <br><b>This is only valid if the Message was actually sent in a TextChannel.</b> This will return {@code null}
      * if the message was not sent in a TextChannel, or if the message was sent by a Webhook.
      * <br>You can check the type of channel this message was sent from using {@link #isFromType(ChannelType)} or {@link #getChannelType()}.
+     *
+     * <p>Discord does not provide a member object for messages returned by {@link RestAction RestActions} of any kind.
+     * This will return null if the message was retrieved through {@link MessageChannel#retrieveMessageById(long)} or similar means,
+     * unless the member is already cached.
      *
      * @throws java.lang.UnsupportedOperationException
      *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
@@ -143,7 +143,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
 
     /**
      * Retrieves the {@link Member} who added or removed the reaction.
-     * <br>If a member is known, this will return {@link #getUser()}.
+     * <br>If a member is known, this will return {@link #getMember()}.
      *
      * <p>Note that banning a member will also fire {@link MessageReactionRemoveEvent} and no member will be available
      * in those cases. An {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER} error response
@@ -164,7 +164,8 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      * Retrieves the message for this reaction event.
      * <br>Simple shortcut for {@code getChannel().retrieveMessageById(getMessageId())}.
      *
-     * <p>The {@link Message#getMember() getMember()} method will always return null for the resulting message.
+     * <p>The {@link Message#getMember() Message.getMember()} method will always return null for the resulting message.
+     *  You can, instead, retrieve the member via {@link #getMember()} or {@link #retrieveMember()}.
      *
      * @return {@link RestAction} - Type: {@link Message}
      */

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
@@ -18,10 +18,14 @@ package net.dv8tion.jda.api.events.message.react;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.internal.requests.CompletedRestAction;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -120,5 +124,54 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();
+    }
+
+    /**
+     * Retrieves the {@link User} who added or removed the reaction.
+     * <br>If a user is known, this will return {@link #getUser()}.
+     *
+     * @return {@link RestAction} - Type: {@link User}
+     */
+    @Nonnull
+    @CheckReturnValue
+    public RestAction<User> retrieveUser()
+    {
+        if (issuer != null)
+            return new CompletedRestAction<>(getJDA(), issuer);
+        return getJDA().retrieveUserById(getUserIdLong());
+    }
+
+    /**
+     * Retrieves the {@link Member} who added or removed the reaction.
+     * <br>If a member is known, this will return {@link #getUser()}.
+     *
+     * <p>Note that banning a member will also fire {@link MessageReactionRemoveEvent} and no member will be available
+     * in those cases. An {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER} error response
+     * should be the failure result.
+     *
+     * @return {@link RestAction} - Type: {@link Member}
+     */
+    @Nonnull
+    @CheckReturnValue
+    public RestAction<Member> retrieveMember()
+    {
+        if (member != null)
+            return new CompletedRestAction<>(getJDA(), member);
+        return getGuild().retrieveMemberById(getUserIdLong());
+    }
+
+    /**
+     * Retrieves the message for this reaction event.
+     * <br>Simple shortcut for {@code getChannel().retrieveMessageById(getMessageId())}.
+     *
+     * <p>The {@link Message#getMember() getMember()} method will always return null for the resulting message.
+     *
+     * @return {@link RestAction} - Type: {@link Message}
+     */
+    @Nonnull
+    @CheckReturnValue
+    public RestAction<Message> retrieveMessage()
+    {
+        return getChannel().retrieveMessageById(getMessageId());
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds a few convenience methods to reaction events. You can now retrieve the target message and reaction issuer directly from the event.

### Example

```java
@Override
public void onMessageReactionRemove(MessageReactionRemoveEvent event) {
    event.retrieveMessage()
         .map(Message::getContentDisplay)
         .queue(System.out::println);
}
```
