### PR TITLE
Add Discord Certified Moderator flag

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -349,26 +349,26 @@ public interface User extends IMentionable, IFakeable
      */
     enum UserFlag
     {
-        STAFF(             0, "Discord Employee"),
-        PARTNER(           1, "Partnered Server Owner"),
-        HYPESQUAD(         2, "HypeSquad Events"),
-        BUG_HUNTER_LEVEL_1(3, "Bug Hunter Level 1"),
+        STAFF(               0, "Discord Employee"),
+        PARTNER(             1, "Partnered Server Owner"),
+        HYPESQUAD(           2, "HypeSquad Events"),
+        BUG_HUNTER_LEVEL_1(  3, "Bug Hunter Level 1"),
 
-        // HypeSquad
+        // Hypesquad
         HYPESQUAD_BRAVERY(   6, "HypeSquad Bravery"),
         HYPESQUAD_BRILLIANCE(7, "HypeSquad Brilliance"),
         HYPESQUAD_BALANCE(   8, "HypeSquad Balance"),
 
-        EARLY_SUPPORTER(    9, "Early Supporter"),
-        TEAM_USER(         10, "Team User"),
+        EARLY_SUPPORTER(     9, "Early Supporter"),
+        TEAM_USER(          10, "Team User"),
         @Deprecated
         @ForRemoval
         @ReplaceWith("User.isSystem()")
         @DeprecatedSince("4.3.0")
-        SYSTEM(            12, "System User"),
-        BUG_HUNTER_LEVEL_2(14, "Bug Hunter Level 2"),
-        VERIFIED_BOT(      16, "Verified Bot"),
-        VERIFIED_DEVELOPER(17, "Early Verified Bot Developer"),
+        SYSTEM(             12, "System User"),
+        BUG_HUNTER_LEVEL_2( 14, "Bug Hunter Level 2"),
+        VERIFIED_BOT(       16, "Verified Bot"),
+        VERIFIED_DEVELOPER( 17, "Early Verified Bot Developer"),
         CERTIFIED_MODERATOR(18, "Discord Certified Moderator"),
         
         UNKNOWN(-1, "Unknown");

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -354,7 +354,7 @@ public interface User extends IMentionable, IFakeable
         HYPESQUAD(           2, "HypeSquad Events"),
         BUG_HUNTER_LEVEL_1(  3, "Bug Hunter Level 1"),
 
-        // Hypesquad
+        // HypeSquad
         HYPESQUAD_BRAVERY(   6, "HypeSquad Bravery"),
         HYPESQUAD_BRILLIANCE(7, "HypeSquad Brilliance"),
         HYPESQUAD_BALANCE(   8, "HypeSquad Balance"),

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -369,6 +369,7 @@ public interface User extends IMentionable, IFakeable
         BUG_HUNTER_LEVEL_2(14, "Bug Hunter Level 2"),
         VERIFIED_BOT(      16, "Verified Bot"),
         VERIFIED_DEVELOPER(17, "Early Verified Bot Developer"),
+        CERTIFIED_MODERATOR(18, "Discord Certified Moderator"),
         
         UNKNOWN(-1, "Unknown");
 


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This pull request implements the Discord Certified Moderator flag:
<img width="322" alt="Screen Shot 2021-05-18 at 9 05 05 AM" src="https://user-images.githubusercontent.com/16168171/118675829-c2c85200-b7af-11eb-83a5-bb813023368d.png">

Nobody to my knowledge has this flag yet so it may be better to hold off until it's "officially" released or at least documented on the api docs ([#2946](https://github.com/discord/discord-api-docs/pull/2946)).