### PR TITLE
new method to check if an attachment is tagged as spoiler

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2347,5 +2347,16 @@ public interface Message extends ISnowflake, Formattable
             String extension = getFileExtension();
             return extension != null && VIDEO_EXTENSIONS.contains(extension.toLowerCase());
         }
+
+        /**
+         * Whether or not this attachment is tagged as spoiler,
+         * based on {@link #getFileName()}.
+         *
+         * @return True if this attachment is tagged as spoiler
+         */
+        public boolean isSpoiler()
+        {
+            return getFileName().startsWith("SPOILER_");
+        }
     }
 }


### PR DESCRIPTION
added a method to determine if a attachement is a spoiler

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

added a new method to determine if an attachment is tagged as spoiler 