### PR TITLE
Make audio thread pool configurable by users

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -69,6 +69,8 @@ public class JDABuilder
     protected boolean shutdownCallbackPool = true;
     protected ExecutorService eventPool = null;
     protected boolean shutdownEventPool = true;
+    protected ScheduledExecutorService audioPool = null;
+    protected boolean shutdownAudioPool = true;
     protected EnumSet<CacheFlag> cacheFlags = EnumSet.allOf(CacheFlag.class);
     protected ConcurrentMap<String, String> contextMap = null;
     protected SessionController controller = null;
@@ -1156,6 +1158,50 @@ public class JDABuilder
     }
 
     /**
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} used by
+     * the audio WebSocket connection. Used for sending keepalives and closing the connection.
+     * <br><b>Only change this pool if you know what you're doing.</b>
+     *
+     * <p>Default: {@link ScheduledThreadPoolExecutor} with 1 thread
+     *
+     * @param  pool
+     *         The thread-pool to use for the audio WebSocket
+     *
+     * @return The JDABuilder instance. Useful for chaining.
+     *
+     * @since 4.2.1
+     */
+    @Nonnull
+    public JDABuilder setAudioPool(@Nullable ScheduledExecutorService pool)
+    {
+        return setAudioPool(pool, pool == null);
+    }
+
+    /**
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} used by
+     * the audio WebSocket connection. Used for sending keepalives and closing the connection.
+     * <br><b>Only change this pool if you know what you're doing.</b>
+     *
+     * <p>Default: {@link ScheduledThreadPoolExecutor} with 1 thread
+     *
+     * @param  pool
+     *         The thread-pool to use for the audio WebSocket
+     * @param  automaticShutdown
+     *         Whether {@link JDA#shutdown()} should shutdown this pool
+     *
+     * @return The JDABuilder instance. Useful for chaining.
+     *
+     * @since 4.2.1
+     */
+    @Nonnull
+    public JDABuilder setAudioPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
+    {
+        this.audioPool = pool;
+        this.shutdownAudioPool = automaticShutdown;
+        return this;
+    }
+
+    /**
      * If enabled, JDA will separate the bulk delete event into individual delete events, but this isn't as efficient as
      * handling a single event would be. It is recommended that BulkDelete Splitting be disabled and that the developer
      * should instead handle the {@link net.dv8tion.jda.api.events.message.MessageBulkDeleteEvent MessageBulkDeleteEvent}
@@ -1843,6 +1889,7 @@ public class JDABuilder
         threadingConfig.setGatewayPool(mainWsPool, shutdownMainWsPool);
         threadingConfig.setRateLimitPool(rateLimitPool, shutdownRateLimitPool);
         threadingConfig.setEventPool(eventPool, shutdownEventPool);
+        threadingConfig.setAudioPool(audioPool, shutdownAudioPool);
         SessionConfig sessionConfig = new SessionConfig(controller, httpClient, wsFactory, voiceDispatchInterceptor, flags, maxReconnectDelay, largeThreshold);
         MetaConfig metaConfig = new MetaConfig(maxBufferSize, contextMap, cacheFlags, flags);
 

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -501,6 +501,10 @@ public class DefaultShardManager implements ShardManager
         ExecutorService eventPool = eventPair.executor;
         boolean shutdownEventPool = eventPair.automaticShutdown;
 
+        ExecutorPair<ScheduledExecutorService> audioPair = resolveExecutor(threadingConfig.getAudioPoolProvider(), shardId);
+        ScheduledExecutorService audioPool = audioPair.executor;
+        boolean shutdownAudioPool = audioPair.automaticShutdown;
+
         AuthorizationConfig authConfig = new AuthorizationConfig(token);
         SessionConfig sessionConfig = this.sessionConfig.toSessionConfig(httpClient);
         ThreadingConfig threadingConfig = new ThreadingConfig();
@@ -508,6 +512,7 @@ public class DefaultShardManager implements ShardManager
         threadingConfig.setGatewayPool(gatewayPool, shutdownGatewayPool);
         threadingConfig.setCallbackPool(callbackPool, shutdownCallbackPool);
         threadingConfig.setEventPool(eventPool, shutdownEventPool);
+        threadingConfig.setAudioPool(audioPool, shutdownAudioPool);
         MetaConfig metaConfig = new MetaConfig(this.metaConfig.getMaxBufferSize(), this.metaConfig.getContextMap(shardId), this.metaConfig.getCacheFlags(), this.sessionConfig.getFlags());
         final JDAImpl jda = new JDAImpl(authConfig, sessionConfig, threadingConfig, metaConfig);
         jda.setMemberCachePolicy(shardingConfig.getMemberCachePolicy());

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -85,6 +85,7 @@ public class  DefaultShardManagerBuilder
     protected ThreadPoolProvider<? extends ScheduledExecutorService> gatewayPoolProvider = null;
     protected ThreadPoolProvider<? extends ExecutorService> callbackPoolProvider = null;
     protected ThreadPoolProvider<? extends ExecutorService> eventPoolProvider = null;
+    protected ThreadPoolProvider<? extends ScheduledExecutorService> audioPoolProvider = null;
     protected Collection<Integer> shards = null;
     protected OkHttpClient.Builder httpClientBuilder = null;
     protected OkHttpClient httpClient = null;
@@ -1639,6 +1640,69 @@ public class  DefaultShardManagerBuilder
     }
 
     /**
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} used by
+     * the audio WebSocket connection. Used for sending keepalives and closing the connection.
+     * <br><b>Only change this pool if you know what you're doing.</b>
+     *
+     * <p>Default: {@link ScheduledThreadPoolExecutor} with 1 thread
+     *
+     * @param  pool
+     *         The thread-pool to use for the audio WebSocket
+     *
+     * @return The DefaultShardManagerBuilder instance. Useful for chaining.
+     *
+     * @since 4.2.1
+     */
+    @Nonnull
+    public DefaultShardManagerBuilder setAudioPool(@Nullable ScheduledExecutorService pool)
+    {
+        return setAudioPool(pool, pool == null);
+    }
+
+    /**
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} used by
+     * the audio WebSocket connection. Used for sending keepalives and closing the connection.
+     * <br><b>Only change this pool if you know what you're doing.</b>
+     *
+     * <p>Default: {@link ScheduledThreadPoolExecutor} with 1 thread
+     *
+     * @param  pool
+     *         The thread-pool to use for the audio WebSocket
+     * @param  automaticShutdown
+     *         True, if the executor should be shutdown when JDA shuts down
+     *
+     * @return The DefaultShardManagerBuilder instance. Useful for chaining.
+     *
+     * @since 4.2.1
+     */
+    @Nonnull
+    public DefaultShardManagerBuilder setAudioPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
+    {
+        return setAudioPoolProvider(pool == null ? null : new ThreadPoolProviderImpl<>(pool, automaticShutdown));
+    }
+
+    /**
+     * Sets the {@link ScheduledExecutorService ScheduledExecutorService} used by
+     * the audio WebSocket connection. Used for sending keepalives and closing the connection.
+     * <br><b>Only change this pool if you know what you're doing.</b>
+     *
+     * <p>Default: {@link ScheduledThreadPoolExecutor} with 1 thread
+     *
+     * @param  provider
+     *         The thread-pool provider to use for the audio WebSocket
+     *
+     * @return The DefaultShardManagerBuilder instance. Useful for chaining.
+     *
+     * @since 4.2.1
+     */
+    @Nonnull
+    public DefaultShardManagerBuilder setAudioPoolProvider(@Nullable ThreadPoolProvider<? extends ScheduledExecutorService> provider)
+    {
+        this.audioPoolProvider = provider;
+        return this;
+    }
+
+    /**
      * Sets the maximum amount of time that JDA will back off to wait when attempting to reconnect the MainWebsocket.
      * <br>Provided value must be 32 or greater.
      *
@@ -2221,7 +2285,7 @@ public class  DefaultShardManagerBuilder
         presenceConfig.setActivityProvider(activityProvider);
         presenceConfig.setStatusProvider(statusProvider);
         presenceConfig.setIdleProvider(idleProvider);
-        final ThreadingProviderConfig threadingConfig = new ThreadingProviderConfig(rateLimitPoolProvider, gatewayPoolProvider, callbackPoolProvider, eventPoolProvider, threadFactory);
+        final ThreadingProviderConfig threadingConfig = new ThreadingProviderConfig(rateLimitPoolProvider, gatewayPoolProvider, callbackPoolProvider, eventPoolProvider, audioPoolProvider, threadFactory);
         final ShardingSessionConfig sessionConfig = new ShardingSessionConfig(sessionController, voiceDispatchInterceptor, httpClient, httpClientBuilder, wsFactory, audioSendFactory, flags, shardingFlags, maxReconnectDelay, largeThreshold);
         final ShardingMetaConfig metaConfig = new ShardingMetaConfig(maxBufferSize, contextProvider, cacheFlags, flags, compression, encoding);
         final DefaultShardManager manager = new DefaultShardManager(this.token, this.shards, shardingConfig, eventConfig, presenceConfig, threadingConfig, sessionConfig, metaConfig, chunkingFilter);

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -80,8 +80,6 @@ public class JDAImpl implements JDA
 {
     public static final Logger LOG = JDALogger.getLog(JDA.class);
 
-    protected final Object audioLifeCycleLock = new Object();
-
     protected final SnowflakeCacheViewImpl<User> userCache = new SnowflakeCacheViewImpl<>(User.class, User::getName);
     protected final SnowflakeCacheViewImpl<Guild> guildCache = new SnowflakeCacheViewImpl<>(Guild.class, Guild::getName);
     protected final SnowflakeCacheViewImpl<Category> categories = new SnowflakeCacheViewImpl<>(Category.class, GuildChannel::getName);
@@ -1019,19 +1017,6 @@ public class JDAImpl implements JDA
 
     public ScheduledExecutorService getAudioLifeCyclePool()
     {
-        ScheduledExecutorService pool = threadConfig.getAudioPool();
-        if (pool == null)
-        {
-            synchronized (audioLifeCycleLock)
-            {
-                pool = threadConfig.getAudioPool();
-                if (pool == null)
-                {
-                    pool = ThreadingConfig.newScheduler(1, this::getIdentifierString, "AudioLifeCycle");
-                    threadConfig.setAudioPool(pool, threadConfig.isShutdownAudioPool());
-                }
-            }
-        }
-        return pool;
+        return threadConfig.getAudioPool(this::getIdentifierString);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -58,7 +58,7 @@ class AudioWebSocket extends WebSocketAdapter
 
     private final AudioConnection audioConnection;
     private final ConnectionListener listener;
-    private final ScheduledThreadPoolExecutor keepAlivePool;
+    private final ScheduledExecutorService keepAlivePool;
     private final Guild guild;
     private final String sessionId;
     private final String token;

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
@@ -166,9 +166,7 @@ public class ThreadingConfig
             {
                 pool = audioPool;
                 if (pool == null)
-                {
                     pool = audioPool = ThreadingConfig.newScheduler(1, identifier, "AudioLifeCycle");
-                }
             }
         }
         return pool;

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
@@ -29,11 +29,13 @@ public class ThreadingConfig
     private ScheduledExecutorService gatewayPool;
     private ExecutorService callbackPool;
     private ExecutorService eventPool;
+    private ScheduledExecutorService audioPool;
 
     private boolean shutdownRateLimitPool;
     private boolean shutdownGatewayPool;
     private boolean shutdownCallbackPool;
     private boolean shutdownEventPool;
+    private boolean shutdownAudioPool;
 
     public ThreadingConfig()
     {
@@ -42,6 +44,7 @@ public class ThreadingConfig
         this.shutdownRateLimitPool = true;
         this.shutdownGatewayPool = true;
         this.shutdownCallbackPool = false;
+        this.shutdownAudioPool = true;
     }
 
     public void setRateLimitPool(@Nullable ScheduledExecutorService executor, boolean shutdown)
@@ -68,6 +71,12 @@ public class ThreadingConfig
         this.shutdownEventPool = shutdown;
     }
 
+    public void setAudioPool(@Nullable ScheduledExecutorService executor, boolean shutdown)
+    {
+        this.audioPool = executor;
+        this.shutdownAudioPool = shutdown;
+    }
+
     public void init(@Nonnull Supplier<String> identifier)
     {
         if (this.rateLimitPool == null)
@@ -84,6 +93,8 @@ public class ThreadingConfig
             gatewayPool.shutdown();
         if (shutdownEventPool && eventPool != null)
             eventPool.shutdown();
+        if (shutdownAudioPool && audioPool != null)
+            audioPool.shutdown();
         if (shutdownRateLimitPool)
         {
             if (rateLimitPool instanceof ScheduledThreadPoolExecutor)
@@ -115,6 +126,8 @@ public class ThreadingConfig
             rateLimitPool.shutdownNow();
         if (shutdownEventPool && eventPool != null)
             eventPool.shutdownNow();
+        if (shutdownAudioPool && audioPool != null)
+            audioPool.shutdownNow();
     }
 
     @Nonnull
@@ -141,6 +154,12 @@ public class ThreadingConfig
         return eventPool;
     }
 
+    @Nullable
+    public ScheduledExecutorService getAudioPool()
+    {
+        return audioPool;
+    }
+
     public boolean isShutdownRateLimitPool()
     {
         return shutdownRateLimitPool;
@@ -159,6 +178,11 @@ public class ThreadingConfig
     public boolean isShutdownEventPool()
     {
         return shutdownEventPool;
+    }
+
+    public boolean isShutdownAudioPool()
+    {
+        return shutdownAudioPool;
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ThreadingProviderConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ThreadingProviderConfig.java
@@ -30,6 +30,7 @@ public class ThreadingProviderConfig
     private final ThreadPoolProvider<? extends ScheduledExecutorService> gatewayPoolProvider;
     private final ThreadPoolProvider<? extends ExecutorService> callbackPoolProvider;
     private final ThreadPoolProvider<? extends ExecutorService> eventPoolProvider;
+    private final ThreadPoolProvider<? extends ScheduledExecutorService> audioPoolProvider;
     private final ThreadFactory threadFactory;
 
     public ThreadingProviderConfig(
@@ -37,12 +38,14 @@ public class ThreadingProviderConfig
             @Nullable ThreadPoolProvider<? extends ScheduledExecutorService> gatewayPoolProvider,
             @Nullable ThreadPoolProvider<? extends ExecutorService> callbackPoolProvider,
             @Nullable ThreadPoolProvider<? extends ExecutorService> eventPoolProvider,
+            @Nullable ThreadPoolProvider<? extends ScheduledExecutorService> audioPoolProvider,
             @Nullable ThreadFactory threadFactory)
     {
         this.rateLimitPoolProvider = rateLimitPoolProvider;
         this.gatewayPoolProvider = gatewayPoolProvider;
         this.callbackPoolProvider = callbackPoolProvider;
         this.eventPoolProvider = eventPoolProvider;
+        this.audioPoolProvider = audioPoolProvider;
         this.threadFactory = threadFactory;
     }
 
@@ -76,9 +79,15 @@ public class ThreadingProviderConfig
         return eventPoolProvider;
     }
 
+    @Nullable
+    public ThreadPoolProvider<? extends ScheduledExecutorService> getAudioPoolProvider()
+    {
+        return audioPoolProvider;
+    }
+
     @Nonnull
     public static ThreadingProviderConfig getDefault()
     {
-        return new ThreadingProviderConfig(null, null, null, null, null);
+        return new ThreadingProviderConfig(null, null, null, null, null, null);
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

## Description

Allow the users to provide the thread pool used for the audio stuff.
Why? This helps to get rid of 1 mostly idling thread per shard. In my largest use case, thats 300+ threads gone.