### PR TITLE
Implement new channel order features

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/CategoryOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/CategoryOrderAction.java
@@ -17,8 +17,10 @@
 package net.dv8tion.jda.api.requests.restaction.order;
 
 import net.dv8tion.jda.api.entities.Category;
+import net.dv8tion.jda.api.entities.GuildChannel;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * An extension of {@link ChannelOrderAction ChannelOrderAction} with
@@ -44,4 +46,43 @@ public interface CategoryOrderAction extends ChannelOrderAction
      */
     @Nonnull
     Category getCategory();
+
+    @Nonnull
+    @Override
+    default CategoryOrderAction moveTo(@Nullable Category newParent)
+    {
+        return (CategoryOrderAction) ChannelOrderAction.super.moveTo(newParent);
+    }
+
+    @Nonnull
+    @Override
+    default CategoryOrderAction moveTo(int position, @Nullable Category newParent)
+    {
+        return (CategoryOrderAction) ChannelOrderAction.super.moveTo(position, newParent);
+    }
+
+    @Nonnull
+    @Override
+    default CategoryOrderAction moveTo(@Nonnull GuildChannel entity, @Nullable Category newParent)
+    {
+        return (CategoryOrderAction) ChannelOrderAction.super.moveTo(entity, newParent);
+    }
+
+    @Nonnull
+    @Override
+    default CategoryOrderAction moveTo(int position, @Nullable Category newParent, boolean lockPermissions)
+    {
+        return (CategoryOrderAction) ChannelOrderAction.super.moveTo(position, newParent, lockPermissions);
+    }
+
+    @Nonnull
+    @Override
+    default CategoryOrderAction moveTo(@Nonnull GuildChannel entity, @Nullable Category newParent, boolean lockPermissions)
+    {
+        return (CategoryOrderAction) ChannelOrderAction.super.moveTo(entity, newParent, lockPermissions);
+    }
+
+    @Nonnull
+    @Override
+    CategoryOrderAction moveTo(@Nullable Category newParent, boolean lockPermissions);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/ChannelOrderAction.java
@@ -16,11 +16,13 @@
 
 package net.dv8tion.jda.api.requests.restaction.order;
 
+import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 /**
@@ -71,4 +73,43 @@ public interface ChannelOrderAction extends OrderAction<GuildChannel, ChannelOrd
     {
         return ChannelType.fromSortBucket(getSortBucket());
     }
+
+    /**
+     * Moves the currently selected channel to the provided category.
+     * <br>This will automatically sync the permission overrides with the target category.
+     * You can use {@link #moveTo(Category, boolean) moveTo(newParent, false)} to disable permission sync.
+     *
+     * @param  newParent
+     *         The target category, or null to remove the parent
+     *
+     * @throws IllegalStateException
+     *         If no channel has been selected yet (See {@link #selectPosition(Object)})
+     * @throws IllegalArgumentException
+     *         If the provided category is not from the same guild
+     *
+     * @return The current ChannelOrderAction instance
+     */
+    @Nonnull
+    default ChannelOrderAction moveTo(@Nullable Category newParent)
+    {
+        return moveTo(newParent, true);
+    }
+
+    /**
+     * Moves the currently selected channel to the provided category.
+     *
+     * @param  newParent
+     *         The target category, or null to remove the parent
+     * @param  lockPermissions
+     *         Whether to sync the permissions overrides with the new parent
+     *
+     * @throws IllegalStateException
+     *         If no channel has been selected yet (See {@link #selectPosition(Object)})
+     * @throws IllegalArgumentException
+     *         If the provided category is not from the same guild
+     *
+     * @return The current ChannelOrderAction instance
+     */
+    @Nonnull
+    ChannelOrderAction moveTo(@Nullable Category newParent, boolean lockPermissions);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/ChannelOrderAction.java
@@ -96,6 +96,114 @@ public interface ChannelOrderAction extends OrderAction<GuildChannel, ChannelOrd
     }
 
     /**
+     * Moves the channel at the specified position to the provided category.
+     * <br>This will automatically sync the permission overrides with the target category.
+     * You can use {@link #moveTo(Category, boolean) moveTo(newParent, false)} to disable permission sync.
+     *
+     * @param  position
+     *         The position of the channel that is moved
+     * @param  newParent
+     *         The target category, or null to remove the parent
+     *
+     * @throws IllegalArgumentException
+     *         If the provided category is not from the same guild,
+     *         or if the specified position is out-of-bounds
+     *
+     * @return The current ChannelOrderAction instance
+     */
+    @Nonnull
+    default ChannelOrderAction moveTo(int position, @Nullable Category newParent)
+    {
+        return moveTo(position, newParent, true);
+    }
+
+    /**
+     * Moves the specified channel to the provided category.
+     * <br>This will automatically sync the permission overrides with the target category.
+     * You can use {@link #moveTo(Category, boolean) moveTo(newParent, false)} to disable permission sync.
+     *
+     * @param  entity
+     *         The channel to move
+     * @param  newParent
+     *         The target category, or null to remove the parent
+     *
+     * @throws IllegalArgumentException
+     *         If the provided category is not from the same guild,
+     *         or if the channel to move is null or not tracked by this order action
+     *
+     * @return The current ChannelOrderAction instance
+     */
+    @Nonnull
+    default ChannelOrderAction moveTo(@Nonnull GuildChannel entity, @Nullable Category newParent)
+    {
+        return moveTo(entity, newParent, true);
+    }
+
+    /**
+     * Moves the channel at the specified position to the provided category.
+     *
+     * @param  position
+     *         The position of the channel that is moved
+     * @param  newParent
+     *         The target category, or null to remove the parent
+     * @param  lockPermissions
+     *         Whether to sync the permissions overrides with the new parent
+     *
+     * @throws IllegalArgumentException
+     *         If the provided category is not from the same guild,
+     *         or if the specified position is out-of-bounds
+     *
+     * @return The current ChannelOrderAction instance
+     */
+    @Nonnull
+    default ChannelOrderAction moveTo(int position, @Nullable Category newParent, boolean lockPermissions)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(position).moveTo(newParent, lockPermissions);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return this;
+    }
+
+    /**
+     * Moves the specified channel to the provided category.
+     *
+     * @param  entity
+     *         The channel to move
+     * @param  newParent
+     *         The target category, or null to remove the parent
+     * @param  lockPermissions
+     *         Whether to sync the permissions overrides with the new parent
+     *
+     * @throws IllegalArgumentException
+     *         If the provided category is not from the same guild,
+     *         or if the channel to move is null or not tracked by this order action
+     *
+     * @return The current ChannelOrderAction instance
+     */
+    @Nonnull
+    default ChannelOrderAction moveTo(@Nonnull GuildChannel entity, @Nullable Category newParent, boolean lockPermissions)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(entity).moveTo(newParent, lockPermissions);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return this;
+    }
+
+    /**
      * Moves the currently selected channel to the provided category.
      *
      * @param  newParent

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
@@ -43,6 +43,7 @@ import java.util.function.BooleanSupplier;
  *
  * @since 3.0
  */
+@SuppressWarnings("unchecked")
 public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<Void>
 {
     @Nonnull
@@ -102,6 +103,9 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *         The entity for the new position that will be in focus for all modification
      *         operations
      *
+     * @throws IllegalArgumentException
+     *         If the entity is null or not tracked by this order action
+     *
      * @return The current OrderAction sub-implementation instance
      *
      * @see    #selectPosition(int)
@@ -150,6 +154,72 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
     M moveUp(int amount);
 
     /**
+     * Moves the entity at the specified position {@code amount} positions <b>UP</b>
+     * in order by pushing all entities down by one position.
+     *
+     * @param  position
+     *         The position of the entity which will be moved
+     * @param  amount
+     *         The amount of positions that should be moved
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the specified amount would cause the entity to go out-of-bounds,
+     *         or if the target position is out-of-bounds
+     *
+     * @return The current OrderAction sub-implementation instance
+     *
+     * @see    #moveTo(int)
+     */
+    @Nonnull
+    default M moveUp(int position, int amount)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(position).moveUp(amount);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
+     * Moves the specified entity {@code amount} positions <b>UP</b>
+     * in order by pushing all entities down by one position.
+     *
+     * @param  entity
+     *         The entity which will be moved
+     * @param  amount
+     *         The amount of positions that should be moved
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the specified amount would cause the entity to go out-of-bounds,
+     *         or if the target entity is null or not tracked by this order action
+     *
+     * @return The current OrderAction sub-implementation instance
+     *
+     * @see    #moveTo(int)
+     */
+    @Nonnull
+    default M moveUp(@Nonnull T entity, int amount)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(entity).moveUp(amount);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
      * Moves the currently selected entity {@code amount} positions <b>DOWN</b>
      * in order by pushing all entities up by one position.
      *
@@ -169,9 +239,75 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
     M moveDown(int amount);
 
     /**
+     * Moves the entity at the specified position {@code amount} positions <b>DOWN</b>
+     * in order by pushing all entities down by one position.
+     *
+     * @param  position
+     *         The position of the entity which will be moved
+     * @param  amount
+     *         The amount of positions that should be moved
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the specified amount would cause the entity to go out-of-bounds,
+     *         or if the target position is out-of-bounds
+     *
+     * @return The current OrderAction sub-implementation instance
+     *
+     * @see    #moveTo(int)
+     */
+    @Nonnull
+    default M moveDown(int position, int amount)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(position).moveDown(amount);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
+     * Moves the specified entity {@code amount} positions <b>DOWN</b>
+     * in order by pushing all entities down by one position.
+     *
+     * @param  entity
+     *         The entity which will be moved
+     * @param  amount
+     *         The amount of positions that should be moved
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the specified amount would cause the entity to go out-of-bounds,
+     *         or if the target entity is null or not tracked by this order action
+     *
+     * @return The current OrderAction sub-implementation instance
+     *
+     * @see    #moveTo(int)
+     */
+    @Nonnull
+    default M moveDown(@Nonnull T entity, int amount)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(entity).moveDown(amount);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
      * Moves the currently selected entity to the specified
      * position (0 based index). All entities are moved in the
-     * direction of the left <i>hole</i> to fill the gap.
+     * direction of the left <em>hole</em> to fill the gap.
      *
      * @param  position
      *         The new not-negative position for the currently selected entity
@@ -188,6 +324,73 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      */
     @Nonnull
     M moveTo(int position);
+
+    /**
+     * Moves the entity at the specified position to the new position (0 based index).
+     * All entities are moved in the direction of the left <em>hole</em> to fill the gap.
+     *
+     * @param  position
+     *         The old position
+     * @param  newPosition
+     *         The new not-negative position for the currently selected entity
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If either of the specified positions is out-of-bounds
+     *
+     * @return The current OrderAction sub-implementation instance
+     *
+     * @see    #moveDown(int)
+     * @see    #moveUp(int)
+     */
+    @Nonnull
+    default M moveTo(int position, int newPosition)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(position).moveTo(newPosition);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
+     * Moves the specified entity to the new position (0 based index).
+     * All entities are moved in the direction of the left <em>hole</em> to fill the gap.
+     *
+     * @param  entity
+     *         The entity to move
+     * @param  newPosition
+     *         The new not-negative position for the currently selected entity
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the specified position is out-of-bounds,
+     *         or the entity is null or not tracked by this order action
+     *
+     * @return The current OrderAction sub-implementation instance
+     *
+     * @see    #moveDown(int)
+     * @see    #moveUp(int)
+     */
+    @Nonnull
+    default M moveTo(@Nonnull T entity, int newPosition)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(entity).moveTo(newPosition);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
 
     /**
      * Swaps the currently selected entity with the entity located
@@ -226,6 +429,98 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      */
     @Nonnull
     M swapPosition(@Nonnull T swapEntity);
+
+    /**
+     * Swaps the entities at the specified positions.
+     * No other entities are affected by this operation.
+     *
+     * @param  position1
+     *         0 based index of the first target position
+     * @param  position2
+     *         0 based index of the second target position
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If either of the specified positions is out-of-bounds
+     *
+     * @return The current OrderAction sub-implementation instance
+     */
+    @Nonnull
+    default M swapPosition(int position1, int position2)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(position1).swapPosition(position2);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
+     * Swaps the entities at the specified positions.
+     * No other entities are affected by this operation.
+     *
+     * @param  entity
+     *         The first entity to swap
+     * @param  position2
+     *         0 based index of the second target position
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the specified position is out-of-bounds,
+     *         or if the entity is null or not tracked by this order action
+     *
+     * @return The current OrderAction sub-implementation instance
+     */
+    @Nonnull
+    default M swapPosition(@Nonnull T entity, int position2)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(entity).swapPosition(position2);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
+
+    /**
+     * Swaps the entities at the specified positions.
+     * No other entities are affected by this operation.
+     *
+     * @param  entity1
+     *         The first entity to swap
+     * @param  entity2
+     *         The second entity to swap
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If either of the provided entities is null
+     *         or not tracked by this order action
+     *
+     * @return The current OrderAction sub-implementation instance
+     */
+    @Nonnull
+    default M swapPosition(@Nonnull T entity1, @Nonnull T entity2)
+    {
+        int currentPosition = getSelectedPosition();
+        try
+        {
+            selectPosition(entity1).swapPosition(entity2);
+        }
+        finally
+        {
+            if (currentPosition > -1)
+                selectPosition(currentPosition);
+        }
+        return (M) this;
+    }
 
     /**
      * Reverses the {@link #getCurrentOrder() current order} by using

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/CategoryOrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/CategoryOrderActionImpl.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -51,6 +52,13 @@ public class CategoryOrderActionImpl
     public Category getCategory()
     {
         return category;
+    }
+
+    @Nonnull
+    @Override
+    public CategoryOrderAction moveTo(@Nullable Category newParent, boolean lockPermissions)
+    {
+        return (CategoryOrderAction) super.moveTo(newParent, lockPermissions);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds the new `lock_permissions` and `parent_id` to the `ChannelOrderAction` which can be used to move multiple channels to new categories.

For reference: discord/discord-api-docs#1776
