### PR TITLE
[Docs] Mention that createDefault and createLight may override GatewayIntent#DEFAULT

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -198,6 +198,9 @@ public class JDABuilder
      *     <li>This disables {@link CacheFlag#ACTIVITY} and {@link CacheFlag#CLIENT_STATUS}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     * 
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -210,9 +213,9 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The intent to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The intent to enable
      * @param  intents
-     *         Any other intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         Any other intents to enable
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -238,6 +241,9 @@ public class JDABuilder
      *     <li>This disables {@link CacheFlag#ACTIVITY} and {@link CacheFlag#CLIENT_STATUS}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -250,7 +256,7 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The intents to enable
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -308,6 +314,9 @@ public class JDABuilder
      *     <li>This disables all existing {@link CacheFlag CacheFlags}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -320,9 +329,9 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The first intent to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The first intent to use
      * @param  intents
-     *         The other gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The other gateway intents to use
      *
      * @return The new JDABuilder
      */
@@ -345,6 +354,9 @@ public class JDABuilder
      *     <li>This disables all existing {@link CacheFlag CacheFlags}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -357,7 +369,7 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The gateway intents to use
      *
      * @return The new JDABuilder
      */

--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -210,9 +210,9 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The intent to enable
+     *         The intent to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      * @param  intents
-     *         Any other intents to enable
+     *         Any other intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -250,7 +250,7 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The intents to enable
+     *         The intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -320,9 +320,9 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The first intent to use
+     *         The first intent to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      * @param  intents
-     *         The other gateway intents to use
+     *         The other gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @return The new JDABuilder
      */
@@ -357,7 +357,7 @@ public class JDABuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The gateway intents to use
+     *         The gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @return The new JDABuilder
      */

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -175,6 +175,9 @@ public class  DefaultShardManagerBuilder
      *     <li>This disables {@link CacheFlag#ACTIVITY} and {@link CacheFlag#CLIENT_STATUS}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -187,9 +190,9 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The intent to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The intent to enable
      * @param  intents
-     *         Any other intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         Any other intents to enable
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -215,6 +218,9 @@ public class  DefaultShardManagerBuilder
      *     <li>This disables {@link CacheFlag#ACTIVITY} and {@link CacheFlag#CLIENT_STATUS}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -227,7 +233,7 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The intents to enable
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -285,6 +291,9 @@ public class  DefaultShardManagerBuilder
      *     <li>This disables all existing {@link CacheFlag CacheFlags}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -297,9 +306,9 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The first intent to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The first intent to use
      * @param  intents
-     *         The other gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The other gateway intents to use
      *
      * @return The new DefaultShardManagerBuilder
      */
@@ -322,6 +331,9 @@ public class  DefaultShardManagerBuilder
      *     <li>This disables all existing {@link CacheFlag CacheFlags}</li>
      * </ul>
      *
+     * <p>You can omit intents in this method to use {@link GatewayIntent#DEFAULT} and enable additional intents with
+     * {@link #enableIntents(Collection)}.
+     *
      * <p>If you don't enable certain intents, the cache will be disabled.
      * For instance, if the {@link GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent is disabled, then members will only
      * be cached when a voice state is available.
@@ -334,7 +346,7 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
+     *         The gateway intents to use
      *
      * @return The new DefaultShardManagerBuilder
      */

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -187,9 +187,9 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The intent to enable
+     *         The intent to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      * @param  intents
-     *         Any other intents to enable
+     *         Any other intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -227,7 +227,7 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The intents to enable
+     *         The intents to enable. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @throws IllegalArgumentException
      *         If provided with null intents
@@ -297,9 +297,9 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intent
-     *         The first intent to use
+     *         The first intent to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      * @param  intents
-     *         The other gateway intents to use
+     *         The other gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @return The new DefaultShardManagerBuilder
      */
@@ -334,7 +334,7 @@ public class  DefaultShardManagerBuilder
      * @param  token
      *         The bot token to use
      * @param  intents
-     *         The gateway intents to use
+     *         The gateway intents to use. This will override the {@link GatewayIntent#DEFAULT default Intents} used by this method
      *
      * @return The new DefaultShardManagerBuilder
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The methods `createDefault(String, GatewayIntent, GatewayIntent...)`, `createLight(String, GatewayIntent, GatewayIntent...)` as well as their counter-parts with Collection do not mention that using those essentially overrides the `GatewayIntent#DEFAULT` as you basically have to provide your own ones, instead of adding them to the defaults.
This can cause people to believe that those methods are used to define the default intents and also add additional ones you need (i.e. GUILD_MEMBERS),

The only real mention is, when you compare it to `createDefault(String)`/`createLight(String)` where one extra List entry mentions the intents to be set to `GatewayIntent#DEFAULT`