### PR TITLE
Add watered-down GuildMemberUpdateEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRemoveEvent.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Indicates that a user left a {@link Guild}.
+ * Indicates that a user was removed from a {@link Guild}. This includes kicks, bans, and leaves respectively.
  * <br>This can be fired for uncached members and cached members alike.
  * If the member was not cached by JDA, due to the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
  * or disabled member chunking, then {@link #getMember()} will return {@code null}.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberUpdateEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.member;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Fired for every {@link Member} update, regardless of cache.
+ *
+ * <p>This is a watered-down version of the {@link net.dv8tion.jda.api.events.guild.member.update.GenericGuildMemberUpdateEvent GenericGuildMemberUpdateEvent}
+ * which only provides the updated member instance. This is useful when JDA cannot fire specific update events when the member is uncached.
+ *
+ * <p>You can use this to do stateless checks on member instances to update database entries or check for special roles.
+ * Note that the member might not be in cache when this event is fired due to the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}.
+ *
+ * <h2>Requirements</h2>
+ *
+ * <p>This event requires the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent to be enabled.
+ * <br>{@link net.dv8tion.jda.api.JDABuilder#createDefault(String) createDefault(String)} and
+ * {@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disable this by default!
+ */
+public class GuildMemberUpdateEvent extends GenericGuildMemberEvent
+{
+    public GuildMemberUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    {
+        super(api, responseNumber, member);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberUpdateHandler.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.internal.handle;
 
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberUpdateEvent;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
@@ -63,6 +64,7 @@ public class GuildMemberUpdateHandler extends SocketHandler
         }
 
         getJDA().getEntityBuilder().updateMemberCache(member);
+        getJDA().handleEvent(new GuildMemberUpdateEvent(getJDA(), responseNumber, member));
         return null;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This event will fire for every GUILD_MEMBER_UPDATE dispatch and can be used for stateless handling. This is necessary because the other update events can only function when the member is already in cache. See https://github.com/discord/discord-api-docs/issues/2137
