### PR TITLE
Adds nsfw_level

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2357,12 +2357,12 @@ public interface Guild extends ISnowflake
     ExplicitContentLevel getExplicitContentLevel();
 
     /**
-     * Returns the level of multifactor authentication required to execute administrator restricted functions in this guild.
+     * Returns the NSFW Level that this guild is classified with.
      * <br>For a short description of the different values, see {@link net.dv8tion.jda.api.entities.Guild.NSFWLevel NSFW Level}.
      * <p>
      * This value cannot be modified directly.
      *
-     * @return The NSFWLevel required by this Guild.
+     * @return The NSFWLevel of this guild.
      */
     @Nonnull
     NSFWLevel getNSFWLevel();
@@ -5422,8 +5422,13 @@ public interface Guild extends ISnowflake
         }
     }
     /**
-     * Represents the Guild NSFW level.
-      */
+     * Represents the NSFW level for this guild.
+     * <p>
+     * <br><b>DEFAULT</b>   {@literal ->}  Is yet to be classified by discord.
+     * <br><b>EXPLICIT</b>  {@literal ->} Is classified as a NSFW server
+     * <br><b>SAFE</b>  {@literal ->}  Doesn't classify as a NSFW server
+     * <br><b>AGE_RESTRICTED</b>  {@literal ->} Is classified as NSFW and has an age restriction in place
+     */
     enum NSFWLevel
     {
         DEFAULT(0),

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -2357,6 +2357,17 @@ public interface Guild extends ISnowflake
     ExplicitContentLevel getExplicitContentLevel();
 
     /**
+     * Returns the level of multifactor authentication required to execute administrator restricted functions in this guild.
+     * <br>For a short description of the different values, see {@link net.dv8tion.jda.api.entities.Guild.NSFWLevel NSFW Level}.
+     * <p>
+     * This value cannot be modified directly.
+     *
+     * @return The NSFWLevel required by this Guild.
+     */
+    @Nonnull
+    NSFWLevel getNSFWLevel();
+
+    /**
      * Checks if the current Verification-level of this guild allows JDA to send messages to it.
      *
      * @return True if Verification-level allows sending of messages, false if not.
@@ -5408,6 +5419,54 @@ public interface Guild extends ISnowflake
         public String toString()
         {
             return "GuildBan:" + user + (reason == null ? "" : '(' + reason + ')');
+        }
+    }
+    /**
+     * Represents the Guild NSFW level.
+      */
+    enum NSFWLevel
+    {
+        DEFAULT(0),
+        EXPLICIT(1),
+        SAFE(2),
+        AGE_RESTRICTED(3),
+        UNKNOWN(-1);
+
+        private final int key;
+
+        NSFWLevel(int key)
+        {
+            this.key = key;
+        }
+
+        /**
+         * The Discord id key used to represent this NSFW level.
+         *
+         * @return Integer id for this NSFW level.
+         */
+        public int getKey()
+        {
+            return key;
+        }
+
+        /**
+         * Used to retrieve a {@link net.dv8tion.jda.api.entities.Guild.NSFWLevel NSFWLevel} based
+         * on the Discord id key.
+         *
+         * @param  key
+         *         The Discord id key representing the requested NSFWLevel.
+         *
+         * @return The NSFWLevel related to the provided key, or {@link #UNKNOWN NSFWLevel.UNKNOWN} if the key is not recognized.
+         */
+        @Nonnull
+        public static NSFWLevel fromKey(int key)
+        {
+            for (NSFWLevel level : values())
+            {
+                if (level.getKey() == key)
+                    return level;
+            }
+            return UNKNOWN;
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -5421,20 +5421,31 @@ public interface Guild extends ISnowflake
             return "GuildBan:" + user + (reason == null ? "" : '(' + reason + ')');
         }
     }
+
     /**
      * Represents the NSFW level for this guild.
-     * <p>
-     * <br><b>DEFAULT</b>   {@literal ->}  Is yet to be classified by discord.
-     * <br><b>EXPLICIT</b>  {@literal ->} Is classified as a NSFW server
-     * <br><b>SAFE</b>  {@literal ->}  Doesn't classify as a NSFW server
-     * <br><b>AGE_RESTRICTED</b>  {@literal ->} Is classified as NSFW and has an age restriction in place
      */
     enum NSFWLevel
     {
+        /**
+         * Is yet to be classified by discord.
+         */
         DEFAULT(0),
+        /**
+         * Is classified as a NSFW server
+         */
         EXPLICIT(1),
+        /**
+         * Doesn't classify as a NSFW server
+         */
         SAFE(2),
+        /**
+         * Is classified as NSFW and has an age restriction in place
+         */
         AGE_RESTRICTED(3),
+        /**
+         * Placeholder for unsupported levels.
+         */
         UNKNOWN(-1);
 
         private final int key;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateNSFWLevelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateNSFWLevelEvent.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.events.guild.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Indicates that the {@link Guild.NSFWLevel NSFWLevel} of a {@link Guild Guild} changed.
+ *
+ * <p>Can be used to detect when a NSFWLevel changes and retrieve the old one
+ *
+ * <p>Identifier: {@code nsfw_level}
+ */
+public class GuildUpdateNSFWLevelEvent extends GenericGuildUpdateEvent<Guild.NSFWLevel>
+{
+    public static final String IDENTIFIER = "nsfw_level";
+
+    public GuildUpdateNSFWLevelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.NSFWLevel oldNSFWLevel)
+    {
+        super(api, responseNumber, guild, oldNSFWLevel, guild.getNSFWLevel(), IDENTIFIER);
+    }
+
+    /**
+     * The old {@link Guild.NSFWLevel NSFWLevel}
+     *
+     * @return The old NSFWLevel
+     */
+    @Nonnull
+    public Guild.NSFWLevel getOldNSFWLevel()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The new {@link Guild.NSFWLevel NSFWLevel}
+     *
+     * @return The new NSFWLevel
+     */
+    @Nonnull
+    public Guild.NSFWLevel getNewNSFWLevel()
+    {
+        return getNewValue();
+    }
+
+    @Nonnull
+    @Override
+    public Guild.NSFWLevel getOldValue()
+    {
+        return super.getOldValue();
+    }
+
+    @Nonnull
+    @Override
+    public Guild.NSFWLevel getNewValue()
+    {
+        return super.getNewValue();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -319,6 +319,8 @@ public abstract class ListenerAdapter implements EventListener
     public void onGuildUpdateBoostCount(@Nonnull GuildUpdateBoostCountEvent event) {}
     public void onGuildUpdateMaxMembers(@Nonnull GuildUpdateMaxMembersEvent event) {}
     public void onGuildUpdateMaxPresences(@Nonnull GuildUpdateMaxPresencesEvent event) {}
+    public void onGuildUpdateNSFWLevel(@Nonnull GuildUpdateNSFWLevelEvent event) {}
+
 
     //Guild Invite Events
     public void onGuildInviteCreate(@Nonnull GuildInviteCreateEvent event) {}

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -190,6 +190,7 @@ public class EntityBuilder
         final int maxMembers = guildJson.getInt("max_members", 0);
         final int maxPresences = guildJson.getInt("max_presences", 5000);
         final int mfaLevel = guildJson.getInt("mfa_level", 0);
+        final int nsfwLevel = guildJson.getInt("nsfw_level", 0);
         final int afkTimeout = guildJson.getInt("afk_timeout", 0);
         final int verificationLevel = guildJson.getInt("verification_level", 0);
         final int notificationLevel = guildJson.getInt("default_message_notifications", 0);
@@ -211,6 +212,7 @@ public class EntityBuilder
                 .setDefaultNotificationLevel(Guild.NotificationLevel.fromKey(notificationLevel))
                 .setExplicitContentLevel(Guild.ExplicitContentLevel.fromKey(explicitContentLevel))
                 .setRequiredMFALevel(Guild.MFALevel.fromKey(mfaLevel))
+                .setNSFWLevel(Guild.NSFWLevel.fromKey(nsfwLevel))
                 .setLocale(locale)
                 .setBoostCount(boostCount)
                 .setBoostTier(boostTier)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -105,6 +105,7 @@ public class GuildImpl implements Guild
     private NotificationLevel defaultNotificationLevel = NotificationLevel.UNKNOWN;
     private MFALevel mfaLevel = MFALevel.UNKNOWN;
     private ExplicitContentLevel explicitContentLevel = ExplicitContentLevel.UNKNOWN;
+    private NSFWLevel nsfwLevel = NSFWLevel.UNKNOWN;
     private Timeout afkTimeout;
     private BoostTier boostTier = BoostTier.NONE;
     private Locale preferredLocale = Locale.ENGLISH;
@@ -787,6 +788,14 @@ public class GuildImpl implements Guild
     {
         return mfaLevel;
     }
+
+    @Nonnull
+    @Override
+    public NSFWLevel getNSFWLevel()
+    {
+        return nsfwLevel;
+    }
+
 
     @Nonnull
     @Override
@@ -1641,6 +1650,11 @@ public class GuildImpl implements Guild
     public GuildImpl setExplicitContentLevel(ExplicitContentLevel level)
     {
         this.explicitContentLevel = level;
+        return this;
+    }
+    public GuildImpl setNSFWLevel(NSFWLevel nsfwLevel)
+    {
+        this.nsfwLevel = nsfwLevel;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1652,6 +1652,7 @@ public class GuildImpl implements Guild
         this.explicitContentLevel = level;
         return this;
     }
+
     public GuildImpl setNSFWLevel(NSFWLevel nsfwLevel)
     {
         this.nsfwLevel = nsfwLevel;

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
@@ -79,6 +79,7 @@ public class GuildUpdateHandler extends SocketHandler
         Guild.VerificationLevel verificationLevel = Guild.VerificationLevel.fromKey(content.getInt("verification_level"));
         Guild.NotificationLevel notificationLevel = Guild.NotificationLevel.fromKey(content.getInt("default_message_notifications"));
         Guild.MFALevel mfaLevel = Guild.MFALevel.fromKey(content.getInt("mfa_level"));
+        Guild.NSFWLevel nsfwLevel = Guild.NSFWLevel.fromKey(content.getInt("nsfw_level"));
         Guild.ExplicitContentLevel explicitContentLevel = Guild.ExplicitContentLevel.fromKey(content.getInt("explicit_content_filter"));
         Guild.Timeout afkTimeout = Guild.Timeout.fromKey(content.getInt("afk_timeout"));
         Locale locale = Locale.forLanguageTag(content.getString("preferred_locale"));
@@ -313,6 +314,15 @@ public class GuildUpdateHandler extends SocketHandler
                     new GuildUpdateCommunityUpdatesChannelEvent(
                             getJDA(), responseNumber,
                             guild, oldCommunityUpdatesChannel));
+        }
+        if (!Objects.equals(nsfwLevel, guild.getNSFWLevel()))
+        {
+            Guild.NSFWLevel oldNSFWLevel = guild.getNSFWLevel();
+            guild.setNSFWLevel(nsfwLevel);
+            getJDA().handleEvent(
+                    new GuildUpdateNSFWLevelEvent(
+                            getJDA(), responseNumber,
+                            guild, oldNSFWLevel));
         }
         return null;
     }

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
@@ -79,7 +79,7 @@ public class GuildUpdateHandler extends SocketHandler
         Guild.VerificationLevel verificationLevel = Guild.VerificationLevel.fromKey(content.getInt("verification_level"));
         Guild.NotificationLevel notificationLevel = Guild.NotificationLevel.fromKey(content.getInt("default_message_notifications"));
         Guild.MFALevel mfaLevel = Guild.MFALevel.fromKey(content.getInt("mfa_level"));
-        Guild.NSFWLevel nsfwLevel = Guild.NSFWLevel.fromKey(content.getInt("nsfw_level"));
+        Guild.NSFWLevel nsfwLevel = Guild.NSFWLevel.fromKey(content.getInt("nsfw_level", -1));
         Guild.ExplicitContentLevel explicitContentLevel = Guild.ExplicitContentLevel.fromKey(content.getInt("explicit_content_filter"));
         Guild.Timeout afkTimeout = Guild.Timeout.fromKey(content.getInt("afk_timeout"));
         Locale locale = Locale.forLanguageTag(content.getString("preferred_locale"));


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1625 

## Description

Adds the enum NSFWLevel to the Guild object and an event for when the level changes. 
Initially added the level also to the GuildManager and to AuditLogKey but upon further clarification the level is set automatically by discord.

Pending to document what each level means.