### PR TITLE
Implement support for news channels

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1775,6 +1775,45 @@ public interface Message extends ISnowflake, Formattable
     AuditableRestAction<Void> suppressEmbeds(boolean suppressed);
 
     /**
+     * Attempts to crosspost this message.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#ALREADY_CROSSPOSTED ALREADY_CROSSPOSTED}
+     *     <br>The target message has already been crossposted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in the TextChannel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @throws IllegalStateException
+     *         If the channel is not a text or news channel. See {@link TextChannel#isNews()}.
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} in this channel
+     *         or if this message is from another user and we don't have {@link Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction} - Type: {@link Message}
+     */
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Message> crosspost();
+
+    /**
      * Whether embeds are suppressed for this message.
      * When Embeds are suppressed, they are not displayed on clients nor provided via API until un-suppressed.
      * <br>This is a shortcut method for checking if {@link #getFlags() getFlags()} contains

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNewsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNewsEvent.java
@@ -21,6 +21,14 @@ import net.dv8tion.jda.api.entities.TextChannel;
 
 import javax.annotation.Nonnull;
 
+/**
+ * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s has been converted into a news channel
+ * or reverted into a normal channel.
+ *
+ * <p>Can be used to detect when a TextChannel becomes a news channel.
+ *
+ * <p>Identifier: {@code news}
+ */
 @SuppressWarnings("ConstantConditions")
 public class TextChannelUpdateNewsEvent extends GenericTextChannelUpdateEvent<Boolean>
 {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNewsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNewsEvent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.channel.text.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import javax.annotation.Nonnull;
+
+@SuppressWarnings("ConstantConditions")
+public class TextChannelUpdateNewsEvent extends GenericTextChannelUpdateEvent<Boolean>
+{
+    public static final String IDENTIFIER = "news";
+
+    public TextChannelUpdateNewsEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel)
+    {
+        super(api, responseNumber, channel, !channel.isNews(), channel.isNews(), IDENTIFIER);
+    }
+
+    @Nonnull
+    @Override
+    public Boolean getOldValue()
+    {
+        return super.getOldValue();
+    }
+
+    @Nonnull
+    @Override
+    public Boolean getNewValue()
+    {
+        return super.getNewValue();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -228,6 +228,7 @@ public abstract class ListenerAdapter implements EventListener
     public void onTextChannelUpdateNSFW(@Nonnull TextChannelUpdateNSFWEvent event) {}
     public void onTextChannelUpdateParent(@Nonnull TextChannelUpdateParentEvent event) {}
     public void onTextChannelUpdateSlowmode(@Nonnull TextChannelUpdateSlowmodeEvent event) {}
+    public void onTextChannelUpdateNews(@Nonnull TextChannelUpdateNewsEvent event) {}
     public void onTextChannelCreate(@Nonnull TextChannelCreateEvent event) {}
 
     //VoiceChannel Events
@@ -512,6 +513,8 @@ public abstract class ListenerAdapter implements EventListener
             onTextChannelDelete((TextChannelDeleteEvent) event);
         else if (event instanceof TextChannelUpdatePermissionsEvent)
             onTextChannelUpdatePermissions((TextChannelUpdatePermissionsEvent) event);
+        else if (event instanceof TextChannelUpdateNewsEvent)
+            onTextChannelUpdateNews((TextChannelUpdateNewsEvent) event);
 
         //VoiceChannel Events
         else if (event instanceof VoiceChannelCreateEvent)

--- a/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
@@ -73,6 +73,7 @@ public enum ErrorResponse
     UNAUTHORIZED(                   40001, "Unauthorized"),
     REQUEST_ENTITY_TOO_LARGE(       40005, "Request entity too large"),
     USER_NOT_CONNECTED(             40032, "Target user is not connected to voice."),
+    ALREADY_CROSSPOSTED(            40033, "This message has already been crossposted."),
     MISSING_ACCESS(                 50001, "Missing Access"),
     INVALID_ACCOUNT_TYPE(           50002, "Invalid Account Type"),
     INVALID_DM_ACTION(              50003, "Cannot execute action on a DM channel"),

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -542,6 +542,14 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
+    @Nonnull
+    @Override
+    public RestAction<Message> crosspost()
+    {
+        unsupported();
+        return null;
+    }
+
     @Override
     public boolean isSuppressedEmbeds()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -894,6 +894,7 @@ public class EntityBuilder
             .setTopic(json.getString("topic", null))
             .setPosition(json.getInt("position"))
             .setNSFW(json.getBoolean("nsfw"))
+            .setNews(json.getInt("type") == 5)
             .setSlowmode(json.getInt("rate_limit_per_user", 0));
 
         createOverridesPass(channel, json.getArray("permission_overwrites"));

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -53,6 +53,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
     private String topic;
     private long lastMessageId;
     private boolean nsfw;
+    private boolean news;
     private int slowmode;
 
     public TextChannelImpl(long id, GuildImpl guild)
@@ -269,6 +270,12 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
     public boolean isNSFW()
     {
         return nsfw;
+    }
+
+    @Override
+    public boolean isNews()
+    {
+        return news && getGuild().getFeatures().contains("NEWS");
     }
 
     @Override
@@ -622,6 +629,12 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
     public TextChannelImpl setSlowmode(int slowmode)
     {
         this.slowmode = slowmode;
+        return this;
+    }
+
+    public TextChannelImpl setNews(boolean news)
+    {
+        this.news = news;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
@@ -51,7 +51,9 @@ public class ChannelUpdateHandler extends SocketHandler
     @Override
     protected Long handleInternally(DataObject content)
     {
-        ChannelType type = ChannelType.fromId(content.getInt("type"));
+        int rawType = content.getInt("type");
+        boolean news = rawType == 5;
+        ChannelType type = ChannelType.fromId(rawType);
         if (type == ChannelType.GROUP)
         {
             WebSocketClient.LOG.warn("Ignoring CHANNEL_UPDATE for a group which we don't support");
@@ -168,6 +170,8 @@ public class ChannelUpdateHandler extends SocketHandler
                                     getJDA(), responseNumber,
                                     textChannel, oldSlowmode));
                 }
+
+                textChannel.setNews(news); // TODO: Event
 
                 applyPermissions(textChannel, permOverwrites);
                 break;  //Finish the TextChannelUpdate case

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
@@ -171,7 +171,14 @@ public class ChannelUpdateHandler extends SocketHandler
                                     textChannel, oldSlowmode));
                 }
 
-                textChannel.setNews(news); // TODO: Event
+                if (news != textChannel.isNews())
+                {
+                    textChannel.setNews(news);
+                    getJDA().handleEvent(
+                        new TextChannelUpdateNewsEvent(
+                            getJDA(), responseNumber,
+                            textChannel));
+                }
 
                 applyPermissions(textChannel, permOverwrites);
                 break;  //Finish the TextChannelUpdate case

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -208,6 +208,7 @@ public class Route
 
         public static final Route DELETE_MESSAGE =      new Route(DELETE, "channels/{channel_id}/messages/{message_id}");
         public static final Route GET_MESSAGE_HISTORY = new Route(GET,    "channels/{channel_id}/messages");
+        public static final Route CROSSPOST_MESSAGE =   new Route(POST,   "channels/{channel_id}/messages/{message_id}/crosspost");
 
         //Bot only
         public static final Route GET_MESSAGE =     new Route(GET,  "channels/{channel_id}/messages/{message_id}");


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1357 

## Description

We don't handle news channels by using the NEWS type. We will instead use a boolean which makes the code a lot easier to understand. Using a new channel type only for news channels makes no sense since the only difference to text channels is the possibility to crosspost messages.

You can have news channels in a guild without having the NEWS feature. However, those channels do not support crossposting so it makes sense to simply handle them like they are not news channels.

```java
@Override
public boolean isNews()
{
    return news && getGuild().getFeatures().contains("NEWS");
}
```

This also simplifies the checks we need to perform in our code for crossposting.

Gotcha's:

- Trying to crosspost a message that is already crossposted will result in the error response "ALREADY_CROSSPOSTED"
- You can crosspost your own messages if you can send them
- You can crosspost other people's messages with MESSAGE_MANAGE permission
- You cannot crosspost messages if the guild does not have the NEWS feature enabled

### Example

```java
channel.sendMessage("PSA: I like trains")
       .flatMap(Message::crosspost)
       .queue();
```
