### PR TITLE
Add length check to Activity#playing and similar methods

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -231,7 +231,7 @@ public interface Activity
      *         The streaming url to use, required to display as "streaming".
      *
      * @throws IllegalArgumentException
-     *         If the specified name is null or empty
+     *         If the specified name is null, empty or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name and url
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -122,6 +123,7 @@ public interface Activity
     static Activity playing(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
+        name = name.trim();
         Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.DEFAULT);
     }
@@ -147,6 +149,7 @@ public interface Activity
     static Activity streaming(@Nonnull String name, @Nullable String url)
     {
         Checks.notEmpty(name, "Provided game name");
+        name = Helpers.isBlank(name) ? name : name.trim();
         Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         ActivityType type;
         if (isValidStreamingUrl(url))
@@ -172,6 +175,7 @@ public interface Activity
     static Activity listening(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
+        name = name.trim();
         Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.LISTENING);
     }
@@ -195,6 +199,7 @@ public interface Activity
     static Activity watching(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
+        name = name.trim();
         Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.WATCHING);
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -114,7 +114,7 @@ public interface Activity
      *         The not-null name of the newly created game
      *
      * @throws IllegalArgumentException
-     *         if the specified name is null, empty or blank
+     *         if the specified name is null, empty, blank or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#DEFAULT}
      */
@@ -122,6 +122,7 @@ public interface Activity
     static Activity playing(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
+        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.DEFAULT);
     }
 
@@ -136,7 +137,7 @@ public interface Activity
      *         The streaming url to use, required to display as "streaming"
      *
      * @throws IllegalArgumentException
-     *         If the specified name is null or empty
+     *         If the specified name is null, empty or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name and url
      *
@@ -146,6 +147,7 @@ public interface Activity
     static Activity streaming(@Nonnull String name, @Nullable String url)
     {
         Checks.notEmpty(name, "Provided game name");
+        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         ActivityType type;
         if (isValidStreamingUrl(url))
             type = ActivityType.STREAMING;
@@ -162,7 +164,7 @@ public interface Activity
      *         The not-null name of the newly created game
      *
      * @throws IllegalArgumentException
-     *         if the specified name is null, empty or blank
+     *         if the specified name is null, empty, blank or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#LISTENING}
      */
@@ -170,6 +172,7 @@ public interface Activity
     static Activity listening(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
+        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.LISTENING);
     }
 
@@ -181,7 +184,7 @@ public interface Activity
      *         The not-null name of the newly created game
      *
      * @throws IllegalArgumentException
-     *         if the specified name is null, empty or blank
+     *         if the specified name is null, empty, blank or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#WATCHING}
      *
@@ -192,6 +195,7 @@ public interface Activity
     static Activity watching(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");
+        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.WATCHING);
     }
 
@@ -204,7 +208,7 @@ public interface Activity
      *         The not-null name of the newly created game
      *
      * @throws IllegalArgumentException
-     *         If the specified name is null or empty
+     *         If the specified name is null, empty or longer than 128 characters
      *
      * @return A valid Activity instance with the provided name and url
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Add check to Activity#playing and similar methods to test if the provided name is longer than 128 characters.
Why? Discord won't show activities longer than that.