### PR TITLE
Changed getUserByTag(String username, String discriminator) to use codepoints when checking username length

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -672,7 +672,7 @@ public interface JDA
         Checks.notNull(username, "Username");
         Checks.notNull(discriminator, "Discriminator");
         Checks.check(discriminator.length() == 4 && Helpers.isNumeric(discriminator), "Invalid format for discriminator!");
-        Checks.check(username.length() >= 2 && username.length() <= 32, "Username must be between 2 and 32 characters in length!");
+        Checks.check(username.codePointCount(0, username.length()) >= 2 && username.codePointCount(0, username.length()) <= 32, "Username must be between 2 and 32 codepoints in length!");
         return getUserCache().applyStream(stream ->
             stream.filter(it -> it.getDiscriminator().equals(discriminator))
                   .filter(it -> it.getName().equals(username))

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -672,7 +672,8 @@ public interface JDA
         Checks.notNull(username, "Username");
         Checks.notNull(discriminator, "Discriminator");
         Checks.check(discriminator.length() == 4 && Helpers.isNumeric(discriminator), "Invalid format for discriminator!");
-        Checks.check(username.codePointCount(0, username.length()) >= 2 && username.codePointCount(0, username.length()) <= 32, "Username must be between 2 and 32 codepoints in length!");
+        int codePointLength = username.codePointCount(0, username.length());
+        Checks.check(codePointLength >= 2 && codePointLength <= 32, "Username must be between 2 and 32 codepoints in length!");
         return getUserCache().applyStream(stream ->
             stream.filter(it -> it.getDiscriminator().equals(discriminator))
                   .filter(it -> it.getName().equals(username))


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1556

## Description

Changes the length check to use `String#codePointCount(int beginIndex, int endIndex)` to give compatibility for usernames to include surrogate pairs.
