### PR TITLE
Deprecate UserFlag#SYSTEM and add User#isSystem

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.api.entities;
 
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
@@ -347,6 +348,8 @@ public interface User extends IMentionable, IFakeable
 
         EARLY_SUPPORTER(    9, "Early Supporter"),
         TEAM_USER(         10, "Team User"),
+        @Deprecated
+        @DeprecatedSince("4.2.0")
         SYSTEM(            12, "System User"),
         BUG_HUNTER_LEVEL_2(14, "Bug Hunter Level 2"),
         VERIFIED_BOT(      16, "Verified Bot"),

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -17,6 +17,7 @@ package net.dv8tion.jda.api.entities;
 
 
 import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MiscUtil;

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -360,7 +360,8 @@ public interface User extends IMentionable, IFakeable
         EARLY_SUPPORTER(    9, "Early Supporter"),
         TEAM_USER(         10, "Team User"),
         @Deprecated
-        @DeprecatedSince("4.2.0")
+        @ForRemoval
+        @DeprecatedSince("4.3.0")
         SYSTEM(            12, "System User"),
         BUG_HUNTER_LEVEL_2(14, "Bug Hunter Level 2"),
         VERIFIED_BOT(      16, "Verified Bot"),

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -300,6 +300,17 @@ public interface User extends IMentionable, IFakeable
     boolean isBot();
 
     /**
+     * Returns whether or not the given user is a System account, which includes the urgent message account
+     * and the community updates bot.
+     *
+     * @throws UnsupportedOperationException
+     *         If this User was created with {@link #fromId(long)}
+     *
+     * @return If the User's account is marked as System
+     */
+    boolean isSystem();
+
+    /**
      * Returns the {@link net.dv8tion.jda.api.JDA JDA} instance of this User
      *
      * @throws UnsupportedOperationException

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -306,7 +306,7 @@ public interface User extends IMentionable, IFakeable
      * @throws UnsupportedOperationException
      *         If this User was created with {@link #fromId(long)}
      *
-     * @return If the User's account is marked as System
+     * @return Whether the User's account is marked as System
      */
     boolean isSystem();
 

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ForRemoval;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
@@ -362,6 +363,7 @@ public interface User extends IMentionable, IFakeable
         TEAM_USER(         10, "Team User"),
         @Deprecated
         @ForRemoval
+        @ReplaceWith("User.isSystem()")
         @DeprecatedSince("4.3.0")
         SYSTEM(            12, "System User"),
         BUG_HUNTER_LEVEL_2(14, "Bug Hunter Level 2"),

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -119,7 +119,7 @@ public class EntityBuilder
                 .setDiscriminator(self.getString("discriminator"))
                 .setAvatarId(self.getString("avatar", null))
                 .setBot(self.getBoolean("bot"))
-                .setSystem(self.getBoolean("system", false));
+                .setSystem(self.getBoolean("system"));
 
         return selfUser;
     }
@@ -324,7 +324,7 @@ public class EntityBuilder
                    .setDiscriminator(user.get("discriminator").toString())
                    .setAvatarId(user.getString("avatar", null))
                    .setBot(user.getBoolean("bot"))
-                   .setSystem(user.getBoolean("system", false))
+                   .setSystem(user.getBoolean("system"))
                    .setFlags(user.getInt("public_flags", 0));
         }
         else

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -118,7 +118,8 @@ public class EntityBuilder
                 .setName(self.getString("username"))
                 .setDiscriminator(self.getString("discriminator"))
                 .setAvatarId(self.getString("avatar", null))
-                .setBot(self.getBoolean("bot"));
+                .setBot(self.getBoolean("bot"))
+                .setSystem(self.getBoolean("system", false));
 
         return selfUser;
     }
@@ -323,6 +324,7 @@ public class EntityBuilder
                    .setDiscriminator(user.get("discriminator").toString())
                    .setAvatarId(user.getString("avatar", null))
                    .setBot(user.getBoolean("bot"))
+                   .setSystem(user.getBoolean("system", false))
                    .setFlags(user.getInt("public_flags", 0));
         }
         else

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -119,7 +119,7 @@ public class EntityBuilder
                 .setDiscriminator(self.getString("discriminator"))
                 .setAvatarId(self.getString("avatar", null))
                 .setBot(self.getBoolean("bot"))
-                .setSystem(self.getBoolean("system"));
+                .setSystem(false);
 
         return selfUser;
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserById.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserById.java
@@ -148,6 +148,13 @@ public class UserById implements User
         return false;
     }
 
+    @Override
+    public boolean isSystem()
+    {
+        unsupported();
+        return false;
+    }
+
     @Nonnull
     @Override
     public JDA getJDA()

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -42,6 +42,7 @@ public class UserImpl extends UserById implements User
     protected String avatarId;
     protected long privateChannel = 0L;
     protected boolean bot;
+    protected boolean system;
     protected boolean fake = false;
     protected int flags;
 
@@ -128,6 +129,12 @@ public class UserImpl extends UserById implements User
         return bot;
     }
 
+    @Override
+    public boolean isSystem()
+    {
+        return system;
+    }
+
     @Nonnull
     @Override
     public JDAImpl getJDA()
@@ -191,6 +198,12 @@ public class UserImpl extends UserById implements User
     public UserImpl setBot(boolean bot)
     {
         this.bot = bot;
+        return this;
+    }
+
+    public UserImpl setSystem(boolean system)
+    {
+        this.system = system;
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Deprecates `UserFlag.SYSTEM` as it is an internal flag now and won't show up on any user (see [discord-api-docs issue 2494](https://github.com/discord/discord-api-docs/issues/2494#issuecomment-816970401)), and adds `User#isSystem` as a replacement. 
