### PR TITLE
Only use interrupts when we recover zombie connections

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -281,19 +281,19 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     public void close()
     {
         if (socket != null)
-            socket.disconnect(1000);
+            socket.sendClose(1000);
     }
 
     public void close(int code)
     {
         if (socket != null)
-            socket.disconnect(code);
+            socket.sendClose(code);
     }
 
     public void close(int code, String reason)
     {
         if (socket != null)
-            socket.disconnect(code, reason);
+            socket.sendClose(code, reason);
     }
 
     public synchronized void shutdown()
@@ -644,7 +644,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         {
             missedHeartbeats = 0;
             LOG.warn("Missed 2 heartbeats! Trying to reconnect...");
-            close(4900, "ZOMBIE CONNECTION");
+            socket.disconnect(4900, "ZOMBIE CONNECTION");
         }
         else
         {


### PR DESCRIPTION


[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The disconnect() method interrupts the read thread.
This can become problematic for various reasons.
However, if we are in a zombie state we need to use this method because it will kill the read thread appropriately.
