### PR TITLE
Fixed outdated documentation of an example of builder in EventListener.

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/hooks/EventListener.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/EventListener.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
  * <p><b>Examples: </b>
  * <br>
  * <code>
- *     JDA jda = {@link net.dv8tion.jda.api.JDABuilder JDABuilder}("token").{@link net.dv8tion.jda.api.JDABuilder#addEventListeners(Object...) addEventListeners(listeners)}.{@link net.dv8tion.jda.api.JDABuilder#build() build()};<br>
+ *     JDA jda = {@link net.dv8tion.jda.api.JDABuilder JDABuilder}.createDefault("token").{@link net.dv8tion.jda.api.JDABuilder#addEventListeners(Object...) addEventListeners(listeners)}.{@link net.dv8tion.jda.api.JDABuilder#build() build()};<br>
  *     {@link net.dv8tion.jda.api.JDA#addEventListener(Object...) jda.addEventListener(listeners)};
  * </code>
  *

--- a/src/main/java/net/dv8tion/jda/api/hooks/EventListener.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/EventListener.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
  * <p><b>Examples: </b>
  * <br>
  * <code>
- *     JDA jda = new {@link net.dv8tion.jda.api.JDABuilder JDABuilder}("token").{@link net.dv8tion.jda.api.JDABuilder#addEventListeners(Object...) addEventListeners(listeners)}.{@link net.dv8tion.jda.api.JDABuilder#build() build()};<br>
+ *     JDA jda = {@link net.dv8tion.jda.api.JDABuilder JDABuilder}("token").{@link net.dv8tion.jda.api.JDABuilder#addEventListeners(Object...) addEventListeners(listeners)}.{@link net.dv8tion.jda.api.JDABuilder#build() build()};<br>
  *     {@link net.dv8tion.jda.api.JDA#addEventListener(Object...) jda.addEventListener(listeners)};
  * </code>
  *


### PR DESCRIPTION
Changed a example to the static JDA Builder in place of old constructor.

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.

- [x] I have read the [contributing guidelines][contributing].


### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ 


Closes Issue: NaN

## Description

Corrects a mistake in EventListener where an example of builder in the documentation doesn't the static method.
Changed from `JDA jda = new JDABuilder.createDefault("token").addEventListeners(listeners).build();` to 
`JDA jda = JDABuilder.createDefault("token").addEventListeners(listeners).build();`