### PR TITLE
Add ActivityType.COMPETING

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -205,6 +205,30 @@ public interface Activity
     }
 
     /**
+     * Creates a new Activity instance with the specified name.
+     * <br>This will display as {@code Competing in name} in the official client
+     * 
+     * @param  name
+     *         The not-null name of the newly created game
+     * 
+     * @throws IllegalArgumentException
+     *         If the specified name is null, empty, blank or longer than 128 characters
+     * 
+     * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#COMPETING}
+     *
+     * @incubating This feature is not yet confirmed for the official bot API
+     */
+    @Nonnull
+    @Incubating
+    static Activity competing(@Nonnull String name)
+    {
+        Checks.notBlank(name, "Name");
+        name = name.trim();
+        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in lentgh");
+        return EntityBuilder.createActivity(name, null, ActivityType.COMPETING);
+    }
+
+    /**
      * Creates a new Activity instance with the specified name and url.
      *
      * @param  type
@@ -256,6 +280,8 @@ public interface Activity
                 return listening(name);
             case WATCHING:
                 return watching(name);
+            case COMPETING:
+                return competing(name);
             default:
                 throw new IllegalArgumentException("ActivityType " + type + " is not supported!");
         }
@@ -308,7 +334,13 @@ public interface Activity
          * @incubating This feature is currently not officially documented and might change
          */
         @Incubating
-        CUSTOM_STATUS(4);
+        CUSTOM_STATUS(4),
+
+        /**
+         * Used to indicate that the {@link Activity Activity} should display
+         * as {@code Competing in...} in the official client.
+         */
+        COMPETING(5);
 
         private final int key;
 
@@ -352,6 +384,8 @@ public interface Activity
                     return WATCHING;
                 case 4:
                     return CUSTOM_STATUS;
+                case 5:
+                    return COMPETING;
             }
         }
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -215,11 +215,8 @@ public interface Activity
      *         If the specified name is null, empty, blank or longer than 128 characters
      * 
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#COMPETING}
-     *
-     * @incubating This feature is not yet confirmed for the official bot API
      */
     @Nonnull
-    @Incubating
     static Activity competing(@Nonnull String name)
     {
         Checks.notBlank(name, "Name");

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -224,7 +224,7 @@ public interface Activity
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
-        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in lentgh");
+        Checks.check(name.length() <= 128, "Name must not be greater than 128 characters in length");
         return EntityBuilder.createActivity(name, null, ActivityType.COMPETING);
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds `ActivityType.COMPETING` (ID 5) and `Activity.competing(String)` to the Activity Interface.

This activity type is usable by bots, as shown below by my personal Bot that I quickly used to test this with my fork:
![image](https://user-images.githubusercontent.com/11576465/102504648-5ec72380-4081-11eb-9ba4-1cb74ad969d8.png)

For safety did I add the `@Incubating` annotation and `@incubating` javadoc-tag to the `competing` method. I didn't add those to the ActivityType tho as the reason they are there for wating seems to be, that it is undocumented, which is (partially) wrong? Docs do contain info on the activity types, just not directly related to bots.

Will add this, if required.