### PR TITLE
Allow building DefaultShardManager without starting it

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -256,6 +256,7 @@ public class DefaultShardManager implements ShardManager
         return this.shards;
     }
 
+    @Override
     public void login() throws LoginException
     {
         // building the first one in the current thread ensures that LoginException and IllegalArgumentException can be thrown on login

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2301,7 +2301,7 @@ public class  DefaultShardManagerBuilder
      *         to whether or not loading has finished when this returns.
      */
     @Nonnull
-    public ShardManager build() throws LoginException, IllegalArgumentException
+    public DefaultShardManager build() throws LoginException, IllegalArgumentException
     {
         return build(true);
     }
@@ -2327,7 +2327,7 @@ public class  DefaultShardManagerBuilder
      *         to whether or not loading has finished when this returns.
      */
     @Nonnull
-    public ShardManager build(boolean login) throws LoginException, IllegalArgumentException
+    public DefaultShardManager build(boolean login) throws LoginException, IllegalArgumentException
     {
         checkIntents();
         boolean useShutdownNow = shardingFlags.contains(ShardingConfigFlag.SHUTDOWN_NOW);

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2316,15 +2316,17 @@ public class  DefaultShardManagerBuilder
      * <p>Note that this method is async and as such will <b>not</b> block until all shards are started.
      *
      * @param  login
-     *         Whether the login process will be started
+     *         Whether the login process will be started. If this is false, then you will need to manually call
+     *         {@link net.dv8tion.jda.api.sharding.ShardManager#login()} to start it.
      *
      * @throws  LoginException
      *          If the provided token is invalid.
      * @throws  IllegalArgumentException
      *          If the provided token is empty or null. Or the provided intents/cache configuration is not possible.
      *
-     * @return A {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} instance that has started the login process. It is unknown as
-     *         to whether or not loading has finished when this returns.
+     * @return A {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} instance. If {@code login} is set to
+     * true, then the instance will have started the login process. It is unknown as to whether or not loading has
+     * finished when this returns.
      */
     @Nonnull
     public ShardManager build(boolean login) throws LoginException, IllegalArgumentException

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2344,9 +2344,8 @@ public class  DefaultShardManagerBuilder
         final ShardingMetaConfig metaConfig = new ShardingMetaConfig(maxBufferSize, contextProvider, cacheFlags, flags, compression, encoding);
         final DefaultShardManager manager = new DefaultShardManager(this.token, this.shards, shardingConfig, eventConfig, presenceConfig, threadingConfig, sessionConfig, metaConfig, chunkingFilter);
 
-        if(login) {
-            manager.login();
-        }
+        if (login)
+             manager.login();
 
         return manager;
     }

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2303,6 +2303,32 @@ public class  DefaultShardManagerBuilder
     @Nonnull
     public ShardManager build() throws LoginException, IllegalArgumentException
     {
+        return build(true);
+    }
+
+    /**
+     * Builds a new {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} instance. If the login parameter is true, then it will start the login process.
+     * <br>The login process runs in a different thread, so while this will return immediately, {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} has not
+     * finished loading, thus many {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} methods have the chance to return incorrect information.
+     * <br>The main use of this method is to start the JDA connect process and do other things in parallel while startup is
+     * being performed like database connection or local resource loading.
+     *
+     * <p>Note that this method is async and as such will <b>not</b> block until all shards are started.
+     *
+     * @param  login
+     *         Whether the login process will be started
+     *
+     * @throws  LoginException
+     *          If the provided token is invalid.
+     * @throws  IllegalArgumentException
+     *          If the provided token is empty or null. Or the provided intents/cache configuration is not possible.
+     *
+     * @return A {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} instance that has started the login process. It is unknown as
+     *         to whether or not loading has finished when this returns.
+     */
+    @Nonnull
+    public ShardManager build(boolean login) throws LoginException, IllegalArgumentException
+    {
         checkIntents();
         boolean useShutdownNow = shardingFlags.contains(ShardingConfigFlag.SHUTDOWN_NOW);
         final ShardingConfig shardingConfig = new ShardingConfig(shardsTotal, useShutdownNow, intents, memberCachePolicy);
@@ -2318,7 +2344,9 @@ public class  DefaultShardManagerBuilder
         final ShardingMetaConfig metaConfig = new ShardingMetaConfig(maxBufferSize, contextProvider, cacheFlags, flags, compression, encoding);
         final DefaultShardManager manager = new DefaultShardManager(this.token, this.shards, shardingConfig, eventConfig, presenceConfig, threadingConfig, sessionConfig, metaConfig, chunkingFilter);
 
-        manager.login();
+        if(login) {
+            manager.login();
+        }
 
         return manager;
     }

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2301,7 +2301,7 @@ public class  DefaultShardManagerBuilder
      *         to whether or not loading has finished when this returns.
      */
     @Nonnull
-    public DefaultShardManager build() throws LoginException, IllegalArgumentException
+    public ShardManager build() throws LoginException, IllegalArgumentException
     {
         return build(true);
     }
@@ -2327,7 +2327,7 @@ public class  DefaultShardManagerBuilder
      *         to whether or not loading has finished when this returns.
      */
     @Nonnull
-    public DefaultShardManager build(boolean login) throws LoginException, IllegalArgumentException
+    public ShardManager build(boolean login) throws LoginException, IllegalArgumentException
     {
         checkIntents();
         boolean useShutdownNow = shardingFlags.contains(ShardingConfigFlag.SHUTDOWN_NOW);

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -2320,7 +2320,7 @@ public class  DefaultShardManagerBuilder
      *         {@link net.dv8tion.jda.api.sharding.ShardManager#login()} to start it.
      *
      * @throws  LoginException
-     *          If the provided token is invalid.
+     *          If the provided token is invalid and {@code login} is true
      * @throws  IllegalArgumentException
      *          If the provided token is empty or null. Or the provided intents/cache configuration is not possible.
      *

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -36,6 +36,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.security.auth.login.LoginException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -1500,4 +1501,13 @@ public interface ShardManager
      *         If {@link #shutdown()} has already been invoked
      */
     void start(int shardId);
+
+    /**
+     * Initializes and starts all shards. This should only be called once.
+     *
+     * @throws LoginException
+     *         If the provided token is invalid.
+     */
+    void login() throws LoginException;
+
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

Allows a DefaultShardManager to be built without immediately starting it. This is useful in dependency injection situations, where the ShardManager might need to be injected into several places before it's started.