### PR TITLE
Add fail_if_not_exists

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -965,6 +965,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendMessage(content).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendMessage(CharSequence)} and {@link MessageAction#reference(Message)}.
      *
@@ -984,6 +986,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendMessage(content).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendMessage(MessageEmbed)} and {@link MessageAction#reference(Message)}.
      *
@@ -1003,6 +1007,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendMessage(content).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendMessage(Message)} and {@link MessageAction#reference(Message)}.
      *
@@ -1022,6 +1028,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendMessageFormat(content, args).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendMessageFormat(String, Object...)} and {@link MessageAction#reference(Message)}.
      *
@@ -1043,6 +1051,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendFile(file, options).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendFile(File, net.dv8tion.jda.api.utils.AttachmentOption...)} and {@link MessageAction#reference(Message)}.
      *
@@ -1064,6 +1074,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendFile(data, name, options).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendFile(File, String, net.dv8tion.jda.api.utils.AttachmentOption...)} and {@link MessageAction#reference(Message)}.
      *
@@ -1087,6 +1099,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendFile(data, name, options).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendFile(InputStream, String, net.dv8tion.jda.api.utils.AttachmentOption...)} and {@link MessageAction#reference(Message)}.
      *
@@ -1110,6 +1124,8 @@ public interface Message extends ISnowflake, Formattable
      * Replies and references this message.
      * <br>This is identical to {@code message.getChannel().sendFile(data, name, options).reference(message)}.
      * You can use {@link MessageAction#mentionRepliedUser(boolean) mentionRepliedUser(false)} to not mention the author of the message.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link MessageAction#failOnInvalidReply(boolean)}.
      *
      * <p>For further info, see {@link MessageChannel#sendFile(byte[], String, net.dv8tion.jda.api.utils.AttachmentOption...)} and {@link MessageAction#reference(Message)}.
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -158,7 +158,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * <p>Default: <b>false</b>
      *
      * @param fail
-     *        True, to throw a exception if the referenced message was deleted
+     *        True, to throw a exception if the referenced message does not exist
      */
     static void setDefaultFailOnInvalidReply(boolean fail)
     {
@@ -166,13 +166,13 @@ public interface MessageAction extends RestAction<Message>, Appendable
     }
 
     /**
-     * Returns the default behavior for replies when the referenced message was deleted.
-     * <br>If this is {@code true} then all replies will throw an exception if the referenced message was deleted.
+     * Returns the default behavior for replies when the referenced message does not exist.
+     * <br>If this is {@code true} then all replies will throw an exception if the referenced message does not exist.
      * You can specify this individually with {@link #failOnInvalidReply(boolean)} for each message.
      *
      * <p>Default: <b>false</b>
      *
-     * @return True, to throw a exception if the referenced message was deleted
+     * @return True, to throw a exception if the referenced message does not exist
      */
     static boolean isDefaultFailOnInvalidReply()
     {
@@ -241,6 +241,8 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * Make the message a reply to the referenced message.
      * <br>You can only reply to messages from the same channel!
      * <br>This will mention the author of the target message. You can disable this through {@link #mentionRepliedUser(boolean)}.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link #failOnInvalidReply(boolean)}.
      *
      * <p>This requires {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel!
      *
@@ -257,6 +259,8 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * Make the message a reply to the referenced message.
      * <br>You can only reply to messages from the same channel!
      * <br>This will mention the author of the target message. You can disable this through {@link #mentionRepliedUser(boolean)}.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link #failOnInvalidReply(boolean)}.
      *
      * <p>This requires {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel!
      * You cannot reply to system messages (such as {@link net.dv8tion.jda.api.entities.MessageType#CHANNEL_PINNED_ADD CHANNEL_PINNED_ADD} and similar).
@@ -280,6 +284,8 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * Make the message a reply to the referenced message.
      * <br>You can only reply to messages from the same channel!
      * <br>This will mention the author of the target message. You can disable this through {@link #mentionRepliedUser(boolean)}.
+     * <br>By default there won't be any error thrown if the referenced message does not exist.
+     * This behavior can be changed with {@link #failOnInvalidReply(boolean)}.
      *
      * <p>This requires {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel!
      *
@@ -317,13 +323,13 @@ public interface MessageAction extends RestAction<Message>, Appendable
     MessageAction mentionRepliedUser(boolean mention);
 
     /**
-     * Whether to throw a exception if the referenced message was deleted, when replying to a message.
+     * Whether to throw a exception if the referenced message does not exist, when replying to a message.
      * <br>This only matters in combination with {@link #reference(Message)} and {@link #referenceById(long)}!
      *
      * <p>This is false by default but can be configured using {@link #setDefaultFailOnInvalidReply(boolean)}!
      *
      * @param  fail
-     *         True, to throw a exception if the referenced message was deleted
+     *         True, to throw a exception if the referenced message does not exist
      *
      * @return Updated MessageAction for chaining convenience
      */

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -153,30 +153,30 @@ public interface MessageAction extends RestAction<Message>, Appendable
     }
 
     /**
-     * Sets the default value for {@link #failIfNotExists(boolean)}
+     * Sets the default value for {@link #failOnInvalidReply(boolean)}
      *
      * <p>Default: <b>false</b>
      *
      * @param fail
      *        True, to throw a exception if the referenced message was deleted
      */
-    static void setDefaultFailIfNotExists(boolean fail)
+    static void setDefaultFailOnInvalidReply(boolean fail)
     {
-        MessageActionImpl.setDefaultFailIfNotExists(fail);
+        MessageActionImpl.setDefaultFailOnInvalidReply(fail);
     }
 
     /**
      * Returns the default behavior for replies when the referenced message was deleted.
      * <br>If this is {@code true} then all replies will throw an exception if the referenced message was deleted.
-     * You can specify this individually with {@link #failIfNotExists(boolean)} for each message.
+     * You can specify this individually with {@link #failOnInvalidReply(boolean)} for each message.
      *
      * <p>Default: <b>false</b>
      *
      * @return True, to throw a exception if the referenced message was deleted
      */
-    static boolean isDefaultFailIfNotExists()
+    static boolean isDefaultFailOnInvalidReply()
     {
-        return MessageActionImpl.isDefaultFailIfNotExists();
+        return MessageActionImpl.isDefaultFailOnInvalidReply();
     }
 
     @Nonnull
@@ -320,7 +320,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * Whether to throw a exception if the referenced message was deleted, when replying to a message.
      * <br>This only matters in combination with {@link #reference(Message)} and {@link #referenceById(long)}!
      *
-     * <p>This is false by default but can be configured using {@link #setDefaultFailIfNotExists(boolean)}!
+     * <p>This is false by default but can be configured using {@link #setDefaultFailOnInvalidReply(boolean)}!
      *
      * @param  fail
      *         True, to throw a exception if the referenced message was deleted
@@ -329,7 +329,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      */
     @Nonnull
     @CheckReturnValue
-    MessageAction failIfNotExists(boolean fail);
+    MessageAction failOnInvalidReply(boolean fail);
 
     /**
      * Enable/Disable Text-To-Speech for the resulting message.

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -152,6 +152,33 @@ public interface MessageAction extends RestAction<Message>, Appendable
         return MessageActionImpl.isDefaultMentionRepliedUser();
     }
 
+    /**
+     * Sets the default value for {@link #failIfNotExists(boolean)}
+     *
+     * <p>Default: <b>false</b>
+     *
+     * @param fail
+     *        True, to throw a exception if the referenced message was deleted
+     */
+    static void setDefaultFailIfNotExists(boolean fail)
+    {
+        MessageActionImpl.setDefaultFailIfNotExists(fail);
+    }
+
+    /**
+     * Returns the default behavior for replies when the referenced message was deleted.
+     * <br>If this is {@code true} then all replies will throw an exception if the referenced message was deleted.
+     * You can specify this individually with {@link #failIfNotExists(boolean)} for each message.
+     *
+     * <p>Default: <b>false</b>
+     *
+     * @return True, to throw a exception if the referenced message was deleted
+     */
+    static boolean isDefaultFailIfNotExists()
+    {
+        return MessageActionImpl.isDefaultFailIfNotExists();
+    }
+
     @Nonnull
     @Override
     MessageAction setCheck(@Nullable BooleanSupplier checks);
@@ -288,6 +315,21 @@ public interface MessageAction extends RestAction<Message>, Appendable
     @Nonnull
     @CheckReturnValue
     MessageAction mentionRepliedUser(boolean mention);
+
+    /**
+     * Whether to throw a exception if the referenced message was deleted, when replying to a message.
+     * <br>This only matters in combination with {@link #reference(Message)} and {@link #referenceById(long)}!
+     *
+     * <p>This is false by default but can be configured using {@link #setDefaultFailIfNotExists(boolean)}!
+     *
+     * @param  fail
+     *         True, to throw a exception if the referenced message was deleted
+     *
+     * @return Updated MessageAction for chaining convenience
+     */
+    @Nonnull
+    @CheckReturnValue
+    MessageAction failIfNotExists(boolean fail);
 
     /**
      * Enable/Disable Text-To-Speech for the resulting message.

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -53,7 +53,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     private static final String CONTENT_TOO_BIG = String.format("A message may not exceed %d characters. Please limit your input!", Message.MAX_CONTENT_LENGTH);
     protected static EnumSet<Message.MentionType> defaultMentions = EnumSet.allOf(Message.MentionType.class);
     protected static boolean defaultMentionRepliedUser = true;
-    protected static boolean defaultFailIfNotExists = false;
+    protected static boolean defaultFailOnInvalidReply = false;
     protected final Map<String, InputStream> files = new HashMap<>();
     protected final Set<InputStream> ownedResources = new HashSet<>();
     protected final StringBuilder content;
@@ -62,7 +62,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     protected String nonce = null;
     protected boolean tts = false, override = false;
     protected boolean mentionRepliedUser = defaultMentionRepliedUser;
-    protected boolean failIfNotExists = defaultFailIfNotExists;
+    protected boolean failOnInvalidReply = defaultFailOnInvalidReply;
     protected EnumSet<Message.MentionType> allowedMentions;
     protected Set<String> mentionableUsers = new HashSet<>();
     protected Set<String> mentionableRoles = new HashSet<>();
@@ -91,14 +91,14 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return defaultMentionRepliedUser;
     }
 
-    public static void setDefaultFailIfNotExists(boolean fail)
+    public static void setDefaultFailOnInvalidReply(boolean fail)
     {
-        defaultMentionRepliedUser = fail;
+        defaultFailOnInvalidReply = fail;
     }
 
-    public static boolean isDefaultFailIfNotExists()
+    public static boolean isDefaultFailOnInvalidReply()
     {
-        return defaultMentionRepliedUser;
+        return defaultFailOnInvalidReply;
     }
 
     public MessageActionImpl(JDA api, Route.CompiledRoute route, MessageChannel channel)
@@ -228,9 +228,9 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
 
     @Nonnull
     @Override
-    public MessageAction failIfNotExists(boolean fail)
+    public MessageAction failOnInvalidReply(boolean fail)
     {
-        failIfNotExists = fail;
+        failOnInvalidReply = fail;
         return this;
     }
 
@@ -534,7 +534,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
             obj.put("message_reference", DataObject.empty()
                 .put("message_id", messageReference)
                 .put("channel_id", channel.getId()))
-                .put("fail_if_not_exists", failIfNotExists);
+                .put("fail_if_not_exists", failOnInvalidReply);
         }
         obj.put("tts", tts);
         if ((messageReference != 0L && !mentionRepliedUser) || allowedMentions != null || !mentionableUsers.isEmpty() || !mentionableRoles.isEmpty())

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -53,6 +53,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     private static final String CONTENT_TOO_BIG = String.format("A message may not exceed %d characters. Please limit your input!", Message.MAX_CONTENT_LENGTH);
     protected static EnumSet<Message.MentionType> defaultMentions = EnumSet.allOf(Message.MentionType.class);
     protected static boolean defaultMentionRepliedUser = true;
+    protected static boolean defaultFailIfNotExists = false;
     protected final Map<String, InputStream> files = new HashMap<>();
     protected final Set<InputStream> ownedResources = new HashSet<>();
     protected final StringBuilder content;
@@ -61,6 +62,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     protected String nonce = null;
     protected boolean tts = false, override = false;
     protected boolean mentionRepliedUser = defaultMentionRepliedUser;
+    protected boolean failIfNotExists = defaultFailIfNotExists;
     protected EnumSet<Message.MentionType> allowedMentions;
     protected Set<String> mentionableUsers = new HashSet<>();
     protected Set<String> mentionableRoles = new HashSet<>();
@@ -85,6 +87,16 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     }
 
     public static boolean isDefaultMentionRepliedUser()
+    {
+        return defaultMentionRepliedUser;
+    }
+
+    public static void setDefaultFailIfNotExists(boolean fail)
+    {
+        defaultMentionRepliedUser = fail;
+    }
+
+    public static boolean isDefaultFailIfNotExists()
     {
         return defaultMentionRepliedUser;
     }
@@ -211,6 +223,14 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     public MessageAction mentionRepliedUser(boolean mention)
     {
         mentionRepliedUser = mention;
+        return this;
+    }
+
+    @Nonnull
+    @Override
+    public MessageAction failIfNotExists(boolean fail)
+    {
+        failIfNotExists = fail;
         return this;
     }
 
@@ -513,7 +533,8 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         {
             obj.put("message_reference", DataObject.empty()
                 .put("message_id", messageReference)
-                .put("channel_id", channel.getId()));
+                .put("channel_id", channel.getId()))
+                .put("fail_if_not_exists", failIfNotExists);
         }
         obj.put("tts", tts);
         if ((messageReference != 0L && !mentionRepliedUser) || allowedMentions != null || !mentionableUsers.isEmpty() || !mentionableRoles.isEmpty())

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -533,8 +533,8 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         {
             obj.put("message_reference", DataObject.empty()
                 .put("message_id", messageReference)
-                .put("channel_id", channel.getId()))
-                .put("fail_if_not_exists", failOnInvalidReply);
+                .put("channel_id", channel.getId())
+                .put("fail_if_not_exists", failOnInvalidReply));
         }
         obj.put("tts", tts);
         if ((messageReference != 0L && !mentionRepliedUser) || allowedMentions != null || !mentionableUsers.isEmpty() || !mentionableRoles.isEmpty())


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
This adds the new **fail_if_not_exists field** that can be used to suppress errors when the referenced message was deleted. 
See discord/discord-api-docs#2572