### PR TITLE
Move reason setter to RestAction interface

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/audit/ThreadLocalReason.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/ThreadLocalReason.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 import java.util.function.Consumer;
 
 /**
- * Thread-Local audit-log reason used automatically by {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} instances
+ * Thread-Local audit-log reason used automatically by {@link net.dv8tion.jda.api.requests.RestAction RestAction} instances
  * when no other reason was set.
  *
  * <p>Note that {@link net.dv8tion.jda.api.requests.RestAction#queue(Consumer) RestAction.queue()} will forward any
@@ -56,7 +56,7 @@ import java.util.function.Consumer;
  * </code></pre>
  *
  *
- * @see net.dv8tion.jda.api.requests.restaction.AuditableRestAction#reason(String) AuditableRestAction.reason(String)
+ * @see net.dv8tion.jda.api.requests.RestAction#reason(String) RestAction.reason(String)
  * @see ThreadLocal
  */
 public final class ThreadLocalReason
@@ -69,7 +69,7 @@ public final class ThreadLocalReason
     }
 
     /**
-     * Sets the current reason that should be used for {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}.
+     * Sets the current reason that should be used for {@link net.dv8tion.jda.api.requests.RestAction RestActions}.
      *
      * @param reason
      *        The reason to use, or {@code null} to reset
@@ -98,7 +98,7 @@ public final class ThreadLocalReason
     }
 
     /**
-     * The current reason that should be used for {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}.
+     * The current reason that should be used for {@link net.dv8tion.jda.api.requests.RestAction RestActions}.
      *
      * @return The current thread-local reason, or null
      */

--- a/src/main/java/net/dv8tion/jda/api/managers/Manager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/Manager.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.internal.managers.ManagerBase;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -62,7 +63,7 @@ public interface Manager<M extends Manager<M>> extends AuditableRestAction<Void>
 
     @Nonnull
     @Override
-    M setCheck(BooleanSupplier checks);
+    M setCheck(@Nullable BooleanSupplier checks);
 
     @Nonnull
     @Override
@@ -71,6 +72,10 @@ public interface Manager<M extends Manager<M>> extends AuditableRestAction<Void>
     @Nonnull
     @Override
     M deadline(long timestamp);
+
+    @Nonnull
+    @Override
+    M reason(@Nullable String reason);
 
     @Nonnull
     @CheckReturnValue

--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -17,8 +17,10 @@
 package net.dv8tion.jda.api.requests;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.audit.ThreadLocalReason;
 import net.dv8tion.jda.api.exceptions.ContextException;
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
+import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
 import net.dv8tion.jda.api.utils.Result;
 import net.dv8tion.jda.api.utils.concurrent.DelayedCompletableFuture;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
@@ -503,6 +505,35 @@ public interface RestAction<T>
     default RestAction<T> deadline(long timestamp)
     {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Applies the specified reason as audit-log reason field.
+     * <br>When the provided reason is empty or {@code null} it will be treated as not set.
+     *
+     * <p>Reasons for any RestAction may be retrieved
+     * via {@link net.dv8tion.jda.api.audit.AuditLogEntry#getReason() AuditLogEntry.getReason()}
+     * in iterable {@link AuditLogPaginationAction AuditLogPaginationActions}
+     * from {@link net.dv8tion.jda.api.entities.Guild#retrieveAuditLogs() Guild.retrieveAuditLogs()}!
+     *
+     * <p>This will specify the reason via the {@code X-Audit-Log-Reason} Request Header.
+     * <br>Using methods with a reason parameter will always work and <u>override</u> this header.
+     * (ct. {@link net.dv8tion.jda.api.entities.Guild#ban(net.dv8tion.jda.api.entities.User, int, String) Guild.ban(User, int, String)})
+     *
+     * <p>If this action does not create an {@link net.dv8tion.jda.api.audit.AuditLogEntry AuditLogEntry}, this reason will be ignored.
+     *
+     * @param  reason
+     *         The reason for this action which should be logged in the Guild's AuditLogs
+     *
+     * @return The current RestAction instance for chaining convenience
+     *
+     * @see    ThreadLocalReason
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<T> reason(@Nullable String reason)
+    {
+        return this;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/AuditableRestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/AuditableRestAction.java
@@ -16,9 +16,7 @@
 
 package net.dv8tion.jda.api.requests.restaction;
 
-import net.dv8tion.jda.api.audit.ThreadLocalReason;
 import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,27 +36,8 @@ import java.util.function.BooleanSupplier;
  */
 public interface AuditableRestAction<T> extends RestAction<T>
 {
-    /**
-     * Applies the specified reason as audit-log reason field.
-     * <br>When the provided reason is empty or {@code null} it will be treated as not set.
-     *
-     * <p>Reasons for any AuditableRestAction may be retrieved
-     * via {@link net.dv8tion.jda.api.audit.AuditLogEntry#getReason() AuditLogEntry.getReason()}
-     * in iterable {@link AuditLogPaginationAction AuditLogPaginationActions}
-     * from {@link net.dv8tion.jda.api.entities.Guild#retrieveAuditLogs() Guild.retrieveAuditLogs()}!
-     *
-     * <p>This will specify the reason via the {@code X-Audit-Log-Reason} Request Header.
-     * <br>Using methods with a reason parameter will always work and <u>override</u> this header.
-     * (ct. {@link net.dv8tion.jda.api.entities.Guild#ban(net.dv8tion.jda.api.entities.User, int, String) Guild.ban(User, int, String)})
-     *
-     * @param  reason
-     *         The reason for this action which should be logged in the Guild's AuditLogs
-     *
-     * @return The current AuditableRestAction instance for chaining convenience
-     *
-     * @see    ThreadLocalReason
-     */
     @Nonnull
+    @Override
     AuditableRestAction<T> reason(@Nullable String reason);
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
@@ -59,6 +59,10 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
     @Override
     ChannelAction<T> deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    ChannelAction<T> reason(@Nullable String reason);
+
     /**
      * The guild to create this {@link GuildChannel} in
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/GuildAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/GuildAction.java
@@ -61,6 +61,10 @@ public interface GuildAction extends RestAction<Void>
     @Override
     GuildAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    GuildAction reason(@Nullable String reason);
+
     /**
      * Sets the voice {@link net.dv8tion.jda.api.Region Region} of
      * the resulting {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/InviteAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/InviteAction.java
@@ -45,6 +45,10 @@ public interface InviteAction extends AuditableRestAction<Invite>
     @Override
     InviteAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    InviteAction reason(@Nullable String reason);
+
     /**
      * Sets the max age in seconds for the invite. Set this to {@code 0} if the invite should never expire. Default is {@code 86400} (24 hours).
      * {@code null} will reset this to the default value.

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MemberAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MemberAction.java
@@ -54,6 +54,10 @@ public interface MemberAction extends RestAction<Void>
     @Override
     MemberAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    MemberAction reason(@Nullable String reason);
+
     /**
      * The access token
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -191,6 +191,10 @@ public interface MessageAction extends RestAction<Message>, Appendable
     @Override
     MessageAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    MessageAction reason(@Nullable String reason);
+
     /**
      * The target {@link MessageChannel} for this message
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
 /**
- * Extension of {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} specifically
+ * Extension of {@link net.dv8tion.jda.api.requests.RestAction RestAction} specifically
  * designed to create a {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}
  * for a {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}.
  * This extension allows setting properties before executing the action.
@@ -54,6 +54,10 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
     @Nonnull
     @Override
     PermissionOverrideAction deadline(long timestamp);
+
+    @Nonnull
+    @Override
+    PermissionOverrideAction reason(@Nullable String reason);
 
     /**
      * Shortcut for {@code resetAllow().resetDeny()}.

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/RoleAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/RoleAction.java
@@ -55,6 +55,10 @@ public interface RoleAction extends AuditableRestAction<Role>
     @Override
     RoleAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    RoleAction reason(@Nullable String reason);
+
     /**
      * The guild to create the role in
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/WebhookAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/WebhookAction.java
@@ -47,6 +47,10 @@ public interface WebhookAction extends AuditableRestAction<Webhook>
     @Override
     WebhookAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    WebhookAction reason(@Nullable String reason);
+
     /**
      * The {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} to create this webhook in
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
@@ -57,6 +57,10 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
     @Override
     M deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    M reason(@Nullable String reason);
+
     /**
      * Whether this instance uses ascending order, from the lowest
      * position to the highest.

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -146,6 +146,10 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
     @Override
     M deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    M reason(@Nullable String reason);
+
     /**
      * The current amount of cached entities for this PaginationAction
      *

--- a/src/main/java/net/dv8tion/jda/internal/managers/ManagerBase.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ManagerBase.java
@@ -22,12 +22,14 @@ import net.dv8tion.jda.api.managers.Manager;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
+@SuppressWarnings("unchecked")
 public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestActionImpl<Void> implements Manager<M>
 {
     private static boolean enablePermissionChecks = true;
@@ -50,7 +52,6 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M setCheck(BooleanSupplier checks)
     {
         return (M) super.setCheck(checks);
@@ -58,7 +59,6 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M timeout(long timeout, @Nonnull TimeUnit unit)
     {
         return (M) super.timeout(timeout, unit);
@@ -66,10 +66,16 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M deadline(long timestamp)
     {
         return (M) super.deadline(timestamp);
+    }
+
+    @Nonnull
+    @Override
+    public M reason(@Nullable String reason)
+    {
+        return (M) super.reason(reason);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/requests/DeferredRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/DeferredRestAction.java
@@ -178,8 +178,8 @@ public class DeferredRestAction<T, R extends RestAction<T>> implements Auditable
         action.setCheck(transitiveChecks);
         if (deadline >= 0)
             action.deadline(deadline);
-        if (action instanceof AuditableRestAction && reason != null)
-            ((AuditableRestAction<?>) action).reason(reason);
+        if (reason != null)
+            action.reason(reason);
         return action;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/AuditableRestActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/AuditableRestActionImpl.java
@@ -17,16 +17,13 @@
 package net.dv8tion.jda.internal.requests.restaction;
 
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.audit.ThreadLocalReason;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
-import net.dv8tion.jda.internal.utils.EncodingUtil;
 import okhttp3.RequestBody;
-import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -92,42 +89,9 @@ public class AuditableRestActionImpl<T> extends RestActionImpl<T> implements Aud
 
     @Nonnull
     @CheckReturnValue
-    public AuditableRestActionImpl<T> reason(@Nullable String reason)
+    public AuditableRestAction<T> reason(@Nullable String reason)
     {
         this.reason = reason;
         return this;
-    }
-
-    @Override
-    protected CaseInsensitiveMap<String, String> finalizeHeaders()
-    {
-        CaseInsensitiveMap<String, String> headers = super.finalizeHeaders();
-
-        if (reason == null || reason.isEmpty())
-        {
-            String localReason = ThreadLocalReason.getCurrent();
-            if (localReason == null || localReason.isEmpty())
-                return headers;
-            else
-                return generateHeaders(headers, localReason);
-        }
-
-        return generateHeaders(headers, reason);
-    }
-
-    @Nonnull
-    private CaseInsensitiveMap<String, String> generateHeaders(CaseInsensitiveMap<String, String> headers, String reason)
-    {
-        if (headers == null)
-            headers = new CaseInsensitiveMap<>();
-
-        headers.put("X-Audit-Log-Reason", uriEncode(reason));
-        return headers;
-    }
-
-    private String uriEncode(String input)
-    {
-        String formEncode = EncodingUtil.encodeUTF8(input);
-        return formEncode.replace('+', ' ');
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
@@ -90,6 +90,13 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
 
     @Nonnull
     @Override
+    public ChannelActionImpl<T> reason(String reason)
+    {
+        return (ChannelActionImpl<T>) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     public Guild getGuild()
     {
         return guild;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/GuildActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/GuildActionImpl.java
@@ -82,6 +82,13 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
 
     @Nonnull
     @Override
+    public GuildAction reason(String reason)
+    {
+        return (GuildAction) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     @CheckReturnValue
     public GuildActionImpl setRegion(Region region)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/InviteActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/InviteActionImpl.java
@@ -66,6 +66,13 @@ public class InviteActionImpl extends AuditableRestActionImpl<Invite> implements
 
     @Nonnull
     @Override
+    public InviteActionImpl reason(String reason)
+    {
+        return (InviteActionImpl) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     @CheckReturnValue
     public InviteActionImpl setMaxAge(final Integer maxAge)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MemberActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MemberActionImpl.java
@@ -80,6 +80,13 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
 
     @Nonnull
     @Override
+    public MemberAction reason(String reason)
+    {
+        return (MemberAction) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     public String getAccessToken()
     {
         return accessToken;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -142,6 +142,13 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
 
     @Nonnull
     @Override
+    public MessageAction reason(String reason)
+    {
+        return (MessageAction) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     public MessageChannel getChannel()
     {
         return channel;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
@@ -116,6 +116,13 @@ public class PermissionOverrideActionImpl
 
     @Nonnull
     @Override
+    public PermissionOverrideActionImpl reason(String reason)
+    {
+        return (PermissionOverrideActionImpl) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     public PermissionOverrideAction resetAllow()
     {
         allow = getOriginalAllow();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
@@ -78,6 +78,13 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
 
     @Nonnull
     @Override
+    public RoleActionImpl reason(String reason)
+    {
+        return (RoleActionImpl) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     public Guild getGuild()
     {
         return guild;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookActionImpl.java
@@ -73,6 +73,13 @@ public class WebhookActionImpl extends AuditableRestActionImpl<Webhook> implemen
 
     @Nonnull
     @Override
+    public WebhookActionImpl reason(String reason)
+    {
+        return (WebhookActionImpl) super.reason(reason);
+    }
+
+    @Nonnull
+    @Override
     public TextChannel getChannel()
     {
         return channel;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/OrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/OrderActionImpl.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
+@SuppressWarnings("unchecked")
 public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
     extends RestActionImpl<Void>
     implements OrderAction<T, M>
@@ -74,7 +75,6 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M setCheck(BooleanSupplier checks)
     {
         return (M) super.setCheck(checks);
@@ -82,7 +82,6 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M timeout(long timeout, @Nonnull TimeUnit unit)
     {
         return (M) super.timeout(timeout, unit);
@@ -90,10 +89,16 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M deadline(long timestamp)
     {
         return (M) super.deadline(timestamp);
+    }
+
+    @Nonnull
+    @Override
+    public M reason(String reason)
+    {
+        return (M) super.reason(reason);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
@@ -33,6 +33,7 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
+@SuppressWarnings("unchecked")
 public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     extends RestActionImpl<List<T>>
     implements PaginationAction<T, M>
@@ -111,7 +112,6 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M setCheck(BooleanSupplier checks)
     {
         return (M) super.setCheck(checks);
@@ -119,7 +119,6 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M timeout(long timeout, @Nonnull TimeUnit unit)
     {
         return (M) super.timeout(timeout, unit);
@@ -127,10 +126,16 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
 
     @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
     public M deadline(long timestamp)
     {
         return (M) super.deadline(timestamp);
+    }
+
+    @Nonnull
+    @Override
+    public M reason(String reason)
+    {
+        return (M) super.reason(reason);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This moves the reason setter from `AuditableRestAction` into the `RestAction` interface. This does not mean all `RestActions` support the reason header, but they will just not do anything when a reason is supplied.
