### PR TITLE
Set socket timeout before connecting websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ version was by looking at the [release page](https://github.com/DV8FromTheWorld/
 This project requires **Java 8+**.<br>
 All dependencies are managed automatically by Gradle.
  * NV Websocket Client
-   * Version: **2.9**
+   * Version: **2.14**
    * [Github](https://github.com/TakahikoKawasaki/nv-websocket-client)
    * [JCenter Repository](https://bintray.com/bintray/jcenter/com.neovisionaries%3Anv-websocket-client/view)
  * OkHttp

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     api("org.slf4j:slf4j-api:1.7.25")
 
     //Web Connection Support
-    api("com.neovisionaries:nv-websocket-client:2.10")
+    api("com.neovisionaries:nv-websocket-client:2.14")
     api("com.squareup.okhttp3:okhttp:3.13.0")
 
     //Opus library support

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -122,6 +122,8 @@ class AudioWebSocket extends WebSocketAdapter
         {
             WebSocketFactory socketFactory = new WebSocketFactory(getJDA().getWebSocketFactory());
             IOUtil.setServerName(socketFactory, wssEndpoint);
+            if (socketFactory.getSocketTimeout() < 1000)
+                socketFactory.setSocketTimeout(10000);
             socket = socketFactory.createSocket(wssEndpoint);
             socket.setDirectTextMessage(true);
             socket.addListener(this);

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -122,7 +122,9 @@ class AudioWebSocket extends WebSocketAdapter
         {
             WebSocketFactory socketFactory = new WebSocketFactory(getJDA().getWebSocketFactory());
             IOUtil.setServerName(socketFactory, wssEndpoint);
-            if (socketFactory.getSocketTimeout() < 1000)
+            if (socketFactory.getSocketTimeout() > 0)
+                socketFactory.setSocketTimeout(Math.max(1000, socketFactory.getSocketTimeout()));
+            else
                 socketFactory.setSocketTimeout(10000);
             socket = socketFactory.createSocket(wssEndpoint);
             socket.setDirectTextMessage(true);

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -366,6 +366,8 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         {
             WebSocketFactory socketFactory = new WebSocketFactory(api.getWebSocketFactory());
             IOUtil.setServerName(socketFactory, url);
+            if (socketFactory.getSocketTimeout() < 1000)
+                socketFactory.setSocketTimeout(10000);
             socket = socketFactory.createSocket(url);
             socket.setDirectTextMessage(true);
             socket.addHeader("Accept-Encoding", "gzip")

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -366,7 +366,9 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         {
             WebSocketFactory socketFactory = new WebSocketFactory(api.getWebSocketFactory());
             IOUtil.setServerName(socketFactory, url);
-            if (socketFactory.getSocketTimeout() < 1000)
+            if (socketFactory.getSocketTimeout() > 0)
+                socketFactory.setSocketTimeout(Math.max(1000, socketFactory.getSocketTimeout()));
+            else
                 socketFactory.setSocketTimeout(10000);
             socket = socketFactory.createSocket(url);
             socket.setDirectTextMessage(true);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

By default we use a timeout of 10 seconds, just to prevent it from deadlocking. You can configure a lower timeout (min. 1 second) with `WebSocketFactory#setSocketTimeout` and passing that factory to one of the JDA builders.
