### PR TITLE
Add "missing" dots to permission override methods params

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
@@ -236,10 +236,10 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * @param  target
      *         The not-null {@link net.dv8tion.jda.api.entities.Role Role} or {@link net.dv8tion.jda.api.entities.Member Member} for the override
      * @param  allow
-     *         The granted {@link net.dv8tion.jda.api.Permission Permissions} for the override
+     *         The granted {@link net.dv8tion.jda.api.Permission Permissions} for the override.
      *         Use {@link net.dv8tion.jda.api.Permission#getRawValue()} to retrieve these Permissions.
      * @param  deny
-     *         The denied {@link net.dv8tion.jda.api.Permission Permissions} for the override
+     *         The denied {@link net.dv8tion.jda.api.Permission Permissions} for the override.
      *         Use {@link net.dv8tion.jda.api.Permission#getRawValue()} to retrieve these Permissions.
      *
      * @throws java.lang.IllegalArgumentException
@@ -347,10 +347,10 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * @param  memberId
      *         The id for the member
      * @param  allow
-     *         The granted {@link net.dv8tion.jda.api.Permission Permissions} for the override
+     *         The granted {@link net.dv8tion.jda.api.Permission Permissions} for the override.
      *         Use {@link net.dv8tion.jda.api.Permission#getRawValue()} to retrieve these Permissions.
      * @param  deny
-     *         The denied {@link net.dv8tion.jda.api.Permission Permissions} for the override
+     *         The denied {@link net.dv8tion.jda.api.Permission Permissions} for the override.
      *         Use {@link net.dv8tion.jda.api.Permission#getRawValue()} to retrieve these Permissions.
      *
      * @throws java.lang.IllegalArgumentException
@@ -380,10 +380,10 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * @param  roleId
      *         The id for the role
      * @param  allow
-     *         The granted {@link net.dv8tion.jda.api.Permission Permissions} for the override
+     *         The granted {@link net.dv8tion.jda.api.Permission Permissions} for the override.
      *         Use {@link net.dv8tion.jda.api.Permission#getRawValue()} to retrieve these Permissions.
      * @param  deny
-     *         The denied {@link net.dv8tion.jda.api.Permission Permissions} for the override
+     *         The denied {@link net.dv8tion.jda.api.Permission Permissions} for the override.
      *         Use {@link net.dv8tion.jda.api.Permission#getRawValue()} to retrieve these Permissions.
      *
      * @throws java.lang.IllegalArgumentException


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds dots to the parameters of methods `addPermissionOverride`, `addMemberPermissionOverride` and `addRolePermissionOverride`. The parameters without these dots look a bit strange as there's only a space.

![](https://the-negative-one-in.me/2w5hFN9jo1.png)

#ocd