### PR TITLE
add Guild#getRulesChannel and Guild#getCommunityUpdatesChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/audit/ActionType.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/ActionType.java
@@ -38,6 +38,8 @@ public enum ActionType
      *     <li>{@link net.dv8tion.jda.api.audit.AuditLogKey#GUILD_REGION GUILD_REGION}</li>
      *     <li>{@link net.dv8tion.jda.api.audit.AuditLogKey#GUILD_SPLASH GUILD_SPLASH}</li>
      *     <li>{@link net.dv8tion.jda.api.audit.AuditLogKey#GUILD_SYSTEM_CHANNEL GUILD_SYSTEM_CHANNEL}</li>
+     *     <li>{@link net.dv8tion.jda.api.audit.AuditLogKey#GUILD_RULES_CHANNEL GUILD_RULES_CHANNEL}</li>
+     *     <li>{@link net.dv8tion.jda.api.audit.AuditLogKey#GUILD_COMMUNITY_UPDATES_CHANNEL GUILD_COMMUNITY_UPDATES_CHANNEL}</li>
      * </ul>
      */
     GUILD_UPDATE(1, TargetType.GUILD),

--- a/src/main/java/net/dv8tion/jda/api/audit/AuditLogKey.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/AuditLogKey.java
@@ -101,6 +101,22 @@ public enum AuditLogKey
     GUILD_SYSTEM_CHANNEL("system_channel_id"),
 
     /**
+     * Change of the {@link net.dv8tion.jda.api.entities.Guild#getRulesChannel() Guild.getRulesChannel()} value represented by a TextChannel ID.
+     * <br>Use with {@link net.dv8tion.jda.api.entities.Guild#getTextChannelById(String) Guild.getTextChannelById(String)}
+     *
+     * <p>Expected type: <b>String</b>
+     */
+    GUILD_RULES_CHANNEL("rules_channel_id"),
+
+    /**
+     * Change of the {@link net.dv8tion.jda.api.entities.Guild#getCommunityUpdatesChannel() Guild.getCommunityUpdatesChannel()} value represented by a TextChannel ID.
+     * <br>Use with {@link net.dv8tion.jda.api.entities.Guild#getTextChannelById(String) Guild.getTextChannelById(String)}
+     *
+     * <p>Expected type: <b>String</b>
+     */
+    GUILD_COMMUNITY_UPDATES_CHANNEL("public_updates_channel_id"),
+
+    /**
      * Change of the {@link net.dv8tion.jda.api.entities.Guild#getExplicitContentLevel() Guild.getExplicitContentLevel()} of a Guild.
      * <br>Use with {@link net.dv8tion.jda.api.entities.Guild.ExplicitContentLevel#fromKey(int) Guild.ExplicitContentLevel.fromKey(int)}
      *

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -586,6 +586,30 @@ public interface Guild extends ISnowflake
     TextChannel getSystemChannel();
 
     /**
+     * Provides the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that has been set as the channel
+     * which rules are in.
+     * <br>If this guild doesn't have the COMMUNITY updates feature, this returns {@code null}.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that is the rules Channel.
+     *
+     * @see    #getFeatures()
+     */
+    @Nullable
+    TextChannel getRulesChannel();
+
+    /**
+     * Provides the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that has been set as the channel
+     * which community updates messages will be sent in.
+     * <br>If this guild doesn't have the COMMUNITY updates feature, this returns {@code null}.
+     *
+     * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that is the community updates Channel.
+     *
+     * @see    #getFeatures()
+     */
+    @Nullable
+    TextChannel getCommunityUpdatesChannel();
+
+    /**
      * The {@link net.dv8tion.jda.api.entities.Member Member} object for the owner of this Guild.
      * <br>This is null when the owner is no longer in this guild or not yet loaded (lazy loading).
      * Sometimes owners of guilds delete their account or get banned by Discord.

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -588,11 +588,10 @@ public interface Guild extends ISnowflake
     TextChannel getSystemChannel();
 
     /**
-     * Provides the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that has been set as the channel
-     * which rules are in.
-     * <br>If this guild doesn't have the COMMUNITY updates feature, this returns {@code null}.
+     * Provides the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that lists the rules of the guild.
+     * <br>If this guild doesn't have the COMMUNITY {@link #getFeatures() feature}, this returns {@code null}.
      *
-     * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that is the rules Channel.
+     * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that is the rules channel
      *
      * @see    #getFeatures()
      */
@@ -600,11 +599,10 @@ public interface Guild extends ISnowflake
     TextChannel getRulesChannel();
 
     /**
-     * Provides the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that has been set as the channel
-     * which community updates messages will be sent in.
-     * <br>If this guild doesn't have the COMMUNITY updates feature, this returns {@code null}.
+     * Provides the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that receives community updates.
+     * <br>If this guild doesn't have the COMMUNITY {@link #getFeatures() feature}, this returns {@code null}.
      *
-     * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that is the community updates Channel.
+     * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} that is the community updates channel
      *
      * @see    #getFeatures()
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -292,7 +292,9 @@ public interface Guild extends ISnowflake
      *     <li>ANIMATED_ICON - Guild can have an animated icon</li>
      *     <li>BANNER - Guild can have a banner</li>
      *     <li>COMMERCE - Guild can sell software through a store channel</li>
+     *     <li>COMMUNITY - Guild can enable welcome screen and discovery, and receives community updates. See {@link #getRulesChannel()} and {@link #getCommunityUpdatesChannel()}</li>
      *     <li>DISCOVERABLE - Guild shows up in discovery tab</li>
+     *     <li>FEATURABLE - Guild is able to be featured in discovery tab</li>
      *     <li>INVITE_SPLASH - Guild has custom invite splash. See {@link #getSplashId()} and {@link #getSplashUrl()}</li>
      *     <li>MORE_EMOJI - Guild is able to use more than 50 emoji</li>
      *     <li>NEWS - Guild can create news channels</li>

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateCommunityUpdatesChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateCommunityUpdatesChannelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateCommunityUpdatesChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateCommunityUpdatesChannelEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Indicates that the community updates channel of a {@link Guild Guild} changed.
+ *
+ * <p>Can be used to detect when a guild community updates channel changes and retrieve the old one
+ *
+ * <p>Identifier: {@code community_updates_channel}
+ */
+public class GuildUpdateCommunityUpdatesChannelEvent extends GenericGuildUpdateEvent<TextChannel>
+{
+    public static final String IDENTIFIER = "community_updates_channel";
+
+    public GuildUpdateCommunityUpdatesChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable TextChannel oldCommunityUpdatesChannel)
+    {
+        super(api, responseNumber, guild, oldCommunityUpdatesChannel, guild.getCommunityUpdatesChannel(), IDENTIFIER);
+    }
+
+    /**
+     * The previous community updates channel.
+     * 
+     * @return The previous community updates channel
+     */
+    @Nullable
+    public TextChannel getOldCommunityUpdatesChannel()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The new community updates channel.
+     *
+     * @return The new community updates channel
+     */
+    @Nullable
+    public TextChannel getNewCommunityUpdatesChannel()
+    {
+        return getNewValue();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRulesChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRulesChannelEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRulesChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRulesChannelEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015-2020 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Indicates that the rules channel of a {@link Guild Guild} changed.
+ *
+ * <p>Can be used to detect when a guild rule channel changes and retrieve the old one
+ *
+ * <p>Identifier: {@code rules_channel}
+ */
+public class GuildUpdateRulesChannelEvent extends GenericGuildUpdateEvent<TextChannel>
+{
+    public static final String IDENTIFIER = "rules_channel";
+
+    public GuildUpdateRulesChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable TextChannel oldRulesChannel)
+    {
+        super(api, responseNumber, guild, oldRulesChannel, guild.getRulesChannel(), IDENTIFIER);
+    }
+
+    /**
+     * The previous rules channel.
+     * 
+     * @return The previous rules channel
+     */
+    @Nullable
+    public TextChannel getOldRulesChannel()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The new rules channel.
+     *
+     * @return The new rules channel
+     */
+    @Nullable
+    public TextChannel getNewRulesChannel()
+    {
+        return getNewValue();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -280,6 +280,8 @@ public abstract class ListenerAdapter implements EventListener
     //Guild Update Events
     public void onGuildUpdateAfkChannel(@Nonnull GuildUpdateAfkChannelEvent event) {}
     public void onGuildUpdateSystemChannel(@Nonnull GuildUpdateSystemChannelEvent event) {}
+    public void onGuildUpdateRulesChannel(@Nonnull GuildUpdateRulesChannelEvent event) {}
+    public void onGuildUpdateCommunityUpdatesChannel(@Nonnull GuildUpdateCommunityUpdatesChannelEvent event) {}
     public void onGuildUpdateAfkTimeout(@Nonnull GuildUpdateAfkTimeoutEvent event) {}
     public void onGuildUpdateExplicitContentLevel(@Nonnull GuildUpdateExplicitContentLevelEvent event) {}
     public void onGuildUpdateIcon(@Nonnull GuildUpdateIconEvent event) {}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -265,6 +265,8 @@ public abstract class ListenerAdapter implements EventListener
     //Guild Update Events
     public void onGuildUpdateAfkChannel(@Nonnull GuildUpdateAfkChannelEvent event) {}
     public void onGuildUpdateSystemChannel(@Nonnull GuildUpdateSystemChannelEvent event) {}
+    public void onGuildUpdateRulesChannel(@Nonnull GuildUpdateRulesChannelEvent event) {}
+    public void onGuildUpdateCommunityUpdatesChannel(@Nonnull GuildUpdateCommunityUpdatesChannelEvent event) {}
     public void onGuildUpdateAfkTimeout(@Nonnull GuildUpdateAfkTimeoutEvent event) {}
     public void onGuildUpdateExplicitContentLevel(@Nonnull GuildUpdateExplicitContentLevelEvent event) {}
     public void onGuildUpdateIcon(@Nonnull GuildUpdateIconEvent event) {}
@@ -581,6 +583,10 @@ public abstract class ListenerAdapter implements EventListener
             onGuildUpdateAfkChannel((GuildUpdateAfkChannelEvent) event);
         else if (event instanceof GuildUpdateSystemChannelEvent)
             onGuildUpdateSystemChannel((GuildUpdateSystemChannelEvent) event);
+        else if (event instanceof GuildUpdateRulesChannelEvent)
+            onGuildUpdateRulesChannel((GuildUpdateRulesChannelEvent) event);
+        else if (event instanceof GuildUpdateCommunityUpdatesChannelEvent)
+            onGuildUpdateCommunityUpdatesChannel((GuildUpdateCommunityUpdatesChannelEvent) event);
         else if (event instanceof GuildUpdateAfkTimeoutEvent)
             onGuildUpdateAfkTimeout((GuildUpdateAfkTimeoutEvent) event);
         else if (event instanceof GuildUpdateExplicitContentLevelEvent)

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
@@ -72,6 +72,10 @@ public interface GuildManager extends Manager<GuildManager>
     long VANITY_URL   = 0x1000;
     /** Used to reset the description field */
     long DESCRIPTION  = 0x2000;
+    /** Used to reset the rules channel field */
+    long RULES_CHANNEL              = 0x4000;
+    /** Used to reset the community updates channel field */
+    long COMMUNITY_UPDATES_CHANNEL  = 0x8000;
 
     /**
      * Resets the fields specified by the provided bit-flag pattern.
@@ -87,6 +91,8 @@ public interface GuildManager extends Manager<GuildManager>
      *     <li>{@link #AFK_CHANNEL}</li>
      *     <li>{@link #AFK_TIMEOUT}</li>
      *     <li>{@link #SYSTEM_CHANNEL}</li>
+     *     <li>{@link #RULES_CHANNEL}</li>
+     *     <li>{@link #COMMUNITY_UPDATES_CHANNEL}</li>
      *     <li>{@link #MFA_LEVEL}</li>
      *     <li>{@link #NOTIFICATION_LEVEL}</li>
      *     <li>{@link #EXPLICIT_CONTENT_LEVEL}</li>
@@ -116,6 +122,8 @@ public interface GuildManager extends Manager<GuildManager>
      *     <li>{@link #AFK_CHANNEL}</li>
      *     <li>{@link #AFK_TIMEOUT}</li>
      *     <li>{@link #SYSTEM_CHANNEL}</li>
+     *     <li>{@link #RULES_CHANNEL}</li>
+     *     <li>{@link #COMMUNITY_UPDATES_CHANNEL}</li>
      *     <li>{@link #MFA_LEVEL}</li>
      *     <li>{@link #NOTIFICATION_LEVEL}</li>
      *     <li>{@link #EXPLICIT_CONTENT_LEVEL}</li>
@@ -234,6 +242,38 @@ public interface GuildManager extends Manager<GuildManager>
     @Nonnull
     @CheckReturnValue
     GuildManager setSystemChannel(@Nullable TextChannel systemChannel);
+
+    /**
+     * Sets the rules {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *
+     * @param  rulesChannel
+     *         The new rules channel for this {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         or {@code null} to reset
+     *
+     * @throws IllegalArgumentException
+     *         If the provided channel is not from this guild
+     *
+     * @return GuildManager for chaining convenience
+     */
+    @Nonnull
+    @CheckReturnValue
+    GuildManager setRulesChannel(@Nullable TextChannel rulesChannel);
+
+    /**
+     * Sets the community updates {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *
+     * @param  communityUpdatesChannel
+     *         The new community updates channel for this {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         or {@code null} to reset
+     *
+     * @throws IllegalArgumentException
+     *         If the provided channel is not from this guild
+     *
+     * @return GuildManager for chaining convenience
+     */
+    @Nonnull
+    @CheckReturnValue
+    GuildManager setCommunityUpdatesChannel(@Nullable TextChannel communityUpdatesChannel);
 
     /**
      * Sets the afk {@link net.dv8tion.jda.api.entities.Guild.Timeout Timeout} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
@@ -69,9 +69,9 @@ public interface GuildManager extends Manager<GuildManager>
     /** Used to reset the banner field */
     long BANNER                 = 0x800;
     /** Used to reset the vanity code field */
-    long VANITY_URL   = 0x1000;
+    long VANITY_URL                 = 0x1000;
     /** Used to reset the description field */
-    long DESCRIPTION  = 0x2000;
+    long DESCRIPTION                = 0x2000;
     /** Used to reset the rules channel field */
     long RULES_CHANNEL              = 0x4000;
     /** Used to reset the community updates channel field */

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -180,6 +180,8 @@ public class EntityBuilder
         final long ownerId = guildJson.getUnsignedLong("owner_id", 0L);
         final long afkChannelId = guildJson.getUnsignedLong("afk_channel_id", 0L);
         final long systemChannelId = guildJson.getUnsignedLong("system_channel_id", 0L);
+        final long rulesChannelId = guildJson.getUnsignedLong("rules_channel_id", 0L);
+        final long communityUpdatesChannelId = guildJson.getUnsignedLong("public_updates_channel_id", 0L);
         final int boostCount = guildJson.getInt("premium_subscription_count", 0);
         final int boostTier = guildJson.getInt("premium_tier", 0);
         final int maxMembers = guildJson.getInt("max_members", 0);
@@ -266,7 +268,9 @@ public class EntityBuilder
         createGuildEmotePass(guildObj, emotesArray);
 
         guildObj.setAfkChannel(guildObj.getVoiceChannelById(afkChannelId))
-                .setSystemChannel(guildObj.getTextChannelById(systemChannelId));
+                .setSystemChannel(guildObj.getTextChannelById(systemChannelId))
+                .setRulesChannel(guildObj.getTextChannelById(rulesChannelId))
+                .setCommunityUpdatesChannel(guildObj.getTextChannelById(communityUpdatesChannelId));
 
         return guildObj;
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -102,6 +102,8 @@ public class GuildImpl implements Guild
     private Set<String> features;
     private VoiceChannel afkChannel;
     private TextChannel systemChannel;
+    private TextChannel rulesChannel;
+    private TextChannel communityUpdatesChannel;
     private Role publicRole;
     private VerificationLevel verificationLevel = VerificationLevel.UNKNOWN;
     private NotificationLevel defaultNotificationLevel = NotificationLevel.UNKNOWN;
@@ -326,6 +328,18 @@ public class GuildImpl implements Guild
     public TextChannel getSystemChannel()
     {
         return systemChannel;
+    }
+
+    @Override
+    public TextChannel getRulesChannel()
+    {
+        return rulesChannel;
+    }
+
+    @Override
+    public TextChannel getCommunityUpdatesChannel()
+    {
+        return communityUpdatesChannel;
     }
 
     @Nonnull
@@ -1570,6 +1584,18 @@ public class GuildImpl implements Guild
     public GuildImpl setSystemChannel(TextChannel systemChannel)
     {
         this.systemChannel = systemChannel;
+        return this;
+    }
+
+    public GuildImpl setRulesChannel(TextChannel rulesChannel)
+    {
+        this.rulesChannel = rulesChannel;
+        return this;
+    }
+
+    public GuildImpl setCommunityUpdatesChannel(TextChannel communityUpdatesChannel)
+    {
+        this.communityUpdatesChannel = communityUpdatesChannel;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
@@ -86,6 +86,10 @@ public class GuildUpdateHandler extends SocketHandler
                 ? null : guild.getVoiceChannelsView().get(content.getLong("afk_channel_id"));
         TextChannel systemChannel = content.isNull("system_channel_id")
                 ? null : guild.getTextChannelsView().get(content.getLong("system_channel_id"));
+        TextChannel rulesChannel = content.isNull("rules_channel_id")
+                ? null : guild.getTextChannelsView().get(content.getLong("rules_channel_id"));
+        TextChannel communityUpdatesChannel = content.isNull("public_updates_channel_id")
+                ? null : guild.getTextChannelsView().get(content.getLong("public_updates_channel_id"));
         Set<String> features;
         if (!content.isNull("features"))
         {
@@ -291,6 +295,24 @@ public class GuildUpdateHandler extends SocketHandler
                     new GuildUpdateSystemChannelEvent(
                             getJDA(), responseNumber,
                             guild, oldSystemChannel));
+        }
+        if (!Objects.equals(rulesChannel, guild.getRulesChannel()))
+        {
+            TextChannel oldRulesChannel = guild.getRulesChannel();
+            guild.setRulesChannel(rulesChannel);
+            getJDA().handleEvent(
+                    new GuildUpdateRulesChannelEvent(
+                            getJDA(), responseNumber,
+                            guild, oldRulesChannel));
+        }
+        if (!Objects.equals(communityUpdatesChannel, guild.getCommunityUpdatesChannel()))
+        {
+            TextChannel oldCommunityUpdatesChannel = guild.getCommunityUpdatesChannel();
+            guild.setCommunityUpdatesChannel(communityUpdatesChannel);
+            getJDA().handleEvent(
+                    new GuildUpdateCommunityUpdatesChannelEvent(
+                            getJDA(), responseNumber,
+                            guild, oldCommunityUpdatesChannel));
         }
         return null;
     }

--- a/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
@@ -322,9 +322,9 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         if (shouldUpdate(SYSTEM_CHANNEL))
             body.put("system_channel_id", systemChannel);
         if (shouldUpdate(RULES_CHANNEL))
-            body.put("rules_channel_id", systemChannel);
+            body.put("rules_channel_id", rulesChannel);
         if (shouldUpdate(COMMUNITY_UPDATES_CHANNEL))
-            body.put("public_updates_channel_id", systemChannel);
+            body.put("public_updates_channel_id", communityUpdatesChannel);
         if (shouldUpdate(VERIFICATION_LEVEL))
             body.put("verification_level", verificationLevel);
         if (shouldUpdate(NOTIFICATION_LEVEL))

--- a/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
@@ -41,7 +41,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
     protected String name;
     protected String region;
     protected Icon icon, splash, banner;
-    protected String afkChannel, systemChannel;
+    protected String afkChannel, systemChannel, rulesChannel, communityUpdatesChannel;
     protected String description, vanityCode;
     protected int afkTimeout;
     protected int mfaLevel;
@@ -86,6 +86,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
             this.afkChannel = null;
         if ((fields & SYSTEM_CHANNEL) == SYSTEM_CHANNEL)
             this.systemChannel = null;
+        if ((fields & RULES_CHANNEL) == RULES_CHANNEL)
+            this.rulesChannel = null;
+        if ((fields & COMMUNITY_UPDATES_CHANNEL) == COMMUNITY_UPDATES_CHANNEL)
+            this.communityUpdatesChannel = null;
         if ((fields & DESCRIPTION) == DESCRIPTION)
             this.description = null;
         if ((fields & BANNER) == BANNER)
@@ -185,6 +189,28 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         Checks.check(systemChannel == null || systemChannel.getGuild().equals(getGuild()), "Channel must be from the same guild");
         this.systemChannel = systemChannel == null ? null : systemChannel.getId();
         set |= SYSTEM_CHANNEL;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public GuildManagerImpl setRulesChannel(TextChannel rulesChannel)
+    {
+        Checks.check(rulesChannel == null || rulesChannel.getGuild().equals(getGuild()), "Channel must be from the same guild");
+        this.rulesChannel = rulesChannel == null ? null : rulesChannel.getId();
+        set |= RULES_CHANNEL;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public GuildManagerImpl setCommunityUpdatesChannel(TextChannel communityUpdatesChannel)
+    {
+        Checks.check(communityUpdatesChannel == null || communityUpdatesChannel.getGuild().equals(getGuild()), "Channel must be from the same guild");
+        this.communityUpdatesChannel = communityUpdatesChannel == null ? null : communityUpdatesChannel.getId();
+        set |= COMMUNITY_UPDATES_CHANNEL;
         return this;
     }
 
@@ -295,6 +321,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
             body.put("afk_channel_id", afkChannel);
         if (shouldUpdate(SYSTEM_CHANNEL))
             body.put("system_channel_id", systemChannel);
+        if (shouldUpdate(RULES_CHANNEL))
+            body.put("rules_channel_id", systemChannel);
+        if (shouldUpdate(COMMUNITY_UPDATES_CHANNEL))
+            body.put("public_updates_channel_id", systemChannel);
         if (shouldUpdate(VERIFICATION_LEVEL))
             body.put("verification_level", verificationLevel);
         if (shouldUpdate(NOTIFICATION_LEVEL))


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR adds Guild#getRulesChannel and Guild#getCommunityUpdatesChannel.
i'm not sure about being able to set the rules and community updates channel even without the `COMMUNITY` feature, as it works, and Discord doesn't return any error - i've made an issue discord/discord-api-docs#2282 in the api docs repo, so i'm waiting for response there.
ideas and suggestions are welcome
