### PR TITLE
Fix inconsistency with MarkdownSanitizer 

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -71,7 +71,7 @@ public class MarkdownSanitizer
     private static final int ESCAPED_QUOTE_BLOCK = Integer.MIN_VALUE | QUOTE_BLOCK;
 
     private static final Pattern codeLanguage = Pattern.compile("^\\w+\n.*", Pattern.MULTILINE | Pattern.DOTALL);
-    private static final Pattern quote = Pattern.compile("> +\\S.*", Pattern.DOTALL | Pattern.MULTILINE);
+    private static final Pattern quote = Pattern.compile("> +(\\S.*)*", Pattern.DOTALL | Pattern.MULTILINE);
     private static final Pattern quoteBlock = Pattern.compile(">>>\\s+\\S.*", Pattern.DOTALL | Pattern.MULTILINE);
 
     private static final TIntObjectMap<String> tokens;

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -71,7 +71,7 @@ public class MarkdownSanitizer
     private static final int ESCAPED_QUOTE_BLOCK = Integer.MIN_VALUE | QUOTE_BLOCK;
 
     private static final Pattern codeLanguage = Pattern.compile("^\\w+\n.*", Pattern.MULTILINE | Pattern.DOTALL);
-    private static final Pattern quote = Pattern.compile("> +(\\S.*)*", Pattern.DOTALL | Pattern.MULTILINE);
+    private static final Pattern quote = Pattern.compile("> +.*", Pattern.DOTALL | Pattern.MULTILINE);
     private static final Pattern quoteBlock = Pattern.compile(">>>\\s+\\S.*", Pattern.DOTALL | Pattern.MULTILINE);
 
     private static final TIntObjectMap<String> tokens;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

A couple of weeks ago, I submitted a pull request that attempted to resolve the issue causing symbols to not be sanitized correctly inside of quotes. Unfortunately, I found that putting a symbol in front of a quote causes my previous fix to not work correctly.

Example: ``> _Hello \n> _World`` ->``\\> \\_Hello \n> \\_World``

This fixes the issue by changing the regex to allow for quotes that contain just spaces. While Discord removes these extra spaces itself, they are still able to generate quotes (a bit of a weird fix).

BEFORE

``> ​``
(As stated before, these are still valid quotes)
![image](https://user-images.githubusercontent.com/23108066/91099226-ee5b4900-e630-11ea-937c-a0781810d6bc.png)

AFTER

``\> ​``
![image](https://user-images.githubusercontent.com/23108066/91099366-2cf10380-e631-11ea-9005-1714b1441136.png)


If there are any more issues related to this in the future, it might be better just to redo how quotes are handled entirely. 
 