### PR TITLE
Make GuildMessageReactionRemoveEmoteEvent extend GenericGuildMessageEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -17,10 +17,9 @@
 package net.dv8tion.jda.api.events.message.guild.react;
 
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
+import net.dv8tion.jda.api.events.message.guild.GenericGuildMessageEvent;
 
 import javax.annotation.Nonnull;
 
@@ -31,15 +30,15 @@ import javax.annotation.Nonnull;
  *
  * @since  4.2.0
  */
-public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildEvent
+public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEvent
 {
     private final TextChannel channel;
     private final MessageReaction reaction;
     private final long messageId;
 
-    public GuildMessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull TextChannel channel, @Nonnull MessageReaction reaction, long messageId)
+    public GuildMessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nonnull MessageReaction reaction, long messageId)
     {
-        super(api, responseNumber, guild);
+        super(api, responseNumber, messageId, channel);
 
         this.channel = channel;
         this.reaction = reaction;

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -32,17 +32,13 @@ import javax.annotation.Nonnull;
  */
 public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEvent
 {
-    private final TextChannel channel;
     private final MessageReaction reaction;
-    private final long messageId;
 
     public GuildMessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nonnull MessageReaction reaction, long messageId)
     {
         super(api, responseNumber, messageId, channel);
 
-        this.channel = channel;
         this.reaction = reaction;
-        this.messageId = messageId;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmoteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmoteHandler.java
@@ -77,7 +77,7 @@ public class MessageReactionClearEmoteHandler extends SocketHandler
         }
 
         MessageReaction reaction = new MessageReaction(channel, reactionEmote, messageId, false, 0);
-        getJDA().handleEvent(new GuildMessageReactionRemoveEmoteEvent(getJDA(), responseNumber, guild, channel, reaction, messageId));
+        getJDA().handleEvent(new GuildMessageReactionRemoveEmoteEvent(getJDA(), responseNumber, channel, reaction, messageId));
         getJDA().handleEvent(new MessageReactionRemoveEmoteEvent(getJDA(), responseNumber, messageId, channel, reaction));
         return null;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Make GuildMessageReactionRemoveEmoteEvent extend GenericGuildMessageEvent like the other Reaction remove events