### PR TITLE
Update ErrorResponseExecption#getErrorCode() docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
@@ -94,7 +94,7 @@ public class ErrorResponseException extends RuntimeException
      *
      * @return The discord error code.
      *
-     * @see <a href="https://discord.com/developers/docs/topics/response-codes#json-error-response" target="_blank">Discord Error Codes</a>
+     * @see <a href="https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes" target="_blank">Discord Error Codes</a>
      */
     public int getErrorCode()
     {


### PR DESCRIPTION
Updating the referenced link to match with ErrorResponse#getCode() docs

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
ErrorResponseException#getCode() docs should reference the correct link such as ErrorResponse#getCode() does.
