### PR TITLE
Remove wrong @throws JavaDoc from MessageAction#allowedMentions

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -537,9 +537,6 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @param  allowedMentions
      *         MentionTypes that are allowed to being parsed and pinged. {@code null} to disable and allow all mentions.
      *
-     * @throws IllegalArgumentException
-     *         If null is provided
-     *
      * @return Updated MessageAction for chaining convenience
      */
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Remove wrong @throws JavaDoc from MessageAction#allowedMentions

The docs/development branch doesn't have this feature yet so the PR is targeting the development branch.
