### PR TITLE
Properly apply socket timeouts where appropriate

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -35,10 +35,7 @@ import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
 
 import java.io.IOException;
-import java.net.DatagramPacket;
-import java.net.DatagramSocket;
-import java.net.InetSocketAddress;
-import java.net.NoRouteToHostException;
+import java.net.*;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
@@ -645,6 +642,20 @@ class AudioWebSocket extends WebSocketAdapter
     {
         if (keepAliveHandle != null)
             LOG.error("Setting up a KeepAlive runnable while the previous one seems to still be active!!");
+
+        try
+        {
+            if (socket != null)
+            {
+                Socket rawSocket = this.socket.getSocket();
+                if (rawSocket != null)
+                    rawSocket.setSoTimeout(keepAliveInterval + 10000);
+            }
+        }
+        catch (SocketException ex)
+        {
+            LOG.warn("Failed to setup timeout for socket", ex);
+        }
 
         Runnable keepAliveRunnable = () ->
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -54,6 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
+import javax.net.ssl.SSLException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
@@ -1033,7 +1034,11 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     {
         if (cause.getCause() instanceof SocketTimeoutException)
         {
-            LOG.debug("Socket read timed out", cause);
+            LOG.debug("Socket timed out");
+        }
+        else if (cause.getCause() instanceof IOException)
+        {
+            LOG.debug("Encountered I/O error", cause);
         }
         else
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -54,7 +54,6 @@ import org.slf4j.Logger;
 import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
-import javax.net.ssl.SSLException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
@@ -389,7 +388,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     @Override
     public void onConnected(WebSocket websocket, Map<String, List<String>> headers)
     {
-        prepareClose(); // set 10s timeout in-case we discord never sends us a HELLO payload
+        prepareClose(); // set 10s timeout in-case discord never sends us a HELLO payload
         api.setStatus(JDA.Status.IDENTIFYING_SESSION);
         if (sessionId == null)
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -57,6 +57,9 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -278,20 +281,37 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         ratelimitThread.start();
     }
 
+    private void prepareClose()
+    {
+        try
+        {
+            if (socket != null)
+            {
+                Socket rawSocket = this.socket.getSocket();
+                if (rawSocket != null) // attempt to set a 10 second timeout for the close frame
+                    rawSocket.setSoTimeout(10000); // this has no affect if the socket is already stuck in a read call
+            }
+        }
+        catch (SocketException ignored) {}
+    }
+
     public void close()
     {
+        prepareClose();
         if (socket != null)
             socket.sendClose(1000);
     }
 
     public void close(int code)
     {
+        prepareClose();
         if (socket != null)
             socket.sendClose(code);
     }
 
     public void close(int code, String reason)
     {
+        prepareClose();
         if (socket != null)
             socket.sendClose(code, reason);
     }
@@ -368,6 +388,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     @Override
     public void onConnected(WebSocket websocket, Map<String, List<String>> headers)
     {
+        prepareClose(); // set 10s timeout in-case we discord never sends us a HELLO payload
         api.setStatus(JDA.Status.IDENTIFYING_SESSION);
         if (sessionId == null)
         {
@@ -622,8 +643,19 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             previousContext.forEach(MDC::put);
     }
 
-    protected void setupKeepAlive(long timeout)
+    protected void setupKeepAlive(int timeout)
     {
+        try
+        {
+            Socket rawSocket = this.socket.getSocket();
+            if (rawSocket != null)
+                rawSocket.setSoTimeout(timeout + 10000); // setup a timeout when we miss heartbeats
+        }
+        catch (SocketException ex)
+        {
+            LOG.warn("Failed to setup timeout for socket", ex);
+        }
+
         keepAliveThread = executor.scheduleAtFixedRate(() ->
         {
             api.setContext();
@@ -644,6 +676,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         {
             missedHeartbeats = 0;
             LOG.warn("Missed 2 heartbeats! Trying to reconnect...");
+            prepareClose();
             socket.disconnect(4900, "ZOMBIE CONNECTION");
         }
         else
@@ -834,7 +867,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             case WebSocketCode.HELLO:
                 LOG.debug("Got HELLO packet (OP 10). Initializing keep-alive.");
                 final DataObject data = content.getObject("d");
-                setupKeepAlive(data.getLong("heartbeat_interval"));
+                setupKeepAlive(data.getInt("heartbeat_interval"));
                 break;
             case WebSocketCode.HEARTBEAT_ACK:
                 LOG.trace("Got Heartbeat Ack (OP 11).");
@@ -996,16 +1029,17 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     }
 
     @Override
-    public void onUnexpectedError(WebSocket websocket, WebSocketException cause) throws Exception
+    public void onError(WebSocket websocket, WebSocketException cause) throws Exception
     {
-        handleCallbackError(websocket, cause);
-    }
-
-    @Override
-    public void handleCallbackError(WebSocket websocket, Throwable cause)
-    {
-        LOG.error("There was an error in the WebSocket connection", cause);
-        api.handleEvent(new ExceptionEvent(api, cause, true));
+        if (cause.getCause() instanceof SocketTimeoutException)
+        {
+            LOG.debug("Socket read timed out", cause);
+        }
+        else
+        {
+            LOG.error("There was an error in the WebSocket connection", cause);
+            api.handleEvent(new ExceptionEvent(api, cause, true));
+        }
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
@@ -44,11 +44,16 @@ public class SessionConfig
     {
         this.sessionController = sessionController == null ? new ConcurrentSessionController() : sessionController;
         this.httpClient = httpClient;
-        this.webSocketFactory = webSocketFactory == null ? new WebSocketFactory() : webSocketFactory;
+        this.webSocketFactory = webSocketFactory == null ? newWebSocketFactory() : webSocketFactory;
         this.interceptor = interceptor;
         this.flags = flags;
         this.maxReconnectDelay = maxReconnectDelay;
         this.largeThreshold = largeThreshold;
+    }
+
+    private static WebSocketFactory newWebSocketFactory()
+    {
+        return new WebSocketFactory().setConnectionTimeout(10000);
     }
 
     public void setAutoReconnect(boolean autoReconnect)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

We can use timeouts that are 10s longer than the heartbeat_interval. This should hopefully make the "missed 2 heartbeats" warning less frequent and improve stability.
