### PR TITLE
Docs: Nullability in GuildMessageReactionAddEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionAddEvent.java
@@ -39,6 +39,13 @@ public class GuildMessageReactionAddEvent extends GenericGuildMessageReactionEve
         super(api, responseNumber, member, reaction, member.getIdLong());
     }
 
+    /**
+     * The reacting {@link net.dv8tion.jda.api.entities.User User}
+     *
+     * @return The reacting user
+     *
+     * @see    #getUserIdLong()
+     */
     @Nonnull
     @Override
     @SuppressWarnings("ConstantConditions")
@@ -47,6 +54,11 @@ public class GuildMessageReactionAddEvent extends GenericGuildMessageReactionEve
         return super.getUser();
     }
 
+    /**
+     * The {@link net.dv8tion.jda.api.entities.Member Member} instance for the reacting user
+     *
+     * @return The member instance for the reacting user
+     */
     @Nonnull
     @Override
     @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1385

## Description

As of now, the docs for GuildMessageReactionAddEvent are copied from GenericGuildMessageReactionEvent, which states that getMember and getUser can be null. However, GuildMessageReactionAddEvent is guaranteed to have a user and member, and there are annotations in place to indicate this.

This PR adds 2 javadoc sections to GuildMessageReactionAddEvent, so it doesn't wrongly use those of its superclass.

The topic was already brought up in #1385, and deemed not a bug. I'd argue that more documentation and thus less confusion is always good, but if you disagree, it's your call to close this.
