### PR TITLE
Hotfix some issues introduced by v8

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageCreateHandler.java
@@ -104,6 +104,7 @@ public class MessageCreateHandler extends SocketHandler
             {
                 PrivateChannelImpl channel = (PrivateChannelImpl) message.getPrivateChannel();
                 channel.setLastMessageId(message.getIdLong());
+                api.usedPrivateChannel(channel.getIdLong());
                 jda.handleEvent(
                     new PrivateMessageReceivedEvent(
                         jda, responseNumber,

--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -250,10 +250,7 @@ public class BotRateLimiter extends RateLimiter
                 if (response.code() == 429)
                 {
                     String retryAfterHeader = headers.get(RETRY_AFTER_HEADER);
-                    String resetAfterHeader = headers.get(RESET_AFTER_HEADER);
                     long retryAfter = parseLong(retryAfterHeader) * 1000; // seconds precision
-                    if (resetAfterHeader != null) // if available, use better precision
-                        retryAfter = parseDouble(resetAfterHeader); // milliseconds precision
                     // Handle global rate limit if necessary
                     if (global)
                     {


### PR DESCRIPTION

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord sends invalid reset-after headers on 429
Source: https://github.com/discord/discord-api-docs/issues/2761

We should just always cache private channels, even if it's not from a message create.
