### PR TITLE
Improve tracking of voice members without MemberCachePolicy.VOICE

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -406,7 +406,6 @@ public class EntityBuilder
                 VoiceChannelImpl connectedChannel = (VoiceChannelImpl) voiceState.getChannel();
                 if (connectedChannel != null)
                     connectedChannel.getConnectedMembersMap().remove(member.getIdLong());
-                voiceState.setConnectedChannel(null);
             }
 
             return false;
@@ -523,8 +522,7 @@ public class EntityBuilder
                   .setGuildDeafened(voiceStateJson.getBoolean("deaf"))
                   .setSuppressed(voiceStateJson.getBoolean("suppress"))
                   .setSessionId(voiceStateJson.getString("session_id"))
-                  .setStream(voiceStateJson.getBoolean("self_stream"))
-                  .setConnectedChannel(voiceChannel);
+                  .setStream(voiceStateJson.getBoolean("self_stream"));
     }
 
     public void updateMember(GuildImpl guild, MemberImpl member, DataObject content, List<Role> newRoles)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -30,7 +30,6 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     private Guild guild;
     private Member member;
 
-    private VoiceChannel connectedChannel;
     private String sessionId;
     private boolean selfMuted = false;
     private boolean selfDeafened = false;
@@ -110,7 +109,11 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     @Override
     public VoiceChannel getChannel()
     {
-        return connectedChannel;
+        return getGuild().getVoiceChannelCache().applyStream(stream ->
+            stream.map(VoiceChannelImpl.class::cast)
+                .filter(vc -> vc.getConnectedMembersMap().containsKey(member.getIdLong()))
+                .findFirst().orElse(null)
+        );
     }
 
     @Nonnull
@@ -163,12 +166,6 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     }
 
     // -- Setters --
-
-    public GuildVoiceStateImpl setConnectedChannel(VoiceChannel connectedChannel)
-    {
-        this.connectedChannel = connectedChannel;
-        return this;
-    }
 
     public GuildVoiceStateImpl setSessionId(String sessionId)
     {

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMemberRemoveHandler.java
@@ -95,7 +95,6 @@ public class GuildMemberRemoveHandler extends SocketHandler
         if (voiceState != null && voiceState.inVoiceChannel())//If this user was in a VoiceChannel, fire VoiceLeaveEvent.
         {
             VoiceChannel channel = voiceState.getChannel();
-            voiceState.setConnectedChannel(null);
             ((VoiceChannelImpl) channel).getConnectedMembersMap().remove(userId);
             getJDA().handleEvent(
                 new GuildVoiceLeaveEvent(


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

By tracking the connected channel independently from the member, we can persist the information regardless of the member cache policy. VoiceChannels track the connected members internally, for optimization purposes and bypasses the cache policy in that regard. This means `GuildVoiceState#getChannel` is now depending on the voice state cache, rather than being atomic. We could in theory try to optimize this by using some kinda lazy caching system, but that isn't really worth it I presume.
