### PR TITLE
Replace SnowflakeReference

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -38,7 +38,6 @@ import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.InviteActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -51,7 +50,6 @@ import java.util.stream.Collectors;
 public abstract class AbstractChannelImpl<T extends GuildChannel, M extends AbstractChannelImpl<T, M>> implements GuildChannel
 {
     protected final long id;
-    protected final SnowflakeReference<Guild> guild;
     protected final JDAImpl api;
 
     protected final TLongObjectMap<PermissionOverride> overrides = MiscUtil.newLongMap();
@@ -59,6 +57,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     protected final ReentrantLock mngLock = new ReentrantLock();
     protected volatile ChannelManager manager;
 
+    protected GuildImpl guild;
     protected long parentId;
     protected String name;
     protected int rawPosition;
@@ -67,7 +66,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     {
         this.id = id;
         this.api = guild.getJDA();
-        this.guild = new SnowflakeReference<>(guild, api::getGuildById);
+        this.guild = guild;
     }
 
     @Override
@@ -103,7 +102,10 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     @Override
     public GuildImpl getGuild()
     {
-        return (GuildImpl) guild.resolve();
+        GuildImpl realGuild = (GuildImpl) api.getGuildById(guild.getIdLong());
+        if (realGuild != null)
+            guild = realGuild;
+        return guild;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -21,15 +21,14 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 
 import javax.annotation.Nonnull;
 
 public class GuildVoiceStateImpl implements GuildVoiceState
 {
-    private final SnowflakeReference<Guild> guild;
-    private final SnowflakeReference<Member> member;
     private final JDA api;
+    private Guild guild;
+    private Member member;
 
     private VoiceChannel connectedChannel;
     private String sessionId;
@@ -43,8 +42,8 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     public GuildVoiceStateImpl(Member member)
     {
         this.api = member.getJDA();
-        this.guild = new SnowflakeReference<>(member.getGuild(), api::getGuildById);
-        this.member = new SnowflakeReference<>(member, (id) -> guild.resolve().getMemberById(id));
+        this.guild = member.getGuild();
+        this.member = member;
     }
 
     @Override
@@ -118,14 +117,20 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     @Override
     public Guild getGuild()
     {
-        return this.guild.resolve();
+        Guild realGuild = api.getGuildById(guild.getIdLong());
+        if (realGuild != null)
+            guild = realGuild;
+        return guild;
     }
 
     @Nonnull
     @Override
     public Member getMember()
     {
-        return this.member.resolve();
+        Member realMember = getGuild().getMemberById(member.getIdLong());
+        if (realMember != null)
+            member = realMember;
+        return member;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -77,7 +77,7 @@ public class MemberImpl implements Member
     @Override
     public GuildImpl getGuild()
     {
-        GuildImpl realGuild = (GuildImpl) getJDA().getGuildById(guild.getIdLong());
+        GuildImpl realGuild = (GuildImpl) api.getGuildById(guild.getIdLong());
         if (realGuild != null)
             guild = realGuild;
         return guild;

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -33,7 +33,6 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 
 import javax.annotation.Nonnull;
@@ -46,8 +45,8 @@ import java.util.concurrent.locks.ReentrantLock;
 public class RoleImpl implements Role
 {
     private final long id;
-    private final SnowflakeReference<Guild> guild;
     private final JDAImpl api;
+    private Guild guild;
 
     private final ReentrantLock mngLock = new ReentrantLock();
     private volatile RoleManager manager;
@@ -64,7 +63,7 @@ public class RoleImpl implements Role
     {
         this.id = id;
         this.api =(JDAImpl) guild.getJDA();
-        this.guild = new SnowflakeReference<>(guild, api::getGuildById);
+        this.guild = guild;
     }
 
     @Override
@@ -220,7 +219,10 @@ public class RoleImpl implements Role
     @Override
     public Guild getGuild()
     {
-        return guild.resolve();
+        Guild realGuild = api.getGuildById(guild.getIdLong());
+        if (realGuild != null)
+            guild = realGuild;
+        return guild;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/managers/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ChannelManagerImpl.java
@@ -30,7 +30,6 @@ import net.dv8tion.jda.internal.entities.AbstractChannelImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.PermOverrideData;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 import okhttp3.RequestBody;
 
 import javax.annotation.CheckReturnValue;
@@ -39,7 +38,7 @@ import java.util.Collection;
 
 public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements ChannelManager
 {
-    protected final SnowflakeReference<GuildChannel> channel;
+    protected GuildChannel channel;
 
     protected String name;
     protected String parent;
@@ -67,7 +66,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
               Route.Channels.MODIFY_CHANNEL.compile(channel.getId()));
         JDA jda = channel.getJDA();
         ChannelType type = channel.getType();
-        this.channel = new SnowflakeReference<>(channel, (channelId) -> jda.getGuildChannelById(type, channelId));
+        this.channel = channel;
         if (isPermissionChecksEnabled())
             checkPermissions();
         this.overridesAdd = new TLongObjectHashMap<>();
@@ -78,7 +77,10 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
     @Override
     public GuildChannel getChannel()
     {
-        return channel.resolve();
+        GuildChannel realChannel = api.getGuildChannelById(channel.getType(), channel.getIdLong());
+        if (realChannel != null)
+            channel = realChannel;
+        return channel;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
@@ -28,7 +28,6 @@ import net.dv8tion.jda.api.managers.GuildManager;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 import okhttp3.RequestBody;
 
 import javax.annotation.CheckReturnValue;
@@ -37,7 +36,7 @@ import javax.annotation.Nullable;
 
 public class GuildManagerImpl extends ManagerBase<GuildManager> implements GuildManager
 {
-    protected final SnowflakeReference<Guild> guild;
+    protected Guild guild;
 
     protected String name;
     protected String region;
@@ -54,7 +53,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
     {
         super(guild.getJDA(), Route.Guilds.MODIFY_GUILD.compile(guild.getId()));
         JDA api = guild.getJDA();
-        this.guild = new SnowflakeReference<>(guild, api::getGuildById);
+        this.guild = guild;
         if (isPermissionChecksEnabled())
             checkPermissions();
     }
@@ -63,7 +62,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
     @Override
     public Guild getGuild()
     {
-        return guild.resolve();
+        Guild realGuild = api.getGuildById(guild.getIdLong());
+        if (realGuild != null)
+            guild = realGuild;
+        return guild;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/managers/PermOverrideManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PermOverrideManagerImpl.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.exceptions.MissingAccessException;
 import net.dv8tion.jda.api.managers.PermOverrideManager;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.entities.AbstractChannelImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import okhttp3.RequestBody;
 
@@ -33,7 +34,7 @@ import javax.annotation.Nonnull;
 public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> implements PermOverrideManager
 {
     protected final boolean role;
-    protected final PermissionOverride override;
+    protected PermissionOverride override;
 
     protected long allowed;
     protected long denied;
@@ -69,6 +70,10 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
     @Override
     public PermissionOverride getPermissionOverride()
     {
+        AbstractChannelImpl<?, ?> channel = (AbstractChannelImpl<?, ?>) override.getChannel();
+        PermissionOverride realOverride = channel.getOverrideMap().get(override.getIdLong());
+        if (realOverride != null)
+            override = realOverride;
         return override;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/managers/PermOverrideManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PermOverrideManagerImpl.java
@@ -16,15 +16,15 @@
 
 package net.dv8tion.jda.internal.managers;
 
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.PermissionOverride;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.exceptions.MissingAccessException;
 import net.dv8tion.jda.api.managers.PermOverrideManager;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 import okhttp3.RequestBody;
 
 import javax.annotation.CheckReturnValue;
@@ -32,8 +32,8 @@ import javax.annotation.Nonnull;
 
 public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> implements PermOverrideManager
 {
-    protected final SnowflakeReference<PermissionOverride> override;
     protected final boolean role;
+    protected final PermissionOverride override;
 
     protected long allowed;
     protected long denied;
@@ -49,35 +49,12 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         super(override.getJDA(),
               Route.Channels.MODIFY_PERM_OVERRIDE.compile(
                   override.getChannel().getId(), override.getId()));
-        this.override = setupReferent(override);
+        this.override = override;
         this.role = override.isRoleOverride();
         this.allowed = override.getAllowedRaw();
         this.denied = override.getDeniedRaw();
         if (isPermissionChecksEnabled())
             checkPermissions();
-    }
-
-    private SnowflakeReference<PermissionOverride> setupReferent(PermissionOverride override)
-    {
-        JDA api = override.getJDA();
-        GuildChannel channel = override.getChannel();
-        long channelId = channel.getIdLong();
-        ChannelType type = channel.getType();
-        boolean role = override.isRoleOverride();
-        return new SnowflakeReference<>(override, (holderId) -> {
-            GuildChannel targetChannel = api.getGuildChannelById(type, channelId);
-            if (targetChannel == null)
-                return null;
-            Guild guild = targetChannel.getGuild();
-            IPermissionHolder holder;
-            if (role)
-                holder = guild.getRoleById(holderId);
-            else
-                holder = guild.getMemberById(holderId);
-            if (holder == null)
-                return null;
-            return targetChannel.getPermissionOverride(holder);
-        });
     }
 
     private void setupValues()
@@ -92,7 +69,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
     @Override
     public PermissionOverride getPermissionOverride()
     {
-        return override.resolve();
+        return override;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/managers/RoleManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/RoleManagerImpl.java
@@ -27,7 +27,6 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
-import net.dv8tion.jda.internal.utils.cache.SnowflakeReference;
 import okhttp3.RequestBody;
 
 import javax.annotation.CheckReturnValue;
@@ -37,7 +36,7 @@ import java.util.EnumSet;
 
 public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleManager
 {
-    protected final SnowflakeReference<Role> role;
+    protected Role role;
 
     protected String name;
     protected int color;
@@ -55,7 +54,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
     {
         super(role.getJDA(), Route.Roles.MODIFY_ROLE.compile(role.getGuild().getId(), role.getId()));
         JDA api = role.getJDA();
-        this.role = new SnowflakeReference<>(role, api::getRoleById);
+        this.role = role;
         if (isPermissionChecksEnabled())
             checkPermissions();
     }
@@ -64,7 +63,10 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
     @Override
     public Role getRole()
     {
-        return role.resolve();
+        Role realRole = getGuild().getRoleById(role.getIdLong());
+        if (realRole != null)
+            role = realRole;
+        return role;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/managers/RoleManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/RoleManagerImpl.java
@@ -63,7 +63,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
     @Override
     public Role getRole()
     {
-        Role realRole = getGuild().getRoleById(role.getIdLong());
+        Role realRole = role.getGuild().getRoleById(role.getIdLong());
         if (realRole != null)
             role = realRole;
         return role;

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeReference.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeReference.java
@@ -16,12 +16,15 @@
 
 package net.dv8tion.jda.internal.utils.cache;
 
+import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.entities.ISnowflake;
 
 import javax.annotation.Nonnull;
 import java.lang.ref.WeakReference;
 import java.util.function.LongFunction;
 
+@ForRemoval
+@Deprecated
 public class SnowflakeReference<T extends ISnowflake> implements ISnowflake
 {
     private final LongFunction<T> fallbackProvider;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This removes the usage of `SnowflakeReference` which was used to avoid memory leaks from continuously storing JDA entities such as members. Memory leaks are now solved in a different way, by replacing the upstream reference when the cache has updated. This does not handle cases where the entire JDA session is replaced, however that is a specific use-case that we shouldn't need to handle explicitly for the users.

### Motivation

The `SnowflakeReference` class adds a severe overhead in both memory usage and GC usage. Some GC implementations seem to struggle a lot with `WeakReference`, which is a crucial part of this system.
