### PR TITLE
Remove unnecessary checks for permission values

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/GuildAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/GuildAction.java
@@ -302,19 +302,11 @@ public interface GuildAction extends RestAction<Void>
          * @param  rawPermissions
          *         Raw permission value
          *
-         * @throws java.lang.IllegalArgumentException
-         *         If the provided permissions are negative or exceed the maximum permissions
-         *
          * @return The current RoleData instance for chaining convenience
          */
         @Nonnull
         public RoleData setPermissionsRaw(@Nullable Long rawPermissions)
         {
-            if (rawPermissions != null)
-            {
-                Checks.notNegative(rawPermissions, "Raw Permissions");
-                Checks.check(rawPermissions <= Permission.ALL_PERMISSIONS, "Provided permissions may not be greater than a full permission set!");
-            }
             this.permissions = rawPermissions;
             return this;
         }
@@ -665,11 +657,7 @@ public interface GuildAction extends RestAction<Void>
          *         The permissions to deny in the override
          *
          * @throws java.lang.IllegalArgumentException
-         *         <ul>
-         *             <li>If the provided role is {@code null}</li>
-         *             <li>If the provided allow value is negative or exceeds maximum permissions</li>
-         *             <li>If the provided deny value is negative or exceeds maximum permissions</li>
-         *         </ul>
+         *         If the provided role is {@code null}
          *
          * @return This ChannelData instance for chaining convenience
          */
@@ -677,10 +665,6 @@ public interface GuildAction extends RestAction<Void>
         public ChannelData addPermissionOverride(@Nonnull GuildActionImpl.RoleData role, long allow, long deny)
         {
             Checks.notNull(role, "Role");
-            Checks.notNegative(allow, "Granted permissions value");
-            Checks.notNegative(deny, "Denied permissions value");
-            Checks.check(allow <= Permission.ALL_PERMISSIONS, "Specified allow value may not be greater than a full permission set");
-            Checks.check(deny <= Permission.ALL_PERMISSIONS,  "Specified deny value may not be greater than a full permission set");
             this.overrides.add(new PermOverrideData(PermOverrideData.ROLE_TYPE, role.id, allow, deny));
             return this;
         }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
@@ -233,9 +233,6 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *         The <b>positive</b> bits representing the granted
      *         permissions for the new PermissionOverride
      *
-     * @throws java.lang.IllegalArgumentException
-     *         If the provided bits are negative
-     *         or higher than {@link net.dv8tion.jda.api.Permission#ALL_PERMISSIONS Permission.ALL_PERMISSIONS}
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
      *         on the channel and tries to set permissions it does not have in the channel
@@ -391,9 +388,6 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
      *         on the channel and tries to set permissions it does not have in the channel
-     * @throws java.lang.IllegalArgumentException
-     *         If the provided bits are negative
-     *         or higher than {@link net.dv8tion.jda.api.Permission#ALL_PERMISSIONS Permission.ALL_PERMISSIONS}
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      *
@@ -608,9 +602,6 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *         An unsigned bitwise representation
      *         of denied Permissions
      *
-     * @throws java.lang.IllegalArgumentException
-     *         If any of the provided bits are negative
-     *         or higher than {@link net.dv8tion.jda.api.Permission#ALL_PERMISSIONS Permission.ALL_PERMISSIONS}
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
      *         on the channel and tries to set permissions it does not have in the channel

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/RoleAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/RoleAction.java
@@ -196,8 +196,6 @@ public interface RoleAction extends AuditableRestAction<Role>
      *         The raw {@link net.dv8tion.jda.api.Permission Permissions} value for the new role.
      *         To retrieve this use {@link net.dv8tion.jda.api.Permission#getRawValue()}
      *
-     * @throws java.lang.IllegalArgumentException
-     *         If the provided permission value is invalid
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not hold one of the specified permissions
      *

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
@@ -257,10 +257,6 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
 
     private ChannelActionImpl<T> addOverride(long targetId, int type, long allow, long deny)
     {
-        Checks.notNegative(allow, "Granted permissions value");
-        Checks.notNegative(deny, "Denied permissions value");
-        Checks.check(allow <= Permission.ALL_PERMISSIONS, "Specified allow value may not be greater than a full permission set");
-        Checks.check(deny <= Permission.ALL_PERMISSIONS, "Specified deny value may not be greater than a full permission set");
         Member selfMember = getGuild().getSelfMember();
         boolean canSetRoles = selfMember.hasPermission(Permission.ADMINISTRATOR);
         if (!canSetRoles && parent != null) // You can also set MANAGE_ROLES if you have it on the category (apparently?)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
@@ -28,7 +28,6 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.AbstractChannelImpl;
 import net.dv8tion.jda.internal.entities.PermissionOverrideImpl;
 import net.dv8tion.jda.internal.requests.Route;
-import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import okhttp3.RequestBody;
 
@@ -187,8 +186,6 @@ public class PermissionOverrideActionImpl
     @CheckReturnValue
     public PermissionOverrideActionImpl setAllow(long allowBits)
     {
-        Checks.notNegative(allowBits, "Granted permissions value");
-        Checks.check(allowBits <= Permission.ALL_PERMISSIONS, "Specified allow value may not be greater than a full permission set");
         checkPermissions(getCurrentAllow() ^ allowBits);
         this.allow = allowBits;
         this.deny &= ~allowBits;
@@ -201,8 +198,6 @@ public class PermissionOverrideActionImpl
     @CheckReturnValue
     public PermissionOverrideActionImpl setDeny(long denyBits)
     {
-        Checks.notNegative(denyBits, "Denied permissions value");
-        Checks.check(denyBits <= Permission.ALL_PERMISSIONS, "Specified deny value may not be greater than a full permission set");
         checkPermissions(getCurrentDeny() ^ denyBits);
         this.deny = denyBits;
         this.allow &= ~denyBits;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
@@ -127,8 +127,6 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
     {
         if (permissions != null)
         {
-            Checks.notNegative(permissions, "Raw Permissions");
-            Checks.check(permissions <= Permission.ALL_PERMISSIONS, "Provided permissions may not be greater than a full permission set!");
             for (Permission p : Permission.getPermissions(permissions))
                 checkPermission(p);
         }


### PR DESCRIPTION

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

These checks mean you get an error every time discord adds a new permission. We should avoid doing that.

We shouldn't check for unknown enum values
And checking the sign for an unsigned int is bad

