### PR TITLE
Fixed isSynced() in AbstractChannelImpl

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -181,11 +181,15 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
 
     /**
      * Whether or not this GuildChannel's {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} match
-     * those of {@link #getParent() its parent category}. If the channel doesn't have a parent category this will return true.
-     * 
+     * those of {@link #getParent() its parent category}. If the channel doesn't have a parent category, this will return true.
+     *
+     * <p>This requires {@link net.dv8tion.jda.api.utils.cache.CacheFlag#MEMBER_OVERRIDES CacheFlag.MEMBER_OVERRIDES} to be enabled.
+     * <br>{@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disables this CacheFlag by default.
+     *
      * @return True, if this channel is synced with its parent category
      */
     boolean isSynced();
+
     /**
      * Creates a copy of the specified {@link GuildChannel GuildChannel}
      * in the specified {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -168,15 +168,15 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         Stream<PermissionOverride> thisStream = getRolePermissionOverrides().stream().filter(
                 po -> po.getAllowedRaw() != 0 || po.getDeniedRaw() != 0
         );
-        Stream<PermissionOverride> parentStream = getParent().getRolePermissionOverrides().stream().filter(
+        HashMap<Long, PermissionOverride> parentCheck = new HashMap<>();
+        getParent().getRolePermissionOverrides().stream().filter(
                 po -> po.getAllowedRaw() != 0 || po.getDeniedRaw() != 0
-        );
+        ).forEach(po -> parentCheck.put(po.getIdLong(), po));
         Collection<PermissionOverride> thisCheck = thisStream.collect(Collectors.toList());
-        Collection<PermissionOverride> parentCheck = parentStream.collect(Collectors.toList());
 
         for(PermissionOverride check : thisCheck)
         {
-            PermissionOverride matching = parentCheck.stream().filter(po -> check.getIdLong() == po.getIdLong()).findFirst().orElse(null);
+            PermissionOverride matching = parentCheck.getOrDefault(check.getIdLong(), null);
             if(matching == null)
                 return false;
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -38,13 +38,14 @@ import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.InviteActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public abstract class AbstractChannelImpl<T extends GuildChannel, M extends AbstractChannelImpl<T, M>> implements GuildChannel
 {

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -165,11 +165,11 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         if (getParent() == null)
             return true; // Channels without a parent category are always considered synced. Also the case for categories.
 
-        Stream<PermissionOverride> thisStream = getRolePermissionOverrides().stream().filter(
+        Stream<PermissionOverride> thisStream = getPermissionOverrides().stream().filter(
                 po -> po.getAllowedRaw() != 0 || po.getDeniedRaw() != 0
         );
         HashMap<Long, PermissionOverride> parentCheck = new HashMap<>();
-        getParent().getRolePermissionOverrides().stream().filter(
+        getParent().getPermissionOverrides().stream().filter(
                 po -> po.getAllowedRaw() != 0 || po.getDeniedRaw() != 0
         ).forEach(po -> parentCheck.put(po.getIdLong(), po));
         Collection<PermissionOverride> thisCheck = thisStream.collect(Collectors.toList());

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -165,14 +165,14 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         if (getParent() == null)
             return true; // Channels without a parent category are always considered synced. Also the case for categories.
 
-        Stream<PermissionOverride> thisStream = getPermissionOverrides().stream().filter(
+        Collection<PermissionOverride> thisCheck = getPermissionOverrides().stream().filter(
                 po -> po.getAllowedRaw() != 0 || po.getDeniedRaw() != 0
-        );
+        ).collect(Collectors.toList());
+
         HashMap<Long, PermissionOverride> parentCheck = new HashMap<>();
         getParent().getPermissionOverrides().stream().filter(
                 po -> po.getAllowedRaw() != 0 || po.getDeniedRaw() != 0
         ).forEach(po -> parentCheck.put(po.getIdLong(), po));
-        Collection<PermissionOverride> thisCheck = thisStream.collect(Collectors.toList());
 
         for(PermissionOverride check : thisCheck)
         {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1391,6 +1391,9 @@ public class EntityBuilder
 
         long allow = override.getLong("allow_new");
         long deny = override.getLong("deny_new");
+        // Don't cache empty @everyone overrides, they ruin our sync check
+        if (id == chan.getGuild().getIdLong() && (allow | deny) == 0L)
+            return null;
 
         PermissionOverrideImpl permOverride = (PermissionOverrideImpl) chan.getOverrideMap().get(id);
         if (permOverride == null)

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
@@ -347,6 +347,8 @@ public class ChannelUpdateHandler extends SocketHandler
             changed.add(holder);
     }
 
+    // True => override status changed (created/deleted/updated)
+    // False => nothing changed, ignore
     private boolean handlePermissionOverride(PermissionOverride currentOverride, DataObject override, long overrideId, AbstractChannelImpl<?,?> channel)
     {
         final long allow = override.getLong("allow_new");
@@ -366,13 +368,25 @@ public class ChannelUpdateHandler extends SocketHandler
             }
         }
 
-        if (currentOverride != null)
+        if (currentOverride != null) // Permissions were updated?
         {
             long oldAllow = currentOverride.getAllowedRaw();
             long oldDeny = currentOverride.getDeniedRaw();
             PermissionOverrideImpl impl = (PermissionOverrideImpl) currentOverride;
             if (oldAllow == allow && oldDeny == deny)
                 return false;
+
+            if (overrideId == channel.getGuild().getIdLong() && (allow | deny) == 0L)
+            {
+                // We delete empty overrides for the @everyone role because that's what the client also does, otherwise our sync checks don't work!
+                channel.getOverrideMap().remove(overrideId);
+                api.handleEvent(
+                    new PermissionOverrideDeleteEvent(
+                        api, responseNumber,
+                        channel, currentOverride));
+                return true;
+            }
+
             impl.setAllow(allow);
             impl.setDeny(deny);
             api.handleEvent(
@@ -380,8 +394,11 @@ public class ChannelUpdateHandler extends SocketHandler
                     api, responseNumber,
                     channel, currentOverride, oldAllow, oldDeny));
         }
-        else
+        else // New override?
         {
+            // Empty @everyone overrides should be treated as not existing at all
+            if (overrideId == channel.getGuild().getIdLong() && (allow | deny) == 0L)
+                return false;
             PermissionOverrideImpl impl;
             currentOverride = impl = new PermissionOverrideImpl(channel, overrideId, isRole);
             impl.setAllow(allow);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: https://github.com/DV8FromTheWorld/JDA/issues/1485

## Description

This PR fixes, that the isSynced() method in AbstractChannelImpl doesn't check if the permissions of the PermissionOverrides are equal. It just checked, if the category had the PermissionOverrides with the same id.
