### PR TITLE
Fix sanitization issues within quotes

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -504,16 +504,14 @@ public class MarkdownSanitizer
         // Special handling for quote
         if (!isIgnored(QUOTE) && quote.matcher(sequence).matches())
         {
-            int end = sequence.indexOf('\n');
-            if (end < 0)
-                end = sequence.length();
-            StringBuilder builder = new StringBuilder(compute(sequence.substring(2, end)));
+            int start = sequence.indexOf('>');
+            if (start < 0)
+                start = 0;
+            StringBuilder builder = new StringBuilder(compute(sequence.substring(start + 1)));
             if (strategy == SanitizationStrategy.ESCAPE)
-                builder.insert(0, "\\> ");
+                builder.insert(0, "\\>");
             if (newline)
                 builder.insert(0, '\n');
-            if (end < sequence.length())
-                builder.append(compute(sequence.substring(end)));
             return builder.toString();
 
         }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -388,5 +388,6 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\>>> Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
         Assertions.assertEquals("\\>>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
         Assertions.assertEquals("\\>>>\nHello > World", markdown.compute(">>>\nHello > World"));
+        Assertions.assertEquals("\\> \\_Hello \n\\> World\\_", markdown.compute("> _Hello \n> World_"));
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1360 

## Description

This fixes the issue causing characters not to sanitize when put into multiple multiline quotes.

Basically, instead of breaking the quotes by their ending we break them up at the start.



