### PR TITLE
fix npe's and wrong length in EmbedBuilder#length()

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -180,7 +180,7 @@ public class EmbedBuilder
         int length = description.length();
         synchronized (fields)
         {
-            length = fields.stream().map(f -> f.getName().length() + f.getValue().length()).reduce(length, Integer::sum);
+            length += fields.stream().map(f -> f.getName().length() + f.getValue().length()).reduce(length, Integer::sum);
         }
         if (title != null)
             length += title.length();

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -184,9 +184,9 @@ public class EmbedBuilder
         }
         if (title != null)
             length += title.length();
-        if (author != null)
+        if (author != null && author.getName() != null)
             length += author.getName().length();
-        if (footer != null)
+        if (footer != null && footer.getText() != null)
             length += footer.getText().length();
         return length;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes 2 possible npe's and not cumulatively adding the fields' length
