### PR TITLE
Fix IllegalArgumentException in retrievePast/retrieveFuture

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -196,7 +196,7 @@ public class MessageHistory
             DataArray historyJson = response.getArray();
 
             for (int i = 0; i < historyJson.length(); i++)
-                messages.add(builder.createMessage(historyJson.getObject(i)));
+                messages.add(builder.createMessage(historyJson.getObject(i), channel, false));
 
             messages.forEach(msg -> history.put(msg.getIdLong(), msg));
             return messages;
@@ -265,7 +265,7 @@ public class MessageHistory
             DataArray historyJson = response.getArray();
 
             for (int i = 0; i < historyJson.length(); i++)
-                messages.add(builder.createMessage(historyJson.getObject(i)));
+                messages.add(builder.createMessage(historyJson.getObject(i), channel, false));
 
             for (Iterator<Message> it = messages.descendingIterator(); it.hasNext();)
             {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this should fix getting IllegalArgumentException when using retrievePast/retrieveFuture methods for private channels