### PR TITLE
Fix Discord domain in docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -138,7 +138,7 @@ public enum Permission
     /**
      * The binary offset of the permission.
      * <br>For more information about Discord's offset system refer to
-     * <a href="https://discordapp.com/developers/docs/topics/permissions">Discord Permissions</a>.
+     * <a href="https://discord.com/developers/docs/topics/permissions">Discord Permissions</a>.
      *
      * @return The offset that represents this {@link net.dv8tion.jda.api.Permission Permission}.
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Found one place where the old discord domain is still present in the docs.

Powered by 
```
rg '(?<!cdn.)discordapp.com' --pcre2 --files-with-matches | xargs gsed -i 's/discordapp\.com/discord\.com/g'
```
in case you want to fix more projects that you have checked out locally.