### PR TITLE
Feature: Escape All Markdown Characters

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -187,6 +187,35 @@ public class MarkdownSanitizer
                 .withStrategy(SanitizationStrategy.ESCAPE)
                 .compute(sequence);
     }
+    
+    /**
+     * Escapes every markdown formatting found in the provided string.
+     * <br>Example: {@code escape("**Hello** ~~World~~!", MarkdownSanitizer.BOLD | MarkdownSanitizer.STRIKE)}
+     *
+     * @param  sequence
+     *         The string to sanitize
+     * @param  single
+     *         If true removes all markdown characters
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If provided with null
+     *
+     * @return The string with escaped markdown
+     */
+    @Nonnull
+    public static String escape(@Nonnull String sequence, boolean single) {
+    	if(single) {
+        	String cleaned = sequence.replaceAll("([_`~*>])", "\\\\$1");
+           	return new MarkdownSanitizer()
+        			.withStrategy(SanitizationStrategy.ESCAPE)
+        			.compute(cleaned);
+    	} else {
+    	   	return new MarkdownSanitizer()
+        			.withStrategy(SanitizationStrategy.ESCAPE)
+        			.compute(sequence);
+    	}
+ 
+    }
 
     /**
      * Switches the used {@link net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy}.


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x ] I have checked the PRs for upcoming features/bug fixes.
- [ x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1298 

## Description

Added ability to escape all markdown strings by using `MarkdownSanitizer.escape(yourstring, true);`
