### PR TITLE
Adding isSynced() method

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -183,7 +183,7 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
      * Whether or not this GuildChannel's {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
      * those of {@link #getParent() its parent category}. If the channel doesn't have a parent category this will return true.
      * 
-     * @return True, if this channel is synced with its parents category
+     * @return True, if this channel is synced with its parent category
      */
     boolean isSynced();
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -183,7 +183,7 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
      * Whether or not this GuildChannel's {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
      * those of {@link #getParent() its parent category}. If the channel doesn't have a parent category this will return true.
      * 
-     * @return A boolean representing this condition.
+     * @return True, if this channel is synced with its parents category
      */
     boolean isSynced();
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -180,14 +180,12 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
     List<PermissionOverride> getRolePermissionOverrides();
 
     /**
-     * Returns whether or not this GuildChannel is synced.
-     * <br>A GuildChannel is synced when its {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
-     * those of {@link #getParent() its parent category}. If the GuildChannel doesn't have a parent category this will return true.
+     * Whether or not this GuildChannel's {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
+     * those of {@link #getParent() its parent category}. If the channel doesn't have a parent category this will return true.
      * 
-     * @return Whether this GuildChannel is synced with its parent category.
+     * @return A boolean representing this condition.
      */
     boolean isSynced();
-
     /**
      * Creates a copy of the specified {@link GuildChannel GuildChannel}
      * in the specified {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -66,7 +66,7 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
 
     /**
      * Parent {@link net.dv8tion.jda.api.entities.Category Category} of this
-     * GuildChannel. Channels need not have a parent Category.
+     * GuildChannel. Channels don't need to have a parent Category.
      * <br>Note that an {@link net.dv8tion.jda.api.entities.Category Category} will
      * always return {@code null} for this method as nested categories are not supported.
      *
@@ -179,6 +179,13 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
     @Nonnull
     List<PermissionOverride> getRolePermissionOverrides();
 
+    /**
+     * Returns whether or not this GuildChannel is synced.
+     * <br>A GuildChannel is synced when its {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
+     * those of {@link #getParent() its parent category}. If the GuildChannel doesn't have a parent category will this return true.
+     * 
+     * @return Whether this GuildChannel is synced with its parent category.
+     */
     boolean isSynced();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -179,6 +179,8 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
     @Nonnull
     List<PermissionOverride> getRolePermissionOverrides();
 
+    boolean isSynced();
+
     /**
      * Creates a copy of the specified {@link GuildChannel GuildChannel}
      * in the specified {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -182,7 +182,7 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
     /**
      * Returns whether or not this GuildChannel is synced.
      * <br>A GuildChannel is synced when its {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
-     * those of {@link #getParent() its parent category}. If the GuildChannel doesn't have a parent category will this return true.
+     * those of {@link #getParent() its parent category}. If the GuildChannel doesn't have a parent category this will return true.
      * 
      * @return Whether this GuildChannel is synced with its parent category.
      */

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -38,6 +38,7 @@ import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.InviteActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -164,11 +165,9 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     public boolean isSynced()
     {
         if(getParent() == null)
-        {
             return true; // Channels without a parent category are always considered synced. Also the case for categories.
-        }
         
-        return getPermissionOverrides().equals(getParent().getPermissionOverrides());
+        return Helpers.deepEqualsUnordered(getParent().getPermissionOverrides(), getPermissionOverrides());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -164,7 +164,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     @Override
     public boolean isSynced()
     {
-        if(getParent() == null)
+        if (getParent() == null)
             return true; // Channels without a parent category are always considered synced. Also the case for categories.
         
         return Helpers.deepEqualsUnordered(getParent().getPermissionOverrides(), getPermissionOverrides());

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -160,6 +160,17 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
                 .collect(Collectors.toList()));
     }
 
+    @Override
+    public boolean isSynced()
+    {
+        if(getParent() == null)
+        {
+            return true; // Channels without a parent category are always considered synced. Also the case for categories.
+        }
+        
+        return getPermissionOverrides().equals(getParent().getPermissionOverrides());
+    }
+
     @Nonnull
     @Override
     public ChannelManager getManager()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds a `isSynced()` method to the GuildChannel to check whether the Channel is synced with its parent (the category.
I set it to return true when the channel doesn't has a parent.

I'm not sure if the current way of doing this is actually good so I really appreciate if a better method would be provided.
