### PR TITLE
Add ETF support

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/GatewayEncoding.java
+++ b/src/main/java/net/dv8tion/jda/api/GatewayEncoding.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api;
+
+public enum GatewayEncoding
+{
+    JSON, ETF
+}

--- a/src/main/java/net/dv8tion/jda/api/GatewayEncoding.java
+++ b/src/main/java/net/dv8tion/jda/api/GatewayEncoding.java
@@ -16,7 +16,22 @@
 
 package net.dv8tion.jda.api;
 
+/**
+ * Encoding mode used by the gateway for incoming and outgoing payloads.
+ */
 public enum GatewayEncoding
 {
-    JSON, ETF
+    /**
+     * Standard JSON format. This format uses a human-readable string encoding.
+     *
+     * @see <a href="https://www.json.org/json-en.html" target="_blank">JSON Specification</a>
+     */
+    JSON,
+    /**
+     * Erlang External Term Format (binary). This is an optimized format which encodes all payloads
+     * in a binary stream.
+     *
+     * @see <a href="https://erlang.org/doc/apps/erts/erl_ext_dist.html" target="_blank">Erlang -- External Term Format</a>
+     */
+    ETF
 }

--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -537,11 +537,15 @@ public class JDABuilder
      * @param  encoding
      *         The {@link GatewayEncoding} (default: JSON)
      *
+     * @throws IllegalArgumentException
+     *         If null is provided
+     *
      * @return The JDABuilder instance. Useful for chaining.
      */
     @Nonnull
     public JDABuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
     {
+        Checks.notNull(encoding, "GatewayEncoding");
         this.encoding = encoding;
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -531,6 +531,14 @@ public class JDABuilder
         return this;
     }
 
+    /**
+     * Choose which {@link GatewayEncoding} JDA should use.
+     *
+     * @param  encoding
+     *         The {@link GatewayEncoding} (default: JSON)
+     *
+     * @return The JDABuilder instance. Useful for chaining.
+     */
     @Nonnull
     public JDABuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
     {

--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -91,6 +91,7 @@ public class JDABuilder
     protected EnumSet<ConfigFlag> flags = ConfigFlag.getDefault();
     protected ChunkingFilter chunkingFilter = ChunkingFilter.ALL;
     protected MemberCachePolicy memberCachePolicy = MemberCachePolicy.ALL;
+    protected GatewayEncoding encoding = GatewayEncoding.JSON;
 
     /**
      * Creates a completely empty JDABuilder.
@@ -527,6 +528,13 @@ public class JDABuilder
     {
         disableCache(flags);
         this.automaticallyDisabled.addAll(flags);
+        return this;
+    }
+
+    @Nonnull
+    public JDABuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
+    {
+        this.encoding = encoding;
         return this;
     }
 
@@ -1846,7 +1854,7 @@ public class JDABuilder
                 .setCacheActivity(activity)
                 .setCacheIdle(idle)
                 .setCacheStatus(status);
-        jda.login(shardInfo, compression, true, intents);
+        jda.login(shardInfo, compression, true, intents, encoding);
         return jda;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -16,7 +16,6 @@
 package net.dv8tion.jda.api.sharding;
 
 import gnu.trove.set.TIntSet;
-import net.dv8tion.jda.api.GatewayEncoding;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
@@ -592,7 +591,7 @@ public class DefaultShardManager implements ShardManager
         jda.setSelfUser(selfUser);
         jda.setStatus(JDA.Status.INITIALIZED); //This is already set by JDA internally, but this is to make sure the listeners catch it.
 
-        final int shardTotal = jda.login(this.gatewayURL, shardInfo, this.metaConfig.getCompression(), false, shardingConfig.getIntents(), GatewayEncoding.JSON);
+        final int shardTotal = jda.login(this.gatewayURL, shardInfo, this.metaConfig.getCompression(), false, shardingConfig.getIntents(), this.metaConfig.getEncoding());
         if (getShardsTotal() == -1)
             shardingConfig.setShardsTotal(shardTotal);
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.api.sharding;
 
 import gnu.trove.set.TIntSet;
+import net.dv8tion.jda.api.GatewayEncoding;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
@@ -591,7 +592,7 @@ public class DefaultShardManager implements ShardManager
         jda.setSelfUser(selfUser);
         jda.setStatus(JDA.Status.INITIALIZED); //This is already set by JDA internally, but this is to make sure the listeners catch it.
 
-        final int shardTotal = jda.login(this.gatewayURL, shardInfo, this.metaConfig.getCompression(), false, shardingConfig.getIntents());
+        final int shardTotal = jda.login(this.gatewayURL, shardInfo, this.metaConfig.getCompression(), false, shardingConfig.getIntents(), GatewayEncoding.JSON);
         if (getShardsTotal() == -1)
             shardingConfig.setShardsTotal(shardTotal);
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -514,11 +514,15 @@ public class  DefaultShardManagerBuilder
      * @param  encoding
      *         The {@link GatewayEncoding} (default: JSON)
      *
+     * @throws IllegalArgumentException
+     *         If null is provided
+     *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
     @Nonnull
     public DefaultShardManagerBuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
     {
+        Checks.notNull(encoding, "GatewayEncoding");
         this.encoding = encoding;
         return this;
     }

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.sharding;
 import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ReplaceWith;
+import net.dv8tion.jda.api.GatewayEncoding;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.audio.factory.IAudioSendFactory;
@@ -68,6 +69,7 @@ public class  DefaultShardManagerBuilder
     protected EnumSet<ConfigFlag> flags = ConfigFlag.getDefault();
     protected EnumSet<ShardingConfigFlag> shardingFlags = ShardingConfigFlag.getDefault();
     protected Compression compression = Compression.ZLIB;
+    protected GatewayEncoding encoding = GatewayEncoding.JSON;
     protected int shardsTotal = -1;
     protected int maxReconnectDelay = 900;
     protected int largeThreshold = 250;
@@ -503,6 +505,12 @@ public class  DefaultShardManagerBuilder
     {
         this.disableCache(flags);
         this.automaticallyDisabled.addAll(flags);
+        return this;
+    }
+
+    public DefaultShardManagerBuilder setGatewayEncoding(GatewayEncoding encoding)
+    {
+        this.encoding = encoding;
         return this;
     }
 
@@ -2200,7 +2208,7 @@ public class  DefaultShardManagerBuilder
         presenceConfig.setIdleProvider(idleProvider);
         final ThreadingProviderConfig threadingConfig = new ThreadingProviderConfig(rateLimitPoolProvider, gatewayPoolProvider, callbackPoolProvider, eventPoolProvider, threadFactory);
         final ShardingSessionConfig sessionConfig = new ShardingSessionConfig(sessionController, voiceDispatchInterceptor, httpClient, httpClientBuilder, wsFactory, audioSendFactory, flags, shardingFlags, maxReconnectDelay, largeThreshold);
-        final ShardingMetaConfig metaConfig = new ShardingMetaConfig(maxBufferSize, contextProvider, cacheFlags, flags, compression);
+        final ShardingMetaConfig metaConfig = new ShardingMetaConfig(maxBufferSize, contextProvider, cacheFlags, flags, compression, encoding);
         final DefaultShardManager manager = new DefaultShardManager(this.token, this.shards, shardingConfig, eventConfig, presenceConfig, threadingConfig, sessionConfig, metaConfig, chunkingFilter);
 
         manager.login();

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -508,7 +508,16 @@ public class  DefaultShardManagerBuilder
         return this;
     }
 
-    public DefaultShardManagerBuilder setGatewayEncoding(GatewayEncoding encoding)
+    /**
+     * Choose which {@link GatewayEncoding} JDA should use.
+     *
+     * @param  encoding
+     *         The {@link GatewayEncoding} (default: JSON)
+     *
+     * @return The DefaultShardManagerBuilder instance. Useful for chaining.
+     */
+    @Nonnull
+    public DefaultShardManagerBuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
     {
         this.encoding = encoding;
         return this;

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -32,8 +32,11 @@ import javax.annotation.Nullable;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Represents a list of values used in communication with the Discord API.
@@ -694,5 +697,12 @@ public class DataArray implements Iterable<Object>
     public Iterator<Object> iterator()
     {
         return data.iterator();
+    }
+
+    @Nonnull
+    public <T> Stream<T> stream(BiFunction<? super DataArray, Integer, ? extends T> mapper)
+    {
+        return IntStream.range(0, length())
+                .mapToObj(index -> mapper.apply(this, index));
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -176,7 +176,7 @@ public class DataArray implements Iterable<Object>
     {
         try
         {
-            List<Object> list = (List<Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
+            List<Object> list = ExTermDecoder.unpackList(ByteBuffer.wrap(data));
             return new DataArray(list);
         }
         catch (Exception ex)

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -170,8 +170,19 @@ public class DataArray implements Iterable<Object>
         }
     }
 
+    /**
+     * Parses using {@link ExTermDecoder}.
+     * The provided data must start with the correct version header (131).
+     *
+     * @param  data
+     *         The data to decode
+     *
+     * @throws net.dv8tion.jda.api.exceptions.ParsingException
+     *         If the provided ETF payload is incorrectly formatted or an I/O error occurred
+     *
+     * @return A DataArray instance for the provided payload
+     */
     @Nonnull
-    @SuppressWarnings("unchecked")
     public static DataArray fromETF(@Nonnull byte[] data)
     {
         try
@@ -623,10 +634,11 @@ public class DataArray implements Iterable<Object>
     }
 
     /**
-     * Serialize this object as JSON.
+     * Serializes this object as JSON.
      *
-     * @return a byte array containing the JSON representation of this object.
+     * @return byte array containing the JSON representation of this object
      */
+    @Nonnull
     public byte[] toJson()
     {
         try
@@ -641,6 +653,12 @@ public class DataArray implements Iterable<Object>
         }
     }
 
+    /**
+     * Serializes this object as ETF LIST term.
+     *
+     * @return byte array containing the encoded ETF term
+     */
+    @Nonnull
     public byte[] toETF()
     {
         ByteBuffer buffer = ExTermEncoder.pack(data);

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -174,8 +174,16 @@ public class DataArray implements Iterable<Object>
     @SuppressWarnings("unchecked")
     public static DataArray fromETF(@Nonnull byte[] data)
     {
-        List<Object> list = (List<Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
-        return new DataArray(list);
+        try
+        {
+            List<Object> list = (List<Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
+            return new DataArray(list);
+        }
+        catch (Exception ex)
+        {
+            log.error("Failed to parse ETF data {}", Arrays.toString(data), ex);
+            throw new ParsingException(ex);
+        }
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.type.CollectionType;
 import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.utils.data.etf.ExTermDecoder;
 import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
+import net.dv8tion.jda.internal.utils.Checks;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -177,6 +178,8 @@ public class DataArray implements Iterable<Object>
      * @param  data
      *         The data to decode
      *
+     * @throws IllegalArgumentException
+     *         If the provided data is null
      * @throws net.dv8tion.jda.api.exceptions.ParsingException
      *         If the provided ETF payload is incorrectly formatted or an I/O error occurred
      *
@@ -185,6 +188,7 @@ public class DataArray implements Iterable<Object>
     @Nonnull
     public static DataArray fromETF(@Nonnull byte[] data)
     {
+        Checks.notNull(data, "Data");
         try
         {
             List<Object> list = ExTermDecoder.unpackList(ByteBuffer.wrap(data));

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -21,17 +21,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import net.dv8tion.jda.api.exceptions.ParsingException;
+import net.dv8tion.jda.api.utils.data.etf.ExTermDecoder;
+import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.UncheckedIOException;
+import java.io.*;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -166,6 +165,14 @@ public class DataArray implements Iterable<Object>
         {
             throw new ParsingException(e);
         }
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public static DataArray fromETF(@Nonnull byte[] data)
+    {
+        List<Object> list = (List<Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
+        return new DataArray(list);
     }
 
     /**
@@ -621,6 +628,12 @@ public class DataArray implements Iterable<Object>
         {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public byte[] toETF()
+    {
+        ByteBuffer buffer = ExTermEncoder.pack(data);
+        return Arrays.copyOfRange(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.limit());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -184,8 +184,16 @@ public class DataObject implements SerializableData
     @SuppressWarnings("unchecked")
     public static DataObject fromETF(@Nonnull byte[] data)
     {
-        Map<String, Object> map = (Map<String, Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
-        return new DataObject(map);
+        try
+        {
+            Map<String, Object> map = (Map<String, Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
+            return new DataObject(map);
+        }
+        catch (Exception ex)
+        {
+            log.error("Failed to parse ETF data {}", Arrays.toString(data), ex);
+            throw new ParsingException(ex);
+        }
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.type.MapType;
 import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.utils.data.etf.ExTermDecoder;
 import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
+import net.dv8tion.jda.internal.utils.Checks;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,6 +188,8 @@ public class DataObject implements SerializableData
      * @param  data
      *         The data to decode
      *
+     * @throws IllegalArgumentException
+     *         If the provided data is null
      * @throws net.dv8tion.jda.api.exceptions.ParsingException
      *         If the provided ETF payload is incorrectly formatted or an I/O error occurred
      *
@@ -195,6 +198,7 @@ public class DataObject implements SerializableData
     @Nonnull
     public static DataObject fromETF(@Nonnull byte[] data)
     {
+        Checks.notNull(data, "Data");
         try
         {
             Map<String, Object> map = ExTermDecoder.unpackMap(ByteBuffer.wrap(data));

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -21,17 +21,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.MapType;
 import net.dv8tion.jda.api.exceptions.ParsingException;
+import net.dv8tion.jda.api.utils.data.etf.ExTermDecoder;
+import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.UncheckedIOException;
+import java.io.*;
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -179,6 +178,14 @@ public class DataObject implements SerializableData
         {
             throw new ParsingException(ex);
         }
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    public static DataObject fromETF(@Nonnull byte[] data)
+    {
+        Map<String, Object> map = (Map<String, Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
+        return new DataObject(map);
     }
 
     /**
@@ -664,6 +671,12 @@ public class DataObject implements SerializableData
         {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public byte[] toETF()
+    {
+        ByteBuffer buffer = ExTermEncoder.pack(data);
+        return Arrays.copyOfRange(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.limit());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -186,7 +186,7 @@ public class DataObject implements SerializableData
     {
         try
         {
-            Map<String, Object> map = (Map<String, Object>) ExTermDecoder.unpack(ByteBuffer.wrap(data));
+            Map<String, Object> map = ExTermDecoder.unpackMap(ByteBuffer.wrap(data));
             return new DataObject(map);
         }
         catch (Exception ex)

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -180,8 +180,19 @@ public class DataObject implements SerializableData
         }
     }
 
+    /**
+     * Parses using {@link ExTermDecoder}.
+     * The provided data must start with the correct version header (131).
+     *
+     * @param  data
+     *         The data to decode
+     *
+     * @throws net.dv8tion.jda.api.exceptions.ParsingException
+     *         If the provided ETF payload is incorrectly formatted or an I/O error occurred
+     *
+     * @return A DataObject instance for the provided payload
+     */
     @Nonnull
-    @SuppressWarnings("unchecked")
     public static DataObject fromETF(@Nonnull byte[] data)
     {
         try
@@ -665,8 +676,9 @@ public class DataObject implements SerializableData
     /**
      * Serialize this object as JSON.
      *
-     * @return a byte array containing the JSON representation of this object.
+     * @return byte array containing the JSON representation of this object
      */
+    @Nonnull
     public byte[] toJson()
     {
         try
@@ -681,6 +693,12 @@ public class DataObject implements SerializableData
         }
     }
 
+    /**
+     * Serializes this object as ETF MAP term.
+     *
+     * @return byte array containing the encoded ETF term
+     */
+    @Nonnull
     public byte[] toETF()
     {
         ByteBuffer buffer = ExTermEncoder.pack(data);

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
@@ -81,8 +81,8 @@ public class ExTermDecoder
 
     private static double unpackOldFloat(ByteBuffer buffer)
     {
-        String bytes = (String) unpackAtom(buffer, StandardCharsets.ISO_8859_1, 31);
-        return Double.parseDouble(Objects.requireNonNull(bytes));
+        String bytes = getString(buffer, StandardCharsets.ISO_8859_1, 31);
+        return Double.parseDouble(bytes);
     }
 
     private static double unpackFloat(ByteBuffer buffer)

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
@@ -210,10 +210,13 @@ public class ExTermDecoder
         return buffer.getInt();
     }
 
-    private static String unpackString(ByteBuffer buffer)
+    private static List<Object> unpackString(ByteBuffer buffer)
     {
         int length = Short.toUnsignedInt(buffer.getShort());
-        return getString(buffer, StandardCharsets.UTF_8, length);
+        List<Object> bytes = new ArrayList<>(length);
+        while (length-- > 0)
+            bytes.add(buffer.get());
+        return bytes;
     }
 
     private static String unpackBinary(ByteBuffer buffer)

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils.data.etf;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static net.dv8tion.jda.api.utils.data.etf.ExTermTag.*;
+
+public class ExTermDecoder
+{
+    public static Object unpack(ByteBuffer buffer)
+    {
+        if (buffer.get() != -125)
+            throw new IllegalArgumentException();
+
+        return unpack0(buffer);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> unpackMap(ByteBuffer buffer)
+    {
+        byte tag = buffer.get(1);
+        if (tag != MAP)
+            throw new IllegalArgumentException("Cannot unpack map from tag " + tag);
+        return (Map<String, Object>) unpack(buffer);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<Object> unpackList(ByteBuffer buffer)
+    {
+        byte tag = buffer.get(1);
+        if (tag != LIST)
+            throw new IllegalArgumentException("Cannot unpack list from tag " + tag);
+
+        return (List<Object>) unpack(buffer);
+    }
+
+    private static Object unpack0(ByteBuffer buffer)
+    {
+        int tag = buffer.get();
+        switch (tag) {
+        case SMALL_INT: return unpackSmallInt(buffer);
+        case SMALL_BIGINT: return unpackSmallBigint(buffer);
+        case INT: return unpackInt(buffer);
+
+        case FLOAT: return unpackOldFloat(buffer);
+        case NEW_FLOAT: return unpackFloat(buffer);
+
+        case SMALL_ATOM_UTF8: return unpackSmallAtom(buffer, StandardCharsets.UTF_8);
+        case SMALL_ATOM: return unpackSmallAtom(buffer, StandardCharsets.ISO_8859_1);
+        case ATOM_UTF8: return unpackAtom(buffer, StandardCharsets.UTF_8);
+        case ATOM: return unpackAtom(buffer, StandardCharsets.ISO_8859_1);
+
+        case MAP: return unpackMap0(buffer);
+        case LIST: return unpackList0(buffer);
+        case NIL: return Collections.emptyList();
+
+        case STRING: return unpackString(buffer);
+        case BINARY: return unpackBinary(buffer);
+        default:
+            throw new IllegalArgumentException("Unknown tag " + tag);
+        }
+    }
+
+    private static double unpackOldFloat(ByteBuffer buffer)
+    {
+        String bytes = (String) unpackAtom(buffer, StandardCharsets.ISO_8859_1, 31);
+        return Double.parseDouble(Objects.requireNonNull(bytes));
+    }
+
+    private static double unpackFloat(ByteBuffer buffer)
+    {
+        return buffer.getDouble();
+    }
+
+    private static long unpackSmallBigint(ByteBuffer buffer)
+    {
+        int arity = Byte.toUnsignedInt(buffer.get());
+        int sign = Byte.toUnsignedInt(buffer.get());
+        long sum = 0;
+        long offset = 0;
+        while (arity-- > 0)
+        {
+            sum += Byte.toUnsignedLong(buffer.get()) << offset;
+            offset += 8;
+        }
+
+        return sign == 0 ? sum : -sum;
+    }
+
+    private static int unpackSmallInt(ByteBuffer buffer)
+    {
+        return Byte.toUnsignedInt(buffer.get());
+    }
+
+    private static int unpackInt(ByteBuffer buffer)
+    {
+        return buffer.getInt();
+    }
+
+    private static String unpackString(ByteBuffer buffer)
+    {
+        int length = Short.toUnsignedInt(buffer.getShort());
+        byte[] array = new byte[length];
+        buffer.get(array);
+        return new String(array, StandardCharsets.UTF_8);
+    }
+
+    private static String unpackBinary(ByteBuffer buffer)
+    {
+        int length = buffer.getInt();
+        byte[] array = new byte[length];
+        buffer.get(array);
+        return new String(array, StandardCharsets.UTF_8);
+    }
+
+    private static Object unpackSmallAtom(ByteBuffer buffer, Charset charset)
+    {
+        int length = Byte.toUnsignedInt(buffer.get());
+        return unpackAtom(buffer, charset, length);
+    }
+
+    private static Object unpackAtom(ByteBuffer buffer, Charset charset)
+    {
+        int length = Short.toUnsignedInt(buffer.getShort());
+        return unpackAtom(buffer, charset, length);
+    }
+
+    private static Object unpackAtom(ByteBuffer buffer, Charset charset, int length)
+    {
+        byte[] array = new byte[length];
+        buffer.get(array);
+        String value = new String(array, charset);
+        if (value.equals("true"))
+            return true;
+        if (value.equals("false"))
+            return false;
+        if (value.equals("nil"))
+            return null;
+        return value;
+    }
+
+    private static List<Object> unpackList0(ByteBuffer buffer)
+    {
+        int length = buffer.getInt();
+        List<Object> list = new ArrayList<>(length);
+        while (length-- > 0)
+        {
+            list.add(unpack0(buffer));
+        }
+        Object tail = unpack0(buffer);
+        if (tail != Collections.emptyList())
+            throw new IllegalArgumentException("Unexpected tail " + tail);
+        return list;
+    }
+
+    private static Map<String, Object> unpackMap0(ByteBuffer buffer)
+    {
+        Map<String, Object> map = new HashMap<>();
+        int arity = buffer.getInt();
+        while (arity-- > 0)
+        {
+            String key = (String) unpack0(buffer);
+            Object value = unpack0(buffer);
+            map.put(key, value);
+        }
+        return map;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
@@ -118,17 +118,13 @@ public class ExTermDecoder
     private static String unpackString(ByteBuffer buffer)
     {
         int length = Short.toUnsignedInt(buffer.getShort());
-        byte[] array = new byte[length];
-        buffer.get(array);
-        return new String(array, StandardCharsets.UTF_8);
+        return getString(buffer, StandardCharsets.UTF_8, length);
     }
 
     private static String unpackBinary(ByteBuffer buffer)
     {
         int length = buffer.getInt();
-        byte[] array = new byte[length];
-        buffer.get(array);
-        return new String(array, StandardCharsets.UTF_8);
+        return getString(buffer, StandardCharsets.UTF_8, length);
     }
 
     private static Object unpackSmallAtom(ByteBuffer buffer, Charset charset)
@@ -145,16 +141,21 @@ public class ExTermDecoder
 
     private static Object unpackAtom(ByteBuffer buffer, Charset charset, int length)
     {
+        String value = getString(buffer, StandardCharsets.ISO_8859_1, length);
+        switch (value)
+        {
+        case "true": return true;
+        case "false": return false;
+        case "nil": return null;
+        default: return value;
+        }
+    }
+
+    private static String getString(ByteBuffer buffer, Charset encoding, int length)
+    {
         byte[] array = new byte[length];
         buffer.get(array);
-        String value = new String(array, charset);
-        if (value.equals("true"))
-            return true;
-        if (value.equals("false"))
-            return false;
-        if (value.equals("nil"))
-            return null;
-        return value;
+        return new String(array, StandardCharsets.UTF_8);
     }
 
     private static List<Object> unpackList0(ByteBuffer buffer)

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
@@ -27,8 +27,37 @@ import java.util.zip.InflaterOutputStream;
 
 import static net.dv8tion.jda.api.utils.data.etf.ExTermTag.*;
 
+/**
+ * Decodes an ETF encoded payload to a java object representation.
+ *
+ * @see #unpack(ByteBuffer)
+ * @see #unpackMap(ByteBuffer)
+ * @see #unpackList(ByteBuffer)
+ */
 public class ExTermDecoder
 {
+    /**
+     * Unpacks the provided term into a java object.
+     *
+     * <h2>The mapping is as follows:</h2>
+     * <ul>
+     *     <li>{@code Small Int | Int -> Integer}</li>
+     *     <li>{@code Small BigInt -> Long}</li>
+     *     <li>{@code Float | New Float -> Double}</li>
+     *     <li>{@code Small Atom | Atom -> Boolean | null | String}</li>
+     *     <li>{@code Binary | String -> String}</li>
+     *     <li>{@code List | NIL -> List}</li>
+     *     <li>{@code Map -> Map}</li>
+     * </ul>
+     *
+     * @param  buffer
+     *         The {@link ByteBuffer} containing the encoded term
+     *
+     * @throws IllegalArgumentException
+     *         If the buffer does not start with the version byte {@code 131} or contains an unsupported tag
+     *
+     * @return The java object
+     */
     public static Object unpack(ByteBuffer buffer)
     {
         if (buffer.get() != -125)
@@ -37,6 +66,28 @@ public class ExTermDecoder
         return unpack0(buffer);
     }
 
+    /**
+     * Unpacks the provided term into a java {@link Map}.
+     *
+     * <h2>The mapping is as follows:</h2>
+     * <ul>
+     *     <li>{@code Small Int | Int -> Integer}</li>
+     *     <li>{@code Small BigInt -> Long}</li>
+     *     <li>{@code Float | New Float -> Double}</li>
+     *     <li>{@code Small Atom | Atom -> Boolean | null | String}</li>
+     *     <li>{@code Binary | String -> String}</li>
+     *     <li>{@code List | NIL -> List}</li>
+     *     <li>{@code Map -> Map}</li>
+     * </ul>
+     *
+     * @param  buffer
+     *         The {@link ByteBuffer} containing the encoded term
+     *
+     * @throws IllegalArgumentException
+     *         If the buffer does not start with a Map term, does not have the right version byte, or the format includes an unsupported tag
+     *
+     * @return The parsed {@link Map} instance
+     */
     @SuppressWarnings("unchecked")
     public static Map<String, Object> unpackMap(ByteBuffer buffer)
     {
@@ -46,6 +97,28 @@ public class ExTermDecoder
         return (Map<String, Object>) unpack(buffer);
     }
 
+    /**
+     * Unpacks the provided term into a java {@link List}.
+     *
+     * <h2>The mapping is as follows:</h2>
+     * <ul>
+     *     <li>{@code Small Int | Int -> Integer}</li>
+     *     <li>{@code Small BigInt -> Long}</li>
+     *     <li>{@code Float | New Float -> Double}</li>
+     *     <li>{@code Small Atom | Atom -> Boolean | null | String}</li>
+     *     <li>{@code Binary | String -> String}</li>
+     *     <li>{@code List | NIL -> List}</li>
+     *     <li>{@code Map -> Map}</li>
+     * </ul>
+     *
+     * @param  buffer
+     *         The {@link ByteBuffer} containing the encoded term
+     *
+     * @throws IllegalArgumentException
+     *         If the buffer does not start with a List or NIL term, does not have the right version byte, or the format includes an unsupported tag
+     *
+     * @return The parsed {@link List} instance
+     */
     @SuppressWarnings("unchecked")
     public static List<Object> unpackList(ByteBuffer buffer)
     {

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
@@ -128,7 +128,7 @@ public class ExTermEncoder
 
     private static ByteBuffer packInt(ByteBuffer buffer, int value)
     {
-        if (countBytes(value) == 1 && value >= 0)
+        if (countBytes(value) <= 1 && value >= 0)
             return packSmallInt(buffer, (byte) value);
         buffer = realloc(buffer, 5);
         buffer.put(INT);
@@ -139,7 +139,7 @@ public class ExTermEncoder
     private static ByteBuffer packLong(ByteBuffer buffer, long value)
     {
         byte bytes = countBytes(value);
-        if (bytes == 1) // Use optimized small int encoding
+        if (bytes <= 1) // Use optimized small int encoding
             return packSmallInt(buffer, (byte) value);
         if (bytes <= 4 && value >= 0)
         {

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
@@ -24,8 +24,37 @@ import java.util.Map;
 
 import static net.dv8tion.jda.api.utils.data.etf.ExTermTag.*;
 
+/**
+ * Encodes an object into a binary ETF representation.
+ *
+ * @see #pack(Object)
+ */
 public class ExTermEncoder
 {
+    /**
+     * Encodes the provided object into an ETF buffer.
+     *
+     * <h2>The mapping is as follows:</h2>
+     * <ul>
+     *     <li>{@code String -> Binary}</li>
+     *     <li>{@code Map -> Map}</li>
+     *     <li>{@code Collection -> List | NIL}</li>
+     *     <li>{@code Byte -> Small Int}</li>
+     *     <li>{@code Integer, Short -> Int | Small Int}</li>
+     *     <li>{@code Long -> Small BigInt | Int | Small Int}</li>
+     *     <li>{@code Float, Double -> New Float}</li>
+     *     <li>{@code Boolean -> Atom(Boolean)}</li>
+     *     <li>{@code null -> Atom("nil")}</li>
+     * </ul>
+     *
+     * @param  data
+     *         The object to encode
+     *
+     * @throws UnsupportedOperationException
+     *         If there is no type mapping for the provided object
+     *
+     * @return {@link ByteBuffer} with the encoded ETF term
+     */
     public static ByteBuffer pack(Object data)
     {
         ByteBuffer buffer = ByteBuffer.allocate(1024);

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
@@ -38,7 +38,7 @@ public class ExTermEncoder
     }
 
     @SuppressWarnings("unchecked")
-    public static ByteBuffer pack(ByteBuffer buffer, Object value)
+    private static ByteBuffer pack(ByteBuffer buffer, Object value)
     {
         if (value instanceof String)
             return packBinary(buffer, (String) value);
@@ -52,6 +52,8 @@ public class ExTermEncoder
             return packInt(buffer, (int) value);
         if (value instanceof Long)
             return packLong(buffer, (long) value);
+        if (value instanceof Float || value instanceof Double)
+            return packFloat(buffer, (double) value);
         if (value instanceof Boolean)
             return packAtom(buffer, String.valueOf(value));
         if (value == null)
@@ -159,6 +161,14 @@ public class ExTermEncoder
             value >>>= 8;
         }
 
+        return buffer;
+    }
+
+    private static ByteBuffer packFloat(ByteBuffer buffer, double value)
+    {
+        buffer = realloc(buffer, 9);
+        buffer.put(NEW_FLOAT);
+        buffer.putDouble(value);
         return buffer;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils.data.etf;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static net.dv8tion.jda.api.utils.data.etf.ExTermTag.*;
+
+public class ExTermEncoder
+{
+
+    public static ByteBuffer pack(Object data)
+    {
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put((byte) 131);
+
+        return pack(buffer, data).flip();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ByteBuffer pack(ByteBuffer buffer, Object value)
+    {
+        if (value instanceof String)
+            return packBinary(buffer, (String) value);
+        if (value instanceof Map)
+            return packMap(buffer, (Map<String, Object>) value);
+        if (value instanceof List)
+            return packList(buffer, (List<Object>) value);
+        if (value instanceof Integer)
+            return packInt(buffer, (int) value);
+        if (value instanceof Long)
+            return packLong(buffer, (long) value);
+        if (value instanceof Boolean)
+            return packAtom(buffer, String.valueOf(value));
+        if (value == null)
+            return packAtom(buffer, "nil");
+
+        throw new UnsupportedOperationException();
+    }
+
+    private static ByteBuffer realloc(ByteBuffer buffer, int length)
+    {
+        if (buffer.remaining() >= length)
+            return buffer;
+
+        ByteBuffer allocated = ByteBuffer.allocate((buffer.position() + length) * 2);
+        allocated.put(buffer.flip());
+        return allocated;
+    }
+
+    private static ByteBuffer packMap(ByteBuffer buffer, Map<String, Object> data)
+    {
+        buffer = realloc(buffer, data.size() + 5);
+        buffer.put(MAP);
+        buffer.putInt(data.size());
+
+        for (Map.Entry<String, Object> entry : data.entrySet())
+        {
+            buffer = packBinary(buffer, entry.getKey());
+            buffer = pack(buffer, entry.getValue());
+        }
+
+        return buffer;
+    }
+
+    private static ByteBuffer packList(ByteBuffer buffer, List<Object> data)
+    {
+        buffer = realloc(buffer, data.size() + 5);
+        buffer.put(LIST);
+        buffer.putInt(data.size());
+        for (Object element : data)
+        {
+            buffer = pack(buffer, element);
+        }
+        buffer.put(NIL);
+        return buffer;
+    }
+
+    private static ByteBuffer packBinary(ByteBuffer buffer, String value)
+    {
+        byte[] encoded = value.getBytes(StandardCharsets.UTF_8);
+        buffer = realloc(buffer, encoded.length + 5);
+        buffer.put(BINARY);
+        buffer.putInt(value.length());
+        buffer.put(encoded);
+        return buffer;
+    }
+
+    private static ByteBuffer packInt(ByteBuffer buffer, int value)
+    {
+        buffer = realloc(buffer, 5);
+        buffer.put(INT);
+        buffer.putInt(value);
+        return buffer;
+    }
+
+    private static ByteBuffer packLong(ByteBuffer buffer, long value)
+    {
+        byte sign = (byte) (value < 0 ? 1 : 0);
+        value = Math.abs(value);
+        byte bytes = countBytes(value);
+        buffer = realloc(buffer, 3 + bytes);
+        buffer.put(SMALL_BIGINT);
+        buffer.put(bytes);
+        buffer.put(sign);
+        while (value > 0)
+        {
+            buffer.put((byte) value);
+            value >>>= 8;
+        }
+
+        return buffer;
+    }
+
+    private static ByteBuffer packAtom(ByteBuffer buffer, String value)
+    {
+        byte[] array = value.getBytes(StandardCharsets.ISO_8859_1);
+        buffer = realloc(buffer, array.length + 3);
+        buffer.put(ATOM);
+        buffer.putShort((short) array.length);
+        buffer.put(array);
+        return buffer;
+    }
+
+    private static byte countBytes(long value)
+    {
+        int leadingZeros = Long.numberOfLeadingZeros(value);
+        return (byte) Math.ceil((64 - leadingZeros) / 8.);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.api.utils.data.etf;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -30,7 +31,10 @@ public class ExTermEncoder
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         buffer.put((byte) 131);
 
-        return pack(buffer, data).flip();
+        ByteBuffer packed = pack(buffer, data);
+        // This cast prevents issues with backwards compatibility in the ABI (java 11 made breaking changes)
+        ((Buffer) packed).flip();
+        return packed;
     }
 
     @SuppressWarnings("unchecked")
@@ -60,7 +64,9 @@ public class ExTermEncoder
             return buffer;
 
         ByteBuffer allocated = ByteBuffer.allocate((buffer.position() + length) * 2);
-        allocated.put(buffer.flip());
+        // This cast prevents issues with backwards compatibility in the ABI (java 11 made breaking changes)
+        ((Buffer) buffer).flip();
+        allocated.put(buffer);
         return allocated;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermEncoder.java
@@ -18,14 +18,13 @@ package net.dv8tion.jda.api.utils.data.etf;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 
 import static net.dv8tion.jda.api.utils.data.etf.ExTermTag.*;
 
 public class ExTermEncoder
 {
-
     public static ByteBuffer pack(Object data)
     {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
@@ -41,8 +40,8 @@ public class ExTermEncoder
             return packBinary(buffer, (String) value);
         if (value instanceof Map)
             return packMap(buffer, (Map<String, Object>) value);
-        if (value instanceof List)
-            return packList(buffer, (List<Object>) value);
+        if (value instanceof Collection)
+            return packList(buffer, (Collection<Object>) value);
         if (value instanceof Integer)
             return packInt(buffer, (int) value);
         if (value instanceof Long)
@@ -52,7 +51,7 @@ public class ExTermEncoder
         if (value == null)
             return packAtom(buffer, "nil");
 
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Cannot pack value of type " + value.getClass().getName());
     }
 
     private static ByteBuffer realloc(ByteBuffer buffer, int length)
@@ -80,15 +79,13 @@ public class ExTermEncoder
         return buffer;
     }
 
-    private static ByteBuffer packList(ByteBuffer buffer, List<Object> data)
+    private static ByteBuffer packList(ByteBuffer buffer, Collection<Object> data)
     {
         buffer = realloc(buffer, data.size() + 5);
         buffer.put(LIST);
         buffer.putInt(data.size());
         for (Object element : data)
-        {
             buffer = pack(buffer, element);
-        }
         buffer.put(NIL);
         return buffer;
     }
@@ -113,13 +110,12 @@ public class ExTermEncoder
 
     private static ByteBuffer packLong(ByteBuffer buffer, long value)
     {
-        byte sign = (byte) (value < 0 ? 1 : 0);
-        value = Math.abs(value);
         byte bytes = countBytes(value);
         buffer = realloc(buffer, 3 + bytes);
         buffer.put(SMALL_BIGINT);
         buffer.put(bytes);
-        buffer.put(sign);
+        // We only use "unsigned" value so the sign is always positive
+        buffer.put((byte) 0);
         while (value > 0)
         {
             buffer.put((byte) value);

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils.data.etf;
+
+public class ExTermTag
+{
+    public static final byte NEW_FLOAT = 70;
+    public static final byte SMALL_INT = 97;
+    public static final byte INT = 98;
+    public static final byte FLOAT = 99;
+    public static final byte ATOM = 100;
+    public static final byte NIL = 106;
+    public static final byte STRING = 107;
+    public static final byte LIST = 108;
+    public static final byte BINARY = 109;
+    public static final byte SMALL_BIGINT = 110;
+    public static final byte SMALL_ATOM = 115;
+    public static final byte MAP = 116;
+    public static final byte ATOM_UTF8 = 118;
+    public static final byte SMALL_ATOM_UTF8 = 119;
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
@@ -16,6 +16,10 @@
 
 package net.dv8tion.jda.api.utils.data.etf;
 
+/**
+ * Tags used for encoding and decoding for external terms.
+ * <br>This list in incomplete as not all tags are used by this library.
+ */
 public class ExTermTag
 {
     // 8 IEEE float

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
@@ -18,19 +18,34 @@ package net.dv8tion.jda.api.utils.data.etf;
 
 public class ExTermTag
 {
+    // 8 IEEE float
     public static final byte NEW_FLOAT = 70;
-    public static final byte COMPRESSED = 90;
+    // 4 Uncompressed Size | N ZLIB Compressed Data
+    public static final byte COMPRESSED = 80;
+    // 1 byte unsigned int value
     public static final byte SMALL_INT = 97;
+    // 4 byte signed int value
     public static final byte INT = 98;
-    public static final byte FLOAT = 99;
-    public static final byte ATOM = 100;
+    // 31 bytes string of float value sprintf("%.20e")
+    public static final byte FLOAT = 99; // deprecated
+    // 2 byte length | N bytes latin-1 string
+    public static final byte ATOM = 100; // deprecated
+    // 0 bytes empty list
     public static final byte NIL = 106;
+    // 2 byte length | N bytes
     public static final byte STRING = 107;
+    // 4 byte length | N tags | 1 byte NIL tag
     public static final byte LIST = 108;
+    // 4 byte length | N bytes UTF-8 string
     public static final byte BINARY = 109;
+    // 1 byte length | 1 byte sign | N bytes unsigned SE int
     public static final byte SMALL_BIGINT = 110;
-    public static final byte SMALL_ATOM = 115;
+    // 1 byte length | N bytes latin-1 string
+    public static final byte SMALL_ATOM = 115; // deprecated
+    // 4 byte length | N pairs of KEY,VALUE terms
     public static final byte MAP = 116;
+    // 2 byte length | N bytes of UTF-8 string
     public static final byte ATOM_UTF8 = 118;
+    // 1 byte length | N bytes of UTF-8 string
     public static final byte SMALL_ATOM_UTF8 = 119;
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermTag.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.utils.data.etf;
 public class ExTermTag
 {
     public static final byte NEW_FLOAT = 70;
+    public static final byte COMPRESSED = 90;
     public static final byte SMALL_INT = 97;
     public static final byte INT = 98;
     public static final byte FLOAT = 99;

--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/package-info.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility classes to decode and encode Erlang External Term Format (ETF)
+ *
+ * @see <a href="https://erlang.org/doc/apps/erts/erl_ext_dist.html" target="_blank">Erlang -- External Term Format</a>
+ */
+package net.dv8tion.jda.api.utils.data.etf;

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -22,6 +22,7 @@ import gnu.trove.map.TLongObjectMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.api.AccountType;
+import net.dv8tion.jda.api.GatewayEncoding;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.audio.factory.DefaultSendFactory;
@@ -259,15 +260,15 @@ public class JDAImpl implements JDA
 
     public int login() throws LoginException
     {
-        return login(null, null, Compression.ZLIB, true, GatewayIntent.ALL_INTENTS);
+        return login(null, null, Compression.ZLIB, true, GatewayIntent.ALL_INTENTS, GatewayEncoding.JSON);
     }
 
-    public int login(ShardInfo shardInfo, Compression compression, boolean validateToken, int intents) throws LoginException
+    public int login(ShardInfo shardInfo, Compression compression, boolean validateToken, int intents, GatewayEncoding encoding) throws LoginException
     {
-        return login(null, shardInfo, compression, validateToken, intents);
+        return login(null, shardInfo, compression, validateToken, intents, encoding);
     }
 
-    public int login(String gatewayUrl, ShardInfo shardInfo, Compression compression, boolean validateToken, int intents) throws LoginException
+    public int login(String gatewayUrl, ShardInfo shardInfo, Compression compression, boolean validateToken, int intents, GatewayEncoding encoding) throws LoginException
     {
         this.shardInfo = shardInfo;
         threadConfig.init(this::getIdentifierString);
@@ -301,7 +302,7 @@ public class JDAImpl implements JDA
             LOG.info("Login Successful!");
         }
 
-        client = new WebSocketClient(this, compression, intents);
+        client = new WebSocketClient(this, compression, intents, encoding);
         // remove our MDC metadata when we exit our code
         if (previousContext != null)
             previousContext.forEach(MDC::put);

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageBulkDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageBulkDeleteHandler.java
@@ -18,10 +18,12 @@ package net.dv8tion.jda.internal.handle;
 
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageBulkDeleteEvent;
+import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 
-import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MessageBulkDeleteHandler extends SocketHandler
 {
@@ -64,16 +66,14 @@ public class MessageBulkDeleteHandler extends SocketHandler
             }
 
             if (getJDA().getGuildSetupController().isLocked(channel.getGuild().getIdLong()))
-            {
                 return channel.getGuild().getIdLong();
-            }
 
-            LinkedList<String> msgIds = new LinkedList<>();
-            content.getArray("ids").forEach(id -> msgIds.add((String) id));
+            DataArray array = content.getArray("ids");
+            List<String> messages = array.stream(DataArray::getString).collect(Collectors.toList());
             getJDA().handleEvent(
-                    new MessageBulkDeleteEvent(
-                            getJDA(), responseNumber,
-                            channel, msgIds));
+                new MessageBulkDeleteEvent(
+                    getJDA(), responseNumber,
+                    channel, messages));
         }
         return null;
     }

--- a/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
@@ -207,7 +207,7 @@ public class PresenceImpl implements Presence
             return;
         api.getClient().send(DataObject.empty()
             .put("d", data)
-            .put("op", WebSocketCode.PRESENCE).toString());
+            .put("op", WebSocketCode.PRESENCE));
     }
 
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -19,10 +19,7 @@ package net.dv8tion.jda.internal.requests;
 import com.neovisionaries.ws.client.*;
 import gnu.trove.iterator.TLongObjectIterator;
 import gnu.trove.map.TLongObjectMap;
-import net.dv8tion.jda.api.AccountType;
-import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.JDAInfo;
-import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.*;
 import net.dv8tion.jda.api.audio.hooks.ConnectionListener;
 import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
 import net.dv8tion.jda.api.entities.Guild;
@@ -83,6 +80,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected final Compression compression;
     protected final int gatewayIntents;
     protected final MemberChunkManager chunkManager;
+    protected final GatewayEncoding encoding;
 
     public WebSocket socket;
     protected String sessionId = null;
@@ -103,7 +101,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected final TLongObjectMap<ConnectionRequest> queuedAudioConnections = MiscUtil.newLongMap();
     protected final Queue<DataObject> chunkSyncQueue = new ConcurrentLinkedQueue<>();
-    protected final Queue<String> ratelimitQueue = new ConcurrentLinkedQueue<>();
+    protected final Queue<DataObject> ratelimitQueue = new ConcurrentLinkedQueue<>();
 
     protected volatile long ratelimitResetTime;
     protected final AtomicInteger messagesSent = new AtomicInteger(0);
@@ -120,7 +118,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected volatile ConnectNode connectNode;
 
-    public WebSocketClient(JDAImpl api, Compression compression, int gatewayIntents)
+    public WebSocketClient(JDAImpl api, Compression compression, int gatewayIntents, GatewayEncoding encoding)
     {
         this.api = api;
         this.executor = api.getGatewayPool();
@@ -128,6 +126,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         this.compression = compression;
         this.gatewayIntents = gatewayIntents;
         this.chunkManager = new MemberChunkManager(this);
+        this.encoding = encoding;
         this.shouldReconnect = api.isAutoReconnect();
         this.connectNode = new StartingNode();
         setupHandlers();
@@ -222,7 +221,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         events.forEach(this::onDispatch);
     }
 
-    public void send(String message)
+    public void send(DataObject message)
     {
         locked("Interrupted while trying to add request to queue", () -> ratelimitQueue.add(message));
     }
@@ -238,7 +237,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         locked("Interrupted while trying to add chunk request", () -> chunkSyncQueue.add(request));
     }
 
-    protected boolean send(String message, boolean skipQueue)
+    protected boolean send(DataObject message, boolean skipQueue)
     {
         if (!connected)
             return false;
@@ -256,7 +255,10 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         if (this.messagesSent.get() <= 115 || (skipQueue && this.messagesSent.get() <= 119))   //technically we could go to 120, but we aren't going to chance it
         {
             LOG.trace("<- {}", message);
-            socket.sendText(message);
+            if (encoding == GatewayEncoding.ETF)
+                socket.sendBinary(message.toETF());
+            else
+                socket.sendText(message.toString());
             this.messagesSent.getAndIncrement();
             return true;
         }
@@ -317,7 +319,9 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             throw new RejectedExecutionException("JDA is shutdown!");
         initiating = true;
 
-        String url = api.getGatewayUrl() + "?encoding=json&v=" + JDAInfo.DISCORD_GATEWAY_VERSION;
+        String url = api.getGatewayUrl()
+                + "?encoding=" + encoding.name().toLowerCase()
+                + "&v=" + JDAInfo.DISCORD_GATEWAY_VERSION;
         if (compression != Compression.NONE)
         {
             url += "&compress=" + compression.getKey();
@@ -634,11 +638,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected void sendKeepAlive()
     {
-        String keepAlivePacket =
+        DataObject keepAlivePacket =
                 DataObject.empty()
                     .put("op", WebSocketCode.HEARTBEAT)
                     .put("d", api.getResponseTotal()
-                ).toString();
+                );
 
         if (missedHeartbeats >= 2)
         {
@@ -685,7 +689,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                     .add(shardInfo.getShardId())
                     .add(shardInfo.getShardTotal()));
         }
-        send(identify.toString(), true);
+        send(identify, true);
         handleIdentifyRateLimit = true;
         identifyTime = System.currentTimeMillis();
         sentAuthInfo = true;
@@ -701,7 +705,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                 .put("session_id", sessionId)
                 .put("token", getToken())
                 .put("seq", api.getResponseTotal()));
-        send(resume.toString(), true);
+        send(resume, true);
         //sentAuthInfo = true; set on RESUMED response as this could fail
         api.setStatus(JDA.Status.AWAITING_LOGIN_CONFIRMATION);
     }
@@ -949,14 +953,14 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     @Override
     public void onBinaryMessage(WebSocket websocket, byte[] binary) throws DataFormatException
     {
-        DataObject json;
+        DataObject message;
         // Only acquire lock for decompression and unlock for event handling
         synchronized (readLock)
         {
-            json = handleBinary(binary);
+            message = handleBinary(binary);
         }
-        if (json != null)
-            handleEvent(json);
+        if (message != null)
+            handleEvent(message);
     }
 
     protected DataObject handleBinary(byte[] binary) throws DataFormatException
@@ -964,11 +968,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         if (decompressor == null)
             throw new IllegalStateException("Cannot decompress binary message due to unknown compression algorithm: " + compression);
         // Scoping allows us to print the json that possibly failed parsing
-        byte[] jsonData;
+        byte[] data;
         try
         {
-            jsonData = decompressor.decompress(binary);
-            if (jsonData == null)
+            data = decompressor.decompress(binary);
+            if (data == null)
                 return null;
         }
         catch (DataFormatException e)
@@ -979,14 +983,17 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
         try
         {
-            return DataObject.fromJson(jsonData);
+            if (encoding == GatewayEncoding.ETF)
+                return DataObject.fromETF(data);
+            else
+                return DataObject.fromJson(data);
         }
         catch (ParsingException e)
         {
             String jsonString = "malformed";
             try
             {
-                jsonString = new String(jsonData, StandardCharsets.UTF_8);
+                jsonString = new String(data, StandardCharsets.UTF_8);
             }
             catch (Exception ignored) {}
             // Print the string that could not be parsed and re-throw the exception

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -966,7 +966,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected DataObject handleBinary(byte[] binary) throws DataFormatException
     {
         if (decompressor == null)
+        {
+            if (encoding == GatewayEncoding.ETF)
+                return DataObject.fromETF(binary);
             throw new IllegalStateException("Cannot decompress binary message due to unknown compression algorithm: " + compression);
+        }
         // Scoping allows us to print the json that possibly failed parsing
         byte[] data;
         try

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingMetaConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingMetaConfig.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.internal.utils.config.sharding;
 
+import net.dv8tion.jda.api.GatewayEncoding;
 import net.dv8tion.jda.api.utils.Compression;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.utils.config.MetaConfig;
@@ -29,19 +30,22 @@ import java.util.function.IntFunction;
 
 public class ShardingMetaConfig extends MetaConfig
 {
-    private static final ShardingMetaConfig defaultConfig = new ShardingMetaConfig(2048, null, null, ConfigFlag.getDefault(), Compression.ZLIB);
+    private static final ShardingMetaConfig defaultConfig = new ShardingMetaConfig(2048, null, null, ConfigFlag.getDefault(), Compression.ZLIB, GatewayEncoding.JSON);
     private final Compression compression;
+    private final GatewayEncoding encoding;
     private final IntFunction<? extends ConcurrentMap<String, String>> contextProvider;
 
     public ShardingMetaConfig(
         int maxBufferSize,
         @Nullable IntFunction<? extends ConcurrentMap<String, String>> contextProvider,
-        @Nullable EnumSet<CacheFlag> cacheFlags, EnumSet<ConfigFlag> flags, Compression compression)
+        @Nullable EnumSet<CacheFlag> cacheFlags, EnumSet<ConfigFlag> flags,
+        Compression compression, GatewayEncoding encoding)
     {
         super(maxBufferSize, null, cacheFlags, flags);
 
         this.compression = compression;
         this.contextProvider = contextProvider;
+        this.encoding = encoding;
     }
 
     @Nullable
@@ -53,6 +57,11 @@ public class ShardingMetaConfig extends MetaConfig
     public Compression getCompression()
     {
         return compression;
+    }
+
+    public GatewayEncoding getEncoding()
+    {
+        return encoding;
     }
 
     @Nullable


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds a custom implementation to parse and serialize ETF payloads for the discord gateway connection.

You can enable this by using `JDABuilder#setGatewayEncoding(GatewayEncoding.ETF)`, this will be an opt-in.
