### PR TITLE
Implement a timeout for unavailable guilds

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/ReadyEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/ReadyEvent.java
@@ -37,7 +37,8 @@ public class ReadyEvent extends Event
     {
         super(api, responseNumber);
         this.availableGuilds = (int) getJDA().getGuildCache().size();
-        this.unavailableGuilds = ((JDAImpl) getJDA()).getGuildSetupController().getSetupNodes(GuildSetupController.Status.UNAVAILABLE).size();
+        GuildSetupController setupController = ((JDAImpl) getJDA()).getGuildSetupController();
+        this.unavailableGuilds = setupController.getSetupNodes(GuildSetupController.Status.UNAVAILABLE).size() + setupController.getUnavailableGuilds().size();
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildReadyEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildReadyEvent.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.events.ReadyEvent;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +30,12 @@ import javax.annotation.Nonnull;
  * setup and full reconnects (indicated by {@link net.dv8tion.jda.api.events.ReconnectedEvent ReconnectedEvent}).
  *
  * <p>Can be used to initialize any services that depend on this guild.
+ *
+ * <p>When a guild fails to ready up due to Discord outages you will not receive this event.
+ * Guilds that fail to ready up will either timeout or get marked as unavailable.
+ * <br>You can use {@link ReadyEvent#getGuildUnavailableCount()} and {@link JDA#getUnavailableGuilds()} to check for unavailable guilds.
+ * {@link GuildTimeoutEvent} will be fired for guilds that don't ready up and also don't get marked as unavailable by Discord.
+ * Guilds that timeout will be marked as unavailable by the timeout event, they will <b>not</b> fire a {@link GuildUnavailableEvent} as that event is only indicating that a guild becomes unavailable <b>after</b> ready happened.
  */
 public class GuildReadyEvent extends GenericGuildEvent
 {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildTimeoutEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildTimeoutEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.api.events.ReadyEvent;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Indicates that a guild failed to ready up and timed out.
+ * <br>Usually this event will be fired right before a {@link net.dv8tion.jda.api.events.ReadyEvent ReadyEvent}.
+ *
+ * <p>This will mark the guild as <b>unavailable</b> and it will not be usable when JDA becomes ready.
+ * You can check all unavailable guilds with {@link ReadyEvent#getGuildUnavailableCount()} and {@link JDA#getUnavailableGuilds()}.
+ *
+ * <h2>Developer Note</h2>
+ *
+ * <p>Discord may also explicitly mark guilds as unavailable during the setup, in which case this event will not fire.
+ * It is recommended to check for unavailable guilds in the ready event explicitly to avoid any ambiguity.
+ */
+public class GuildTimeoutEvent extends Event
+{
+    private final long guildId;
+
+    public GuildTimeoutEvent(@Nonnull JDA api, long guildId)
+    {
+        super(api);
+        this.guildId = guildId;
+    }
+
+    /**
+     * The guild id for the timed out guild
+     *
+     * @return The guild id
+     */
+    public long getGuildIdLong()
+    {
+        return guildId;
+    }
+
+    /**
+     * The guild id for the timed out guild
+     *
+     * @return The guild id
+     */
+    @Nonnull
+    public String getGuildId()
+    {
+        return Long.toUnsignedString(guildId);
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildJoinedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildJoinedEvent.java
@@ -24,6 +24,7 @@ import javax.annotation.Nonnull;
 /**
  * Indicates that you joined a {@link net.dv8tion.jda.api.entities.Guild Guild} that is not yet available.
  * <b>This does not extend {@link net.dv8tion.jda.api.events.guild.GenericGuildEvent GenericGuildEvent}</b>
+ * <br>This will be followed by a {@link GuildAvailableEvent} once the guild becomes available again.
  *
  * <p>Can be used to retrieve id of new unavailable Guild.
  */

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -267,6 +267,7 @@ public abstract class ListenerAdapter implements EventListener
 
     //Guild Events
     public void onGuildReady(@Nonnull GuildReadyEvent event) {}
+    public void onGuildTimeout(@Nonnull GuildTimeoutEvent event) {}
     public void onGuildJoin(@Nonnull GuildJoinEvent event) {}
     public void onGuildLeave(@Nonnull GuildLeaveEvent event) {}
     public void onGuildAvailable(@Nonnull GuildAvailableEvent event) {}

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -44,7 +44,7 @@ public class GuildSetupController
 {
     protected static final Logger log = JDALogger.getLog(GuildSetupController.class);
 
-    private static final long timeoutDuration = 10; // seconds
+    private static final long timeoutDuration = 75; // seconds
     private static final int timeoutThreshold = 60; // Half of 120 rate limit
 
     private final JDAImpl api;

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -21,6 +21,7 @@ import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
+import net.dv8tion.jda.api.events.guild.GuildTimeoutEvent;
 import net.dv8tion.jda.api.events.guild.UnavailableGuildLeaveEvent;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.api.utils.data.DataArray;
@@ -370,7 +371,7 @@ public class GuildSetupController
 
     private void startTimeout()
     {
-        if (timeoutHandle != null)
+        if (timeoutHandle != null || incompleteCount < 1) // We don't need to start a timeout for 0 guilds
             return;
 
         log.debug("Starting {} second timeout for {} guilds", timeoutDuration, incompleteCount);
@@ -395,6 +396,8 @@ public class GuildSetupController
             GuildSetupNode node = iterator.value();
             iterator.remove();
             unavailableGuilds.add(node.getIdLong());
+            // Inform users that the guild timed out
+            getJDA().handleEvent(new GuildTimeoutEvent(getJDA(), node.getIdLong()));
         }
         incompleteCount = 0;
         checkReady();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This timeout handler will automatically mark all guilds unavailable after ~~10~~ 75 seconds when hitting <=60 finished guilds. ~~I'm not entirely sure if 10 seconds is an appropriate timeout here, considering that the websocket rate limit is 60 seconds long. Maybe we should use 70 seconds instead? This would theoretically only be an issue for bots with a lot of guilds that perform chunking for every guild.~~ This is now set to 75 seconds which is the rate limit period plus 15 additional seconds for them to respond.
