### PR TITLE
Fix deny/grant on override action

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
@@ -322,10 +322,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      */
     @Nonnull
     @CheckReturnValue
-    default PermissionOverrideAction grant(long allowBits)
-    {
-        return setAllow(getAllow() | allowBits);
-    }
+    PermissionOverrideAction grant(long allowBits);
 
     /**
      * Grants the specified permissions.
@@ -346,7 +343,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
     @CheckReturnValue
     default PermissionOverrideAction grant(@Nonnull Collection<Permission> permissions)
     {
-        return setAllow(getAllow() | Permission.getRaw(permissions));
+        return grant(Permission.getRaw(permissions));
     }
 
     /**
@@ -368,7 +365,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
     @CheckReturnValue
     default PermissionOverrideAction grant(@Nonnull Permission... permissions)
     {
-        return setAllow(getAllow() | Permission.getRaw(permissions));
+        return grant(Permission.getRaw(permissions));
     }
 
 
@@ -474,10 +471,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      */
     @Nonnull
     @CheckReturnValue
-    default PermissionOverrideAction deny(long denyBits)
-    {
-        return setDeny(getDeny() | denyBits);
-    }
+    PermissionOverrideAction deny(long denyBits);
 
     /**
      * Denies the specified permissions.
@@ -498,7 +492,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
     @CheckReturnValue
     default PermissionOverrideAction deny(@Nonnull Collection<Permission> permissions)
     {
-        return setDeny(getDeny() | Permission.getRaw(permissions));
+        return deny(Permission.getRaw(permissions));
     }
 
     /**
@@ -520,7 +514,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
     @CheckReturnValue
     default PermissionOverrideAction deny(@Nonnull Permission... permissions)
     {
-        return setDeny(getDeny() | Permission.getRaw(permissions));
+        return deny(Permission.getRaw(permissions));
     }
 
     /**
@@ -539,10 +533,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      */
     @Nonnull
     @CheckReturnValue
-    default PermissionOverrideAction clear(long inheritedBits)
-    {
-        return setDeny(getDeny() & ~inheritedBits).setAllow(getAllow() & ~inheritedBits);
-    }
+    PermissionOverrideAction clear(long inheritedBits);
 
     /**
      * Clears the provided {@link net.dv8tion.jda.api.Permission Permissions} bits

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
@@ -118,7 +118,7 @@ public class PermissionOverrideActionImpl
     @Override
     public PermissionOverrideAction resetAllow()
     {
-        allow = getCurrentAllow();
+        allow = getOriginalAllow();
         allowSet = false;
         return this;
     }
@@ -127,7 +127,7 @@ public class PermissionOverrideActionImpl
     @Override
     public PermissionOverrideAction resetDeny()
     {
-        deny = getCurrentDeny();
+        deny = getOriginalDeny();
         denySet = false;
         return this;
     }
@@ -186,7 +186,7 @@ public class PermissionOverrideActionImpl
     @CheckReturnValue
     public PermissionOverrideActionImpl setAllow(long allowBits)
     {
-        checkPermissions(getCurrentAllow() ^ allowBits);
+        checkPermissions(getOriginalAllow() ^ allowBits);
         this.allow = allowBits;
         this.deny &= ~allowBits;
         allowSet = denySet = true;
@@ -205,7 +205,7 @@ public class PermissionOverrideActionImpl
     @CheckReturnValue
     public PermissionOverrideActionImpl setDeny(long denyBits)
     {
-        checkPermissions(getCurrentDeny() ^ denyBits);
+        checkPermissions(getOriginalDeny() ^ denyBits);
         this.deny = denyBits;
         this.allow &= ~denyBits;
         allowSet = denySet = true;
@@ -253,18 +253,28 @@ public class PermissionOverrideActionImpl
 
     private long getCurrentAllow()
     {
-        if (isOverride)
-            return 0;
-        PermissionOverride override = channel.getOverrideMap().get(id);
-        return override == null ? 0 : override.getAllowedRaw();
+        if (allowSet)
+            return allow;
+        return isOverride ? 0 : getOriginalAllow();
     }
 
     private long getCurrentDeny()
     {
-        if (isOverride)
-            return 0;
+        if (denySet)
+            return deny;
+        return isOverride ? 0 : getOriginalDeny();
+    }
+
+    private long getOriginalDeny()
+    {
         PermissionOverride override = channel.getOverrideMap().get(id);
         return override == null ? 0 : override.getDeniedRaw();
+    }
+
+    private long getOriginalAllow()
+    {
+        PermissionOverride override = channel.getOverrideMap().get(id);
+        return override == null ? 0 : override.getAllowedRaw();
     }
 
     @Override
@@ -272,8 +282,8 @@ public class PermissionOverrideActionImpl
     {
         DataObject object = DataObject.empty();
         object.put("type", isRole() ? "role" : "member");
-        object.put("allow", allowSet ? allow : getCurrentAllow());
-        object.put("deny", denySet ? deny : getCurrentDeny());
+        object.put("allow", getCurrentAllow());
+        object.put("deny", getCurrentDeny());
         reset();
         return getRequestBody(object);
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
@@ -195,6 +195,13 @@ public class PermissionOverrideActionImpl
 
     @Nonnull
     @Override
+    public PermissionOverrideAction grant(long allowBits)
+    {
+        return setAllow(getCurrentAllow() | allowBits);
+    }
+
+    @Nonnull
+    @Override
     @CheckReturnValue
     public PermissionOverrideActionImpl setDeny(long denyBits)
     {
@@ -203,6 +210,20 @@ public class PermissionOverrideActionImpl
         this.allow &= ~denyBits;
         allowSet = denySet = true;
         return this;
+    }
+
+    @Nonnull
+    @Override
+    public PermissionOverrideAction deny(long denyBits)
+    {
+        return setDeny(getCurrentDeny() | denyBits);
+    }
+
+    @Nonnull
+    @Override
+    public PermissionOverrideAction clear(long inheritedBits)
+    {
+        return setAllow(getCurrentAllow() & ~inheritedBits).setDeny(getCurrentDeny() & ~inheritedBits);
     }
 
     protected void checkPermissions(long changed)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The `reset()` call that was removed in #1549 was used to initialize the allow/deny fields in the override action. Since we no longer reset it on every call, this is now broken.

This PR addresses this problem by properly initializing the current allow/deny values lazily.