### PR TITLE
remove nullability note for GuildChannel#getName

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -48,8 +48,7 @@ public interface GuildChannel extends ISnowflake, Comparable<GuildChannel>
     ChannelType getType();
 
     /**
-     * The human readable name of the  GuildChannel.
-     * <br>If no name has been set, this returns null.
+     * The human readable name of the GuildChannel.
      *
      * @return The name of this GuildChannel
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR removes a note about nullability in GuildChannel#getName docs, as it's annotated as `@Nonnull` and i can't think of any scenario where the name could indeed be null. if it can indeed be null, then i'll rather change the annotation
