### PR TITLE
Introduce better methods to load members

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -191,7 +191,6 @@ public interface Guild extends ISnowflake
 
     /**
      * Re-apply the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy} of this session to all {@link Member Members} of this Guild.
-     * <br>This can be useful if used in combination with {@link #retrieveMembers()}.
      *
      * <h2>Example</h2>
      * <pre>{@code
@@ -216,7 +215,6 @@ public interface Guild extends ISnowflake
      *
      * @see #unloadMember(long)
      * @see JDA#unloadUser(long)
-     * @see #retrieveMembers()
      */
     void pruneMemberCache();
 
@@ -830,7 +828,7 @@ public interface Guild extends ISnowflake
      *
      * @return Immutable list of all <b>cached</b> members in this Guild.
      *
-     * @see    #retrieveMembers()
+     * @see    #loadMembers()
      */
     @Nonnull
     default List<Member> getMembers()
@@ -966,7 +964,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.MemberCacheView MemberCacheView}
      *
-     * @see    #retrieveMembers()
+     * @see    #loadMembers()
      */
     @Nonnull
     MemberCacheView getMemberCache();

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -53,6 +53,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 /**
  * Represents a Discord {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -2229,7 +2230,61 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      */
     @Nonnull
+    @Deprecated
+    @DeprecatedSince("TBD")
+    @ReplaceWith("loadMembers(Consumer<Member>) or loadMembers()")
     CompletableFuture<Void> retrieveMembers();
+
+    /**
+     * Retrieves and collects members of this guild into a list.
+     * <br>This will use the configured {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+     * to decide which members to retain in cache.
+     *
+     * <p><b>This requires the privileged GatewayIntent.GUILD_MEMBERS to be enabled!</b>
+     *
+     * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
+     * The response handling happens on the event thread by default.
+     *
+     * @throws IllegalStateException
+     *         If the {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS} is not enabled
+     *
+     * @return {@link Task} - Type: {@link List} of {@link Member}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default Task<List<Member>> loadMembers()
+    {
+        List<Member> list = new ArrayList<>();
+        CompletableFuture<List<Member>> future = new CompletableFuture<>();
+        Task<Void> reference = loadMembers(list::add);
+        GatewayTask<List<Member>> task = new GatewayTask<>(future, reference::cancel);
+        reference.onSuccess(it -> future.complete(list))
+                 .onError(future::completeExceptionally);
+        return task;
+    }
+
+    /**
+     * Retrieves and collects members of this guild into a list.
+     * <br>This will use the configured {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+     * to decide which members to retain in cache.
+     *
+     * <p><b>This requires the privileged GatewayIntent.GUILD_MEMBERS to be enabled!</b>
+     *
+     * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
+     * The response handling happens on the event thread by default.
+     *
+     * @param  callback
+     *         Consumer callback for each member
+     *
+     * @throws IllegalArgumentException
+     *         If the callback is null
+     * @throws IllegalStateException
+     *         If the {@link GatewayIntent#GUILD_MEMBERS GatewayIntent.GUILD_MEMBERS} is not enabled
+     *
+     * @return {@link Task} cancellable handle for this request
+     */
+    @Nonnull
+    Task<Void> loadMembers(@Nonnull Consumer<Member> callback);
 
     /**
      * Load the member for the specified user.

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2239,6 +2239,8 @@ public interface Guild extends ISnowflake
      * <br>This will use the configured {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
      * to decide which members to retain in cache.
      *
+     * <p>You can use {@link #findMembers(Predicate)} to filter specific members.
+     *
      * <p><b>This requires the privileged GatewayIntent.GUILD_MEMBERS to be enabled!</b>
      *
      * <p><b>You MUST NOT use blocking operations such as {@link Task#get()}!</b>
@@ -2253,7 +2255,7 @@ public interface Guild extends ISnowflake
     @CheckReturnValue
     default Task<List<Member>> loadMembers()
     {
-        return loadMembers((m) -> true);
+        return findMembers((m) -> true);
     }
 
     /**
@@ -2278,7 +2280,7 @@ public interface Guild extends ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    default Task<List<Member>> loadMembers(@Nonnull Predicate<? super Member> filter)
+    default Task<List<Member>> findMembers(@Nonnull Predicate<? super Member> filter)
     {
         Checks.notNull(filter, "Filter");
         List<Member> list = new ArrayList<>();
@@ -2294,7 +2296,7 @@ public interface Guild extends ISnowflake
     }
 
     /**
-     * Retrieves and collects members of this guild into a list.
+     * Retrieves all members of this guild.
      * <br>This will use the configured {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
      * to decide which members to retain in cache.
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2227,10 +2227,12 @@ public interface Guild extends ISnowflake
      * @return {@link CompletableFuture} representing the chunking task
      *
      * @see    #pruneMemberCache()
+     *
+     * @deprecated Replace with {@link #loadMembers()}, {@link #loadMembers(Consumer)}, or {@link #findMembers(Predicate)}
      */
     @Nonnull
     @Deprecated
-    @DeprecatedSince("TBD")
+    @DeprecatedSince("4.2.0")
     @ReplaceWith("loadMembers(Consumer<Member>) or loadMembers()")
     CompletableFuture<Void> retrieveMembers();
 

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -17,10 +17,8 @@
 package net.dv8tion.jda.internal;
 
 import com.neovisionaries.ws.client.WebSocketFactory;
-import gnu.trove.TCollections;
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.set.TLongSet;
-import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
@@ -49,7 +47,6 @@ import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
-import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.handle.EventCache;
 import net.dv8tion.jda.internal.handle.GuildSetupController;
@@ -106,7 +103,6 @@ public class JDAImpl implements JDA
 
     protected final GuildSetupController guildSetupController;
     protected final DirectAudioControllerImpl audioController;
-    protected final TLongSet chunkingRequested = TCollections.synchronizedSet(new TLongHashSet());
 
     protected final AuthorizationConfig authConfig;
     protected final ThreadingConfig threadConfig;
@@ -149,16 +145,6 @@ public class JDAImpl implements JDA
         this.audioController = new DirectAudioControllerImpl(this);
         this.eventCache = new EventCache();
         this.eventManager = new EventManagerProxy(new InterfacedEventManager(), this.threadConfig.getEventPool());
-    }
-
-    public void onChunksRequested(GuildImpl guild)
-    {
-        this.chunkingRequested.add(guild.getIdLong());
-    }
-
-    public void onChunksFinished(GuildImpl guild)
-    {
-        this.chunkingRequested.remove(guild.getIdLong());
     }
 
     public void handleEvent(@Nonnull GenericEvent event)
@@ -204,8 +190,6 @@ public class JDAImpl implements JDA
 
     public boolean chunkGuild(long id)
     {
-        if (chunkingRequested.contains(id))
-            return true;
         try
         {
             return isIntent(GatewayIntent.GUILD_MEMBERS) && chunkingFilter.filter(id);

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -852,7 +852,8 @@ public class GuildImpl implements Guild
         }
 
         MemberChunkManager chunkManager = getJDA().getClient().getChunkManager();
-        CompletableFuture<Void> handler = chunkManager.chunkGuild(this, false, (last, list) -> list.forEach(callback));
+        boolean includePresences = getJDA().isIntent(GatewayIntent.GUILD_PRESENCES);
+        CompletableFuture<Void> handler = chunkManager.chunkGuild(this, includePresences, (last, list) -> list.forEach(callback));
         return new GatewayTask<>(handler, () -> handler.cancel(false));
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
@@ -21,7 +21,6 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.entities.GuildImpl;
-import net.dv8tion.jda.internal.requests.MemberChunkManager;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 
 public class GuildMembersChunkHandler extends SocketHandler
@@ -49,8 +48,6 @@ public class GuildMembersChunkHandler extends SocketHandler
                 DataObject object = members.getObject(i);
                 builder.updateMemberCache(builder.createMember(guild, object));
             }
-            if (MemberChunkManager.isLastChunk(content))
-                guild.completeChunking();
             return null;
         }
         getJDA().getGuildSetupController().onMemberChunk(guildId, content);

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
@@ -16,11 +16,14 @@
 
 package net.dv8tion.jda.internal.handle;
 
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 
 public class GuildMembersChunkHandler extends SocketHandler
@@ -42,11 +45,18 @@ public class GuildMembersChunkHandler extends SocketHandler
                 return null;
             WebSocketClient.LOG.debug("Received member chunk for guild that is already in cache. GuildId: {} Count: {} Index: {}/{}",
                     guildId, members.length(), content.getInt("chunk_index"), content.getInt("chunk_count"));
+            // Chunk handling
             EntityBuilder builder = getJDA().getEntityBuilder();
+            TLongObjectMap<DataObject> presences = content.optArray("presences").map(it ->
+                builder.convertToUserMap(o -> o.getObject("user").getUnsignedLong("id"), it)
+            ).orElseGet(TLongObjectHashMap::new);
             for (int i = 0; i < members.length(); i++)
             {
                 DataObject object = members.getObject(i);
-                builder.updateMemberCache(builder.createMember(guild, object));
+                long userId = object.getObject("user").getUnsignedLong("id");
+                DataObject presence = presences.get(userId);
+                MemberImpl member = builder.createMember(guild, object, null, presence);
+                builder.updateMemberCache(member);
             }
             return null;
         }

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
@@ -387,8 +387,6 @@ public class GuildSetupNode
         GuildSetupController.log.debug("Finished setup for guild {} firing cached events {}", id, cachedEvents.size());
         api.getClient().handle(cachedEvents);
         api.getEventCache().playbackCache(EventCache.Type.GUILD, id);
-        if (requestedChunk || expectedMemberCount == members.size())
-            guild.completeChunking();
     }
 
     private void ensureMembers()

--- a/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
@@ -18,11 +18,19 @@ package net.dv8tion.jda.internal.requests;
 
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.utils.MiscUtil;
+import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.entities.EntityBuilder;
+import net.dv8tion.jda.internal.entities.GuildImpl;
+import net.dv8tion.jda.internal.entities.MemberImpl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 
 public class MemberChunkManager
 {
@@ -61,28 +69,42 @@ public class MemberChunkManager
             timeoutHandle.cancel(false);
     }
 
-    public CompletableFuture<DataObject> chunkGuild(long guildId, String query, int limit)
+    public CompletableFuture<Void> chunkGuild(GuildImpl guild, boolean presence, BiConsumer<Boolean, List<Member>> handler)
     {
         init();
         DataObject request = DataObject.empty()
-                .put("guild_id", guildId)
-                .put("limit", Math.min(100, Math.max(1, limit)))
-                .put("query", query);
+                .put("guild_id", guild.getId())
+                .put("presences", presence)
+                .put("limit", 0)
+                .put("query", "");
 
-        ChunkRequest chunkRequest = new ChunkRequest(request);
+        ChunkRequest chunkRequest = new ChunkRequest(handler, guild, request);
         makeRequest(chunkRequest);
         return chunkRequest;
     }
 
-    public CompletableFuture<DataObject> chunkGuild(long guildId, boolean presence, long[] userIds)
+    public CompletableFuture<Void> chunkGuild(GuildImpl guild, String query, int limit, BiConsumer<Boolean, List<Member>> handler)
     {
         init();
         DataObject request = DataObject.empty()
-                .put("guild_id", guildId)
+                .put("guild_id", guild.getId())
+                .put("limit", Math.min(100, Math.max(1, limit)))
+                .put("query", query);
+
+        ChunkRequest chunkRequest = new ChunkRequest(handler, guild, request);
+        makeRequest(chunkRequest);
+        return chunkRequest;
+    }
+
+    public CompletableFuture<Void> chunkGuild(GuildImpl guild, boolean presence, long[] userIds, BiConsumer<Boolean, List<Member>> handler)
+    {
+        init();
+        DataObject request = DataObject.empty()
+                .put("guild_id", guild.getId())
                 .put("presences", presence)
                 .put("user_ids", userIds);
 
-        ChunkRequest chunkRequest = new ChunkRequest(request);
+        ChunkRequest chunkRequest = new ChunkRequest(handler, guild, request);
         makeRequest(chunkRequest);
         return chunkRequest;
     }
@@ -93,11 +115,18 @@ public class MemberChunkManager
             String nonce = response.getString("nonce", null);
             if (nonce == null || nonce.isEmpty())
                 return false;
-            ChunkRequest request = requests.remove(Long.parseLong(nonce));
+            long key = Long.parseLong(nonce);
+            ChunkRequest request = requests.get(key);
             if (request == null)
                 return false;
 
-            request.complete(response);
+            boolean lastChunk = isLastChunk(response);
+            request.handleChunk(lastChunk, response);
+            if (lastChunk || request.isCancelled())
+            {
+                requests.remove(key);
+                request.complete(null);
+            }
             return true;
         });
     }
@@ -122,14 +151,18 @@ public class MemberChunkManager
         client.sendChunkRequest(request);
     }
 
-    private class ChunkRequest extends CompletableFuture<DataObject>
+    private class ChunkRequest extends CompletableFuture<Void>
     {
+        private final BiConsumer<Boolean, List<Member>> handler;
+        private final GuildImpl guild;
         private final DataObject request;
         private final long nonce;
         private long startTime;
 
-        public ChunkRequest(DataObject request)
+        public ChunkRequest(BiConsumer<Boolean, List<Member>> handler, GuildImpl guild, DataObject request)
         {
+            this.handler = handler;
+            this.guild = guild;
             this.nonce = ThreadLocalRandom.current().nextLong() & ~1;
             this.request = request.put("nonce", getNonce());
         }
@@ -153,6 +186,31 @@ public class MemberChunkManager
         {
             startTime = System.currentTimeMillis();
             return request;
+        }
+
+        private List<Member> toMembers(DataObject chunk)
+        {
+            EntityBuilder builder = guild.getJDA().getEntityBuilder();
+            DataArray memberArray = chunk.getArray("members");
+            TLongObjectMap<DataObject> presences = chunk.optArray("presences").map(it ->
+                builder.convertToUserMap(o -> o.getObject("user").getUnsignedLong("id"), it)
+            ).orElse(null);
+            List<Member> collect = new ArrayList<>(memberArray.length());
+            for (int i = 0; i < memberArray.length(); i++)
+            {
+                DataObject json = memberArray.getObject(i);
+                DataObject presence = presences == null ? null : presences.get(json.getObject("user").getUnsignedLong("id"));
+                MemberImpl member = builder.createMember(guild, json, null, presence);
+                builder.updateMemberCache(member);
+                collect.add(member);
+            }
+            return collect;
+        }
+
+        public void handleChunk(boolean last, DataObject chunk)
+        {
+            if (!isCancelled())
+                handler.accept(last, toMembers(chunk));
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
@@ -194,12 +194,13 @@ public class MemberChunkManager
             DataArray memberArray = chunk.getArray("members");
             TLongObjectMap<DataObject> presences = chunk.optArray("presences").map(it ->
                 builder.convertToUserMap(o -> o.getObject("user").getUnsignedLong("id"), it)
-            ).orElse(null);
+            ).orElseGet(TLongObjectHashMap::new);
             List<Member> collect = new ArrayList<>(memberArray.length());
             for (int i = 0; i < memberArray.length(); i++)
             {
                 DataObject json = memberArray.getObject(i);
-                DataObject presence = presences == null ? null : presences.get(json.getObject("user").getUnsignedLong("id"));
+                long userId = json.getObject("user").getUnsignedLong("id");
+                DataObject presence = presences.get(userId);
                 MemberImpl member = builder.createMember(guild, json, null, presence);
                 builder.updateMemberCache(member);
                 collect.add(member);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This introduces better methods for loading members on a guild.

### Example

**Current:**
```java
guild.retrieveMembers().thenRun(() -> {
  List<Member> members = guild.getMembers();
  members.forEach(System.out::println);
  guild.pruneMemberCache(); // manually clear the cache again
});

guild.retrieveMembers().thenRun(() -> {
  List<Member> members = guild.getMembers();
  System.out.println(members.size());
  guild.pruneMemberCache(); // manually clear the cache again
});
```
**New:**
```java
guild.loadMembers(System.out::println); // only adds members to cache which the policy accepts
guild.loadMembers().onSuccess((members) -> {
  System.out.println(members.size());
});
```
