### PR TITLE
Make String.format usage locale safe

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -120,7 +120,7 @@ public class EmbedBuilder
         if (isEmpty())
             throw new IllegalStateException("Cannot build an empty embed!");
         if (description.length() > MessageEmbed.TEXT_MAX_LENGTH)
-            throw new IllegalStateException(String.format("Description is longer than %d! Please limit your input!", MessageEmbed.TEXT_MAX_LENGTH));
+            throw new IllegalStateException(Helpers.format("Description is longer than %d! Please limit your input!", MessageEmbed.TEXT_MAX_LENGTH));
         if (length() > MessageEmbed.EMBED_MAX_LENGTH_BOT)
             throw new IllegalStateException("Cannot build an embed with more than " + MessageEmbed.EMBED_MAX_LENGTH_BOT + " characters!");
         final String description = this.description.length() < 1 ? null : this.description.toString();

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -508,7 +508,7 @@ public interface Activity
         @Override
         public String toString()
         {
-            return String.format("RichPresenceTimestamp(%d-%d)", start, end);
+            return Helpers.format("RichPresenceTimestamp(%d-%d)", start, end);
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/RichPresence.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/RichPresence.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.internal.utils.Helpers;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.EnumSet;
@@ -251,7 +253,7 @@ public interface RichPresence extends Activity
         @Override
         public String toString()
         {
-            return String.format("RichPresenceParty(%s | [%d, %d])", id, size, max);
+            return Helpers.format("RichPresenceParty(%s | [%d, %d])", id, size, max);
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/api/exceptions/RateLimitedException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/RateLimitedException.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.exceptions;
 
 import net.dv8tion.jda.internal.requests.Route;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 /**
  * Indicates that we received a {@code 429: Too Many Requests} response
@@ -33,7 +34,7 @@ public class RateLimitedException extends Exception
 
     public RateLimitedException(String route, long retryAfter)
     {
-        super(String.format("The request was ratelimited! Retry-After: %d  Route: %s", retryAfter, route));
+        super(Helpers.format("The request was ratelimited! Retry-After: %d  Route: %s", retryAfter, route));
         this.rateLimitedRoute = route;
         this.retryAfter = retryAfter;
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Requester;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -140,7 +141,7 @@ public class WidgetUtil
         Checks.notNull(theme, "WidgetTheme");
         Checks.notNegative(width, "Width");
         Checks.notNegative(height, "Height");
-        return String.format(WIDGET_HTML, guildId, theme.name().toLowerCase(), width, height);
+        return Helpers.format(WIDGET_HTML, guildId, theme.name().toLowerCase(), width, height);
     }
     
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.utils.data.etf.ExTermDecoder;
 import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -722,7 +723,7 @@ public class DataArray implements Iterable<Object>
         else if (numberMapper != null && value instanceof Number)
             return numberMapper.apply((Number) value);
 
-        throw new ParsingException(String.format("Cannot parse value for index %d into type %s: %s instance of %s",
+        throw new ParsingException(Helpers.format("Cannot parse value for index %d into type %s: %s instance of %s",
                                                       index, type.getSimpleName(), value, value.getClass().getSimpleName()));
     }
 

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.utils.data.etf.ExTermDecoder;
 import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 import org.jetbrains.annotations.Contract;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -769,7 +770,7 @@ public class DataObject implements SerializableData
         else if (value instanceof String && stringParse != null)
             return stringParse.apply((String) value);
 
-        throw new ParsingException(String.format("Cannot parse value for %s into type %s: %s instance of %s",
+        throw new ParsingException(Helpers.format("Cannot parse value for %s into type %s: %s instance of %s",
                                                       key, type.getSimpleName(), value, value.getClass().getSimpleName()));
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioWebSocket.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import org.slf4j.Logger;
@@ -89,7 +90,7 @@ class AudioWebSocket extends WebSocketAdapter
         keepAlivePool = getJDA().getAudioLifeCyclePool();
 
         //Append the Secure Websocket scheme so that our websocket library knows how to connect
-        wssEndpoint = String.format("wss://%s/?v=%d", endpoint, JDAInfo.AUDIO_GATEWAY_VERSION);
+        wssEndpoint = Helpers.format("wss://%s/?v=%d", endpoint, JDAInfo.AUDIO_GATEWAY_VERSION);
 
         if (sessionId == null || sessionId.isEmpty())
             throw new IllegalArgumentException("Cannot create a voice connection using a null/empty sessionId!");

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.DeferredRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.EnumSet;
@@ -63,7 +64,7 @@ public class UserImpl extends UserById implements User
     @Override
     public String getDiscriminator()
     {
-        return String.format("%04d", discriminator);
+        return Helpers.format("%04d", discriminator);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.ratelimit.BotRateLimiter;
+import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
 import okhttp3.Call;
@@ -48,7 +49,7 @@ import java.util.concurrent.RejectedExecutionException;
 public class Requester
 {
     public static final Logger LOG = JDALogger.getLog(Requester.class);
-    public static final String DISCORD_API_PREFIX = String.format(Locale.ROOT, "https://discord.com/api/v%d/", JDAInfo.DISCORD_REST_VERSION);
+    public static final String DISCORD_API_PREFIX = Helpers.format("https://discord.com/api/v%d/", JDAInfo.DISCORD_REST_VERSION);
     public static final String USER_AGENT = "DiscordBot (" + JDAInfo.GITHUB + ", " + JDAInfo.VERSION + ")";
     public static final RequestBody EMPTY_BODY = RequestBody.create(null, new byte[0]);
     public static final MediaType MEDIA_TYPE_JSON  = MediaType.parse("application/json; charset=utf-8");

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -39,6 +39,7 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -47,7 +48,7 @@ import java.util.concurrent.RejectedExecutionException;
 public class Requester
 {
     public static final Logger LOG = JDALogger.getLog(Requester.class);
-    public static final String DISCORD_API_PREFIX = String.format("https://discord.com/api/v%d/", JDAInfo.DISCORD_REST_VERSION);
+    public static final String DISCORD_API_PREFIX = String.format(Locale.ROOT, "https://discord.com/api/v%d/", JDAInfo.DISCORD_REST_VERSION);
     public static final String USER_AGENT = "DiscordBot (" + JDAInfo.GITHUB + ", " + JDAInfo.VERSION + ")";
     public static final RequestBody EMPTY_BODY = RequestBody.create(null, new byte[0]);
     public static final MediaType MEDIA_TYPE_JSON  = MediaType.parse("application/json; charset=utf-8");

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -50,7 +50,7 @@ import java.util.function.Consumer;
 
 public class MessageActionImpl extends RestActionImpl<Message> implements MessageAction
 {
-    private static final String CONTENT_TOO_BIG = String.format("A message may not exceed %d characters. Please limit your input!", Message.MAX_CONTENT_LENGTH);
+    private static final String CONTENT_TOO_BIG = Helpers.format("A message may not exceed %d characters. Please limit your input!", Message.MAX_CONTENT_LENGTH);
     protected static EnumSet<Message.MentionType> defaultMentions = EnumSet.allOf(Message.MentionType.class);
     protected static boolean defaultMentionRepliedUser = true;
     protected static boolean defaultFailOnInvalidReply = false;

--- a/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
@@ -28,7 +28,8 @@ public final class Helpers
 
     // locale-safe String#format
 
-    public static String format(String format, Object... args) {
+    public static String format(String format, Object... args)
+    {
         return String.format(Locale.ROOT, format, args);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
@@ -16,10 +16,7 @@
 
 package net.dv8tion.jda.internal.utils;
 
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * This class has major inspiration from <a href="https://commons.apache.org/proper/commons-lang/" target="_blank">Lang 3</a>
@@ -28,6 +25,12 @@ import java.util.Objects;
  */
 public final class Helpers
 {
+
+    // locale-safe String#format
+
+    public static String format(String format, Object... args) {
+        return String.format(Locale.ROOT, format, args);
+    }
 
     // ## StringUtils ##
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Replaces internal String#format calls in JDA to use a helper method that has the locale set to Locale.ROOT. This fixes issues with JDA not being locale-safe, such as replacing `8` in the API version to the Arabic numeral 8, when the default locale is Arabic.