### PR TITLE
Improve some logging for large rate limits

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -266,11 +266,12 @@ public class BotRateLimiter extends RateLimiter
                     // Handle hard rate limit, pretty much just log that it happened
                     else
                     {
-                        boolean firstHit = hitRatelimit.add(baseRoute);
+                        boolean firstHit = retryAfter >= 6000 || hitRatelimit.add(baseRoute);
                         // Update the bucket to the new information
                         bucket.remaining = 0;
                         bucket.reset = getNow() + retryAfter;
                         // don't log warning if we hit the rate limit for the first time, likely due to initialization of the bucket
+                        // unless its a long retry-after delay (more than a minute)
                         if (firstHit)
                             log.debug("Encountered 429 on route {} with bucket {} Retry-After: {} ms", baseRoute, bucket.bucketId, retryAfter);
                         else
@@ -377,6 +378,11 @@ public class BotRateLimiter extends RateLimiter
             requests.addFirst(request);
         }
 
+        private boolean isGlobalRateLimit()
+        {
+            return requester.getJDA().getSessionController().getGlobalRatelimit() > getNow();
+        }
+
         public long getRateLimit()
         {
             long now = getNow();
@@ -440,7 +446,11 @@ public class BotRateLimiter extends RateLimiter
                 if (rateLimit > 0L)
                 {
                     // We need to backoff since we ran out of remaining uses or hit the global rate limit
-                    log.debug("Backing off {} ms for bucket {}", rateLimit, bucketId);
+                    Request request = requests.peekFirst(); // this *should* not be null
+                    String baseRoute = request != null ? request.getRoute().getBaseRoute().toString() : "N/A";
+                    if (!isGlobalRateLimit() && rateLimit >= 1000 * 60 * 30) // 30 minutes
+                        log.warn("Encountered long {} minutes Rate-Limit on route {}", TimeUnit.MILLISECONDS.toMinutes(rateLimit), baseRoute);
+                    log.debug("Backing off {} ms for bucket {} on route {}", rateLimit, bucketId, baseRoute);
                     break;
                 }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -266,7 +266,7 @@ public class BotRateLimiter extends RateLimiter
                     // Handle hard rate limit, pretty much just log that it happened
                     else
                     {
-                        boolean firstHit = retryAfter < 6000 || hitRatelimit.add(baseRoute);
+                        boolean firstHit = retryAfter < 60000 || hitRatelimit.add(baseRoute);
                         // Update the bucket to the new information
                         bucket.remaining = 0;
                         bucket.reset = getNow() + retryAfter;

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -266,7 +266,7 @@ public class BotRateLimiter extends RateLimiter
                     // Handle hard rate limit, pretty much just log that it happened
                     else
                     {
-                        boolean firstHit = retryAfter < 60000 || hitRatelimit.add(baseRoute);
+                        boolean firstHit = hitRatelimit.add(baseRoute) && retryAfter < 60000;
                         // Update the bucket to the new information
                         bucket.remaining = 0;
                         bucket.reset = getNow() + retryAfter;

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -266,7 +266,7 @@ public class BotRateLimiter extends RateLimiter
                     // Handle hard rate limit, pretty much just log that it happened
                     else
                     {
-                        boolean firstHit = retryAfter >= 6000 || hitRatelimit.add(baseRoute);
+                        boolean firstHit = retryAfter < 6000 || hitRatelimit.add(baseRoute);
                         // Update the bucket to the new information
                         bucket.remaining = 0;
                         bucket.reset = getNow() + retryAfter;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

We should always log long rate limits on warn level, unless its also a global rate limit (which is already logged elsewhere).
