### PR TITLE
Remove nonsense runtime dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,11 +61,11 @@ dependencies {
     /* ABI dependencies */
 
     //Code safety
-    api("com.google.code.findbugs:jsr305:3.0.2")
-    api("org.jetbrains:annotations:16.0.1")
+    compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+    compileOnly("org.jetbrains:annotations:21.0.1")
 
     //Logger
-    api("org.slf4j:slf4j-api:1.7.25")
+    implementation("org.slf4j:slf4j-api:1.7.25")
 
     //Web Connection Support
     api("com.neovisionaries:nv-websocket-client:2.14")

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -23,9 +23,9 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.*;
 import java.time.temporal.TemporalAccessor;
@@ -114,7 +114,7 @@ public class EmbedBuilder
      *
      * @return the built, sendable {@link net.dv8tion.jda.api.entities.MessageEmbed}
      */
-    @Nonnull
+    @NotNull
     public MessageEmbed build()
     {
         if (isEmpty())
@@ -135,7 +135,7 @@ public class EmbedBuilder
      *
      * @return The current EmbedBuilder with default values
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder clear()
     {
         description.setLength(0);
@@ -226,7 +226,7 @@ public class EmbedBuilder
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    public boolean isValidLength(@Nonnull AccountType type)
+    public boolean isValidLength(@NotNull AccountType type)
     {
         Checks.notNull(type, "AccountType");
         final int length = length();
@@ -257,7 +257,7 @@ public class EmbedBuilder
      *
      * @return the builder after the title has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setTitle(@Nullable String title)
     {
         return setTitle(title, null);
@@ -284,7 +284,7 @@ public class EmbedBuilder
      *
      * @return the builder after the title has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setTitle(@Nullable String title, @Nullable String url)
     {
         if (title == null)
@@ -313,7 +313,7 @@ public class EmbedBuilder
      *
      * @return StringBuilder with current description context
      */
-    @Nonnull
+    @NotNull
     public StringBuilder getDescriptionBuilder()
     {
         return description;
@@ -332,7 +332,7 @@ public class EmbedBuilder
      *
      * @return the builder after the description has been set
      */
-    @Nonnull
+    @NotNull
     public final EmbedBuilder setDescription(@Nullable CharSequence description)
     {
         this.description.setLength(0);
@@ -357,8 +357,8 @@ public class EmbedBuilder
      *
      * @return the builder after the description has been set
      */
-    @Nonnull
-    public EmbedBuilder appendDescription(@Nonnull CharSequence description)
+    @NotNull
+    public EmbedBuilder appendDescription(@NotNull CharSequence description)
     {
         Checks.notNull(description, "description");
         Checks.check(this.description.length() + description.length() <= MessageEmbed.TEXT_MAX_LENGTH,
@@ -380,7 +380,7 @@ public class EmbedBuilder
      *
      * @return the builder after the timestamp has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setTimestamp(@Nullable TemporalAccessor temporal)
     {
         if (temporal == null)
@@ -437,7 +437,7 @@ public class EmbedBuilder
      *
      * @see    #setColor(int)
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setColor(@Nullable Color color)
     {
         this.color = color == null ? Role.DEFAULT_COLOR_RAW : color.getRGB();
@@ -456,7 +456,7 @@ public class EmbedBuilder
      *
      * @see    #setColor(java.awt.Color)
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setColor(int color)
     {
         this.color = color;
@@ -494,7 +494,7 @@ public class EmbedBuilder
      *
      * @return the builder after the thumbnail has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setThumbnail(@Nullable String url)
     {
         if (url == null)
@@ -542,7 +542,7 @@ public class EmbedBuilder
      *
      * @see    net.dv8tion.jda.api.entities.MessageChannel#sendFile(java.io.File, String, net.dv8tion.jda.api.utils.AttachmentOption...) MessageChannel.sendFile(...)
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setImage(@Nullable String url)
     {
         if (url == null)
@@ -572,7 +572,7 @@ public class EmbedBuilder
      *
      * @return the builder after the author has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setAuthor(@Nullable String name)
     {
         return setAuthor(name, null, null);
@@ -599,7 +599,7 @@ public class EmbedBuilder
      *
      * @return the builder after the author has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setAuthor(@Nullable String name, @Nullable String url)
     {
         return setAuthor(name, url, null);
@@ -644,7 +644,7 @@ public class EmbedBuilder
      *
      * @return the builder after the author has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setAuthor(@Nullable String name, @Nullable String url, @Nullable String iconUrl)
     {
         //We only check if the name is null because its presence is what determines if the
@@ -676,7 +676,7 @@ public class EmbedBuilder
      *
      * @return the builder after the footer has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setFooter(@Nullable String text)
     {
         return setFooter(text, null);
@@ -716,7 +716,7 @@ public class EmbedBuilder
      *
      * @return the builder after the footer has been set
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder setFooter(@Nullable String text, @Nullable String iconUrl)
     {
         //We only check if the text is null because its presence is what determines if the
@@ -743,7 +743,7 @@ public class EmbedBuilder
      *
      * @return the builder after the field has been added
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder addField(@Nullable MessageEmbed.Field field)
     {
         return field == null ? this : addField(field.getName(), field.getValue(), field.isInline());
@@ -774,7 +774,7 @@ public class EmbedBuilder
      *
      * @return the builder after the field has been added
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder addField(@Nullable String name, @Nullable String value, boolean inline)
     {
         if (name == null && value == null)
@@ -794,7 +794,7 @@ public class EmbedBuilder
      *
      * @return the builder after the field has been added
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder addBlankField(boolean inline)
     {
         this.fields.add(new MessageEmbed.Field(ZERO_WIDTH_SPACE, ZERO_WIDTH_SPACE, inline));
@@ -809,7 +809,7 @@ public class EmbedBuilder
      *
      * @return the builder after the field has been added
      */
-    @Nonnull
+    @NotNull
     public EmbedBuilder clearFields()
     {
         this.fields.clear();
@@ -824,7 +824,7 @@ public class EmbedBuilder
      *
      * @return Mutable List of {@link net.dv8tion.jda.api.entities.MessageEmbed.Field Fields}
      */
-    @Nonnull
+    @NotNull
     public List<MessageEmbed.Field> getFields()
     {
         return fields;

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -39,10 +39,10 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.io.IOException;
 import java.net.URI;
@@ -204,7 +204,7 @@ public interface JDA
      *
      * @return Current JDA status.
      */
-    @Nonnull
+    @NotNull
     Status getStatus();
 
     /**
@@ -212,7 +212,7 @@ public interface JDA
      * 
      * @return {@link EnumSet} of active gateway intents
      */
-    @Nonnull
+    @NotNull
     EnumSet<GatewayIntent> getGatewayIntents();
 
     /**
@@ -220,7 +220,7 @@ public interface JDA
      *
      * @return Copy of the EnumSet of cache flags for this session
      */
-    @Nonnull
+    @NotNull
     EnumSet<CacheFlag> getCacheFlags();
 
     /**
@@ -269,7 +269,7 @@ public interface JDA
      *
      * @see    #getGatewayPing()
      */
-    @Nonnull
+    @NotNull
     default RestAction<Long> getRestPing()
     {
         AtomicLong time = new AtomicLong();
@@ -311,8 +311,8 @@ public interface JDA
      *
      * @return The current JDA instance, for chaining convenience
      */
-    @Nonnull
-    default JDA awaitStatus(@Nonnull JDA.Status status) throws InterruptedException
+    @NotNull
+    default JDA awaitStatus(@NotNull JDA.Status status) throws InterruptedException
     {
         //This is done to retain backwards compatible ABI as it would otherwise change the signature of the method
         // which would require recompilation for all users (including extension libraries)
@@ -349,8 +349,8 @@ public interface JDA
      *
      * @return The current JDA instance, for chaining convenience
      */
-    @Nonnull
-    JDA awaitStatus(@Nonnull JDA.Status status, @Nonnull JDA.Status... failOn) throws InterruptedException;
+    @NotNull
+    JDA awaitStatus(@NotNull JDA.Status status, @NotNull JDA.Status... failOn) throws InterruptedException;
 
     /**
      * This method will block until JDA has reached the status {@link Status#CONNECTED}.
@@ -363,7 +363,7 @@ public interface JDA
      *
      * @return The current JDA instance, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     default JDA awaitReady() throws InterruptedException
     {
         return awaitStatus(Status.CONNECTED);
@@ -392,7 +392,7 @@ public interface JDA
      *
      * @since 4.0.0
      */
-    @Nonnull
+    @NotNull
     ScheduledExecutorService getRateLimitPool();
 
     /**
@@ -403,7 +403,7 @@ public interface JDA
      *
      * @since 4.0.0
      */
-    @Nonnull
+    @NotNull
     ScheduledExecutorService getGatewayPool();
 
     /**
@@ -416,7 +416,7 @@ public interface JDA
      *
      * @since 4.0.0
      */
-    @Nonnull
+    @NotNull
     ExecutorService getCallbackPool();
 
     /**
@@ -426,7 +426,7 @@ public interface JDA
      *
      * @since 4.0.0
      */
-    @Nonnull
+    @NotNull
     OkHttpClient getHttpClient();
 
     /**
@@ -443,7 +443,7 @@ public interface JDA
      *
      * @since 4.0.0
      */
-    @Nonnull
+    @NotNull
     DirectAudioController getDirectAudioController();
 
     /**
@@ -471,7 +471,7 @@ public interface JDA
      * @throws java.lang.IllegalArgumentException
      *         If either listeners or one of it's objects is {@code null}.
      */
-    void addEventListener(@Nonnull Object... listeners);
+    void addEventListener(@NotNull Object... listeners);
 
     /**
      * Removes all provided listeners from the event-listeners and no longer uses them to handle events.
@@ -482,14 +482,14 @@ public interface JDA
      * @throws java.lang.IllegalArgumentException
      *         If either listeners or one of it's objects is {@code null}.
      */
-    void removeEventListener(@Nonnull Object... listeners);
+    void removeEventListener(@NotNull Object... listeners);
 
     /**
      * Immutable List of Objects that have been registered as EventListeners.
      *
      * @return List of currently registered Objects acting as EventListeners.
      */
-    @Nonnull
+    @NotNull
     List<Object> getRegisteredListeners();
 
     /**
@@ -511,9 +511,9 @@ public interface JDA
      * @return {@link GuildAction GuildAction}
      *         <br>Allows for setting various details for the resulting Guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildAction createGuild(@Nonnull String name);
+    GuildAction createGuild(@NotNull String name);
 
     /**
      * {@link net.dv8tion.jda.api.utils.cache.CacheView CacheView} of
@@ -525,7 +525,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.CacheView CacheView}
      */
-    @Nonnull
+    @NotNull
     CacheView<AudioManager> getAudioManagerCache();
 
     /**
@@ -533,7 +533,7 @@ public interface JDA
      *
      * @return Immutable list of all created AudioManager instances
      */
-    @Nonnull
+    @NotNull
     default List<AudioManager> getAudioManagers()
     {
         return getAudioManagerCache().asList();
@@ -545,7 +545,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<User> getUserCache();
 
     /**
@@ -566,7 +566,7 @@ public interface JDA
      *
      * @return Immutable list of all {@link net.dv8tion.jda.api.entities.User Users} that are visible to JDA.
      */
-    @Nonnull
+    @NotNull
     default List<User> getUsers()
     {
         return getUserCache().asList();
@@ -589,7 +589,7 @@ public interface JDA
      * @see    #retrieveUserById(String)
      */
     @Nullable
-    default User getUserById(@Nonnull String id)
+    default User getUserById(@NotNull String id)
     {
         return getUserCache().getElementById(id);
     }
@@ -634,7 +634,7 @@ public interface JDA
      * @return The {@link net.dv8tion.jda.api.entities.User} for the discord tag or null if no user has the provided tag
      */
     @Nullable
-    default User getUserByTag(@Nonnull String tag)
+    default User getUserByTag(@NotNull String tag)
     {
         Checks.notNull(tag, "Tag");
         Matcher matcher = User.USER_TAG.matcher(tag);
@@ -667,7 +667,7 @@ public interface JDA
      * @return The {@link net.dv8tion.jda.api.entities.User} for the discord tag or null if no user has the provided tag
      */
     @Nullable
-    default User getUserByTag(@Nonnull String username, @Nonnull String discriminator)
+    default User getUserByTag(@NotNull String username, @NotNull String discriminator)
     {
         Checks.notNull(username, "Username");
         Checks.notNull(discriminator, "Discriminator");
@@ -697,8 +697,8 @@ public interface JDA
      *
      * @return Possibly-empty immutable list of {@link net.dv8tion.jda.api.entities.User Users} that all have the same name as the provided name.
      */
-    @Nonnull
-    default List<User> getUsersByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<User> getUsersByName(@NotNull String name, boolean ignoreCase)
     {
         return getUserCache().getElementsByName(name, ignoreCase);
     }
@@ -713,8 +713,8 @@ public interface JDA
      *
      * @see    Guild#isMember(net.dv8tion.jda.api.entities.User)
      */
-    @Nonnull
-    List<Guild> getMutualGuilds(@Nonnull User... users);
+    @NotNull
+    List<Guild> getMutualGuilds(@NotNull User... users);
 
     /**
      * Gets all {@link net.dv8tion.jda.api.entities.Guild Guilds} that contain all given users as their members.
@@ -724,8 +724,8 @@ public interface JDA
      *
      * @return Immutable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
      */
-    @Nonnull
-    List<Guild> getMutualGuilds(@Nonnull Collection<User> users);
+    @NotNull
+    List<Guild> getMutualGuilds(@NotNull Collection<User> users);
 
     /**
      * Attempts to retrieve a {@link net.dv8tion.jda.api.entities.User User} object based on the provided id.
@@ -759,9 +759,9 @@ public interface JDA
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.User User}
      *         <br>On request, gets the User with id matching provided id from Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<User> retrieveUserById(@Nonnull String id)
+    default RestAction<User> retrieveUserById(@NotNull String id)
     {
         return retrieveUserById(id, true);
     }
@@ -790,7 +790,7 @@ public interface JDA
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.User User}
      *         <br>On request, gets the User with id matching provided id from Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<User> retrieveUserById(long id)
     {
@@ -829,9 +829,9 @@ public interface JDA
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.User User}
      *         <br>On request, gets the User with id matching provided id from Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<User> retrieveUserById(@Nonnull String id, boolean update)
+    default RestAction<User> retrieveUserById(@NotNull String id, boolean update)
     {
         return retrieveUserById(MiscUtil.parseSnowflake(id), update);
     }
@@ -860,7 +860,7 @@ public interface JDA
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.User User}
      *         <br>On request, gets the User with id matching provided id from Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<User> retrieveUserById(long id, boolean update);
 
@@ -870,7 +870,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<Guild> getGuildCache();
 
     /**
@@ -890,7 +890,7 @@ public interface JDA
      *
      * @return Possibly-empty immutable list of all the {@link net.dv8tion.jda.api.entities.Guild Guilds} that this account is connected to.
      */
-    @Nonnull
+    @NotNull
     default List<Guild> getGuilds()
     {
         return getGuildCache().asList();
@@ -909,7 +909,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Guild Guild} with matching id.
      */
     @Nullable
-    default Guild getGuildById(@Nonnull String id)
+    default Guild getGuildById(@NotNull String id)
     {
         return getGuildCache().getElementById(id);
     }
@@ -940,8 +940,8 @@ public interface JDA
      *
      * @return Possibly-empty immutable list of all the {@link net.dv8tion.jda.api.entities.Guild Guilds} that all have the same name as the provided name.
      */
-    @Nonnull
-    default List<Guild> getGuildsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Guild> getGuildsByName(@NotNull String name, boolean ignoreCase)
     {
         return getGuildCache().getElementsByName(name, ignoreCase);
     }
@@ -955,7 +955,7 @@ public interface JDA
      *
      * @return Possibly-empty set of guild IDs for unavailable guilds
      */
-    @Nonnull
+    @NotNull
     Set<String> getUnavailableGuilds();
 
     /**
@@ -976,7 +976,7 @@ public interface JDA
      *
      * @see    net.dv8tion.jda.api.utils.cache.CacheView#allSnowflakes(java.util.function.Supplier) CacheView.allSnowflakes(...)
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<Role> getRoleCache();
 
     /**
@@ -991,7 +991,7 @@ public interface JDA
      *
      * @return Immutable List of all visible Roles
      */
-    @Nonnull
+    @NotNull
     default List<Role> getRoles()
     {
         return getRoleCache().asList();
@@ -1011,7 +1011,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Role Role} for the specified ID
      */
     @Nullable
-    default Role getRoleById(@Nonnull String id)
+    default Role getRoleById(@NotNull String id)
     {
         return getRoleCache().getElementById(id);
     }
@@ -1044,8 +1044,8 @@ public interface JDA
      *
      * @return Immutable List of all Roles matching the parameters provided.
      */
-    @Nonnull
-    default List<Role> getRolesByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Role> getRolesByName(@NotNull String name, boolean ignoreCase)
     {
         return getRoleCache().getElementsByName(name, ignoreCase);
     }
@@ -1073,7 +1073,7 @@ public interface JDA
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull String id)
+    default GuildChannel getGuildChannelById(@NotNull String id)
     {
         return getGuildChannelById(MiscUtil.parseSnowflake(id));
     }
@@ -1136,7 +1136,7 @@ public interface JDA
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, @Nonnull String id)
+    default GuildChannel getGuildChannelById(@NotNull ChannelType type, @NotNull String id)
     {
         return getGuildChannelById(type, MiscUtil.parseSnowflake(id));
     }
@@ -1165,7 +1165,7 @@ public interface JDA
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, long id)
+    default GuildChannel getGuildChannelById(@NotNull ChannelType type, long id)
     {
         Checks.notNull(type, "ChannelType");
         switch (type)
@@ -1188,7 +1188,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<Category> getCategoryCache();
 
     /**
@@ -1204,7 +1204,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Category Category} for the provided ID.
      */
     @Nullable
-    default Category getCategoryById(@Nonnull String id)
+    default Category getCategoryById(@NotNull String id)
     {
         return getCategoryCache().getElementById(id);
     }
@@ -1234,7 +1234,7 @@ public interface JDA
      *
      * @return An immutable list of all visible {@link net.dv8tion.jda.api.entities.Category Categories}.
      */
-    @Nonnull
+    @NotNull
     default List<Category> getCategories()
     {
         return getCategoryCache().asList();
@@ -1254,8 +1254,8 @@ public interface JDA
      *
      * @return Immutable list of all categories matching the provided name
      */
-    @Nonnull
-    default List<Category> getCategoriesByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Category> getCategoriesByName(@NotNull String name, boolean ignoreCase)
     {
         return getCategoryCache().getElementsByName(name, ignoreCase);
     }
@@ -1267,7 +1267,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<StoreChannel> getStoreChannelCache();
 
     /**
@@ -1285,7 +1285,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel} with matching id.
      */
     @Nullable
-    default StoreChannel getStoreChannelById(@Nonnull String id)
+    default StoreChannel getStoreChannelById(@NotNull String id)
     {
         return getStoreChannelCache().getElementById(id);
     }
@@ -1318,7 +1318,7 @@ public interface JDA
      *
      * @return Possibly-empty immutable List of all known {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel}.
      */
-    @Nonnull
+    @NotNull
     default List<StoreChannel> getStoreChannels()
     {
         return getStoreChannelCache().asList();
@@ -1335,8 +1335,8 @@ public interface JDA
      *
      * @return Possibly-empty immutable list of all StoreChannels with names that match the provided name.
      */
-    @Nonnull
-    default List<StoreChannel> getStoreChannelsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<StoreChannel> getStoreChannelsByName(@NotNull String name, boolean ignoreCase)
     {
         return getStoreChannelCache().getElementsByName(name, ignoreCase);
     }
@@ -1347,7 +1347,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<TextChannel> getTextChannelCache();
 
     /**
@@ -1367,7 +1367,7 @@ public interface JDA
      *
      * @return Possibly-empty list of all known {@link net.dv8tion.jda.api.entities.TextChannel TextChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<TextChannel> getTextChannels()
     {
         return getTextChannelCache().asList();
@@ -1392,7 +1392,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} with matching id.
      */
     @Nullable
-    default TextChannel getTextChannelById(@Nonnull String id)
+    default TextChannel getTextChannelById(@NotNull String id)
     {
         return getTextChannelCache().getElementById(id);
     }
@@ -1437,8 +1437,8 @@ public interface JDA
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.TextChannel TextChannels} that all have the
      *         same name as the provided name.
      */
-    @Nonnull
-    default List<TextChannel> getTextChannelsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<TextChannel> getTextChannelsByName(@NotNull String name, boolean ignoreCase)
     {
         return getTextChannelCache().getElementsByName(name, ignoreCase);
     }
@@ -1449,7 +1449,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<VoiceChannel> getVoiceChannelCache();
 
     /**
@@ -1463,7 +1463,7 @@ public interface JDA
      *
      * @return Possible-empty list of all known {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<VoiceChannel> getVoiceChannels()
     {
         return getVoiceChannelCache().asList();
@@ -1482,7 +1482,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} with matching id.
      */
     @Nullable
-    default VoiceChannel getVoiceChannelById(@Nonnull String id)
+    default VoiceChannel getVoiceChannelById(@NotNull String id)
     {
         return getVoiceChannelCache().getElementById(id);
     }
@@ -1518,12 +1518,12 @@ public interface JDA
      * @deprecated
      *         Replace with {@link #getVoiceChannelsByName(String, boolean)}
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @DeprecatedSince("4.0.0")
     @ForRemoval(deadline="4.3.0")
     @ReplaceWith("jda.getVoiceChannelsByName(name, ignoreCase)")
-    default List<VoiceChannel> getVoiceChannelByName(@Nonnull String name, boolean ignoreCase)
+    default List<VoiceChannel> getVoiceChannelByName(@NotNull String name, boolean ignoreCase)
     {
         return getVoiceChannelsByName(name, ignoreCase);
     }
@@ -1540,8 +1540,8 @@ public interface JDA
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels} that all have the
      *         same name as the provided name.
      */
-    @Nonnull
-    default List<VoiceChannel> getVoiceChannelsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<VoiceChannel> getVoiceChannelsByName(@NotNull String name, boolean ignoreCase)
     {
         return getVoiceChannelCache().getElementsByName(name, ignoreCase);
     }
@@ -1552,7 +1552,7 @@ public interface JDA
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<PrivateChannel> getPrivateChannelCache();
 
     /**
@@ -1565,7 +1565,7 @@ public interface JDA
      *
      * @return Possibly-empty list of all {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<PrivateChannel> getPrivateChannels()
     {
         return getPrivateChannelCache().asList();
@@ -1584,7 +1584,7 @@ public interface JDA
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} with matching id.
      */
     @Nullable
-    default PrivateChannel getPrivateChannelById(@Nonnull String id)
+    default PrivateChannel getPrivateChannelById(@NotNull String id)
     {
         return getPrivateChannelCache().getElementById(id);
     }
@@ -1629,7 +1629,7 @@ public interface JDA
      *
      * @see    User#openPrivateChannel()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<PrivateChannel> openPrivateChannelById(long userId);
 
@@ -1659,9 +1659,9 @@ public interface JDA
      *
      * @see    User#openPrivateChannel()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<PrivateChannel> openPrivateChannelById(@Nonnull String userId)
+    default RestAction<PrivateChannel> openPrivateChannelById(@NotNull String userId)
     {
         return openPrivateChannelById(MiscUtil.parseSnowflake(userId));
     }
@@ -1674,7 +1674,7 @@ public interface JDA
      *
      * @see    net.dv8tion.jda.api.utils.cache.CacheView#allSnowflakes(java.util.function.Supplier) CacheView.allSnowflakes(...)
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<Emote> getEmoteCache();
 
     /**
@@ -1694,7 +1694,7 @@ public interface JDA
      *
      * @return An immutable list of Emotes (which may or may not be available to usage).
      */
-    @Nonnull
+    @NotNull
     default List<Emote> getEmotes()
     {
         return getEmoteCache().asList();
@@ -1716,7 +1716,7 @@ public interface JDA
      *         our cache.
      */
     @Nullable
-    default Emote getEmoteById(@Nonnull String id)
+    default Emote getEmoteById(@NotNull String id)
     {
         return getEmoteCache().getElementById(id);
     }
@@ -1756,8 +1756,8 @@ public interface JDA
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.Emote Emotes} that all have the same
      *         name as the provided name.
      */
-    @Nonnull
-    default List<Emote> getEmotesByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Emote> getEmotesByName(@NotNull String name, boolean ignoreCase)
     {
         return getEmoteCache().getElementsByName(name, ignoreCase);
     }
@@ -1767,7 +1767,7 @@ public interface JDA
      *
      * @return The {@link net.dv8tion.jda.api.hooks.IEventManager}
      */
-    @Nonnull
+    @NotNull
     IEventManager getEventManager();
 
     /**
@@ -1777,7 +1777,7 @@ public interface JDA
      *
      * @return The currently logged in account.
      */
-    @Nonnull
+    @NotNull
     SelfUser getSelfUser();
 
     /**
@@ -1786,7 +1786,7 @@ public interface JDA
      *
      * @return The never-null {@link net.dv8tion.jda.api.managers.Presence Presence} for this session.
      */
-    @Nonnull
+    @NotNull
     Presence getPresence();
 
     /**
@@ -1795,7 +1795,7 @@ public interface JDA
      *
      * @return The shard information for this shard
      */
-    @Nonnull
+    @NotNull
     ShardInfo getShardInfo();
 
     /**
@@ -1803,7 +1803,7 @@ public interface JDA
      *
      * @return Never-null, 18 character length string containing the auth token.
      */
-    @Nonnull
+    @NotNull
     String getToken();
 
     /**
@@ -1904,7 +1904,7 @@ public interface JDA
      *
      * @return The current AccountType.
      */
-    @Nonnull
+    @NotNull
     AccountType getAccountType();
 
     /**
@@ -1918,7 +1918,7 @@ public interface JDA
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link ApplicationInfo ApplicationInfo}
      *         <br>The {@link ApplicationInfo ApplicationInfo} of the bot's application.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<ApplicationInfo> retrieveApplicationInfo();
 
@@ -1938,7 +1938,7 @@ public interface JDA
      *
      * @return A valid OAuth2 invite url for the currently logged in Bot-Account
      */
-    @Nonnull
+    @NotNull
     String getInviteUrl(@Nullable Permission... permissions);
 
     /**
@@ -1957,7 +1957,7 @@ public interface JDA
      *
      * @return A valid OAuth2 invite url for the currently logged in Bot-Account
      */
-    @Nonnull
+    @NotNull
     String getInviteUrl(@Nullable Collection<Permission> permissions);
 
     /**
@@ -1994,9 +1994,9 @@ public interface JDA
      * @see    Guild#retrieveWebhooks()
      * @see    TextChannel#retrieveWebhooks()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Webhook> retrieveWebhookById(@Nonnull String webhookId);
+    RestAction<Webhook> retrieveWebhookById(@NotNull String webhookId);
 
     /**
      * Retrieves a {@link net.dv8tion.jda.api.entities.Webhook Webhook} by its id.
@@ -2020,7 +2020,7 @@ public interface JDA
      * @see    Guild#retrieveWebhooks()
      * @see    TextChannel#retrieveWebhooks()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Webhook> retrieveWebhookById(long webhookId)
     {
@@ -2036,7 +2036,7 @@ public interface JDA
      * @return {@link AuditableRestAction} - Type: int
      *         Provides the resulting used port
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Integer> installAuxiliaryPort()
     {

--- a/src/main/java/net/dv8tion/jda/api/JDABuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/JDABuilder.java
@@ -37,10 +37,10 @@ import net.dv8tion.jda.internal.utils.config.SessionConfig;
 import net.dv8tion.jda.internal.utils.config.ThreadingConfig;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.security.auth.login.LoginException;
 import java.util.*;
 import java.util.concurrent.*;
@@ -164,7 +164,7 @@ public class JDABuilder
     @ForRemoval(deadline="4.3.0")
     @ReplaceWith("JDABuilder.create(String)")
     @DeprecatedSince("4.2.0")
-    public JDABuilder(@Nonnull AccountType accountType)
+    public JDABuilder(@NotNull AccountType accountType)
     {
         throw new UnsupportedOperationException("You cannot use the deprecated constructor anymore. Please use create(...), createDefault(...), or createLight(...) instead.");
     }
@@ -194,7 +194,7 @@ public class JDABuilder
      * @see    #disableIntents(GatewayIntent, GatewayIntent...)
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public static JDABuilder createDefault(@Nullable String token)
     {
@@ -235,9 +235,9 @@ public class JDABuilder
      *
      * @return The new JDABuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder createDefault(@Nullable String token, @Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static JDABuilder createDefault(@Nullable String token, @NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -276,9 +276,9 @@ public class JDABuilder
      *
      * @return The new JDABuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder createDefault(@Nullable String token, @Nonnull Collection<GatewayIntent> intents)
+    public static JDABuilder createDefault(@Nullable String token, @NotNull Collection<GatewayIntent> intents)
     {
         return create(token, intents).applyDefault();
     }
@@ -310,7 +310,7 @@ public class JDABuilder
      * @see    #disableIntents(GatewayIntent, GatewayIntent...)
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public static JDABuilder createLight(@Nullable String token)
     {
@@ -348,9 +348,9 @@ public class JDABuilder
      *
      * @return The new JDABuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder createLight(@Nullable String token, @Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static JDABuilder createLight(@Nullable String token, @NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -386,9 +386,9 @@ public class JDABuilder
      *
      * @return The new JDABuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder createLight(@Nullable String token, @Nonnull Collection<GatewayIntent> intents)
+    public static JDABuilder createLight(@Nullable String token, @NotNull Collection<GatewayIntent> intents)
     {
         return create(token, intents).applyLight();
     }
@@ -430,9 +430,9 @@ public class JDABuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder create(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static JDABuilder create(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         return create(null, intent, intents);
     }
@@ -463,9 +463,9 @@ public class JDABuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder create(@Nonnull Collection<GatewayIntent> intents)
+    public static JDABuilder create(@NotNull Collection<GatewayIntent> intents)
     {
         return create(null, intents);
     }
@@ -497,9 +497,9 @@ public class JDABuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder create(@Nullable String token, @Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static JDABuilder create(@Nullable String token, @NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         return new JDABuilder(token, GatewayIntent.getRaw(intent, intents)).applyIntents();
     }
@@ -528,9 +528,9 @@ public class JDABuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static JDABuilder create(@Nullable String token, @Nonnull Collection<GatewayIntent> intents)
+    public static JDABuilder create(@Nullable String token, @NotNull Collection<GatewayIntent> intents)
     {
         return new JDABuilder(token, GatewayIntent.getRaw(intents)).applyIntents();
     }
@@ -571,8 +571,8 @@ public class JDABuilder
      *
      * @since  4.2.1
      */
-    @Nonnull
-    public JDABuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
+    @NotNull
+    public JDABuilder setGatewayEncoding(@NotNull GatewayEncoding encoding)
     {
         Checks.notNull(encoding, "GatewayEncoding");
         this.encoding = encoding;
@@ -590,7 +590,7 @@ public class JDABuilder
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setRawEventsEnabled(boolean enable)
     {
         return setFlag(ConfigFlag.RAW_EVENTS, enable);
@@ -615,7 +615,7 @@ public class JDABuilder
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setRelativeRateLimit(boolean enable)
     {
         return setFlag(ConfigFlag.USE_RELATIVE_RATELIMIT, enable);
@@ -639,7 +639,7 @@ public class JDABuilder
      *             You should use {@link #enableCache(Collection)} and {@link #disableCache(Collection)} instead,
      *             to disable and enable cache flags without side-effects that may break in future versions.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ReplaceWith("enableCache(flags) and disableCache(flags)")
     @DeprecatedSince("4.2.0")
@@ -664,8 +664,8 @@ public class JDABuilder
      * @see    #enableCache(CacheFlag, CacheFlag...) 
      * @see    #disableCache(Collection)
      */
-    @Nonnull
-    public JDABuilder enableCache(@Nonnull Collection<CacheFlag> flags)
+    @NotNull
+    public JDABuilder enableCache(@NotNull Collection<CacheFlag> flags)
     {
         Checks.noneNull(flags, "CacheFlags");
         cacheFlags.addAll(flags);
@@ -689,8 +689,8 @@ public class JDABuilder
      * @see    #enableCache(Collection) 
      * @see    #disableCache(CacheFlag, CacheFlag...)
      */
-    @Nonnull
-    public JDABuilder enableCache(@Nonnull CacheFlag flag, @Nonnull CacheFlag... flags)
+    @NotNull
+    public JDABuilder enableCache(@NotNull CacheFlag flag, @NotNull CacheFlag... flags)
     {
         Checks.notNull(flag, "CacheFlag");
         Checks.noneNull(flags, "CacheFlag");
@@ -712,7 +712,7 @@ public class JDABuilder
      *             You should use {@link #enableCache(Collection)} and {@link #disableCache(Collection)} instead,
      *             to disable and enable cache flags without side-effects that may break in future versions.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ReplaceWith("enableCache(flags) and disableCache(flags)")
     @DeprecatedSince("4.2.0")
@@ -736,8 +736,8 @@ public class JDABuilder
      * @see    #disableCache(CacheFlag, CacheFlag...) 
      * @see    #enableCache(Collection)
      */
-    @Nonnull
-    public JDABuilder disableCache(@Nonnull Collection<CacheFlag> flags)
+    @NotNull
+    public JDABuilder disableCache(@NotNull Collection<CacheFlag> flags)
     {
         Checks.noneNull(flags, "CacheFlags");
         automaticallyDisabled.removeAll(flags);
@@ -762,8 +762,8 @@ public class JDABuilder
      * @see    #disableCache(Collection) 
      * @see    #enableCache(CacheFlag, CacheFlag...)
      */
-    @Nonnull
-    public JDABuilder disableCache(@Nonnull CacheFlag flag, @Nonnull CacheFlag... flags)
+    @NotNull
+    public JDABuilder disableCache(@NotNull CacheFlag flag, @NotNull CacheFlag... flags)
     {
         Checks.notNull(flag, "CacheFlag");
         Checks.noneNull(flags, "CacheFlag");
@@ -806,7 +806,7 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setMemberCachePolicy(@Nullable MemberCachePolicy policy)
     {
         if (policy == null)
@@ -832,7 +832,7 @@ public class JDABuilder
      * @see    <a href="https://www.slf4j.org/api/org/slf4j/MDC.html" target="_blank">MDC Javadoc</a>
      * @see    #setContextEnabled(boolean)
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setContextMap(@Nullable ConcurrentMap<String, String> map)
     {
         this.contextMap = map;
@@ -853,7 +853,7 @@ public class JDABuilder
      * @see    <a href="https://www.slf4j.org/api/org/slf4j/MDC.html" target="_blank">MDC Javadoc</a>
      * @see    #setContextMap(java.util.concurrent.ConcurrentMap)
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setContextEnabled(boolean enable)
     {
         return setFlag(ConfigFlag.MDC_CONTEXT, enable);
@@ -879,8 +879,8 @@ public class JDABuilder
      *
      * @see    <a href="https://discord.com/developers/docs/topics/gateway#transport-compression" target="_blank">Official Discord Documentation - Transport Compression</a>
      */
-    @Nonnull
-    public JDABuilder setCompression(@Nonnull Compression compression)
+    @NotNull
+    public JDABuilder setCompression(@NotNull Compression compression)
     {
         Checks.notNull(compression, "Compression");
         this.compression = compression;
@@ -899,7 +899,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setRequestTimeoutRetry(boolean retryOnTimeout)
     {
         return setFlag(ConfigFlag.RETRY_TIMEOUT, retryOnTimeout);
@@ -922,7 +922,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setToken(@Nullable String token)
     {
         this.token = token;
@@ -938,7 +938,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setHttpClientBuilder(@Nullable OkHttpClient.Builder builder)
     {
         this.httpClientBuilder = builder;
@@ -954,7 +954,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setHttpClient(@Nullable OkHttpClient client)
     {
         this.httpClient = client;
@@ -970,7 +970,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setWebsocketFactory(@Nullable WebSocketFactory factory)
     {
         this.wsFactory = factory;
@@ -995,7 +995,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setRateLimitPool(@Nullable ScheduledExecutorService pool)
     {
         return setRateLimitPool(pool, pool == null);
@@ -1019,7 +1019,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setRateLimitPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
     {
         this.rateLimitPool = pool;
@@ -1053,7 +1053,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setGatewayPool(@Nullable ScheduledExecutorService pool)
     {
         return setGatewayPool(pool, pool == null);
@@ -1085,7 +1085,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setGatewayPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
     {
         this.mainWsPool = pool;
@@ -1111,7 +1111,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setCallbackPool(@Nullable ExecutorService executor)
     {
         return setCallbackPool(executor, executor == null);
@@ -1135,7 +1135,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setCallbackPool(@Nullable ExecutorService executor, boolean automaticShutdown)
     {
         this.callbackPool = executor;
@@ -1157,7 +1157,7 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setEventPool(@Nullable ExecutorService executor)
     {
         return setEventPool(executor, executor == null);
@@ -1176,7 +1176,7 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setEventPool(@Nullable ExecutorService executor, boolean automaticShutdown)
     {
         this.eventPool = executor;
@@ -1198,7 +1198,7 @@ public class JDABuilder
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setAudioPool(@Nullable ScheduledExecutorService pool)
     {
         return setAudioPool(pool, pool == null);
@@ -1220,7 +1220,7 @@ public class JDABuilder
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setAudioPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
     {
         this.audioPool = pool;
@@ -1240,7 +1240,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setBulkDeleteSplittingEnabled(boolean enabled)
     {
         return setFlag(ConfigFlag.BULK_DELETE_SPLIT, enabled);
@@ -1258,7 +1258,7 @@ public class JDABuilder
      *
      * @return Return the {@link net.dv8tion.jda.api.JDABuilder JDABuilder } instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setEnableShutdownHook(boolean enable)
     {
         return setFlag(ConfigFlag.SHUTDOWN_HOOK, enable);
@@ -1275,7 +1275,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setAutoReconnect(boolean autoReconnect)
     {
         return setFlag(ConfigFlag.AUTO_RECONNECT, autoReconnect);
@@ -1299,7 +1299,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setEventManager(@Nullable IEventManager manager)
     {
         this.eventManager = manager;
@@ -1317,7 +1317,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setAudioSendFactory(@Nullable IAudioSendFactory factory)
     {
         this.audioSendFactory = factory;
@@ -1335,7 +1335,7 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setIdle(boolean) Presence.setIdle(boolean)
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setIdle(boolean idle)
     {
         this.idle = idle;
@@ -1356,7 +1356,7 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setActivity(net.dv8tion.jda.api.entities.Activity)  Presence.setActivity(Activity)
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setActivity(@Nullable Activity activity)
     {
         this.activity = activity;
@@ -1377,9 +1377,9 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setStatus(OnlineStatus) Presence.setStatus(OnlineStatus)
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("ConstantConditions") // we have to enforce the nonnull at runtime
-    public JDABuilder setStatus(@Nonnull OnlineStatus status)
+    public JDABuilder setStatus(@NotNull OnlineStatus status)
     {
         if (status == null || status == OnlineStatus.UNKNOWN)
             throw new IllegalArgumentException("OnlineStatus cannot be null or unknown!");
@@ -1406,8 +1406,8 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.JDA#addEventListener(Object...) JDA.addEventListener(Object...)
      */
-    @Nonnull
-    public JDABuilder addEventListeners(@Nonnull Object... listeners)
+    @NotNull
+    public JDABuilder addEventListeners(@NotNull Object... listeners)
     {
         Checks.noneNull(listeners, "listeners");
 
@@ -1428,8 +1428,8 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.JDA#removeEventListener(Object...) JDA.removeEventListener(Object...)
      */
-    @Nonnull
-    public JDABuilder removeEventListeners(@Nonnull Object... listeners)
+    @NotNull
+    public JDABuilder removeEventListeners(@NotNull Object... listeners)
     {
         Checks.noneNull(listeners, "listeners");
 
@@ -1451,7 +1451,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setMaxReconnectDelay(int maxReconnectDelay)
     {
         Checks.check(maxReconnectDelay >= 32, "Max reconnect delay must be 32 seconds or greater. You provided %d.", maxReconnectDelay);
@@ -1482,7 +1482,7 @@ public class JDABuilder
      * @see    net.dv8tion.jda.api.JDA#getShardInfo() JDA.getShardInfo()
      * @see    net.dv8tion.jda.api.sharding.ShardManager ShardManager
      */
-    @Nonnull
+    @NotNull
     public JDABuilder useSharding(int shardId, int shardTotal)
     {
         Checks.notNegative(shardId, "Shard ID");
@@ -1508,7 +1508,7 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.utils.SessionControllerAdapter SessionControllerAdapter
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setSessionController(@Nullable SessionController controller)
     {
         this.controller = controller;
@@ -1527,7 +1527,7 @@ public class JDABuilder
      *
      * @see    VoiceDispatchInterceptor
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setVoiceDispatchInterceptor(@Nullable VoiceDispatchInterceptor interceptor)
     {
         this.voiceDispatchInterceptor = interceptor;
@@ -1550,7 +1550,7 @@ public class JDABuilder
      * @see    ChunkingFilter#include(long...)
      * @see    ChunkingFilter#exclude(long...)
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setChunkingFilter(@Nullable ChunkingFilter filter)
     {
         this.chunkingFilter = filter == null ? ChunkingFilter.ALL : filter;
@@ -1578,7 +1578,7 @@ public class JDABuilder
      * @deprecated This is now superseded by {@link #setDisabledIntents(Collection)} and {@link #setMemberCachePolicy(MemberCachePolicy)}.
      *             To get identical behavior you can do {@code setMemberCachePolicy(VOICE).setDisabledIntents(GatewayIntent.GUILD_PRESENCES, GatewayIntent.GUILD_MESSAGE_TYPING, GatewayIntent.GUILD_MEMBERS)}
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ReplaceWith("setDisabledIntents(...).setMemberCachePolicy(...)")
     @DeprecatedSince("4.2.0")
@@ -1617,8 +1617,8 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
-    public JDABuilder setDisabledIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public JDABuilder setDisabledIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "Intents");
         Checks.noneNull(intents, "Intents");
@@ -1645,7 +1645,7 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setDisabledIntents(@Nullable Collection<GatewayIntent> intents)
     {
         this.intents = GatewayIntent.ALL_INTENTS;
@@ -1672,8 +1672,8 @@ public class JDABuilder
      *
      * @see    #enableIntents(Collection)
      */
-    @Nonnull
-    public JDABuilder disableIntents(@Nonnull Collection<GatewayIntent> intents)
+    @NotNull
+    public JDABuilder disableIntents(@NotNull Collection<GatewayIntent> intents)
     {
         Checks.noneNull(intents, "GatewayIntent");
         int raw = GatewayIntent.getRaw(intents);
@@ -1701,8 +1701,8 @@ public class JDABuilder
      *
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
-    public JDABuilder disableIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public JDABuilder disableIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -1736,8 +1736,8 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
-    public JDABuilder setEnabledIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public JDABuilder setEnabledIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "Intents");
         Checks.noneNull(intents, "Intents");
@@ -1765,7 +1765,7 @@ public class JDABuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setEnabledIntents(@Nullable Collection<GatewayIntent> intents)
     {
         if (intents == null || intents.isEmpty())
@@ -1791,8 +1791,8 @@ public class JDABuilder
      *
      * @see    #disableIntents(Collection)
      */
-    @Nonnull
-    public JDABuilder enableIntents(@Nonnull Collection<GatewayIntent> intents)
+    @NotNull
+    public JDABuilder enableIntents(@NotNull Collection<GatewayIntent> intents)
     {
         Checks.noneNull(intents, "GatewayIntent");
         int raw = GatewayIntent.getRaw(intents);
@@ -1816,8 +1816,8 @@ public class JDABuilder
      *
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
-    public JDABuilder enableIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public JDABuilder enableIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -1839,7 +1839,7 @@ public class JDABuilder
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setLargeThreshold(int threshold)
     {
         this.largeThreshold = Math.max(50, Math.min(250, threshold)); // enforce 50 <= t <= 250
@@ -1862,7 +1862,7 @@ public class JDABuilder
      *
      * @return The JDABuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public JDABuilder setMaxBufferSize(int bufferSize)
     {
         Checks.notNegative(bufferSize, "The buffer size");
@@ -1892,7 +1892,7 @@ public class JDABuilder
      *
      * @see    net.dv8tion.jda.api.JDA#awaitReady()
      */
-    @Nonnull
+    @NotNull
     public JDA build() throws LoginException
     {
         checkIntents();

--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -27,9 +27,9 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.regex.Matcher;
 
@@ -106,7 +106,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder setTTS(boolean tts)
     {
         this.isTTS = tts;
@@ -122,7 +122,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder setEmbed(@Nullable MessageEmbed embed)
     {
         this.embed = embed;
@@ -144,7 +144,7 @@ public class MessageBuilder implements Appendable
      * @see    net.dv8tion.jda.api.entities.Message#getNonce()
      * @see    <a href="https://en.wikipedia.org/wiki/Cryptographic_nonce" target="_blank">Cryptographic Nonce - Wikipedia</a>
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder setNonce(@Nullable String nonce)
     {
         this.nonce = nonce;
@@ -162,7 +162,7 @@ public class MessageBuilder implements Appendable
      *
      * @see    net.dv8tion.jda.api.entities.Message#getContentRaw()
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder setContent(@Nullable String content)
     {
         if (content == null)
@@ -177,7 +177,7 @@ public class MessageBuilder implements Appendable
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageBuilder append(@Nullable CharSequence text)
     {
@@ -185,7 +185,7 @@ public class MessageBuilder implements Appendable
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageBuilder append(@Nullable CharSequence text, int start, int end)
     {
@@ -193,7 +193,7 @@ public class MessageBuilder implements Appendable
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageBuilder append(char c)
     {
@@ -210,7 +210,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder append(@Nullable Object object)
     {
         return append(String.valueOf(object));
@@ -232,8 +232,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder append(@Nonnull IMentionable mention)
+    @NotNull
+    public MessageBuilder append(@NotNull IMentionable mention)
     {
         Checks.notNull(mention, "Mentionable");
         builder.append(mention.getAsMention());
@@ -250,8 +250,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder append(@Nullable CharSequence text, @Nonnull Formatting... format)
+    @NotNull
+    public MessageBuilder append(@Nullable CharSequence text, @NotNull Formatting... format)
     {
         boolean blockPresent = false;
         for (Formatting formatting : format)
@@ -329,8 +329,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder appendFormat(@Nonnull String format, @Nonnull Object... args)
+    @NotNull
+    public MessageBuilder appendFormat(@NotNull String format, @NotNull Object... args)
     {
         Checks.notEmpty(format, "Format String");
         this.append(String.format(format, args));
@@ -346,7 +346,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder appendCodeLine(@Nullable CharSequence text)
     {
         this.append(text, Formatting.BLOCK);
@@ -365,7 +365,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder appendCodeBlock(@Nullable CharSequence text, @Nullable CharSequence language)
     {
         builder.append("```").append(language).append('\n').append(text).append("\n```");
@@ -410,8 +410,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder replace(@Nonnull String target, @Nonnull String replacement)
+    @NotNull
+    public MessageBuilder replace(@NotNull String target, @NotNull String replacement)
     {
         int index = builder.indexOf(target);
         while (index != -1)
@@ -432,8 +432,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder replaceFirst(@Nonnull String target, @Nonnull String replacement)
+    @NotNull
+    public MessageBuilder replaceFirst(@NotNull String target, @NotNull String replacement)
     {
         int index = builder.indexOf(target);
         if (index != -1)
@@ -453,8 +453,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder replaceLast(@Nonnull String target, @Nonnull String replacement)
+    @NotNull
+    public MessageBuilder replaceLast(@NotNull String target, @NotNull String replacement)
     {
         int index = builder.lastIndexOf(target);
         if (index != -1)
@@ -471,7 +471,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder clearMentionedUsers()
     {
         mentionedUsers.clear();
@@ -485,7 +485,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder clearMentionedRoles()
     {
         mentionedRoles.clear();
@@ -500,7 +500,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder clearMentions()
     {
         return clearMentionedUsers().clearMentionedRoles();
@@ -515,7 +515,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder setAllowedMentions(@Nullable Collection<Message.MentionType> mentionTypes)
     {
         this.allowedMentions = mentionTypes == null
@@ -535,8 +535,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder allowMentions(@Nonnull Message.MentionType... types)
+    @NotNull
+    public MessageBuilder allowMentions(@NotNull Message.MentionType... types)
     {
         Checks.noneNull(types, "MentionTypes");
         if (types.length > 0)
@@ -559,8 +559,8 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public MessageBuilder denyMentions(@Nonnull Message.MentionType... types)
+    @NotNull
+    public MessageBuilder denyMentions(@NotNull Message.MentionType... types)
     {
         Checks.noneNull(types, "MentionTypes");
         if (types.length > 0)
@@ -591,8 +591,8 @@ public class MessageBuilder implements Appendable
      * @see    #clearMentions()
      * @see    MessageAction#mention(IMentionable...)
      */
-    @Nonnull
-    public MessageBuilder mention(@Nonnull IMentionable... mentions)
+    @NotNull
+    public MessageBuilder mention(@NotNull IMentionable... mentions)
     {
         Checks.noneNull(mentions, "Mentions");
 
@@ -624,8 +624,8 @@ public class MessageBuilder implements Appendable
      * @see    #clearMentions()
      * @see    MessageAction#mention(IMentionable...)
      */
-    @Nonnull
-    public MessageBuilder mention(@Nonnull Collection<? extends IMentionable> mentions)
+    @NotNull
+    public MessageBuilder mention(@NotNull Collection<? extends IMentionable> mentions)
     {
         Checks.noneNull(mentions, "Mentions");
         return mention(mentions.toArray(new IMentionable[0]));
@@ -650,8 +650,8 @@ public class MessageBuilder implements Appendable
      * @see    #clearMentionedUsers()
      * @see    MessageAction#mentionUsers(String...)
      */
-    @Nonnull
-    public MessageBuilder mentionUsers(@Nonnull String... users)
+    @NotNull
+    public MessageBuilder mentionUsers(@NotNull String... users)
     {
         Checks.noneNull(users, "Users");
         Collections.addAll(mentionedUsers, users);
@@ -677,8 +677,8 @@ public class MessageBuilder implements Appendable
      * @see    #clearMentionedRoles()
      * @see    MessageAction#mentionRoles(String...)
      */
-    @Nonnull
-    public MessageBuilder mentionRoles(@Nonnull String... roles)
+    @NotNull
+    public MessageBuilder mentionRoles(@NotNull String... roles)
     {
         Checks.noneNull(roles, "Roles");
         Collections.addAll(mentionedRoles, roles);
@@ -704,8 +704,8 @@ public class MessageBuilder implements Appendable
      * @see    #clearMentionedUsers()
      * @see    MessageAction#mentionUsers(long...)
      */
-    @Nonnull
-    public MessageBuilder mentionUsers(@Nonnull long... users)
+    @NotNull
+    public MessageBuilder mentionUsers(@NotNull long... users)
     {
         Checks.notNull(users, "Users");
         return mentionUsers(toStringArray(users));
@@ -730,8 +730,8 @@ public class MessageBuilder implements Appendable
      * @see    #clearMentionedRoles()
      * @see    MessageAction#mentionRoles(long...)
      */
-    @Nonnull
-    public MessageBuilder mentionRoles(@Nonnull long... roles)
+    @NotNull
+    public MessageBuilder mentionRoles(@NotNull long... roles)
     {
         Checks.notNull(roles, "Roles");
         return mentionRoles(toStringArray(roles));
@@ -751,12 +751,12 @@ public class MessageBuilder implements Appendable
      * @deprecated This is not a reliable way to remove mentions from the content,
      *             you should use {@link #setAllowedMentions(Collection)} instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @ReplaceWith("setAllowedMentions(Collections.emptyList())")
     @DeprecatedSince("4.2.0")
-    public MessageBuilder stripMentions(@Nonnull JDA jda)
+    public MessageBuilder stripMentions(@NotNull JDA jda)
     {
         // Note: Users can rename to "everyone" or "here", so those
         // should be stripped after the USER mention is stripped.
@@ -778,12 +778,12 @@ public class MessageBuilder implements Appendable
      * @deprecated This is not a reliable way to remove mentions from the content,
      *             you should use {@link #setAllowedMentions(Collection)} instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @ReplaceWith("setAllowedMentions(Collections.emptyList())")
     @DeprecatedSince("4.2.0")
-    public MessageBuilder stripMentions(@Nonnull Guild guild)
+    public MessageBuilder stripMentions(@NotNull Guild guild)
     {
         // Note: Users can rename to "everyone" or "here", so those
         // should be stripped after the USER mention is stripped.
@@ -807,12 +807,12 @@ public class MessageBuilder implements Appendable
      * @deprecated This is not a reliable way to remove mentions from the content,
      *             you should use {@link #setAllowedMentions(Collection)} instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @ReplaceWith("denyMentions(types)")
     @DeprecatedSince("4.2.0")
-    public MessageBuilder stripMentions(@Nonnull Guild guild, @Nonnull Message.MentionType... types)
+    public MessageBuilder stripMentions(@NotNull Guild guild, @NotNull Message.MentionType... types)
     {
         return this.stripMentions(guild.getJDA(), guild, types);
     }
@@ -833,17 +833,17 @@ public class MessageBuilder implements Appendable
      * @deprecated This is not a reliable way to remove mentions from the content,
      *             you should use {@link #setAllowedMentions(Collection)} instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @ReplaceWith("denyMentions(types)")
     @DeprecatedSince("4.2.0")
-    public MessageBuilder stripMentions(@Nonnull JDA jda, @Nonnull Message.MentionType... types)
+    public MessageBuilder stripMentions(@NotNull JDA jda, @NotNull Message.MentionType... types)
     {
         return this.stripMentions(jda, null, types);
     }
 
-    @Nonnull
+    @NotNull
     private MessageBuilder stripMentions(JDA jda, Guild guild, Message.MentionType... types)
     {
         if (types == null)
@@ -942,7 +942,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The {@link StringBuilder} used by this {@link MessageBuilder}
      */
-    @Nonnull
+    @NotNull
     public StringBuilder getStringBuilder()
     {
         return this.builder;
@@ -955,7 +955,7 @@ public class MessageBuilder implements Appendable
      *
      * @return The MessageBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public MessageBuilder clear() {
         this.builder.setLength(0);
         this.embed = null;
@@ -986,7 +986,7 @@ public class MessageBuilder implements Appendable
      * @return the index of the first occurrence of the specified substring between
      *         the specified indices or {@code -1} if there is no such occurrence.
      */
-    public int indexOf(@Nonnull CharSequence target, int fromIndex, int endIndex)
+    public int indexOf(@NotNull CharSequence target, int fromIndex, int endIndex)
     {
         if (fromIndex < 0)
             throw new IndexOutOfBoundsException("index out of range: " + fromIndex);
@@ -1052,7 +1052,7 @@ public class MessageBuilder implements Appendable
      * @return the index of the last occurrence of the specified substring between
      *         the specified indices or {@code -1} if there is no such occurrence.
      */
-    public int lastIndexOf(@Nonnull CharSequence target, int fromIndex, int endIndex)
+    public int lastIndexOf(@NotNull CharSequence target, int fromIndex, int endIndex)
     {
         if (fromIndex < 0)
             throw new IndexOutOfBoundsException("index out of range: " + fromIndex);
@@ -1122,12 +1122,12 @@ public class MessageBuilder implements Appendable
      *
      * @deprecated Use {@link MessageChannel#sendMessage(Message) channel.sendMessage(builder.build())} instead
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @DeprecatedSince("4.2.1")
     @ForRemoval(deadline="4.3.0")
     @ReplaceWith("channel.sendMessage(builder.build())")
-    public MessageAction sendTo(@Nonnull MessageChannel channel)
+    public MessageAction sendTo(@NotNull MessageChannel channel)
     {
         Checks.notNull(channel, "Target Channel");
         switch (channel.getType())
@@ -1166,7 +1166,7 @@ public class MessageBuilder implements Appendable
      *
      * @return the created {@link net.dv8tion.jda.api.entities.Message Message}
      */
-    @Nonnull
+    @NotNull
     public Message build()
     {
         String message = builder.toString();
@@ -1196,7 +1196,7 @@ public class MessageBuilder implements Appendable
      *
      * @return the created {@link net.dv8tion.jda.api.entities.Message Messages}
      */
-    @Nonnull
+    @NotNull
     public Queue<Message> buildAll(@Nullable SplitPolicy... policy)
     {
         if (this.isEmpty())
@@ -1245,7 +1245,7 @@ public class MessageBuilder implements Appendable
         return messages;
     }
 
-    @Nonnull
+    @NotNull
     protected DataMessage build(int beginIndex, int endIndex)
     {
         String[] ids = new String[0];
@@ -1292,8 +1292,8 @@ public class MessageBuilder implements Appendable
          *
          * @return a new {@link SplitPolicy}
          */
-        @Nonnull
-        static SplitPolicy onChars(@Nonnull CharSequence chars, boolean remove)
+        @NotNull
+        static SplitPolicy onChars(@NotNull CharSequence chars, boolean remove)
         {
             return new CharSequenceSplitPolicy(chars, remove);
         }
@@ -1306,7 +1306,7 @@ public class MessageBuilder implements Appendable
             private final boolean remove;
             private final CharSequence chars;
 
-            private CharSequenceSplitPolicy(@Nonnull final CharSequence chars, final boolean remove)
+            private CharSequenceSplitPolicy(@NotNull final CharSequence chars, final boolean remove)
             {
                 this.chars = chars;
                 this.remove = remove;
@@ -1361,7 +1361,7 @@ public class MessageBuilder implements Appendable
             this.tag = tag;
         }
 
-        @Nonnull
+        @NotNull
         private String getTag()
         {
             return tag;

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -16,8 +16,8 @@
 package net.dv8tion.jda.api;
 
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -116,7 +116,7 @@ public enum Permission
     private final boolean isGuild, isChannel;
     private final String name;
 
-    Permission(int offset, boolean isGuild, boolean isChannel, @Nonnull String name)
+    Permission(int offset, boolean isGuild, boolean isChannel, @NotNull String name)
     {
         this.offset = offset;
         this.raw = 1L << offset;
@@ -130,7 +130,7 @@ public enum Permission
      *
      * @return The readable name of this {@link net.dv8tion.jda.api.Permission Permission}.
      */
-    @Nonnull
+    @NotNull
     public String getName()
     {
         return this.name;
@@ -211,7 +211,7 @@ public enum Permission
      *
      * @return {@link net.dv8tion.jda.api.Permission Permission} relating to the provided offset.
      */
-    @Nonnull
+    @NotNull
     public static Permission getFromOffset(int offset)
     {
         for (Permission perm : values())
@@ -235,7 +235,7 @@ public enum Permission
      * @return Possibly-empty EnumSet of {@link net.dv8tion.jda.api.Permission Permissions}.
      *
      */
-    @Nonnull
+    @NotNull
     public static EnumSet<Permission> getPermissions(long permissions)
     {
         if (permissions == 0)
@@ -258,7 +258,7 @@ public enum Permission
      *
      * @return Unsigned long representing the provided permissions.
      */
-    public static long getRaw(@Nonnull Permission... permissions)
+    public static long getRaw(@NotNull Permission... permissions)
     {
         long raw = 0;
         for (Permission perm : permissions)
@@ -282,7 +282,7 @@ public enum Permission
      *
      * @see    java.util.EnumSet EnumSet
      */
-    public static long getRaw(@Nonnull Collection<Permission> permissions)
+    public static long getRaw(@NotNull Collection<Permission> permissions)
     {
         Checks.notNull(permissions, "Permission Collection");
 

--- a/src/main/java/net/dv8tion/jda/api/Region.java
+++ b/src/main/java/net/dv8tion/jda/api/Region.java
@@ -15,8 +15,8 @@
  */
 package net.dv8tion.jda.api;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents the Regions used for Audio connections.
@@ -81,7 +81,7 @@ public enum Region
      *
      * @return The name of this region
      */
-    @Nonnull
+    @NotNull
     public String getName()
     {
         return name;
@@ -92,7 +92,7 @@ public enum Region
      *
      * @return The key (internal name) of this region
      */
-    @Nonnull
+    @NotNull
     public String getKey()
     {
         return key;
@@ -103,7 +103,7 @@ public enum Region
      * 
      * @return Possibly-null unicode for the region's flag
      */
-    @Nonnull
+    @NotNull
     public String getEmoji()
     {
         return emoji;
@@ -130,7 +130,7 @@ public enum Region
      * @return The {@link net.dv8tion.jda.api.Region Region} matching the key. If there is no match,
      *         returns {@link net.dv8tion.jda.api.Region#UNKNOWN UNKNOWN}.
      */
-    @Nonnull
+    @NotNull
     public static Region fromKey(@Nullable String key)
     {
         for (Region region : values())

--- a/src/main/java/net/dv8tion/jda/api/audio/AudioReceiveHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/AudioReceiveHandler.java
@@ -17,8 +17,8 @@
 package net.dv8tion.jda.api.audio;
 
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import javax.sound.sampled.AudioFormat;
 
 /**
@@ -81,7 +81,7 @@ public interface AudioReceiveHandler
      *
      * @since  4.0.0
      */
-    default void handleEncodedAudio(@Nonnull OpusPacket packet) {}
+    default void handleEncodedAudio(@NotNull OpusPacket packet) {}
 
     /**
      * If {@link #canReceiveCombined()} returns true, JDA will provide a {@link net.dv8tion.jda.api.audio.CombinedAudio CombinedAudio}
@@ -102,7 +102,7 @@ public interface AudioReceiveHandler
      * @param  combinedAudio
      *         The combined audio data.
      */
-    default void handleCombinedAudio(@Nonnull CombinedAudio combinedAudio) {}
+    default void handleCombinedAudio(@NotNull CombinedAudio combinedAudio) {}
 
     /**
      * If {@link #canReceiveUser()} returns true, JDA will provide a {@link net.dv8tion.jda.api.audio.UserAudio UserAudio}
@@ -125,7 +125,7 @@ public interface AudioReceiveHandler
      * @param  userAudio
      *         The user audio data
      */
-    default void handleUserAudio(@Nonnull UserAudio userAudio) {}
+    default void handleUserAudio(@NotNull UserAudio userAudio) {}
 
     /**
      * This method is a filter predicate used by JDA to determine whether or not to include a
@@ -145,7 +145,7 @@ public interface AudioReceiveHandler
      * @return If true, JDA will include the user's audio when merging audio sources when created packets
      *         for {@link #handleCombinedAudio(CombinedAudio)}
      */
-    default boolean includeUserInCombinedAudio(@Nonnull User user)
+    default boolean includeUserInCombinedAudio(@NotNull User user)
     {
         return true;
     }

--- a/src/main/java/net/dv8tion/jda/api/audio/AudioSendHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/AudioSendHandler.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.api.audio;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
+
 import javax.sound.sampled.AudioFormat;
 import java.nio.ByteBuffer;
 

--- a/src/main/java/net/dv8tion/jda/api/audio/CombinedAudio.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/CombinedAudio.java
@@ -17,8 +17,8 @@
 package net.dv8tion.jda.api.audio;
 
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,7 +30,7 @@ public class CombinedAudio
     protected List<User> users;
     protected short[] audioData;
 
-    public CombinedAudio(@Nonnull List<User> users, @Nonnull short[] audioData)
+    public CombinedAudio(@NotNull List<User> users, @NotNull short[] audioData)
     {
         this.users = Collections.unmodifiableList(users);
         this.audioData = audioData;
@@ -44,7 +44,7 @@ public class CombinedAudio
      *
      * @return Never-null list of all users that provided audio.
      */
-    @Nonnull
+    @NotNull
     public List<User> getUsers()
     {
         return users;
@@ -64,7 +64,7 @@ public class CombinedAudio
      *
      * @return Never-null byte array of PCM data defined by {@link net.dv8tion.jda.api.audio.AudioReceiveHandler#OUTPUT_FORMAT AudioReceiveHandler.OUTPUT_FORMAT}
      */
-    @Nonnull
+    @NotNull
     public byte[] getAudioData(double volume)
     {
         return OpusPacket.getAudioData(audioData, volume);

--- a/src/main/java/net/dv8tion/jda/api/audio/OpusPacket.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/OpusPacket.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.audio;
 
 import net.dv8tion.jda.internal.audio.AudioPacket;
 import net.dv8tion.jda.internal.audio.Decoder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -51,7 +51,7 @@ public final class OpusPacket implements Comparable<OpusPacket>
     private short[] decoded;
     private boolean triedDecode;
 
-    public OpusPacket(@Nonnull AudioPacket packet, long userId, @Nullable Decoder decoder)
+    public OpusPacket(@NotNull AudioPacket packet, long userId, @Nullable Decoder decoder)
     {
         this.rawPacket = packet;
         this.userId = userId;
@@ -124,7 +124,7 @@ public final class OpusPacket implements Comparable<OpusPacket>
      *
      * @return The raw opus audio
      */
-    @Nonnull
+    @NotNull
     public byte[] getOpusAudio()
     {
         //prevent write access to backing array
@@ -172,7 +172,7 @@ public final class OpusPacket implements Comparable<OpusPacket>
      *
      * @return The stereo PCM audio data as specified by {@link net.dv8tion.jda.api.audio.AudioReceiveHandler#OUTPUT_FORMAT}.
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("ConstantConditions") // the null case is handled with an exception
     public byte[] getAudioData(double volume)
     {
@@ -194,9 +194,9 @@ public final class OpusPacket implements Comparable<OpusPacket>
      *
      * @return The stereo PCM audio data as specified by {@link net.dv8tion.jda.api.audio.AudioReceiveHandler#OUTPUT_FORMAT}.
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("ConstantConditions") // the null case is handled with an exception
-    public static byte[] getAudioData(@Nonnull short[] decoded, double volume)
+    public static byte[] getAudioData(@NotNull short[] decoded, double volume)
     {
         if (decoded == null)
             throw new IllegalArgumentException("Cannot get audio data from null");
@@ -217,7 +217,7 @@ public final class OpusPacket implements Comparable<OpusPacket>
     }
 
     @Override
-    public int compareTo(@Nonnull OpusPacket o)
+    public int compareTo(@NotNull OpusPacket o)
     {
         return getSequence() - o.getSequence();
     }

--- a/src/main/java/net/dv8tion/jda/api/audio/SpeakingMode.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/SpeakingMode.java
@@ -16,8 +16,9 @@
 
 package net.dv8tion.jda.api.audio;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Collection;
 import java.util.EnumSet;
 
@@ -53,7 +54,7 @@ public enum SpeakingMode
      *
      * @return {@link EnumSet EnumSet} containing the speaking modes
      */
-    @Nonnull
+    @NotNull
     public static EnumSet<SpeakingMode> getModes(int mask)
     {
         final EnumSet<SpeakingMode> modes = EnumSet.noneOf(SpeakingMode.class);

--- a/src/main/java/net/dv8tion/jda/api/audio/UserAudio.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/UserAudio.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.audio;
 
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a packet of User specific audio.
@@ -28,7 +27,7 @@ public class UserAudio
     protected User user;
     protected short[] audioData;
 
-    public UserAudio(@Nonnull User user, @Nonnull short[] audioData)
+    public UserAudio(@NotNull User user, @NotNull short[] audioData)
     {
         this.user = user;
         this.audioData = audioData;
@@ -39,7 +38,7 @@ public class UserAudio
      *
      * @return Never-null {@link net.dv8tion.jda.api.entities.User User} object.
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return user;
@@ -57,7 +56,7 @@ public class UserAudio
      *
      * @return Never-null byte array of PCM data defined by {@link net.dv8tion.jda.api.audio.AudioReceiveHandler#OUTPUT_FORMAT AudioReceiveHandler.OUTPUT_FORMAT}
      */
-    @Nonnull
+    @NotNull
     public byte[] getAudioData(double volume)
     {
         return OpusPacket.getAudioData(audioData, volume);

--- a/src/main/java/net/dv8tion/jda/api/audio/factory/DefaultSendFactory.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/factory/DefaultSendFactory.java
@@ -16,16 +16,16 @@
 
 package net.dv8tion.jda.api.audio.factory;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The default implementation of the {@link net.dv8tion.jda.api.audio.factory.IAudioSendFactory IAudioSendFactory}.
  */
 public class DefaultSendFactory implements IAudioSendFactory
 {
-    @Nonnull
+    @NotNull
     @Override
-    public IAudioSendSystem createSendSystem(@Nonnull IPacketProvider packetProvider)
+    public IAudioSendSystem createSendSystem(@NotNull IPacketProvider packetProvider)
     {
         return new DefaultSendSystem(packetProvider);
     }

--- a/src/main/java/net/dv8tion/jda/api/audio/factory/IAudioSendFactory.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/factory/IAudioSendFactory.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.audio.factory;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Factory interface for the creation of new {@link net.dv8tion.jda.api.audio.factory.IAudioSendSystem IAudioSendSystem} objects.
@@ -38,6 +38,6 @@ public interface IAudioSendFactory
      *
      * @return The newly constructed IAudioSendSystem, ready for {@link IAudioSendSystem#start()} to be called.
      */
-    @Nonnull
-    IAudioSendSystem createSendSystem(@Nonnull IPacketProvider packetProvider);
+    @NotNull
+    IAudioSendSystem createSendSystem(@NotNull IPacketProvider packetProvider);
 }

--- a/src/main/java/net/dv8tion/jda/api/audio/factory/IPacketProvider.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/factory/IPacketProvider.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.audio.factory;
 
 import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
 import net.dv8tion.jda.api.entities.VoiceChannel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -43,7 +43,7 @@ public interface IPacketProvider
      *
      * @return Never-null String unique to this audio connection.
      */
-    @Nonnull
+    @NotNull
     String getIdentifier();
 
     /**
@@ -51,7 +51,7 @@ public interface IPacketProvider
      *
      * @return The {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} that this connection is sending to.
      */
-    @Nonnull
+    @NotNull
     VoiceChannel getConnectedChannel();
 
     /**
@@ -63,7 +63,7 @@ public interface IPacketProvider
      *
      * @return The UDP socket connection used for audio sending.
      */
-    @Nonnull
+    @NotNull
     DatagramSocket getUdpSocket();
 
     /**
@@ -72,7 +72,7 @@ public interface IPacketProvider
      *
      * @return {@link InetSocketAddress} of the current UDP connection
      */
-    @Nonnull
+    @NotNull
     InetSocketAddress getSocketAddress();
 
     /**
@@ -133,7 +133,7 @@ public interface IPacketProvider
      *         The {@link net.dv8tion.jda.api.audio.hooks.ConnectionStatus ConnectionStatus} being reported to JDA
      *         indicating an error with connection.
      */
-    void onConnectionError(@Nonnull ConnectionStatus status);
+    void onConnectionError(@NotNull ConnectionStatus status);
 
     /**
      * This method is used to indicate to JDA that the UDP connection has been lost, whether that be due internet loss

--- a/src/main/java/net/dv8tion/jda/api/audio/hooks/ConnectionListener.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/hooks/ConnectionListener.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.audio.hooks;
 
 import net.dv8tion.jda.api.audio.SpeakingMode;
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
 /**
@@ -44,7 +44,7 @@ public interface ConnectionListener
      * @param  status
      *         The new {@link net.dv8tion.jda.api.audio.hooks.ConnectionStatus ConnectionStatus} of the audio connection.
      */
-    void onStatusChange(@Nonnull ConnectionStatus status);
+    void onStatusChange(@NotNull ConnectionStatus status);
 
     /**
      * This method is an easy way to detect if a user is talking. Discord sends us an event when a user starts or stops
@@ -68,7 +68,7 @@ public interface ConnectionListener
      * @param  speaking
      *         If true, the user has begun transmitting audio.
      */
-    void onUserSpeaking(@Nonnull User user, boolean speaking);
+    void onUserSpeaking(@NotNull User user, boolean speaking);
 
     /**
      * This method is an easy way to detect if a user is talking. Discord sends us an event when a user starts or stops
@@ -96,7 +96,7 @@ public interface ConnectionListener
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.audio.SpeakingMode SpeakingMode
      */
-    default void onUserSpeaking(@Nonnull User user, @Nonnull EnumSet<SpeakingMode> modes) {}
+    default void onUserSpeaking(@NotNull User user, @NotNull EnumSet<SpeakingMode> modes) {}
 
 
     /**
@@ -123,5 +123,5 @@ public interface ConnectionListener
      * @param  soundshare
      *         If true, the user is using soundshare
      */
-    default void onUserSpeaking(@Nonnull User user, boolean speaking, boolean soundshare) {}
+    default void onUserSpeaking(@NotNull User user, boolean speaking, boolean soundshare) {}
 }

--- a/src/main/java/net/dv8tion/jda/api/audio/hooks/ListenerProxy.java
+++ b/src/main/java/net/dv8tion/jda/api/audio/hooks/ListenerProxy.java
@@ -18,10 +18,10 @@ package net.dv8tion.jda.api.audio.hooks;
 
 import net.dv8tion.jda.api.audio.SpeakingMode;
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
 public class ListenerProxy implements ConnectionListener
@@ -49,7 +49,7 @@ public class ListenerProxy implements ConnectionListener
     }
 
     @Override
-    public void onStatusChange(@Nonnull ConnectionStatus status)
+    public void onStatusChange(@NotNull ConnectionStatus status)
     {
         if (listener == null)
             return;
@@ -68,7 +68,7 @@ public class ListenerProxy implements ConnectionListener
     }
 
     @Override
-    public void onUserSpeaking(@Nonnull User user, @Nonnull EnumSet<SpeakingMode> modes)
+    public void onUserSpeaking(@NotNull User user, @NotNull EnumSet<SpeakingMode> modes)
     {
         if (listener == null)
             return;
@@ -91,7 +91,7 @@ public class ListenerProxy implements ConnectionListener
     }
 
     @Override
-    public void onUserSpeaking(@Nonnull User user, boolean speaking) {}
+    public void onUserSpeaking(@NotNull User user, boolean speaking) {}
 
     public void setListener(ConnectionListener listener)
     {

--- a/src/main/java/net/dv8tion/jda/api/audit/AuditLogChange.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/AuditLogChange.java
@@ -16,8 +16,9 @@
 
 package net.dv8tion.jda.api.audit;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -83,7 +84,7 @@ public class AuditLogChange
      *
      * @return The key
      */
-    @Nonnull
+    @NotNull
     public String getKey()
     {
         return key;

--- a/src/main/java/net/dv8tion/jda/api/audit/AuditLogEntry.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/AuditLogEntry.java
@@ -25,9 +25,9 @@ import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.UserImpl;
 import net.dv8tion.jda.internal.entities.WebhookImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -96,7 +96,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return The target id
      */
-    @Nonnull
+    @NotNull
     public String getTargetId()
     {
         return Long.toUnsignedString(targetId);
@@ -118,7 +118,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return The Guild instance
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return guild;
@@ -152,7 +152,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return The corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     public JDA getJDA()
     {
         return guild.getJDA();
@@ -166,7 +166,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Key-Value Map of changes
      */
-    @Nonnull
+    @NotNull
     public Map<String, AuditLogChange> getChanges()
     {
         return changes;
@@ -213,8 +213,8 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Possibly-empty, never-null immutable list of {@link AuditLogChange AuditLogChanges}
      */
-    @Nonnull
-    public List<AuditLogChange> getChangesForKeys(@Nonnull AuditLogKey... keys)
+    @NotNull
+    public List<AuditLogChange> getChangesForKeys(@NotNull AuditLogKey... keys)
     {
         Checks.notNull(keys, "Keys");
         List<AuditLogChange> changes = new ArrayList<>(keys.length);
@@ -239,7 +239,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Key-Value Map of changes
      */
-    @Nonnull
+    @NotNull
     public Map<String, Object> getOptions()
     {
         return options;
@@ -282,7 +282,7 @@ public class AuditLogEntry implements ISnowflake
      * @return Possibly-null value corresponding to the specified option constant
      */
     @Nullable
-    public <T> T getOption(@Nonnull AuditLogOption option)
+    public <T> T getOption(@NotNull AuditLogOption option)
     {
         Checks.notNull(option, "Option");
         return getOptionByName(option.getKey());
@@ -302,8 +302,8 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return Unmodifiable list of representative values
      */
-    @Nonnull
-    public List<Object> getOptions(@Nonnull AuditLogOption... options)
+    @NotNull
+    public List<Object> getOptions(@NotNull AuditLogOption... options)
     {
         Checks.notNull(options, "Options");
         List<Object> items = new ArrayList<>(options.length);
@@ -322,7 +322,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return The {@link net.dv8tion.jda.api.audit.ActionType ActionType}
      */
-    @Nonnull
+    @NotNull
     public ActionType getType()
     {
         return type;
@@ -346,7 +346,7 @@ public class AuditLogEntry implements ISnowflake
      *
      * @return The {@link net.dv8tion.jda.api.audit.TargetType TargetType}
      */
-    @Nonnull
+    @NotNull
     public TargetType getTargetType()
     {
         return type.getTargetType();

--- a/src/main/java/net/dv8tion/jda/api/audit/ThreadLocalReason.java
+++ b/src/main/java/net/dv8tion/jda/api/audit/ThreadLocalReason.java
@@ -16,8 +16,9 @@
 
 package net.dv8tion.jda.api.audit;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.function.Consumer;
 
 /**
@@ -117,7 +118,7 @@ public final class ThreadLocalReason
      *
      * @return The closable instance
      */
-    @Nonnull
+    @NotNull
     public static Closable closable(@Nullable String reason)
     {
         return new ThreadLocalReason.Closable(reason);

--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.temporal.TemporalUnit;
 import java.util.Objects;
@@ -71,7 +71,7 @@ public interface Activity
      *
      * @return String containing the Activity's name.
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -88,7 +88,7 @@ public interface Activity
      *
      * @return Never-null {@link net.dv8tion.jda.api.entities.Activity.ActivityType ActivityType} representing the type of Activity
      */
-    @Nonnull
+    @NotNull
     ActivityType getType();
 
     /**
@@ -120,8 +120,8 @@ public interface Activity
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#DEFAULT}
      */
-    @Nonnull
-    static Activity playing(@Nonnull String name)
+    @NotNull
+    static Activity playing(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
@@ -146,8 +146,8 @@ public interface Activity
      *
      * @see    #isValidStreamingUrl(String)
      */
-    @Nonnull
-    static Activity streaming(@Nonnull String name, @Nullable String url)
+    @NotNull
+    static Activity streaming(@NotNull String name, @Nullable String url)
     {
         Checks.notEmpty(name, "Provided game name");
         name = Helpers.isBlank(name) ? name : name.trim();
@@ -172,8 +172,8 @@ public interface Activity
      *
      * @return A valid Activity instance with the provided name with {@link net.dv8tion.jda.api.entities.Activity.ActivityType#LISTENING}
      */
-    @Nonnull
-    static Activity listening(@Nonnull String name)
+    @NotNull
+    static Activity listening(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
@@ -195,9 +195,9 @@ public interface Activity
      *
      * @incubating This feature is not yet confirmed for the official bot API
      */
-    @Nonnull
+    @NotNull
     @Incubating
-    static Activity watching(@Nonnull String name)
+    static Activity watching(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
@@ -219,8 +219,8 @@ public interface Activity
      *
      * @since  4.2.1
      */
-    @Nonnull
-    static Activity competing(@Nonnull String name)
+    @NotNull
+    static Activity competing(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
@@ -241,8 +241,8 @@ public interface Activity
      *
      * @return A valid Activity instance with the provided name and url
      */
-    @Nonnull
-    static Activity of(@Nonnull ActivityType type, @Nonnull String name)
+    @NotNull
+    static Activity of(@NotNull ActivityType type, @NotNull String name)
     {
         return of(type, name, null);
     }
@@ -266,8 +266,8 @@ public interface Activity
      *
      * @see    #isValidStreamingUrl(String)
      */
-    @Nonnull
-    static Activity of(@Nonnull ActivityType type, @Nonnull String name, @Nullable String url)
+    @NotNull
+    static Activity of(@NotNull ActivityType type, @NotNull String name, @Nullable String url)
     {
         Checks.notNull(type, "Type");
         switch (type)
@@ -370,7 +370,7 @@ public interface Activity
          *
          * @return The ActivityType that has the key provided, or {@link #DEFAULT} for unknown key.
          */
-        @Nonnull
+        @NotNull
         public static ActivityType fromKey(int key)
         {
             switch (key)
@@ -557,7 +557,7 @@ public interface Activity
          *
          * @see    #getAsCodepoints()
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             return name;
@@ -574,7 +574,7 @@ public interface Activity
          *
          * @see    #getName()
          */
-        @Nonnull
+        @NotNull
         public String getAsCodepoints()
         {
             if (!isEmoji())
@@ -629,7 +629,7 @@ public interface Activity
             return id != 0;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getAsMention()
         {

--- a/src/main/java/net/dv8tion/jda/api/entities/ActivityFlag.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ActivityFlag.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.EnumSet;
 
 /**
@@ -71,7 +72,7 @@ public enum ActivityFlag
      * @see    RichPresence#getFlags()
      * @see    EnumSet EnumSet
      */
-    @Nonnull
+    @NotNull
     public static EnumSet<ActivityFlag> getFlags(int raw)
     {
         EnumSet<ActivityFlag> set = EnumSet.noneOf(ActivityFlag.class);

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -50,7 +50,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The description of the bot's application or an empty {@link String} if no description is defined
      */
-    @Nonnull
+    @NotNull
     String getDescription();
 
     /**
@@ -92,7 +92,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The link used to invite the bot
      */
-    @Nonnull
+    @NotNull
     default String getInviteUrl(@Nullable Collection<Permission> permissions)
     {
         return getInviteUrl(null, permissions);
@@ -110,7 +110,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The link used to invite the bot
      */
-    @Nonnull
+    @NotNull
     default String getInviteUrl(@Nullable Permission... permissions)
     {
         return getInviteUrl(null, permissions);
@@ -134,7 +134,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The link used to invite the bot
      */
-    @Nonnull
+    @NotNull
     String getInviteUrl(@Nullable String guildId, @Nullable Collection<Permission> permissions);
 
     /**
@@ -152,7 +152,7 @@ public interface ApplicationInfo extends ISnowflake
      *
      * @return The link used to invite the bot
      */
-    @Nonnull
+    @NotNull
     default String getInviteUrl(long guildId, @Nullable Collection<Permission> permissions)
     {
         return getInviteUrl(Long.toUnsignedString(guildId), permissions);
@@ -176,7 +176,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The link used to invite the bot
      */
-    @Nonnull
+    @NotNull
     default String getInviteUrl(@Nullable String guildId, @Nullable Permission... permissions)
     {
         return getInviteUrl(guildId, permissions == null ? null : Arrays.asList(permissions));
@@ -197,7 +197,7 @@ public interface ApplicationInfo extends ISnowflake
      *
      * @return The link used to invite the bot
      */
-    @Nonnull
+    @NotNull
     default String getInviteUrl(long guildId, @Nullable Permission... permissions)
     {
         return getInviteUrl(Long.toUnsignedString(guildId), permissions);
@@ -209,7 +209,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The JDA instance of this ApplicationInfo
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -218,7 +218,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The name of the bot's application.
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -226,7 +226,7 @@ public interface ApplicationInfo extends ISnowflake
      * 
      * @return The owner of the bot's application
      */
-    @Nonnull
+    @NotNull
     User getOwner();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationTeam.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationTeam.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -51,7 +51,7 @@ public interface ApplicationTeam extends ISnowflake
      *
      * @return The owner id
      */
-    @Nonnull
+    @NotNull
     default String getOwnerId()
     {
         return Long.toUnsignedString(getOwnerIdLong());
@@ -91,7 +91,7 @@ public interface ApplicationTeam extends ISnowflake
      *
      * @return Immutable list of team members
      */
-    @Nonnull
+    @NotNull
     List<TeamMember> getMembers();
 
     /**
@@ -105,7 +105,7 @@ public interface ApplicationTeam extends ISnowflake
      *
      * @return True, if the provided user is a member of this team
      */
-    default boolean isMember(@Nonnull User user)
+    default boolean isMember(@NotNull User user)
     {
         return getMember(user) != null;
     }
@@ -123,7 +123,7 @@ public interface ApplicationTeam extends ISnowflake
      * @return The {@link net.dv8tion.jda.api.entities.TeamMember TeamMember} for the user or null
      */
     @Nullable
-    default TeamMember getMember(@Nonnull User user)
+    default TeamMember getMember(@NotNull User user)
     {
         Checks.notNull(user, "User");
         return getMemberById(user.getIdLong());
@@ -142,7 +142,7 @@ public interface ApplicationTeam extends ISnowflake
      * @return The {@link net.dv8tion.jda.api.entities.TeamMember TeamMember} for the user or null
      */
     @Nullable
-    default TeamMember getMemberById(@Nonnull String userId)
+    default TeamMember getMemberById(@NotNull String userId)
     {
         return getMemberById(MiscUtil.parseSnowflake(userId));
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/Category.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Category.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
 import net.dv8tion.jda.api.requests.restaction.order.ChannelOrderAction;
 import net.dv8tion.jda.api.requests.restaction.order.OrderAction;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -53,7 +53,7 @@ public interface Category extends GuildChannel
      *
      * @return Immutable list of all child channels
      */
-    @Nonnull
+    @NotNull
     List<GuildChannel> getChannels();
 
     /**
@@ -64,7 +64,7 @@ public interface Category extends GuildChannel
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     List<StoreChannel> getStoreChannels();
 
     /**
@@ -73,7 +73,7 @@ public interface Category extends GuildChannel
      *
      * @return Immutable list of all child TextChannels
      */
-    @Nonnull
+    @NotNull
     List<TextChannel> getTextChannels();
 
     /**
@@ -82,7 +82,7 @@ public interface Category extends GuildChannel
      *
      * @return Immutable list of all child VoiceChannels
      */
-    @Nonnull
+    @NotNull
     List<VoiceChannel> getVoiceChannels();
 
     /**
@@ -118,9 +118,9 @@ public interface Category extends GuildChannel
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new TextChannel before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<TextChannel> createTextChannel(@Nonnull String name);
+    ChannelAction<TextChannel> createTextChannel(@NotNull String name);
 
     /**
      * Creates a new {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} with this Category as parent.
@@ -155,9 +155,9 @@ public interface Category extends GuildChannel
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new VoiceChannel before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<VoiceChannel> createVoiceChannel(@Nonnull String name);
+    ChannelAction<VoiceChannel> createVoiceChannel(@NotNull String name);
 
     /**
      * Modifies the positional order of this Category's nested {@link #getTextChannels() TextChannels} and {@link #getStoreChannels() StoreChannels}.
@@ -183,7 +183,7 @@ public interface Category extends GuildChannel
      *         ordering the Category's {@link net.dv8tion.jda.api.entities.TextChannel TextChannels}
      *         and {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannels}.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     CategoryOrderAction modifyTextChannelPositions();
 
@@ -210,15 +210,15 @@ public interface Category extends GuildChannel
      * @return A {@link CategoryOrderAction CategoryOrderAction} for
      *         ordering the Category's {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     CategoryOrderAction modifyVoiceChannelPositions();
 
-    @Nonnull
+    @NotNull
     @Override
-    ChannelAction<Category> createCopy(@Nonnull Guild guild);
+    ChannelAction<Category> createCopy(@NotNull Guild guild);
 
-    @Nonnull
+    @NotNull
     @Override
     ChannelAction<Category> createCopy();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/ChannelType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ChannelType.java
@@ -15,7 +15,8 @@
  */
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.EnumSet;
 
 /**
@@ -107,7 +108,7 @@ public enum ChannelType
      *
      * @return The ChannelType that is referred to by the provided key. If the id key is unknown, {@link #UNKNOWN} is returned.
      */
-    @Nonnull
+    @NotNull
     public static ChannelType fromId(int id)
     {
         if (id == 5) // NEWS = TEXT
@@ -128,7 +129,7 @@ public enum ChannelType
      *
      * @return Possibly-empty {@link java.util.EnumSet} for the bucket
      */
-    @Nonnull
+    @NotNull
     public static EnumSet<ChannelType> fromSortBucket(int bucket)
     {
         EnumSet<ChannelType> types = EnumSet.noneOf(ChannelType.class);

--- a/src/main/java/net/dv8tion/jda/api/entities/ClientType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ClientType.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The type of client a user might be active on.
@@ -60,8 +60,8 @@ public enum ClientType
      *
      * @return The resolved ClientType or {@link #UNKNOWN}
      */
-    @Nonnull
-    public static ClientType fromKey(@Nonnull String key)
+    @NotNull
+    public static ClientType fromKey(@NotNull String key)
     {
         for (ClientType type : values())
         {

--- a/src/main/java/net/dv8tion/jda/api/entities/EmbedType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/EmbedType.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents the embedded resource type.
@@ -47,7 +47,7 @@ public enum EmbedType
      * @return The {@link net.dv8tion.jda.api.entities.EmbedType EmbedType} matching the provided key,
      *         or {@link net.dv8tion.jda.api.entities.EmbedType#UNKNOWN UNKNOWN}.
      */
-    @Nonnull
+    @NotNull
     public static EmbedType fromKey(String key)
     {
         for (EmbedType type : values())

--- a/src/main/java/net/dv8tion/jda/api/entities/Emote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emote.java
@@ -22,10 +22,10 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.managers.EmoteManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -76,7 +76,7 @@ public interface Emote extends IMentionable, IFakeable
      *
      * @see    #canProvideRoles()
      */
-    @Nonnull
+    @NotNull
     List<Role> getRoles();
 
     /**
@@ -113,7 +113,7 @@ public interface Emote extends IMentionable, IFakeable
      *
      * @return String representation of this emote's name
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -148,7 +148,7 @@ public interface Emote extends IMentionable, IFakeable
      *
      * @return The JDA instance of this Emote
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -174,7 +174,7 @@ public interface Emote extends IMentionable, IFakeable
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *         The RestAction to delete this Emote.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 
@@ -193,7 +193,7 @@ public interface Emote extends IMentionable, IFakeable
      *
      * @return The EmoteManager for this Emote
      */
-    @Nonnull
+    @NotNull
     EmoteManager getManager();
 
     /**
@@ -211,7 +211,7 @@ public interface Emote extends IMentionable, IFakeable
      *
      * @return Discord CDN link to the Emote's image
      */
-    @Nonnull
+    @NotNull
     default String getImageUrl()
     {
         return String.format(ICON_URL, getId(), isAnimated() ? "gif" : "png");
@@ -225,7 +225,7 @@ public interface Emote extends IMentionable, IFakeable
      *
      * @see    <a href="https://discord.com/developers/docs/resources/channel#message-formatting">Message Formatting</a>
      */
-    @Nonnull
+    @NotNull
     @Override
     default String getAsMention()
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -47,10 +47,10 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -82,7 +82,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type {@link java.util.EnumSet EnumSet}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<EnumSet<Region>> retrieveRegions()
     {
@@ -97,7 +97,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type {@link java.util.EnumSet EnumSet}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<EnumSet<Region>> retrieveRegions(boolean includeDeprecated);
 
@@ -122,9 +122,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.7.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MemberAction addMember(@Nonnull String accessToken, @Nonnull String userId);
+    MemberAction addMember(@NotNull String accessToken, @NotNull String userId);
 
     /**
      * Adds the provided user to this guild.
@@ -147,9 +147,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.7.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MemberAction addMember(@Nonnull String accessToken, @Nonnull User user)
+    default MemberAction addMember(@NotNull String accessToken, @NotNull User user)
     {
         Checks.notNull(user, "User");
         return addMember(accessToken, user.getId());
@@ -176,9 +176,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.7.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MemberAction addMember(@Nonnull String accessToken, long userId)
+    default MemberAction addMember(@NotNull String accessToken, long userId)
     {
         return addMember(accessToken, Long.toUnsignedString(userId));
     }
@@ -255,7 +255,7 @@ public interface Guild extends ISnowflake
      *
      * @return Never-null String containing the Guild's name.
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -292,7 +292,7 @@ public interface Guild extends ISnowflake
      *
      * @return Never-null, unmodifiable Set containing all of the Guild's features.
      */
-    @Nonnull
+    @NotNull
     Set<String> getFeatures();
 
     /**
@@ -353,7 +353,7 @@ public interface Guild extends ISnowflake
      * @see    #getFeatures()
      * @see    #getVanityCode()
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.0.0")
@@ -416,7 +416,7 @@ public interface Guild extends ISnowflake
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<VanityInvite> retrieveVanityInvite();
 
@@ -443,7 +443,7 @@ public interface Guild extends ISnowflake
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     Locale getLocale();
 
     /**
@@ -486,7 +486,7 @@ public interface Guild extends ISnowflake
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     BoostTier getBoostTier();
 
     /**
@@ -505,7 +505,7 @@ public interface Guild extends ISnowflake
      *
      * @return Possibly-immutable list of members who boost this guild
      */
-    @Nonnull
+    @NotNull
     List<Member> getBoosters();
 
     /**
@@ -579,7 +579,7 @@ public interface Guild extends ISnowflake
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<MetaData> retrieveMetaData();
 
@@ -668,7 +668,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #getOwner()
      */
-    @Nonnull
+    @NotNull
     default String getOwnerId()
     {
         return Long.toUnsignedString(getOwnerIdLong());
@@ -685,7 +685,7 @@ public interface Guild extends ISnowflake
      *
      * @return The {@link net.dv8tion.jda.api.entities.Guild.Timeout Timeout} set for this Guild.
      */
-    @Nonnull
+    @NotNull
     Timeout getAfkTimeout();
 
     /**
@@ -698,7 +698,7 @@ public interface Guild extends ISnowflake
      *
      * @return The the audio Region this Guild is using for audio connections. Can return Region.UNKNOWN.
      */
-    @Nonnull
+    @NotNull
     default Region getRegion()
     {
         return Region.fromKey(getRegionRaw());
@@ -713,7 +713,7 @@ public interface Guild extends ISnowflake
      *
      * @return Raw region name
      */
-    @Nonnull
+    @NotNull
     String getRegionRaw();
 
     /**
@@ -726,7 +726,7 @@ public interface Guild extends ISnowflake
      *
      * @return True - if this user is present in this guild.
      */
-    boolean isMember(@Nonnull User user);
+    boolean isMember(@NotNull User user);
 
     /**
      * Gets the {@link net.dv8tion.jda.api.entities.Member Member} object of the currently logged in account in this guild.
@@ -734,7 +734,7 @@ public interface Guild extends ISnowflake
      *
      * @return The Member object of the currently logged in account.
      */
-    @Nonnull
+    @NotNull
     Member getSelfMember();
 
     /**
@@ -755,7 +755,7 @@ public interface Guild extends ISnowflake
      * @see    #retrieveMember(User)
      */
     @Nullable
-    Member getMember(@Nonnull User user);
+    Member getMember(@NotNull User user);
 
     /**
      * Gets a {@link net.dv8tion.jda.api.entities.Member Member} object via the id of the user. The id relates to
@@ -776,7 +776,7 @@ public interface Guild extends ISnowflake
      * @see    #retrieveMemberById(String)
      */
     @Nullable
-    default Member getMemberById(@Nonnull String userId)
+    default Member getMemberById(@NotNull String userId)
     {
         return getMemberCache().getElementById(userId);
     }
@@ -829,7 +829,7 @@ public interface Guild extends ISnowflake
      * @see    net.dv8tion.jda.api.JDA#getUserByTag(String)
      */
     @Nullable
-    default Member getMemberByTag(@Nonnull String tag)
+    default Member getMemberByTag(@NotNull String tag)
     {
         User user = getJDA().getUserByTag(tag);
         return user == null ? null : getMember(user);
@@ -863,7 +863,7 @@ public interface Guild extends ISnowflake
      * @see    #getMemberByTag(String)
      */
     @Nullable
-    default Member getMemberByTag(@Nonnull String username, @Nonnull String discriminator)
+    default Member getMemberByTag(@NotNull String username, @NotNull String discriminator)
     {
         User user = getJDA().getUserByTag(username, discriminator);
         return user == null ? null : getMember(user);
@@ -885,7 +885,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #loadMembers()
      */
-    @Nonnull
+    @NotNull
     default List<Member> getMembers()
     {
         return getMemberCache().asList();
@@ -911,8 +911,8 @@ public interface Guild extends ISnowflake
      *
      * @see    #retrieveMembersByPrefix(String, int)
      */
-    @Nonnull
-    default List<Member> getMembersByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Member> getMembersByName(@NotNull String name, boolean ignoreCase)
     {
         return getMemberCache().getElementsByUsername(name, ignoreCase);
     }
@@ -934,7 +934,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #retrieveMembersByPrefix(String, int)
      */
-    @Nonnull
+    @NotNull
     default List<Member> getMembersByNickname(@Nullable String nickname, boolean ignoreCase)
     {
         return getMemberCache().getElementsByNickname(nickname, ignoreCase);
@@ -960,8 +960,8 @@ public interface Guild extends ISnowflake
      *
      * @see    #retrieveMembersByPrefix(String, int)
      */
-    @Nonnull
-    default List<Member> getMembersByEffectiveName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Member> getMembersByEffectiveName(@NotNull String name, boolean ignoreCase)
     {
         return getMemberCache().getElementsByName(name, ignoreCase);
     }
@@ -984,8 +984,8 @@ public interface Guild extends ISnowflake
      *
      * @see    #findMembersWithRoles(Role...)
      */
-    @Nonnull
-    default List<Member> getMembersWithRoles(@Nonnull Role... roles)
+    @NotNull
+    default List<Member> getMembersWithRoles(@NotNull Role... roles)
     {
         return getMemberCache().getElementsWithRoles(roles);
     }
@@ -1008,8 +1008,8 @@ public interface Guild extends ISnowflake
      *
      * @see    #findMembersWithRoles(Collection)
      */
-    @Nonnull
-    default List<Member> getMembersWithRoles(@Nonnull Collection<Role> roles)
+    @NotNull
+    default List<Member> getMembersWithRoles(@NotNull Collection<Role> roles)
     {
         return getMemberCache().getElementsWithRoles(roles);
     }
@@ -1025,7 +1025,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #loadMembers()
      */
-    @Nonnull
+    @NotNull
     MemberCacheView getMemberCache();
 
     /**
@@ -1051,7 +1051,7 @@ public interface Guild extends ISnowflake
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull String id)
+    default GuildChannel getGuildChannelById(@NotNull String id)
     {
         return getGuildChannelById(MiscUtil.parseSnowflake(id));
     }
@@ -1112,7 +1112,7 @@ public interface Guild extends ISnowflake
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, @Nonnull String id)
+    default GuildChannel getGuildChannelById(@NotNull ChannelType type, @NotNull String id)
     {
         return getGuildChannelById(type, MiscUtil.parseSnowflake(id));
     }
@@ -1138,7 +1138,7 @@ public interface Guild extends ISnowflake
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, long id)
+    default GuildChannel getGuildChannelById(@NotNull ChannelType type, long id)
     {
         Checks.notNull(type, "ChannelType");
         switch (type)
@@ -1170,7 +1170,7 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Category Category} for the provided ID.
      */
     @Nullable
-    default Category getCategoryById(@Nonnull String id)
+    default Category getCategoryById(@NotNull String id)
     {
         return getCategoryCache().getElementById(id);
     }
@@ -1203,7 +1203,7 @@ public interface Guild extends ISnowflake
      *
      * @return An immutable list of all {@link net.dv8tion.jda.api.entities.Category Categories} in this Guild.
      */
-    @Nonnull
+    @NotNull
     default List<Category> getCategories()
     {
         return getCategoryCache().asList();
@@ -1223,8 +1223,8 @@ public interface Guild extends ISnowflake
      *
      * @return Immutable list of all categories matching the provided name
      */
-    @Nonnull
-    default List<Category> getCategoriesByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Category> getCategoriesByName(@NotNull String name, boolean ignoreCase)
     {
         return getCategoryCache().getElementsByName(name, ignoreCase);
     }
@@ -1236,7 +1236,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SortedSnowflakeCacheView<Category> getCategoryCache();
 
     /**
@@ -1257,7 +1257,7 @@ public interface Guild extends ISnowflake
      * @since  4.0.0
      */
     @Nullable
-    default StoreChannel getStoreChannelById(@Nonnull String id)
+    default StoreChannel getStoreChannelById(@NotNull String id)
     {
         return getStoreChannelCache().getElementById(id);
     }
@@ -1295,7 +1295,7 @@ public interface Guild extends ISnowflake
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     default List<StoreChannel> getStoreChannels()
     {
         return getStoreChannelCache().asList();
@@ -1315,8 +1315,8 @@ public interface Guild extends ISnowflake
      *
      * @since  4.0.0
      */
-    @Nonnull
-    default List<StoreChannel> getStoreChannelsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<StoreChannel> getStoreChannelsByName(@NotNull String name, boolean ignoreCase)
     {
         return getStoreChannelCache().getElementsByName(name, ignoreCase);
     }
@@ -1330,7 +1330,7 @@ public interface Guild extends ISnowflake
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     SortedSnowflakeCacheView<StoreChannel> getStoreChannelCache();
 
     /**
@@ -1349,7 +1349,7 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} with matching id.
      */
     @Nullable
-    default TextChannel getTextChannelById(@Nonnull String id)
+    default TextChannel getTextChannelById(@NotNull String id)
     {
         return getTextChannelCache().getElementById(id);
     }
@@ -1383,7 +1383,7 @@ public interface Guild extends ISnowflake
      *
      * @return An immutable List of all {@link net.dv8tion.jda.api.entities.TextChannel TextChannels} in this Guild.
      */
-    @Nonnull
+    @NotNull
     default List<TextChannel> getTextChannels()
     {
         return getTextChannelCache().asList();
@@ -1401,8 +1401,8 @@ public interface Guild extends ISnowflake
      *
      * @return Possibly-empty immutable list of all TextChannels names that match the provided name.
      */
-    @Nonnull
-    default List<TextChannel> getTextChannelsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<TextChannel> getTextChannelsByName(@NotNull String name, boolean ignoreCase)
     {
         return getTextChannelCache().getElementsByName(name, ignoreCase);
     }
@@ -1414,7 +1414,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SortedSnowflakeCacheView<TextChannel> getTextChannelCache();
 
     /**
@@ -1433,7 +1433,7 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} with matching id.
      */
     @Nullable
-    default VoiceChannel getVoiceChannelById(@Nonnull String id)
+    default VoiceChannel getVoiceChannelById(@NotNull String id)
     {
         return getVoiceChannelCache().getElementById(id);
     }
@@ -1467,7 +1467,7 @@ public interface Guild extends ISnowflake
      *
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<VoiceChannel> getVoiceChannels()
     {
         return getVoiceChannelCache().asList();
@@ -1485,8 +1485,8 @@ public interface Guild extends ISnowflake
      *
      * @return Possibly-empty immutable list of all VoiceChannel names that match the provided name.
      */
-    @Nonnull
-    default List<VoiceChannel> getVoiceChannelsByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<VoiceChannel> getVoiceChannelsByName(@NotNull String name, boolean ignoreCase)
     {
         return getVoiceChannelCache().getElementsByName(name, ignoreCase);
     }
@@ -1498,7 +1498,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SortedSnowflakeCacheView<VoiceChannel> getVoiceChannelCache();
 
     /**
@@ -1522,7 +1522,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #getChannels(boolean)
      */
-    @Nonnull
+    @NotNull
     default List<GuildChannel> getChannels()
     {
         return getChannels(true);
@@ -1552,7 +1552,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #getChannels()
      */
-    @Nonnull
+    @NotNull
     List<GuildChannel> getChannels(boolean includeHidden);
 
     /**
@@ -1570,7 +1570,7 @@ public interface Guild extends ISnowflake
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Role Role} with matching id.
      */
     @Nullable
-    default Role getRoleById(@Nonnull String id)
+    default Role getRoleById(@NotNull String id)
     {
         return getRoleCache().getElementById(id);
     }
@@ -1604,7 +1604,7 @@ public interface Guild extends ISnowflake
      *
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.Role Roles}.
      */
-    @Nonnull
+    @NotNull
     default List<Role> getRoles()
     {
         return getRoleCache().asList();
@@ -1622,8 +1622,8 @@ public interface Guild extends ISnowflake
      *
      * @return Possibly-empty immutable list of all Role names that match the provided name.
      */
-    @Nonnull
-    default List<Role> getRolesByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Role> getRolesByName(@NotNull String name, boolean ignoreCase)
     {
         return getRoleCache().getElementsByName(name, ignoreCase);
     }
@@ -1672,7 +1672,7 @@ public interface Guild extends ISnowflake
      * @return The bot role, or null if no role matches
      */
     @Nullable
-    default Role getRoleByBot(@Nonnull String userId)
+    default Role getRoleByBot(@NotNull String userId)
     {
         return getRoleByBot(MiscUtil.parseSnowflake(userId));
     }
@@ -1696,7 +1696,7 @@ public interface Guild extends ISnowflake
      * @return The bot role, or null if no role matches
      */
     @Nullable
-    default Role getRoleByBot(@Nonnull User user)
+    default Role getRoleByBot(@NotNull User user)
     {
         Checks.notNull(user, "User");
         return getRoleByBot(user.getIdLong());
@@ -1748,7 +1748,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView SortedSnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     SortedSnowflakeCacheView<Role> getRoleCache();
 
     /**
@@ -1772,7 +1772,7 @@ public interface Guild extends ISnowflake
      * @see    #retrieveEmoteById(String)
      */
     @Nullable
-    default Emote getEmoteById(@Nonnull String id)
+    default Emote getEmoteById(@NotNull String id)
     {
         return getEmoteCache().getElementById(id);
     }
@@ -1817,7 +1817,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #retrieveEmotes()
      */
-    @Nonnull
+    @NotNull
     default List<Emote> getEmotes()
     {
         return getEmoteCache().asList();
@@ -1839,8 +1839,8 @@ public interface Guild extends ISnowflake
      *
      * @return Possibly-empty immutable list of all Emotes that match the provided name.
      */
-    @Nonnull
-    default List<Emote> getEmotesByName(@Nonnull String name, boolean ignoreCase)
+    @NotNull
+    default List<Emote> getEmotesByName(@NotNull String name, boolean ignoreCase)
     {
         return getEmoteCache().getElementsByName(name, ignoreCase);
     }
@@ -1856,7 +1856,7 @@ public interface Guild extends ISnowflake
      *
      * @see    #retrieveEmotes()
      */
-    @Nonnull
+    @NotNull
     SnowflakeCacheView<Emote> getEmoteCache();
 
     /**
@@ -1869,7 +1869,7 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<List<ListedEmote>> retrieveEmotes();
 
@@ -1897,9 +1897,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<ListedEmote> retrieveEmoteById(@Nonnull String id);
+    RestAction<ListedEmote> retrieveEmoteById(@NotNull String id);
 
     /**
      * Retrieves a listed emote together with its respective creator.
@@ -1921,7 +1921,7 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<ListedEmote> retrieveEmoteById(long id)
     {
@@ -1948,9 +1948,9 @@ public interface Guild extends ISnowflake
      *
      * @since  3.8.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<ListedEmote> retrieveEmote(@Nonnull Emote emote)
+    default RestAction<ListedEmote> retrieveEmote(@NotNull Emote emote)
     {
         Checks.notNull(emote, "Emote");
         if (emote.getGuild() != null)
@@ -1987,7 +1987,7 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@literal List<}{@link net.dv8tion.jda.api.entities.Guild.Ban Ban}{@literal >}
      *         <br>Retrieves an immutable list of all users currently banned from this Guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<List<Ban>> retrieveBanList();
 
@@ -2015,7 +2015,7 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.Guild.Ban Ban}
      *         <br>An unmodifiable ban object for the user banned from this guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Ban> retrieveBanById(long userId)
     {
@@ -2046,9 +2046,9 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.Guild.Ban Ban}
      *         <br>An unmodifiable ban object for the user banned from this guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Ban> retrieveBanById(@Nonnull String userId);
+    RestAction<Ban> retrieveBanById(@NotNull String userId);
 
     /**
      * Retrieves a {@link net.dv8tion.jda.api.entities.Guild.Ban Ban} of the provided {@link net.dv8tion.jda.api.entities.User User}
@@ -2074,9 +2074,9 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.Guild.Ban Ban}
      *         <br>An unmodifiable ban object for the user banned from this guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Ban> retrieveBan(@Nonnull User bannedUser)
+    default RestAction<Ban> retrieveBan(@NotNull User bannedUser)
     {
         Checks.notNull(bannedUser, "bannedUser");
         return retrieveBanById(bannedUser.getId());
@@ -2104,7 +2104,7 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Integer
      *         <br>The amount of Members that would be affected.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Integer> retrievePrunableMemberCount(int days);
 
@@ -2118,7 +2118,7 @@ public interface Guild extends ISnowflake
      *
      * @return The @everyone {@link net.dv8tion.jda.api.entities.Role Role}
      */
-    @Nonnull
+    @NotNull
     Role getPublicRole();
 
     /**
@@ -2147,7 +2147,7 @@ public interface Guild extends ISnowflake
      *
      * @return The Manager of this Guild
      */
-    @Nonnull
+    @NotNull
     GuildManager getManager();
 
     /**
@@ -2182,7 +2182,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link AuditLogPaginationAction AuditLogPaginationAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditLogPaginationAction retrieveAuditLogs();
 
@@ -2196,7 +2196,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> leave();
 
@@ -2211,7 +2211,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> delete();
 
@@ -2232,7 +2232,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> delete(@Nullable String mfaCode);
 
@@ -2250,7 +2250,7 @@ public interface Guild extends ISnowflake
      *
      * @see    net.dv8tion.jda.api.JDA#getAudioManagerCache() JDA.getAudioManagerCache()
      */
-    @Nonnull
+    @NotNull
     AudioManager getAudioManager();
 
     /**
@@ -2258,7 +2258,7 @@ public interface Guild extends ISnowflake
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -2277,7 +2277,7 @@ public interface Guild extends ISnowflake
      *
      * @see     GuildChannel#retrieveInvites()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<List<Invite>> retrieveInvites();
 
@@ -2296,7 +2296,7 @@ public interface Guild extends ISnowflake
      *
      * @see     TextChannel#retrieveWebhooks()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<List<Webhook>> retrieveWebhooks();
 
@@ -2309,7 +2309,7 @@ public interface Guild extends ISnowflake
      *
      * @return Never-empty immutable list containing all the {@link GuildVoiceState GuildVoiceStates} on this {@link net.dv8tion.jda.api.entities.Guild Guild}.
      */
-    @Nonnull
+    @NotNull
     List<GuildVoiceState> getVoiceStates();
 
     /**
@@ -2321,7 +2321,7 @@ public interface Guild extends ISnowflake
      *
      * @return The Verification-Level of this Guild.
      */
-    @Nonnull
+    @NotNull
     VerificationLevel getVerificationLevel();
 
     /**
@@ -2333,7 +2333,7 @@ public interface Guild extends ISnowflake
      *
      * @return The default message Notification-Level of this Guild.
      */
-    @Nonnull
+    @NotNull
     NotificationLevel getDefaultNotificationLevel();
 
     /**
@@ -2344,7 +2344,7 @@ public interface Guild extends ISnowflake
      *
      * @return The MFA-Level required by this Guild.
      */
-    @Nonnull
+    @NotNull
     MFALevel getRequiredMFALevel();
 
     /**
@@ -2353,7 +2353,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.entities.Guild.ExplicitContentLevel ExplicitContentLevel} for this Guild
      */
-    @Nonnull
+    @NotNull
     ExplicitContentLevel getExplicitContentLevel();
 
     /**
@@ -2404,7 +2404,7 @@ public interface Guild extends ISnowflake
      *
      * @deprecated Replace with {@link #loadMembers()}, {@link #loadMembers(Consumer)}, or {@link #findMembers(Predicate)}
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @DeprecatedSince("4.2.0")
     @ReplaceWith("loadMembers(Consumer<Member>) or loadMembers()")
@@ -2427,7 +2427,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} - Type: {@link List} of {@link Member}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default Task<List<Member>> loadMembers()
     {
@@ -2454,9 +2454,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} - Type: {@link List} of {@link Member}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> findMembers(@Nonnull Predicate<? super Member> filter)
+    default Task<List<Member>> findMembers(@NotNull Predicate<? super Member> filter)
     {
         Checks.notNull(filter, "Filter");
         List<Member> list = new ArrayList<>();
@@ -2493,9 +2493,9 @@ public interface Guild extends ISnowflake
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> findMembersWithRoles(@Nonnull Collection<Role> roles)
+    default Task<List<Member>> findMembersWithRoles(@NotNull Collection<Role> roles)
     {
         Checks.noneNull(roles, "Roles");
         for (Role role : roles)
@@ -2532,9 +2532,9 @@ public interface Guild extends ISnowflake
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> findMembersWithRoles(@Nonnull Role... roles)
+    default Task<List<Member>> findMembersWithRoles(@NotNull Role... roles)
     {
         Checks.noneNull(roles, "Roles");
         return findMembersWithRoles(Arrays.asList(roles));
@@ -2560,8 +2560,8 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} cancellable handle for this request
      */
-    @Nonnull
-    Task<Void> loadMembers(@Nonnull Consumer<Member> callback);
+    @NotNull
+    Task<Void> loadMembers(@NotNull Consumer<Member> callback);
 
     /**
      * Load the member for the specified user.
@@ -2594,8 +2594,8 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      * @see    #unloadMember(long)
      */
-    @Nonnull
-    default RestAction<Member> retrieveMember(@Nonnull User user)
+    @NotNull
+    default RestAction<Member> retrieveMember(@NotNull User user)
     {
         Checks.notNull(user, "User");
         return retrieveMemberById(user.getId());
@@ -2634,8 +2634,8 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      * @see    #unloadMember(long)
      */
-    @Nonnull
-    default RestAction<Member> retrieveMemberById(@Nonnull String id)
+    @NotNull
+    default RestAction<Member> retrieveMemberById(@NotNull String id)
     {
         return retrieveMemberById(MiscUtil.parseSnowflake(id));
     }
@@ -2668,7 +2668,7 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      * @see    #unloadMember(long)
      */
-    @Nonnull
+    @NotNull
     default RestAction<Member> retrieveMemberById(long id)
     {
         return retrieveMemberById(id, true);
@@ -2700,7 +2700,7 @@ public interface Guild extends ISnowflake
      * @see    #getOwnerIdLong()
      * @see    #retrieveMemberById(long)
      */
-    @Nonnull
+    @NotNull
     default RestAction<Member> retrieveOwner()
     {
         return retrieveMemberById(getOwnerIdLong());
@@ -2736,8 +2736,8 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      * @see    #unloadMember(long)
      */
-    @Nonnull
-    default RestAction<Member> retrieveMember(@Nonnull User user, boolean update)
+    @NotNull
+    default RestAction<Member> retrieveMember(@NotNull User user, boolean update)
     {
         Checks.notNull(user, "User");
         return retrieveMemberById(user.getId(), update);
@@ -2775,8 +2775,8 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      * @see    #unloadMember(long)
      */
-    @Nonnull
-    default RestAction<Member> retrieveMemberById(@Nonnull String id, boolean update)
+    @NotNull
+    default RestAction<Member> retrieveMemberById(@NotNull String id, boolean update)
     {
         return retrieveMemberById(MiscUtil.parseSnowflake(id), update);
     }
@@ -2808,7 +2808,7 @@ public interface Guild extends ISnowflake
      * @see    #pruneMemberCache()
      * @see    #unloadMember(long)
      */
-    @Nonnull
+    @NotNull
     RestAction<Member> retrieveMemberById(long id, boolean update);
 
     /**
@@ -2837,7 +2837,7 @@ public interface Guild extends ISnowflake
      * @see    #getOwnerIdLong()
      * @see    #retrieveMemberById(long)
      */
-    @Nonnull
+    @NotNull
     default RestAction<Member> retrieveOwner(boolean update)
     {
         return retrieveMemberById(getOwnerIdLong(), update);
@@ -2869,9 +2869,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembers(@Nonnull Collection<User> users)
+    default Task<List<Member>> retrieveMembers(@NotNull Collection<User> users)
     {
         Checks.noneNull(users, "Users");
         if (users.isEmpty())
@@ -2907,9 +2907,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(@Nonnull Collection<Long> ids)
+    default Task<List<Member>> retrieveMembersByIds(@NotNull Collection<Long> ids)
     {
         Checks.noneNull(ids, "IDs");
         if (ids.isEmpty())
@@ -2945,9 +2945,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(@Nonnull String... ids)
+    default Task<List<Member>> retrieveMembersByIds(@NotNull String... ids)
     {
         Checks.notNull(ids, "Array");
         if (ids.length == 0)
@@ -2985,9 +2985,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(@Nonnull long... ids)
+    default Task<List<Member>> retrieveMembersByIds(@NotNull long... ids)
     {
         boolean presence = getJDA().getGatewayIntents().contains(GatewayIntent.GUILD_PRESENCES);
         return retrieveMembersByIds(presence, ids);
@@ -3020,9 +3020,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembers(boolean includePresence, @Nonnull Collection<User> users)
+    default Task<List<Member>> retrieveMembers(boolean includePresence, @NotNull Collection<User> users)
     {
         Checks.noneNull(users, "Users");
         if (users.isEmpty())
@@ -3059,9 +3059,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(boolean includePresence, @Nonnull Collection<Long> ids)
+    default Task<List<Member>> retrieveMembersByIds(boolean includePresence, @NotNull Collection<Long> ids)
     {
         Checks.noneNull(ids, "IDs");
         if (ids.isEmpty())
@@ -3098,9 +3098,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default Task<List<Member>> retrieveMembersByIds(boolean includePresence, @Nonnull String... ids)
+    default Task<List<Member>> retrieveMembersByIds(boolean includePresence, @NotNull String... ids)
     {
         Checks.notNull(ids, "Array");
         if (ids.length == 0)
@@ -3139,9 +3139,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link Task} handle for the request
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    Task<List<Member>> retrieveMembersByIds(boolean includePresence, @Nonnull long... ids);
+    Task<List<Member>> retrieveMembersByIds(boolean includePresence, @NotNull long... ids);
 
     /**
      * Queries a list of members using a radix tree based on the provided name prefix.
@@ -3171,9 +3171,9 @@ public interface Guild extends ISnowflake
      * @see    #getMembersByNickname(String, boolean)
      * @see    #getMembersByEffectiveName(String, boolean)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    Task<List<Member>> retrieveMembersByPrefix(@Nonnull String prefix, int limit);
+    Task<List<Member>> retrieveMembersByPrefix(@NotNull String prefix, int limit);
 
     /* From GuildController */
 
@@ -3223,9 +3223,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> moveVoiceMember(@Nonnull Member member, @Nullable VoiceChannel voiceChannel);
+    RestAction<Void> moveVoiceMember(@NotNull Member member, @Nullable VoiceChannel voiceChannel);
 
     /**
      * Used to kick a {@link net.dv8tion.jda.api.entities.Member Member} from a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel}.
@@ -3264,9 +3264,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> kickVoiceMember(@Nonnull Member member)
+    default RestAction<Void> kickVoiceMember(@NotNull Member member)
     {
         return moveVoiceMember(member, null);
     }
@@ -3312,9 +3312,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> modifyNickname(@Nonnull Member member, @Nullable String nickname);
+    AuditableRestAction<Void> modifyNickname(@NotNull Member member, @Nullable String nickname);
 
     /**
      * This method will prune (kick) all members who were offline for at least <i>days</i> days.
@@ -3349,9 +3349,9 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: Integer
      *         <br>The amount of Members that were pruned from the Guild.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Integer> prune(int days, @Nonnull Role... roles)
+    default AuditableRestAction<Integer> prune(int days, @NotNull Role... roles)
     {
         return prune(days, true, roles);
     }
@@ -3390,9 +3390,9 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: Integer
      *         <br>Provides the amount of Members that were pruned from the Guild, if wait is true.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Integer> prune(int days, boolean wait, @Nonnull Role... roles);
+    AuditableRestAction<Integer> prune(int days, boolean wait, @NotNull Role... roles);
 
     /**
      * Kicks the {@link net.dv8tion.jda.api.entities.Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -3429,9 +3429,9 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *         Kicks the provided Member from the current Guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> kick(@Nonnull Member member, @Nullable String reason);
+    AuditableRestAction<Void> kick(@NotNull Member member, @Nullable String reason);
 
     /**
      * Kicks the {@link net.dv8tion.jda.api.entities.Member Member} specified by the userId from the from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -3467,9 +3467,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> kick(@Nonnull String userId, @Nullable String reason);
+    AuditableRestAction<Void> kick(@NotNull String userId, @Nullable String reason);
 
     /**
      * Kicks a {@link net.dv8tion.jda.api.entities.Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -3501,9 +3501,9 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *         Kicks the provided Member from the current Guild
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> kick(@Nonnull Member member)
+    default AuditableRestAction<Void> kick(@NotNull Member member)
     {
         return kick(member, null);
     }
@@ -3537,9 +3537,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> kick(@Nonnull String userId)
+    default AuditableRestAction<Void> kick(@NotNull String userId)
     {
         return kick(userId, null);
     }
@@ -3587,9 +3587,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> ban(@Nonnull User user, int delDays, @Nullable String reason);
+    AuditableRestAction<Void> ban(@NotNull User user, int delDays, @Nullable String reason);
 
     /**
      * Bans the user specified by the userId and deletes messages sent by the user
@@ -3634,9 +3634,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> ban(@Nonnull String userId, int delDays, @Nullable String reason);
+    AuditableRestAction<Void> ban(@NotNull String userId, int delDays, @Nullable String reason);
 
     /**
      * Bans the {@link net.dv8tion.jda.api.entities.Member Member} and deletes messages sent by the user
@@ -3682,9 +3682,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> ban(@Nonnull Member member, int delDays, @Nullable String reason)
+    default AuditableRestAction<Void> ban(@NotNull Member member, int delDays, @Nullable String reason)
     {
         Checks.notNull(member, "Member");
         //Don't check if the provided member is from this guild. It doesn't matter if they are or aren't.
@@ -3732,9 +3732,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> ban(@Nonnull Member member, int delDays)
+    default AuditableRestAction<Void> ban(@NotNull Member member, int delDays)
     {
         return ban(member, delDays, null);
     }
@@ -3779,9 +3779,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> ban(@Nonnull User user, int delDays)
+    default AuditableRestAction<Void> ban(@NotNull User user, int delDays)
     {
         return ban(user, delDays, null);
     }
@@ -3826,9 +3826,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> ban(@Nonnull String userId, int delDays)
+    default AuditableRestAction<Void> ban(@NotNull String userId, int delDays)
     {
         return ban(userId, delDays, null);
     }
@@ -3856,9 +3856,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> unban(@Nonnull User user)
+    default AuditableRestAction<Void> unban(@NotNull User user)
     {
         Checks.notNull(user, "User");
 
@@ -3888,9 +3888,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> unban(@Nonnull String userId);
+    AuditableRestAction<Void> unban(@NotNull String userId);
 
     /**
      * Sets the Guild Deafened state state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
@@ -3926,9 +3926,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> deafen(@Nonnull Member member, boolean deafen);
+    AuditableRestAction<Void> deafen(@NotNull Member member, boolean deafen);
 
     /**
      * Sets the Guild Muted state state of the {@link net.dv8tion.jda.api.entities.Member Member} based on the provided
@@ -3964,9 +3964,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> mute(@Nonnull Member member, boolean mute);
+    AuditableRestAction<Void> mute(@NotNull Member member, boolean mute);
 
     /**
      * Atomically assigns the provided {@link net.dv8tion.jda.api.entities.Role Role} to the specified {@link net.dv8tion.jda.api.entities.Member Member}.
@@ -4008,9 +4008,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> addRoleToMember(@Nonnull Member member, @Nonnull Role role);
+    AuditableRestAction<Void> addRoleToMember(@NotNull Member member, @NotNull Role role);
 
     /**
      * Atomically assigns the provided {@link net.dv8tion.jda.api.entities.Role Role} to the specified member by their user id.
@@ -4052,9 +4052,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> addRoleToMember(long userId, @Nonnull Role role)
+    default AuditableRestAction<Void> addRoleToMember(long userId, @NotNull Role role)
     {
         Checks.notNull(role, "Role");
         Checks.check(role.getGuild().equals(this), "Role must be from the same guild! Trying to use role from %s in %s", role.getGuild().toString(), toString());
@@ -4110,9 +4110,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> addRoleToMember(@Nonnull String userId, @Nonnull Role role)
+    default AuditableRestAction<Void> addRoleToMember(@NotNull String userId, @NotNull Role role)
     {
         return addRoleToMember(MiscUtil.parseSnowflake(userId), role);
     }
@@ -4157,9 +4157,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> removeRoleFromMember(@Nonnull Member member, @Nonnull Role role);
+    AuditableRestAction<Void> removeRoleFromMember(@NotNull Member member, @NotNull Role role);
 
     /**
      * Atomically removes the provided {@link net.dv8tion.jda.api.entities.Role Role} from the specified member by their user id.
@@ -4201,9 +4201,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> removeRoleFromMember(long userId, @Nonnull Role role)
+    default AuditableRestAction<Void> removeRoleFromMember(long userId, @NotNull Role role)
     {
         Checks.notNull(role, "Role");
         Checks.check(role.getGuild().equals(this), "Role must be from the same guild! Trying to use role from %s in %s", role.getGuild().toString(), toString());
@@ -4259,9 +4259,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> removeRoleFromMember(@Nonnull String userId, @Nonnull Role role)
+    default AuditableRestAction<Void> removeRoleFromMember(@NotNull String userId, @NotNull Role role)
     {
         return removeRoleFromMember(MiscUtil.parseSnowflake(userId), role);
     }
@@ -4332,9 +4332,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, @Nullable Collection<Role> rolesToAdd, @Nullable Collection<Role> rolesToRemove);
+    AuditableRestAction<Void> modifyMemberRoles(@NotNull Member member, @Nullable Collection<Role> rolesToAdd, @Nullable Collection<Role> rolesToRemove);
 
     /**
      * Modifies the complete {@link net.dv8tion.jda.api.entities.Role Role} set of the specified {@link net.dv8tion.jda.api.entities.Member Member}
@@ -4389,9 +4389,9 @@ public interface Guild extends ISnowflake
      *
      * @see    #modifyMemberRoles(Member, Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, @Nonnull Role... roles)
+    default AuditableRestAction<Void> modifyMemberRoles(@NotNull Member member, @NotNull Role... roles)
     {
         return modifyMemberRoles(member, Arrays.asList(roles));
     }
@@ -4452,9 +4452,9 @@ public interface Guild extends ISnowflake
      *
      * @see    #modifyMemberRoles(Member, Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, @Nonnull Collection<Role> roles);
+    AuditableRestAction<Void> modifyMemberRoles(@NotNull Member member, @NotNull Collection<Role> roles);
 
     /**
      * Transfers the Guild ownership to the specified {@link net.dv8tion.jda.api.entities.Member Member}
@@ -4484,9 +4484,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> transferOwnership(@Nonnull Member newOwner);
+    AuditableRestAction<Void> transferOwnership(@NotNull Member newOwner);
 
     /**
      * Creates a new {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} in this Guild.
@@ -4513,9 +4513,9 @@ public interface Guild extends ISnowflake
      * @return A specific {@link net.dv8tion.jda.api.requests.restaction.ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new TextChannel before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelAction<TextChannel> createTextChannel(@Nonnull String name)
+    default ChannelAction<TextChannel> createTextChannel(@NotNull String name)
     {
         return createTextChannel(name, null);
     }
@@ -4548,9 +4548,9 @@ public interface Guild extends ISnowflake
      * @return A specific {@link net.dv8tion.jda.api.requests.restaction.ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new TextChannel before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<TextChannel> createTextChannel(@Nonnull String name, @Nullable Category parent);
+    ChannelAction<TextChannel> createTextChannel(@NotNull String name, @Nullable Category parent);
 
     /**
      * Creates a new {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} in this Guild.
@@ -4577,9 +4577,9 @@ public interface Guild extends ISnowflake
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new VoiceChannel before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelAction<VoiceChannel> createVoiceChannel(@Nonnull String name)
+    default ChannelAction<VoiceChannel> createVoiceChannel(@NotNull String name)
     {
         return createVoiceChannel(name, null);
     }
@@ -4612,9 +4612,9 @@ public interface Guild extends ISnowflake
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new VoiceChannel before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<VoiceChannel> createVoiceChannel(@Nonnull String name, @Nullable Category parent);
+    ChannelAction<VoiceChannel> createVoiceChannel(@NotNull String name, @Nullable Category parent);
 
     /**
      * Creates a new {@link net.dv8tion.jda.api.entities.Category Category} in this Guild.
@@ -4641,9 +4641,9 @@ public interface Guild extends ISnowflake
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new Category before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<Category> createCategory(@Nonnull String name);
+    ChannelAction<Category> createCategory(@NotNull String name);
 
     /**
      * Creates a copy of the specified {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}
@@ -4688,10 +4688,10 @@ public interface Guild extends ISnowflake
      * @see    #createVoiceChannel(String)
      * @see    ChannelAction ChannelAction
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     @SuppressWarnings("unchecked") // we need to do an unchecked cast for the channel type here
-    default <T extends GuildChannel> ChannelAction<T> createCopyOfChannel(@Nonnull T channel)
+    default <T extends GuildChannel> ChannelAction<T> createCopyOfChannel(@NotNull T channel)
     {
         Checks.notNull(channel, "Channel");
         return (ChannelAction<T>) channel.createCopy(this);
@@ -4718,7 +4718,7 @@ public interface Guild extends ISnowflake
      * @return {@link net.dv8tion.jda.api.requests.restaction.RoleAction RoleAction}
      *         <br>Creates a new role with previously selected field values
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleAction createRole();
 
@@ -4752,9 +4752,9 @@ public interface Guild extends ISnowflake
      * @return {@link RoleAction RoleAction}
      *         <br>RoleAction with already copied values from the specified {@link net.dv8tion.jda.api.entities.Role Role}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RoleAction createCopyOfRole(@Nonnull Role role)
+    default RoleAction createCopyOfRole(@NotNull Role role)
     {
         Checks.notNull(role, "Role");
         return role.createCopy(this);
@@ -4792,9 +4792,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: {@link net.dv8tion.jda.api.entities.Emote Emote}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Emote> createEmote(@Nonnull String name, @Nonnull Icon icon, @Nonnull Role... roles);
+    AuditableRestAction<Emote> createEmote(@NotNull String name, @NotNull Icon icon, @NotNull Role... roles);
 
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.api.entities.Guild#getCategories() Guild.getCategories()}
@@ -4814,7 +4814,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.order.ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.api.entities.Category Category}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelOrderAction modifyCategoryPositions();
 
@@ -4836,7 +4836,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelOrderAction modifyTextChannelPositions();
 
@@ -4858,7 +4858,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link ChannelOrderAction ChannelOrderAction} - Type: {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelOrderAction modifyVoiceChannelPositions();
 
@@ -4888,9 +4888,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction CategoryOrderAction} - Type: {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    CategoryOrderAction modifyTextChannelPositions(@Nonnull Category category);
+    CategoryOrderAction modifyTextChannelPositions(@NotNull Category category);
 
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.api.entities.Category#getVoiceChannels() Category#getVoiceChannels()}
@@ -4918,9 +4918,9 @@ public interface Guild extends ISnowflake
      *
      * @return {@link CategoryOrderAction CategoryOrderAction} - Type: {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    CategoryOrderAction modifyVoiceChannelPositions(@Nonnull Category category);
+    CategoryOrderAction modifyVoiceChannelPositions(@NotNull Category category);
 
     /**
      * Modifies the positional order of {@link net.dv8tion.jda.api.entities.Guild#getRoles() Guild.getRoles()}
@@ -4946,7 +4946,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.order.RoleOrderAction RoleOrderAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RoleOrderAction modifyRolePositions()
     {
@@ -4978,7 +4978,7 @@ public interface Guild extends ISnowflake
      *
      * @return {@link RoleOrderAction RoleOrderAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleOrderAction modifyRolePositions(boolean useAscendingOrder);
 
@@ -5026,7 +5026,7 @@ public interface Guild extends ISnowflake
          *
          * @return The {@link net.dv8tion.jda.api.entities.Guild.Timeout Timeout} related to the amount of seconds provided.
          */
-        @Nonnull
+        @NotNull
         public static Timeout fromKey(int seconds)
         {
             for (Timeout t : values())
@@ -5083,7 +5083,7 @@ public interface Guild extends ISnowflake
          *
          * @return The VerificationLevel related to the provided key, or {@link #UNKNOWN VerificationLevel.UNKNOWN} if the key is not recognized.
          */
-        @Nonnull
+        @NotNull
         public static VerificationLevel fromKey(int key)
         {
             for (VerificationLevel level : VerificationLevel.values())
@@ -5134,7 +5134,7 @@ public interface Guild extends ISnowflake
          *
          * @return The NotificationLevel related to the provided key, or {@link #UNKNOWN NotificationLevel.UNKNOWN} if the key is not recognized.
          */
-        @Nonnull
+        @NotNull
         public static NotificationLevel fromKey(int key)
         {
             for (NotificationLevel level : values())
@@ -5185,7 +5185,7 @@ public interface Guild extends ISnowflake
          *
          * @return The MFALevel related to the provided key, or {@link #UNKNOWN MFALevel.UNKNOWN} if the key is not recognized.
          */
-        @Nonnull
+        @NotNull
         public static MFALevel fromKey(int key)
         {
             for (MFALevel level : values())
@@ -5233,13 +5233,13 @@ public interface Guild extends ISnowflake
          *
          * @return Description for this level
          */
-        @Nonnull
+        @NotNull
         public String getDescription()
         {
             return description;
         }
 
-        @Nonnull
+        @NotNull
         public static ExplicitContentLevel fromKey(int key)
         {
             for (ExplicitContentLevel level : values())
@@ -5353,7 +5353,7 @@ public interface Guild extends ISnowflake
          *
          * @return The BoostTier or {@link #UNKNOWN}
          */
-        @Nonnull
+        @NotNull
         public static BoostTier fromKey(int key)
         {
             for (BoostTier tier : values())
@@ -5387,7 +5387,7 @@ public interface Guild extends ISnowflake
          *
          * @return The banned User
          */
-        @Nonnull
+        @NotNull
         public User getUser()
         {
             return user;

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -22,10 +22,10 @@ import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -44,7 +44,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return The channel type
      */
-    @Nonnull
+    @NotNull
     ChannelType getType();
 
     /**
@@ -53,7 +53,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return The name of this GuildChannel
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -61,7 +61,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return Never-null {@link net.dv8tion.jda.api.entities.Guild Guild} that this GuildChannel is part of.
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -86,7 +86,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return An immutable List of {@link net.dv8tion.jda.api.entities.Member Members} that are in this GuildChannel.
      */
-    @Nonnull
+    @NotNull
     List<Member> getMembers();
 
     /**
@@ -118,7 +118,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -137,7 +137,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *         relating to the provided Member or Role.
      */
     @Nullable
-    PermissionOverride getPermissionOverride(@Nonnull IPermissionHolder permissionHolder);
+    PermissionOverride getPermissionOverride(@NotNull IPermissionHolder permissionHolder);
 
     /**
      * Gets all of the {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} that are part
@@ -152,7 +152,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      * @return Possibly-empty immutable list of all {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides}
      *         for this {@link GuildChannel GuildChannel}.
      */
-    @Nonnull
+    @NotNull
     List<PermissionOverride> getPermissionOverrides();
 
     /**
@@ -165,7 +165,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *         for {@link net.dv8tion.jda.api.entities.Member Member}
      *         for this {@link GuildChannel GuildChannel}.
      */
-    @Nonnull
+    @NotNull
     List<PermissionOverride> getMemberPermissionOverrides();
 
     /**
@@ -176,7 +176,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *         for {@link net.dv8tion.jda.api.entities.Role Roles}
      *         for this {@link GuildChannel GuildChannel}.
      */
-    @Nonnull
+    @NotNull
     List<PermissionOverride> getRolePermissionOverrides();
 
     /**
@@ -228,9 +228,9 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new GuildChannel before creating it!
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<? extends GuildChannel> createCopy(@Nonnull Guild guild);
+    ChannelAction<? extends GuildChannel> createCopy(@NotNull Guild guild);
 
     /**
      * Creates a copy of the specified {@link GuildChannel GuildChannel}.
@@ -260,7 +260,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      * @return A specific {@link ChannelAction ChannelAction}
      *         <br>This action allows to set fields for the new GuildChannel before creating it!
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default ChannelAction<? extends GuildChannel> createCopy()
     {
@@ -280,7 +280,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return The ChannelManager of this GuildChannel
      */
-    @Nonnull
+    @NotNull
     ChannelManager getManager();
 
     /**
@@ -305,7 +305,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 
@@ -337,9 +337,9 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      * @return {@link PermissionOverrideAction PermissionOverrideAction}
      *         Provides the newly created PermissionOverride for the specified permission holder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    PermissionOverrideAction createPermissionOverride(@Nonnull IPermissionHolder permissionHolder);
+    PermissionOverrideAction createPermissionOverride(@NotNull IPermissionHolder permissionHolder);
 
     /**
      * Creates a {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}
@@ -357,9 +357,9 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      * @return {@link PermissionOverrideAction PermissionOverrideAction}
      *         Provides the newly created PermissionOverride for the specified permission holder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    PermissionOverrideAction putPermissionOverride(@Nonnull IPermissionHolder permissionHolder);
+    PermissionOverrideAction putPermissionOverride(@NotNull IPermissionHolder permissionHolder);
 
     /**
      * Creates a new override or updates an existing one.
@@ -378,9 +378,9 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction upsertPermissionOverride(@Nonnull IPermissionHolder permissionHolder)
+    default PermissionOverrideAction upsertPermissionOverride(@NotNull IPermissionHolder permissionHolder)
     {
         PermissionOverride override = getPermissionOverride(permissionHolder);
         if (override != null)
@@ -402,7 +402,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      * 
      * @see    InviteAction
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     InviteAction createInvite();
 
@@ -419,7 +419,7 @@ public interface GuildChannel extends ISnowflake, IMentionable, Comparable<Guild
      *
      * @see    net.dv8tion.jda.api.entities.Guild#retrieveInvites()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<List<Invite>> retrieveInvites();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -17,9 +17,8 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents the voice state of a {@link net.dv8tion.jda.api.entities.Member Member} in a
@@ -34,7 +33,7 @@ public interface GuildVoiceState
      *
      * @return The corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -116,7 +115,7 @@ public interface GuildVoiceState
      *
      * @return the Member's Guild
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -125,7 +124,7 @@ public interface GuildVoiceState
      *
      * @return the Member that holds this GuildVoiceState
      */
-    @Nonnull
+    @NotNull
     Member getMember();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/IMentionable.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/IMentionable.java
@@ -17,8 +17,8 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.utils.MiscUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Formattable;
 import java.util.FormattableFlags;
 import java.util.Formatter;
@@ -57,7 +57,7 @@ public interface IMentionable extends Formattable, ISnowflake
      *
      * @return A resolvable mention.
      */
-    @Nonnull
+    @NotNull
     String getAsMention();
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/IPermissionHolder.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/IPermissionHolder.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.EnumSet;
 
@@ -38,7 +38,7 @@ public interface IPermissionHolder extends ISnowflake
      * 
      * @return A never-null Guild to which this PermissionHolder is linked
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -47,7 +47,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return An EnumSet of Permissions granted to this PermissionHolder.
      */
-    @Nonnull
+    @NotNull
     EnumSet<Permission> getPermissions();
 
     /**
@@ -64,8 +64,8 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return Set of Permissions granted to this Permission Holder in the specified channel.
      */
-    @Nonnull
-    EnumSet<Permission> getPermissions(@Nonnull GuildChannel channel);
+    @NotNull
+    EnumSet<Permission> getPermissions(@NotNull GuildChannel channel);
 
     /**
      * The explicitly granted permissions for this permission holder in the guild.
@@ -75,7 +75,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return EnumSet of the explicitly granted permissions
      */
-    @Nonnull
+    @NotNull
     EnumSet<Permission> getPermissionsExplicit();
 
     /**
@@ -93,8 +93,8 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return EnumSet of the explicitly granted permissions in the specified channel
      */
-    @Nonnull
-    EnumSet<Permission> getPermissionsExplicit(@Nonnull GuildChannel channel);
+    @NotNull
+    EnumSet<Permission> getPermissionsExplicit(@NotNull GuildChannel channel);
 
     /**
      * Checks whether or not this PermissionHolder has the given {@link net.dv8tion.jda.api.Permission Permissions} in the Guild.
@@ -107,7 +107,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return True, if all of the specified Permissions are granted to this PermissionHolder.
      */
-    boolean hasPermission(@Nonnull Permission... permissions);
+    boolean hasPermission(@NotNull Permission... permissions);
 
     /**
      * Checks whether or not this PermissionHolder has the {@link net.dv8tion.jda.api.Permission Permissions} in the provided
@@ -123,7 +123,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @see    java.util.EnumSet EnumSet
      */
-    boolean hasPermission(@Nonnull Collection<Permission> permissions);
+    boolean hasPermission(@NotNull Collection<Permission> permissions);
 
     /**
      * Checks whether or not this PermissionHolder has the given {@link net.dv8tion.jda.api.Permission Permissions} in the specified GuildChannel.
@@ -140,7 +140,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @see    java.util.EnumSet EnumSet
      */
-    boolean hasPermission(@Nonnull GuildChannel channel, @Nonnull Permission... permissions);
+    boolean hasPermission(@NotNull GuildChannel channel, @NotNull Permission... permissions);
 
     /**
      * Checks whether or not this PermissionHolder has the {@link net.dv8tion.jda.api.Permission Permissions} in the provided
@@ -156,7 +156,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return True, if all of the specified Permissions are granted to this PermissionHolder in the provided GuildChannel.
      */
-    boolean hasPermission(@Nonnull GuildChannel channel, @Nonnull Collection<Permission> permissions);
+    boolean hasPermission(@NotNull GuildChannel channel, @NotNull Collection<Permission> permissions);
 
     /**
      * Checks whether or not this PermissionHolder has {@link Permission#VIEW_CHANNEL VIEW_CHANNEL}
@@ -170,7 +170,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return True, if the PermissionHolder has access
      */
-    default boolean hasAccess(@Nonnull GuildChannel channel)
+    default boolean hasAccess(@NotNull GuildChannel channel)
     {
         Checks.notNull(channel, "Channel");
         return channel.getType() == ChannelType.VOICE
@@ -195,7 +195,7 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return True, if the channels can be synced
      */
-    boolean canSync(@Nonnull GuildChannel targetChannel, @Nonnull GuildChannel syncSource);
+    boolean canSync(@NotNull GuildChannel targetChannel, @NotNull GuildChannel syncSource);
 
     /**
      * Whether the permissions of this PermissionHolder are good enough to sync the target channel with any other channel.
@@ -211,5 +211,5 @@ public interface IPermissionHolder extends ISnowflake
      *
      * @return True, if the channel can be synced
      */
-    boolean canSync(@Nonnull GuildChannel channel);
+    boolean canSync(@NotNull GuildChannel channel);
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/ISnowflake.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ISnowflake.java
@@ -17,8 +17,8 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.utils.TimeUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
 
 /**
@@ -33,7 +33,7 @@ public interface ISnowflake
      *
      * @return Never-null String containing the Id.
      */
-    @Nonnull
+    @NotNull
     default String getId()
     {
         return Long.toUnsignedString(getIdLong());
@@ -53,7 +53,7 @@ public interface ISnowflake
      *
      * @see    TimeUtil#getTimeCreated(long)
      */
-    @Nonnull
+    @NotNull
     default OffsetDateTime getTimeCreated()
     {
         return TimeUtil.getTimeCreated(getIdLong());

--- a/src/main/java/net/dv8tion/jda/api/entities/Icon.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Icon.java
@@ -19,8 +19,8 @@ package net.dv8tion.jda.api.entities;
 import net.dv8tion.jda.api.managers.AccountManager;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.IOUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,7 +46,7 @@ public class Icon
 {
     protected final String encoding;
 
-    protected Icon(@Nonnull IconType type, @Nonnull String base64Encoding)
+    protected Icon(@NotNull IconType type, @NotNull String base64Encoding)
     {
         //Note: the usage of `image/jpeg` does not mean png/gif are not supported!
         this.encoding = type.getHeader() + base64Encoding;
@@ -57,7 +57,7 @@ public class Icon
      *
      * @return String representation of the encoded data for this icon
      */
-    @Nonnull
+    @NotNull
     public String getEncoding()
     {
         return encoding;
@@ -77,8 +77,8 @@ public class Icon
      *
      * @return An Icon instance representing the specified File
      */
-    @Nonnull
-    public static Icon from(@Nonnull File file) throws IOException
+    @NotNull
+    public static Icon from(@NotNull File file) throws IOException
     {
         Checks.notNull(file, "Provided File");
         Checks.check(file.exists(), "Provided file does not exist!");
@@ -107,8 +107,8 @@ public class Icon
      *
      * @return An Icon instance representing the specified InputStream
      */
-    @Nonnull
-    public static Icon from(@Nonnull InputStream stream) throws IOException
+    @NotNull
+    public static Icon from(@NotNull InputStream stream) throws IOException
     {
         return from(stream, IconType.JPEG);
     }
@@ -126,8 +126,8 @@ public class Icon
      *
      * @return An Icon instance representing the specified image data
      */
-    @Nonnull
-    public static Icon from(@Nonnull byte[] data)
+    @NotNull
+    public static Icon from(@NotNull byte[] data)
     {
         return from(data, IconType.JPEG);
     }
@@ -148,8 +148,8 @@ public class Icon
      *
      * @return An Icon instance representing the specified File
      */
-    @Nonnull
-    public static Icon from(@Nonnull File file, @Nonnull IconType type) throws IOException
+    @NotNull
+    public static Icon from(@NotNull File file, @NotNull IconType type) throws IOException
     {
         Checks.notNull(file, "Provided File");
         Checks.notNull(type, "IconType");
@@ -175,8 +175,8 @@ public class Icon
      *
      * @return An Icon instance representing the specified InputStream
      */
-    @Nonnull
-    public static Icon from(@Nonnull InputStream stream, @Nonnull IconType type) throws IOException
+    @NotNull
+    public static Icon from(@NotNull InputStream stream, @NotNull IconType type) throws IOException
     {
         Checks.notNull(stream, "InputStream");
         Checks.notNull(type, "IconType");
@@ -197,8 +197,8 @@ public class Icon
      *
      * @return An Icon instance representing the specified image data
      */
-    @Nonnull
-    public static Icon from(@Nonnull byte[] data, @Nonnull IconType type)
+    @NotNull
+    public static Icon from(@NotNull byte[] data, @NotNull IconType type)
     {
         Checks.notNull(data, "Provided byte[]");
         Checks.notNull(type, "IconType");
@@ -226,7 +226,7 @@ public class Icon
         private final String mime;
         private final String header;
 
-        IconType(@Nonnull String mime)
+        IconType(@NotNull String mime)
         {
             this.mime = mime;
             this.header = "data:" + mime + ";base64,";
@@ -239,7 +239,7 @@ public class Icon
          *
          * @see    <a href="https://en.wikipedia.org/wiki/MIME" target="_blank">MIME</a>
          */
-        @Nonnull
+        @NotNull
         public String getMIME()
         {
             return mime;
@@ -250,7 +250,7 @@ public class Icon
          *
          * @return The data header
          */
-        @Nonnull
+        @NotNull
         public String getHeader()
         {
             return header;
@@ -265,8 +265,8 @@ public class Icon
          *
          * @return The resolved IconType or {@link #UNKNOWN}.
          */
-        @Nonnull
-        public static IconType fromMIME(@Nonnull String mime)
+        @NotNull
+        public static IconType fromMIME(@NotNull String mime)
         {
             Checks.notNull(mime, "MIME Type");
             for (IconType type : values())
@@ -286,8 +286,8 @@ public class Icon
          *
          * @return The resolved IconType or {@link #UNKNOWN}.
          */
-        @Nonnull
-        public static IconType fromExtension(@Nonnull String extension)
+        @NotNull
+        public static IconType fromExtension(@NotNull String extension)
         {
             Checks.notNull(extension, "Extension Type");
             switch (extension.toLowerCase())

--- a/src/main/java/net/dv8tion/jda/api/entities/Invite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Invite.java
@@ -23,10 +23,10 @@ import net.dv8tion.jda.api.entities.Guild.VerificationLevel;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.entities.InviteImpl;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
@@ -64,8 +64,8 @@ public interface Invite
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.Invite Invite}
      *         <br>The Invite object
      */
-    @Nonnull
-    static RestAction<Invite> resolve(@Nonnull final JDA api, @Nonnull final String code)
+    @NotNull
+    static RestAction<Invite> resolve(@NotNull final JDA api, @NotNull final String code)
     {
         return resolve(api, code, false);
     }
@@ -90,8 +90,8 @@ public interface Invite
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.Invite Invite}
      *         <br>The Invite object
      */
-    @Nonnull
-    static RestAction<Invite> resolve(@Nonnull final JDA api, @Nonnull final String code, final boolean withCounts)
+    @NotNull
+    static RestAction<Invite> resolve(@NotNull final JDA api, @NotNull final String code, final boolean withCounts)
     {
         return InviteImpl.resolve(api, code, withCounts);
     }
@@ -106,7 +106,7 @@ public interface Invite
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 
@@ -130,7 +130,7 @@ public interface Invite
      * @see    #getType()
      * @see    #isExpanded()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Invite> expand();
 
@@ -139,7 +139,7 @@ public interface Invite
      *
      * @return The invites's type
      */
-    @Nonnull
+    @NotNull
     Invite.InviteType getType();
 
     /**
@@ -158,7 +158,7 @@ public interface Invite
      *
      * @return the invite code
      */
-    @Nonnull
+    @NotNull
     String getCode();
 
     /**
@@ -178,7 +178,7 @@ public interface Invite
      *
      * @return Invite URL for this Invite
      */
-    @Nonnull
+    @NotNull
     default String getUrl()
     {
         return "https://discord.gg/" + getCode();
@@ -200,7 +200,7 @@ public interface Invite
      * @deprecated
      *         Use {@link #getTimeCreated()} instead
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @DeprecatedSince("4.0.0")
     @ReplaceWith("getTimeCreated()")
@@ -230,7 +230,7 @@ public interface Invite
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -276,7 +276,7 @@ public interface Invite
      * @see    #expand()
      * @see    #isExpanded()
      */
-    @Nonnull
+    @NotNull
     OffsetDateTime getTimeCreated();
 
     /**
@@ -331,7 +331,7 @@ public interface Invite
          *
          * @return The channels's name
          */
-        @Nonnull
+        @NotNull
         String getName();
 
         /**
@@ -340,7 +340,7 @@ public interface Invite
          *
          * @return The channel's type
          */
-        @Nonnull
+        @NotNull
         ChannelType getType();
     }
 
@@ -376,7 +376,7 @@ public interface Invite
          *
          * @return The guilds's name
          */
-        @Nonnull
+        @NotNull
         String getName();
 
         /**
@@ -404,7 +404,7 @@ public interface Invite
          * 
          * @return the verification level of the guild
          */
-        @Nonnull
+        @NotNull
         VerificationLevel getVerificationLevel();
         
         /**
@@ -441,7 +441,7 @@ public interface Invite
          *
          * @return Never-null, unmodifiable Set containing all of the Guild's features.
          */
-        @Nonnull
+        @NotNull
         Set<String> getFeatures();
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/ListedEmote.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ListedEmote.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an emote retrieved from {@link Guild#retrieveEmotes()} or {@link Guild#retrieveEmoteById(long)}
@@ -44,7 +44,7 @@ public interface ListedEmote extends Emote
      *
      * @see    #hasUser()
      */
-    @Nonnull
+    @NotNull
     User getUser();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.OffsetDateTime;
 import java.util.Collection;
@@ -55,7 +55,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return {@link net.dv8tion.jda.api.entities.User User}
      */
-    @Nonnull
+    @NotNull
     User getUser();
 
     /**
@@ -63,7 +63,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -71,7 +71,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return The current JDA instance.
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -85,7 +85,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return The time at which this user has joined the guild.
      */
-    @Nonnull
+    @NotNull
     OffsetDateTime getTimeJoined();
 
     /**
@@ -132,7 +132,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return Immutable list of {@link Activity Activities} for the user
      */
-    @Nonnull
+    @NotNull
     List<Activity> getActivities();
 
     /**
@@ -143,7 +143,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return The current {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} of the {@link net.dv8tion.jda.api.entities.User User}.
      */
-    @Nonnull
+    @NotNull
     OnlineStatus getOnlineStatus();
 
     /**
@@ -166,8 +166,8 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
-    OnlineStatus getOnlineStatus(@Nonnull ClientType type);
+    @NotNull
+    OnlineStatus getOnlineStatus(@NotNull ClientType type);
 
     /**
      * A Set of all active {@link net.dv8tion.jda.api.entities.ClientType ClientTypes} of this Member.
@@ -185,7 +185,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     EnumSet<ClientType> getActiveClients();
 
     /**
@@ -204,7 +204,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return The Nickname of this Member or the Username if no Nickname is present.
      */
-    @Nonnull
+    @NotNull
     String getEffectiveName();
 
     /**
@@ -224,7 +224,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      * @see    Guild#removeRoleFromMember(Member, Role)
      * @see    Guild#modifyMemberRoles(Member, Collection, Collection)
      */
-    @Nonnull
+    @NotNull
     List<Role> getRoles();
 
     /**
@@ -263,7 +263,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return True, if this Member is able to interact with the specified Member
      */
-    boolean canInteract(@Nonnull Member member);
+    boolean canInteract(@NotNull Member member);
 
     /**
      * Whether this Member can interact with the provided {@link net.dv8tion.jda.api.entities.Role Role}
@@ -281,7 +281,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return True, if this member is able to interact with the specified Role
      */
-    boolean canInteract(@Nonnull Role role);
+    boolean canInteract(@NotNull Role role);
 
     /**
      * Whether this Member can interact with the provided {@link net.dv8tion.jda.api.entities.Emote Emote}
@@ -297,7 +297,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @return True, if this Member is able to interact with the specified Emote
      */
-    boolean canInteract(@Nonnull Emote emote);
+    boolean canInteract(@NotNull Emote emote);
 
     /**
      * Checks whether this member is the owner of its related {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -371,7 +371,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> ban(int delDays)
     {
@@ -420,7 +420,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> ban(int delDays, @Nullable String reason)
     {
@@ -454,7 +454,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> kick()
     {
@@ -493,7 +493,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> kick(@Nullable String reason)
     {
@@ -532,7 +532,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> mute(boolean mute)
     {
@@ -570,7 +570,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> deafen(boolean deafen)
     {
@@ -614,7 +614,7 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> modifyNickname(@Nullable String nickname)
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -32,10 +32,10 @@ import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import org.apache.commons.collections4.Bag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.*;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -230,7 +230,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return immutable list of mentioned users
      */
-    @Nonnull
+    @NotNull
     List<User> getMentionedUsers();
 
     /**
@@ -263,7 +263,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @see    #getMentionedUsers()
      */
-    @Nonnull
+    @NotNull
     Bag<User> getMentionedUsersBag();
 
     /**
@@ -277,7 +277,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return immutable list of mentioned TextChannels
      */
-    @Nonnull
+    @NotNull
     List<TextChannel> getMentionedChannels();
 
     /**
@@ -310,7 +310,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @see    #getMentionedChannels()
      */
-    @Nonnull
+    @NotNull
     Bag<TextChannel> getMentionedChannelsBag();
 
     /**
@@ -325,7 +325,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return immutable list of mentioned Roles
      */
-    @Nonnull
+    @NotNull
     List<Role> getMentionedRoles();
 
     /**
@@ -359,7 +359,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @see    #getMentionedRoles()
      */
-    @Nonnull
+    @NotNull
     Bag<Role> getMentionedRolesBag();
 
     /**
@@ -382,8 +382,8 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  3.4.0
      */
-    @Nonnull
-    List<Member> getMentionedMembers(@Nonnull Guild guild);
+    @NotNull
+    List<Member> getMentionedMembers(@NotNull Guild guild);
 
     /**
      * Creates an immutable list of {@link net.dv8tion.jda.api.entities.Member Members}
@@ -401,7 +401,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  3.4.0
      */
-    @Nonnull
+    @NotNull
     List<Member> getMentionedMembers();
 
     /**
@@ -424,8 +424,8 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  3.4.0
      */
-    @Nonnull
-    List<IMentionable> getMentions(@Nonnull MentionType... types);
+    @NotNull
+    List<IMentionable> getMentions(@NotNull MentionType... types);
 
     /**
      * Checks if given {@link net.dv8tion.jda.api.entities.IMentionable IMentionable}
@@ -449,7 +449,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return True, if the given mentionable was mentioned in this message
      */
-    boolean isMentioned(@Nonnull IMentionable mentionable, @Nonnull MentionType... types);
+    boolean isMentioned(@NotNull IMentionable mentionable, @NotNull MentionType... types);
 
     /**
      * Indicates if this Message mentions everyone using @everyone or @here.
@@ -492,7 +492,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Message author
      */
-    @Nonnull
+    @NotNull
     User getAuthor();
 
     /**
@@ -524,7 +524,7 @@ public interface Message extends ISnowflake, Formattable
      * 
      * @return A String representing the jump-to URL for the message
      */
-    @Nonnull
+    @NotNull
     String getJumpUrl();
 
     /**
@@ -546,7 +546,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return The textual content of the message with mentions resolved to be visually like the Discord client.
      */
-    @Nonnull
+    @NotNull
     String getContentDisplay();
 
     /**
@@ -557,7 +557,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return The raw textual content of the message, containing unresolved Discord message formatting.
      */
-    @Nonnull
+    @NotNull
     String getContentRaw();
 
     /**
@@ -570,7 +570,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return The textual content from {@link #getContentDisplay()} with all text formatting characters removed or escaped.
      */
-    @Nonnull
+    @NotNull
     String getContentStripped();
 
     /**
@@ -588,7 +588,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Immutable list of invite codes
      */
-    @Nonnull
+    @NotNull
     List<String> getInvites();
 
     /**
@@ -623,7 +623,7 @@ public interface Message extends ISnowflake, Formattable
      * @return True if the {@link net.dv8tion.jda.api.entities.ChannelType ChannelType} which this message was received
      *         from is the same as the one specified by {@code type}.
      */
-    boolean isFromType(@Nonnull ChannelType type);
+    boolean isFromType(@NotNull ChannelType type);
 
     /**
      * Whether this message was sent in a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -646,7 +646,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return The ChannelType which this message was received from.
      */
-    @Nonnull
+    @NotNull
     ChannelType getChannelType();
 
     /**
@@ -669,7 +669,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return The MessageChannel of this Message
      */
-    @Nonnull
+    @NotNull
     MessageChannel getChannel();
 
     /**
@@ -691,7 +691,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     PrivateChannel getPrivateChannel();
 
     /**
@@ -713,7 +713,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     TextChannel getTextChannel();
 
     /**
@@ -746,7 +746,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -758,7 +758,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Immutable list of {@link net.dv8tion.jda.api.entities.Message.Attachment Attachments}.
      */
-    @Nonnull
+    @NotNull
     List<Attachment> getAttachments();
 
     /**
@@ -770,7 +770,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Immutable list of all given MessageEmbeds.
      */
-    @Nonnull
+    @NotNull
     List<MessageEmbed> getEmbeds();
 
     /**
@@ -786,7 +786,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return An immutable list of the Emotes used in this message (example match {@literal <:jda:230988580904763393>})
      */
-    @Nonnull
+    @NotNull
     List<Emote> getEmotes();
 
     /**
@@ -818,7 +818,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @see    #getEmotes()
      */
-    @Nonnull
+    @NotNull
     Bag<Emote> getEmotesBag();
 
     /**
@@ -829,7 +829,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Immutable list of all MessageReactions on this message.
      */
-    @Nonnull
+    @NotNull
     List<MessageReaction> getReactions();
 
     /**
@@ -840,7 +840,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return Immutable list of all MessageStickers in this message.
      */
-    @Nonnull
+    @NotNull
     List<MessageSticker> getStickers();
 
     /**
@@ -890,9 +890,9 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The {@link net.dv8tion.jda.api.entities.Message Message} with the updated content
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction editMessage(@Nonnull CharSequence newContent);
+    MessageAction editMessage(@NotNull CharSequence newContent);
 
     /**
      * Edits this Message's content to the provided {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbed}.
@@ -927,9 +927,9 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The {@link net.dv8tion.jda.api.entities.Message Message} with the updated content
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction editMessage(@Nonnull MessageEmbed newContent);
+    MessageAction editMessage(@NotNull MessageEmbed newContent);
 
     /**
      * Edits this Message's content to the provided format.
@@ -976,9 +976,9 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The {@link net.dv8tion.jda.api.entities.Message Message} with the updated content
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction editMessageFormat(@Nonnull String format, @Nonnull Object... args);
+    MessageAction editMessageFormat(@NotNull String format, @NotNull Object... args);
 
     /**
      * Edits this Message's content to the provided {@link net.dv8tion.jda.api.entities.Message Message}.
@@ -1015,9 +1015,9 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The {@link net.dv8tion.jda.api.entities.Message Message} with the updated content
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction editMessage(@Nonnull Message newContent);
+    MessageAction editMessage(@NotNull Message newContent);
 
     /**
      * Replies and references this message.
@@ -1035,9 +1035,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull CharSequence content)
+    default MessageAction reply(@NotNull CharSequence content)
     {
         return getChannel().sendMessage(content).reference(this);
     }
@@ -1058,9 +1058,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull MessageEmbed content)
+    default MessageAction reply(@NotNull MessageEmbed content)
     {
         return getChannel().sendMessage(content).reference(this);
     }
@@ -1081,9 +1081,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull Message content)
+    default MessageAction reply(@NotNull Message content)
     {
         return getChannel().sendMessage(content).reference(this);
     }
@@ -1106,9 +1106,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction replyFormat(@Nonnull String format, @Nonnull Object... args)
+    default MessageAction replyFormat(@NotNull String format, @NotNull Object... args)
     {
         return getChannel().sendMessageFormat(format, args).reference(this);
     }
@@ -1131,9 +1131,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull File file, @Nonnull AttachmentOption... options)
+    default MessageAction reply(@NotNull File file, @NotNull AttachmentOption... options)
     {
         return getChannel().sendFile(file, options).reference(this);
     }
@@ -1158,9 +1158,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull File data, @Nonnull String name, @Nonnull AttachmentOption... options)
+    default MessageAction reply(@NotNull File data, @NotNull String name, @NotNull AttachmentOption... options)
     {
         return getChannel().sendFile(data, name, options).reference(this);
     }
@@ -1185,9 +1185,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull InputStream data, @Nonnull String name, @Nonnull AttachmentOption... options)
+    default MessageAction reply(@NotNull InputStream data, @NotNull String name, @NotNull AttachmentOption... options)
     {
         return getChannel().sendFile(data, name, options).reference(this);
     }
@@ -1212,9 +1212,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reply(@Nonnull byte[] data, @Nonnull String name, @Nonnull AttachmentOption... options)
+    default MessageAction reply(@NotNull byte[] data, @NotNull String name, @NotNull AttachmentOption... options)
     {
         return getChannel().sendFile(data, name, options).reference(this);
     }
@@ -1261,7 +1261,7 @@ public interface Message extends ISnowflake, Formattable
      * @see    net.dv8tion.jda.api.entities.TextChannel#deleteMessages(java.util.Collection) TextChannel.deleteMessages(Collection)
      * @see    net.dv8tion.jda.api.entities.MessageChannel#purgeMessages(java.util.List) MessageChannel.purgeMessages(List)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 
@@ -1273,7 +1273,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return  the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -1321,7 +1321,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> pin();
 
@@ -1360,7 +1360,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> unpin();
 
@@ -1422,9 +1422,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> addReaction(@Nonnull Emote emote);
+    RestAction<Void> addReaction(@NotNull Emote emote);
 
     /**
      * Adds a reaction to this Message using a unicode emoji.
@@ -1491,9 +1491,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> addReaction(@Nonnull String unicode);
+    RestAction<Void> addReaction(@NotNull String unicode);
 
     /**
      * Removes all reactions from this Message.
@@ -1531,7 +1531,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> clearReactions();
 
@@ -1582,9 +1582,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> clearReactions(@Nonnull String unicode);
+    RestAction<Void> clearReactions(@NotNull String unicode);
 
     /**
      * Removes all reactions for the specified emote.
@@ -1621,9 +1621,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> clearReactions(@Nonnull Emote emote);
+    RestAction<Void> clearReactions(@NotNull Emote emote);
 
     /**
      * Removes a reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emote Emote}.
@@ -1670,9 +1670,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> removeReaction(@Nonnull Emote emote);
+    RestAction<Void> removeReaction(@NotNull Emote emote);
 
     /**
      * Removes a {@link net.dv8tion.jda.api.entities.User User's} reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emote Emote}.
@@ -1732,9 +1732,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user);
+    RestAction<Void> removeReaction(@NotNull Emote emote, @NotNull User user);
 
     /**
      * Removes a reaction from this Message using a unicode emoji.
@@ -1789,9 +1789,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> removeReaction(@Nonnull String unicode);
+    RestAction<Void> removeReaction(@NotNull String unicode);
 
     /**
      * Removes a reaction from this Message using a unicode emoji.
@@ -1852,9 +1852,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user);
+    RestAction<Void> removeReaction(@NotNull String unicode, @NotNull User user);
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted using the given {@link net.dv8tion.jda.api.entities.Emote emote}.
@@ -1893,9 +1893,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ReactionPaginationAction retrieveReactionUsers(@Nonnull Emote emote);
+    ReactionPaginationAction retrieveReactionUsers(@NotNull Emote emote);
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted using the given unicode emoji.
@@ -1936,9 +1936,9 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ReactionPaginationAction retrieveReactionUsers(@Nonnull String unicode);
+    ReactionPaginationAction retrieveReactionUsers(@NotNull String unicode);
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote ReactionEmote} for the given unicode reaction on this message.
@@ -1962,7 +1962,7 @@ public interface Message extends ISnowflake, Formattable
      */
     @Nullable
     @CheckReturnValue
-    MessageReaction.ReactionEmote getReactionByUnicode(@Nonnull String unicode);
+    MessageReaction.ReactionEmote getReactionByUnicode(@NotNull String unicode);
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote ReactionEmote} for the given reaction id on this message.
@@ -1986,7 +1986,7 @@ public interface Message extends ISnowflake, Formattable
      */
     @Nullable
     @CheckReturnValue
-    MessageReaction.ReactionEmote getReactionById(@Nonnull String id);
+    MessageReaction.ReactionEmote getReactionById(@NotNull String id);
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote ReactionEmote} for the given reaction id on this message.
@@ -2044,7 +2044,7 @@ public interface Message extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: {@link java.lang.Void}
      * @see    #isSuppressedEmbeds()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> suppressEmbeds(boolean suppressed);
 
@@ -2087,7 +2087,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Message> crosspost();
 
@@ -2112,7 +2112,7 @@ public interface Message extends ISnowflake, Formattable
      * @return Never-Null EnumSet of present {@link Message.MessageFlag MessageFlags}
      * @see    Message.MessageFlag
      */
-    @Nonnull
+    @NotNull
     EnumSet<MessageFlag> getFlags();
 
     /**
@@ -2127,7 +2127,7 @@ public interface Message extends ISnowflake, Formattable
      *
      * @return The {@link net.dv8tion.jda.api.entities.MessageType MessageType} of this message.
      */
-    @Nonnull
+    @NotNull
     MessageType getType();
 
     /**
@@ -2173,7 +2173,7 @@ public interface Message extends ISnowflake, Formattable
             this.parseKey = parseKey;
         }
 
-        @Nonnull
+        @NotNull
         public Pattern getPattern()
         {
             return pattern;
@@ -2247,7 +2247,7 @@ public interface Message extends ISnowflake, Formattable
          *         Non-Negative integer representing a bitfield of MessageFlags
          * @return Never-Null EnumSet of MessageFlags being found in the bitfield
          */
-        @Nonnull
+        @NotNull
         public static EnumSet<MessageFlag> fromBitField(int bitfield)
         {
             Set<MessageFlag> set = Arrays.stream(MessageFlag.values())
@@ -2265,7 +2265,7 @@ public interface Message extends ISnowflake, Formattable
          *         If the provided Collection is {@code null}
          * @return Integer value of the bitfield representing the given MessageFlags
          */
-        public static int toBitField(@Nonnull Collection<MessageFlag> coll)
+        public static int toBitField(@NotNull Collection<MessageFlag> coll)
         {
             Checks.notNull(coll, "Collection");
             int flags = 0;
@@ -2315,7 +2315,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return The corresponding JDA instance for this Attachment
          */
-        @Nonnull
+        @NotNull
         public JDA getJDA()
         {
             return jda;
@@ -2332,7 +2332,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return Non-null String containing the Attachment URL.
          */
-        @Nonnull
+        @NotNull
         public String getUrl()
         {
             return url;
@@ -2343,7 +2343,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return Non-null String containing the proxied Attachment url.
          */
-        @Nonnull
+        @NotNull
         public String getProxyUrl()
         {
             return proxyUrl;
@@ -2354,7 +2354,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return Non-null String containing the Attachment file name.
          */
-        @Nonnull
+        @NotNull
         public String getFileName()
         {
             return fileName;
@@ -2413,7 +2413,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return {@link java.util.concurrent.CompletableFuture} - Type: {@link java.io.InputStream}
          */
-        @Nonnull
+        @NotNull
         public CompletableFuture<InputStream> retrieveInputStream() // it is expected that the response is closed by the callback!
         {
             CompletableFuture<InputStream> future = new CompletableFuture<>();
@@ -2458,7 +2458,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return {@link java.util.concurrent.CompletableFuture} - Type: {@link java.io.File}
          */
-        @Nonnull
+        @NotNull
         public CompletableFuture<File> downloadToFile() // using relative path
         {
             return downloadToFile(getFileName());
@@ -2491,7 +2491,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return {@link java.util.concurrent.CompletableFuture} - Type: {@link java.io.File}
          */
-        @Nonnull
+        @NotNull
         public CompletableFuture<File> downloadToFile(String path)
         {
             Checks.notNull(path, "Path");
@@ -2526,7 +2526,7 @@ public interface Message extends ISnowflake, Formattable
          * @return {@link java.util.concurrent.CompletableFuture} - Type: {@link java.io.File}
          */
         @SuppressWarnings("ResultOfMethodCallIgnored")
-        @Nonnull
+        @NotNull
         public CompletableFuture<File> downloadToFile(File file)
         {
             Checks.notNull(file, "File");
@@ -2590,7 +2590,7 @@ public interface Message extends ISnowflake, Formattable
          *
          * @return {@link java.util.concurrent.CompletableFuture} - Type: {@link net.dv8tion.jda.api.entities.Icon}
          */
-        @Nonnull
+        @NotNull
         public CompletableFuture<Icon> retrieveAsIcon()
         {
             if (!isImage())

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageActivity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageActivity.java
@@ -15,8 +15,8 @@
  */
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a {@link net.dv8tion.jda.api.entities.Message} activity.
@@ -41,7 +41,7 @@ public class MessageActivity
      *
      * @return the type of the activity, or {@link ActivityType#UNKNOWN UNKNOWN}
      */
-    @Nonnull
+    @NotNull
     public ActivityType getType()
     {
         return type;
@@ -94,7 +94,7 @@ public class MessageActivity
          *
          * @return the applications name
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             return name;
@@ -105,7 +105,7 @@ public class MessageActivity
          *
          * @return the applications description
          */
-        @Nonnull
+        @NotNull
         public String getDescription()
         {
             return description;
@@ -205,7 +205,7 @@ public class MessageActivity
             return id;
         }
 
-        @Nonnull
+        @NotNull
         public static ActivityType fromId(int id)
         {
             for (ActivityType activityType : values())

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -37,9 +37,9 @@ import net.dv8tion.jda.internal.requests.restaction.pagination.MessagePagination
 import net.dv8tion.jda.internal.requests.restaction.pagination.ReactionPaginationActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -92,7 +92,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return The most recent message's id
      */
-    @Nonnull
+    @NotNull
     default String getLatestMessageId()
     {
         return Long.toUnsignedString(getLatestMessageIdLong());
@@ -113,8 +113,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
-    @Nonnull
-    default List<CompletableFuture<Void>> purgeMessagesById(@Nonnull List<String> messageIds)
+    @NotNull
+    default List<CompletableFuture<Void>> purgeMessagesById(@NotNull List<String> messageIds)
     {
         if (messageIds == null || messageIds.isEmpty())
             return Collections.emptyList();
@@ -139,8 +139,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
-    @Nonnull
-    default List<CompletableFuture<Void>> purgeMessagesById(@Nonnull String... messageIds)
+    @NotNull
+    default List<CompletableFuture<Void>> purgeMessagesById(@NotNull String... messageIds)
     {
         if (messageIds == null || messageIds.length == 0)
             return Collections.emptyList();
@@ -167,8 +167,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
-    @Nonnull
-    default List<CompletableFuture<Void>> purgeMessages(@Nonnull Message... messages)
+    @NotNull
+    default List<CompletableFuture<Void>> purgeMessages(@NotNull Message... messages)
     {
         if (messages == null || messages.length == 0)
             return Collections.emptyList();
@@ -195,8 +195,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
-    @Nonnull
-    default List<CompletableFuture<Void>> purgeMessages(@Nonnull List<? extends Message> messages)
+    @NotNull
+    default List<CompletableFuture<Void>> purgeMessages(@NotNull List<? extends Message> messages)
     {
         if (messages == null || messages.isEmpty())
             return Collections.emptyList();
@@ -235,8 +235,8 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
-    @Nonnull
-    default List<CompletableFuture<Void>> purgeMessagesById(@Nonnull long... messageIds)
+    @NotNull
+    default List<CompletableFuture<Void>> purgeMessagesById(@NotNull long... messageIds)
     {
         if (messageIds == null || messageIds.length == 0)
             return Collections.emptyList();
@@ -289,7 +289,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return Never-null "name" of the MessageChannel. Different implementations determine what the name.
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -297,7 +297,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return The ChannelType for this channel
      */
-    @Nonnull
+    @NotNull
     ChannelType getType();
 
     /**
@@ -305,7 +305,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -335,9 +335,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see net.dv8tion.jda.api.MessageBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendMessage(@Nonnull CharSequence text)
+    default MessageAction sendMessage(@NotNull CharSequence text)
     {
         Checks.notEmpty(text, "Provided text for message");
         Checks.check(text.length() <= 2000, "Provided text for message must be less than 2000 characters in length");
@@ -388,9 +388,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The newly created Message after it has been sent to Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendMessageFormat(@Nonnull String format, @Nonnull Object... args)
+    default MessageAction sendMessageFormat(@NotNull String format, @NotNull Object... args)
     {
         Checks.notEmpty(format, "Format");
         return sendMessage(String.format(format, args));
@@ -431,9 +431,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @see    net.dv8tion.jda.api.MessageBuilder
      * @see    net.dv8tion.jda.api.EmbedBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendMessage(@Nonnull MessageEmbed embed)
+    default MessageAction sendMessage(@NotNull MessageEmbed embed)
     {
         Checks.notNull(embed, "Provided embed");
 
@@ -492,9 +492,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.MessageBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendMessage(@Nonnull Message msg)
+    default MessageAction sendMessage(@NotNull Message msg)
     {
         Checks.notNull(msg, "Message");
 
@@ -552,9 +552,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>Providing the {@link net.dv8tion.jda.api.entities.Message Message} created from this upload.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull File file, @Nonnull AttachmentOption... options)
+    default MessageAction sendFile(@NotNull File file, @NotNull AttachmentOption... options)
     {
         Checks.notNull(file, "file");
 
@@ -639,9 +639,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>Providing the {@link net.dv8tion.jda.api.entities.Message Message} created from this upload.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull File file, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    default MessageAction sendFile(@NotNull File file, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         Checks.notNull(file, "file");
         Checks.check(file.exists() && file.canRead(),
@@ -705,9 +705,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>Provides the {@link net.dv8tion.jda.api.entities.Message Message} created from this upload.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    default MessageAction sendFile(@NotNull InputStream data, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         Checks.notNull(data, "data InputStream");
         Checks.notNull(fileName, "fileName");
@@ -766,9 +766,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>Provides the {@link net.dv8tion.jda.api.entities.Message Message} created from this upload.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    default MessageAction sendFile(@NotNull byte[] data, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         Checks.notNull(data, "data");
         Checks.notNull(fileName, "fileName");
@@ -819,9 +819,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Message
      *         <br>The Message defined by the provided id.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Message> retrieveMessageById(@Nonnull String messageId)
+    default RestAction<Message> retrieveMessageById(@NotNull String messageId)
     {
         AccountTypeException.check(getJDA().getAccountType(), AccountType.BOT);
         Checks.isSnowflake(messageId, "Message ID");
@@ -873,7 +873,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Message
      *         <br>The Message defined by the provided id.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Message> retrieveMessageById(long messageId)
     {
@@ -917,9 +917,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Void
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AuditableRestAction<Void> deleteMessageById(@Nonnull String messageId)
+    default AuditableRestAction<Void> deleteMessageById(@NotNull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
 
@@ -964,7 +964,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Void
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AuditableRestAction<Void> deleteMessageById(long messageId)
     {
@@ -1015,7 +1015,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link MessagePaginationAction MessagePaginationAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default MessagePaginationAction getIterableHistory()
     {
@@ -1081,9 +1081,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAround(MessageChannel, String) MessageHistory.getHistoryAround(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageHistory.MessageRetrieveAction getHistoryAround(@Nonnull String messageId, int limit)
+    default MessageHistory.MessageRetrieveAction getHistoryAround(@NotNull String messageId, int limit)
     {
         return MessageHistory.getHistoryAround(this, messageId).limit(limit);
     }
@@ -1147,7 +1147,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAround(MessageChannel, String) MessageHistory.getHistoryAround(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default MessageHistory.MessageRetrieveAction getHistoryAround(long messageId, int limit)
     {
@@ -1213,9 +1213,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAround(MessageChannel, String) MessageHistory.getHistoryAround(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageHistory.MessageRetrieveAction getHistoryAround(@Nonnull Message message, int limit)
+    default MessageHistory.MessageRetrieveAction getHistoryAround(@NotNull Message message, int limit)
     {
         Checks.notNull(message, "Provided target message");
         return getHistoryAround(message.getId(), limit);
@@ -1272,9 +1272,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageHistory.MessageRetrieveAction getHistoryAfter(@Nonnull String messageId, int limit)
+    default MessageHistory.MessageRetrieveAction getHistoryAfter(@NotNull String messageId, int limit)
     {
         return MessageHistory.getHistoryAfter(this, messageId).limit(limit);
     }
@@ -1327,7 +1327,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default MessageHistory.MessageRetrieveAction getHistoryAfter(long messageId, int limit)
     {
@@ -1385,9 +1385,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageHistory.MessageRetrieveAction getHistoryAfter(@Nonnull Message message, int limit)
+    default MessageHistory.MessageRetrieveAction getHistoryAfter(@NotNull Message message, int limit)
     {
         Checks.notNull(message, "Message");
         return getHistoryAfter(message.getId(), limit);
@@ -1444,9 +1444,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryBefore(MessageChannel, String) MessageHistory.getHistoryBefore(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageHistory.MessageRetrieveAction getHistoryBefore(@Nonnull String messageId, int limit)
+    default MessageHistory.MessageRetrieveAction getHistoryBefore(@NotNull String messageId, int limit)
     {
         return MessageHistory.getHistoryBefore(this, messageId).limit(limit);
     }
@@ -1502,7 +1502,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryBefore(MessageChannel, String) MessageHistory.getHistoryBefore(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default MessageHistory.MessageRetrieveAction getHistoryBefore(long messageId, int limit)
     {
@@ -1560,9 +1560,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryBefore(MessageChannel, String) MessageHistory.getHistoryBefore(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageHistory.MessageRetrieveAction getHistoryBefore(@Nonnull Message message, int limit)
+    default MessageHistory.MessageRetrieveAction getHistoryBefore(@NotNull Message message, int limit)
     {
         Checks.notNull(message, "Message");
         return getHistoryBefore(message.getId(), limit);
@@ -1624,7 +1624,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @see    net.dv8tion.jda.api.entities.MessageHistory#retrieveFuture(int)                     MessageHistory.retrieveFuture(int)
      * @see    net.dv8tion.jda.api.entities.MessageHistory#getHistoryAfter(MessageChannel, String) MessageHistory.getHistoryAfter(MessageChannel, String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default MessageHistory.MessageRetrieveAction getHistoryFromBeginning(int limit)
     {
@@ -1659,7 +1659,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Void
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Void> sendTyping()
     {
@@ -1737,9 +1737,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> addReactionById(@Nonnull String messageId, @Nonnull String unicode)
+    default RestAction<Void> addReactionById(@NotNull String messageId, @NotNull String unicode)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(unicode, "Provided Unicode");
@@ -1822,9 +1822,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> addReactionById(long messageId, @Nonnull String unicode)
+    default RestAction<Void> addReactionById(long messageId, @NotNull String unicode)
     {
         return addReactionById(Long.toUnsignedString(messageId), unicode);
     }
@@ -1883,9 +1883,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> addReactionById(@Nonnull String messageId, @Nonnull Emote emote)
+    default RestAction<Void> addReactionById(@NotNull String messageId, @NotNull Emote emote)
     {
         Checks.notNull(emote, "Emote");
         return addReactionById(messageId, emote.getName() + ":" + emote.getId());
@@ -1945,9 +1945,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> addReactionById(long messageId, @Nonnull Emote emote)
+    default RestAction<Void> addReactionById(long messageId, @NotNull Emote emote)
     {
         return addReactionById(Long.toUnsignedString(messageId), emote);
     }
@@ -2005,9 +2005,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode)
+    default RestAction<Void> removeReactionById(@NotNull String messageId, @NotNull String unicode)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(unicode, "Provided Unicode");
@@ -2073,9 +2073,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(long messageId, @Nonnull String unicode)
+    default RestAction<Void> removeReactionById(long messageId, @NotNull String unicode)
     {
         return removeReactionById(Long.toUnsignedString(messageId), unicode);
     }
@@ -2125,9 +2125,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull Emote emote)
+    default RestAction<Void> removeReactionById(@NotNull String messageId, @NotNull Emote emote)
     {
         Checks.notNull(emote, "Emote");
         return removeReactionById(messageId, emote.getName() + ":" + emote.getId());
@@ -2178,9 +2178,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(long messageId, @Nonnull Emote emote)
+    default RestAction<Void> removeReactionById(long messageId, @NotNull Emote emote)
     {
         return removeReactionById(Long.toUnsignedString(messageId), emote);
     }
@@ -2229,9 +2229,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ReactionPaginationAction retrieveReactionUsersById(@Nonnull String messageId, @Nonnull String unicode)
+    default ReactionPaginationAction retrieveReactionUsersById(@NotNull String messageId, @NotNull String unicode)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notEmpty(unicode, "Emoji");
@@ -2284,9 +2284,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ReactionPaginationAction retrieveReactionUsersById(long messageId, @Nonnull String unicode)
+    default ReactionPaginationAction retrieveReactionUsersById(long messageId, @NotNull String unicode)
     {
         return retrieveReactionUsersById(Long.toUnsignedString(messageId), unicode);
     }
@@ -2332,9 +2332,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ReactionPaginationAction retrieveReactionUsersById(@Nonnull String messageId, @Nonnull Emote emote)
+    default ReactionPaginationAction retrieveReactionUsersById(@NotNull String messageId, @NotNull Emote emote)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(emote, "Emote");
@@ -2385,9 +2385,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ReactionPaginationAction retrieveReactionUsersById(long messageId, @Nonnull Emote emote)
+    default ReactionPaginationAction retrieveReactionUsersById(long messageId, @NotNull Emote emote)
     {
         return retrieveReactionUsersById(Long.toUnsignedString(messageId), emote);
     }
@@ -2429,9 +2429,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> pinMessageById(@Nonnull String messageId)
+    default RestAction<Void> pinMessageById(@NotNull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
 
@@ -2476,7 +2476,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Void> pinMessageById(long messageId)
     {
@@ -2520,9 +2520,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> unpinMessageById(@Nonnull String messageId)
+    default RestAction<Void> unpinMessageById(@NotNull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
 
@@ -2567,7 +2567,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Void> unpinMessageById(long messageId)
     {
@@ -2596,7 +2596,7 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: List{@literal <}{@link net.dv8tion.jda.api.entities.Message}{@literal >}
      *         <br>Retrieves an immutable list of pinned messages
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<List<Message>> retrievePinnedMessages()
     {
@@ -2658,9 +2658,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageById(@Nonnull String messageId, @Nonnull CharSequence newContent)
+    default MessageAction editMessageById(@NotNull String messageId, @NotNull CharSequence newContent)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notEmpty(newContent, "Provided message content");
@@ -2714,9 +2714,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageById(long messageId, @Nonnull CharSequence newContent)
+    default MessageAction editMessageById(long messageId, @NotNull CharSequence newContent)
     {
         return editMessageById(Long.toUnsignedString(messageId), newContent);
     }
@@ -2763,9 +2763,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to discord
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageById(@Nonnull String messageId, @Nonnull Message newContent)
+    default MessageAction editMessageById(@NotNull String messageId, @NotNull Message newContent)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(newContent, "message");
@@ -2816,9 +2816,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to discord
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageById(long messageId, @Nonnull Message newContent)
+    default MessageAction editMessageById(long messageId, @NotNull Message newContent)
     {
         return editMessageById(Long.toUnsignedString(messageId), newContent);
     }
@@ -2874,9 +2874,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to discord
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageFormatById(@Nonnull String messageId, @Nonnull String format, @Nonnull Object... args)
+    default MessageAction editMessageFormatById(@NotNull String messageId, @NotNull String format, @NotNull Object... args)
     {
         Checks.notBlank(format, "Format String");
         return editMessageById(messageId, String.format(format, args));
@@ -2933,9 +2933,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to discord
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageFormatById(long messageId, @Nonnull String format, @Nonnull Object... args)
+    default MessageAction editMessageFormatById(long messageId, @NotNull String format, @NotNull Object... args)
     {
         Checks.notBlank(format, "Format String");
         return editMessageById(messageId, String.format(format, args));
@@ -2984,9 +2984,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to discord
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageById(@Nonnull String messageId, @Nonnull MessageEmbed newEmbed)
+    default MessageAction editMessageById(@NotNull String messageId, @NotNull MessageEmbed newEmbed)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(newEmbed, "MessageEmbed");
@@ -3038,9 +3038,9 @@ public interface MessageChannel extends ISnowflake, Formattable
      * @return {@link MessageAction MessageAction}
      *         <br>The modified Message after it has been sent to discord
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction editMessageById(long messageId, @Nonnull MessageEmbed newEmbed)
+    default MessageAction editMessageById(long messageId, @NotNull MessageEmbed newEmbed)
     {
         return editMessageById(Long.toUnsignedString(messageId), newEmbed);
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -24,9 +24,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -190,7 +190,7 @@ public class MessageEmbed implements SerializableData
      *
      * @return The {@link net.dv8tion.jda.api.entities.EmbedType EmbedType} of this embed.
      */
-    @Nonnull
+    @NotNull
     public EmbedType getType()
     {
         return type;
@@ -284,7 +284,7 @@ public class MessageEmbed implements SerializableData
      * @return Never-null (but possibly empty) immutable  List of {@link net.dv8tion.jda.api.entities.MessageEmbed.Field Field} objects
      *         containing field information.
      */
-    @Nonnull
+    @NotNull
     public List<Field> getFields()
     {
         return fields;
@@ -415,7 +415,7 @@ public class MessageEmbed implements SerializableData
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    public boolean isSendable(@Nonnull AccountType type)
+    public boolean isSendable(@NotNull AccountType type)
     {
         Checks.notNull(type, "AccountType");
         final int length = getLength();
@@ -459,7 +459,7 @@ public class MessageEmbed implements SerializableData
      *
      * @return JSONObject for this embed
      */
-    @Nonnull
+    @NotNull
     @Override
     public DataObject toData()
     {

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -33,10 +33,10 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import org.apache.commons.collections4.map.ListOrderedMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.UncheckedIOException;
 import java.util.*;
 
@@ -64,7 +64,7 @@ public class MessageHistory
      * @param  channel
      *         The {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} to retrieval history from.
      */
-    public MessageHistory(@Nonnull MessageChannel channel)
+    public MessageHistory(@NotNull MessageChannel channel)
     {
         Checks.notNull(channel, "Channel");
         this.channel = channel;
@@ -84,7 +84,7 @@ public class MessageHistory
      *
      * @return The corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     public JDA getJDA()
     {
         return channel.getJDA();
@@ -119,7 +119,7 @@ public class MessageHistory
      *
      * @return The MessageChannel of this history.
      */
-    @Nonnull
+    @NotNull
     public MessageChannel getChannel()
     {
         return channel;
@@ -176,7 +176,7 @@ public class MessageHistory
      *         <br>Retrieved Messages are placed in a List and provided in order of most recent to oldest with most recent
      *         starting at index 0. If the list is empty, there were no more messages left to retrieve.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<List<Message>> retrievePast(int amount)
     {
@@ -246,7 +246,7 @@ public class MessageHistory
      *         <br>Retrieved Messages are placed in a List and provided in order of most recent to oldest with most recent
      *         starting at index 0. If the list is empty, there were no more messages left to retrieve.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<List<Message>> retrieveFuture(int amount)
     {
@@ -287,7 +287,7 @@ public class MessageHistory
      *
      * @return An immutable List of Messages, sorted newest to oldest.
      */
-    @Nonnull
+    @NotNull
     public List<Message> getRetrievedHistory()
     {
         int size = size();
@@ -317,7 +317,7 @@ public class MessageHistory
      * @return Possibly-null Message with the same {@code id} as the one provided.
      */
     @Nullable
-    public Message getMessageById(@Nonnull String id)
+    public Message getMessageById(@NotNull String id)
     {
         return getMessageById(MiscUtil.parseSnowflake(id));
     }
@@ -377,9 +377,9 @@ public class MessageHistory
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryAfter(long, int)    MessageChannel.getHistoryAfter(long, int)
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryAfter(Message, int) MessageChannel.getHistoryAfter(Message, int)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static MessageRetrieveAction getHistoryAfter(@Nonnull MessageChannel channel, @Nonnull String messageId)
+    public static MessageRetrieveAction getHistoryAfter(@NotNull MessageChannel channel, @NotNull String messageId)
     {
         checkArguments(channel, messageId);
         Route.CompiledRoute route = Route.Messages.GET_MESSAGE_HISTORY.compile(channel.getId()).withQueryParams("after", messageId);
@@ -422,9 +422,9 @@ public class MessageHistory
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryBefore(long, int)    MessageChannel.getHistoryBefore(long, int)
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryBefore(Message, int) MessageChannel.getHistoryBefore(Message, int)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static MessageRetrieveAction getHistoryBefore(@Nonnull MessageChannel channel, @Nonnull String messageId)
+    public static MessageRetrieveAction getHistoryBefore(@NotNull MessageChannel channel, @NotNull String messageId)
     {
         checkArguments(channel, messageId);
         Route.CompiledRoute route = Route.Messages.GET_MESSAGE_HISTORY.compile(channel.getId()).withQueryParams("before", messageId);
@@ -467,9 +467,9 @@ public class MessageHistory
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryAround(long, int)    MessageChannel.getHistoryAround(long, int)
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryAround(Message, int) MessageChannel.getHistoryAround(Message, int)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static MessageRetrieveAction getHistoryAround(@Nonnull MessageChannel channel, @Nonnull String messageId)
+    public static MessageRetrieveAction getHistoryAround(@NotNull MessageChannel channel, @NotNull String messageId)
     {
         checkArguments(channel, messageId);
         Route.CompiledRoute route = Route.Messages.GET_MESSAGE_HISTORY.compile(channel.getId()).withQueryParams("around", messageId);
@@ -500,9 +500,9 @@ public class MessageHistory
      *
      * @see    net.dv8tion.jda.api.entities.MessageChannel#getHistoryFromBeginning(int)  MessageChannel.getHistoryFromBeginning(int)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static MessageRetrieveAction getHistoryFromBeginning(@Nonnull MessageChannel channel)
+    public static MessageRetrieveAction getHistoryFromBeginning(@NotNull MessageChannel channel)
     {
         return getHistoryAfter(channel, "0");
     }
@@ -548,7 +548,7 @@ public class MessageHistory
          *
          * @return The current MessageRetrieveAction for chaining convenience
          */
-        @Nonnull
+        @NotNull
         @CheckReturnValue
         public MessageRetrieveAction limit(@Nullable Integer limit)
         {

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -27,10 +27,10 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.pagination.ReactionPaginationActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -66,7 +66,7 @@ public class MessageReaction
      * @param  count
      *         The amount of people that reacted with this Reaction
      */
-    public MessageReaction(@Nonnull MessageChannel channel, @Nonnull ReactionEmote emote, long messageId, boolean self, int count)
+    public MessageReaction(@NotNull MessageChannel channel, @NotNull ReactionEmote emote, long messageId, boolean self, int count)
     {
         this.channel = channel;
         this.emote = emote;
@@ -80,7 +80,7 @@ public class MessageReaction
      *
      * @return The JDA instance of this Reaction
      */
-    @Nonnull
+    @NotNull
     public JDA getJDA()
     {
         return channel.getJDA();
@@ -139,7 +139,7 @@ public class MessageReaction
      *
      * @return The ChannelType
      */
-    @Nonnull
+    @NotNull
     public ChannelType getChannelType()
     {
         return channel.getType();
@@ -154,7 +154,7 @@ public class MessageReaction
      *
      * @return True, if this Reaction was used in a MessageChannel from the specified ChannelType
      */
-    public boolean isFromType(@Nonnull ChannelType type)
+    public boolean isFromType(@NotNull ChannelType type)
     {
         return getChannelType() == type;
     }
@@ -203,7 +203,7 @@ public class MessageReaction
      *
      * @return The channel this Reaction was used in
      */
-    @Nonnull
+    @NotNull
     public MessageChannel getChannel()
     {
         return channel;
@@ -215,7 +215,7 @@ public class MessageReaction
      *
      * @return The final instance of this Reaction's Emote/Emoji
      */
-    @Nonnull
+    @NotNull
     public ReactionEmote getReactionEmote()
     {
         return emote;
@@ -226,7 +226,7 @@ public class MessageReaction
      *
      * @return The message id this reaction is attached to
      */
-    @Nonnull
+    @NotNull
     public String getMessageId()
     {
         return Long.toUnsignedString(messageId);
@@ -260,7 +260,7 @@ public class MessageReaction
      *
      * @return {@link ReactionPaginationAction ReactionPaginationAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public ReactionPaginationAction retrieveUsers()
     {
@@ -287,7 +287,7 @@ public class MessageReaction
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Void
      *         Nothing is returned on success
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<Void> removeReaction()
     {
@@ -328,9 +328,9 @@ public class MessageReaction
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction}
      *         Nothing is returned on success
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public RestAction<Void> removeReaction(@Nonnull User user)
+    public RestAction<Void> removeReaction(@NotNull User user)
     {
         Checks.notNull(user, "User");
         boolean self = user.equals(getJDA().getSelfUser());
@@ -381,7 +381,7 @@ public class MessageReaction
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<Void> clearReactions()
     {
@@ -434,7 +434,7 @@ public class MessageReaction
         private final long id;
         private final Emote emote;
 
-        private ReactionEmote(@Nonnull String name, @Nonnull JDA api)
+        private ReactionEmote(@NotNull String name, @NotNull JDA api)
         {
             this.name = name;
             this.api = api;
@@ -442,7 +442,7 @@ public class MessageReaction
             this.emote = null;
         }
 
-        private ReactionEmote(@Nonnull Emote emote)
+        private ReactionEmote(@NotNull Emote emote)
         {
             this.api = emote.getJDA();
             this.name = emote.getName();
@@ -450,14 +450,14 @@ public class MessageReaction
             this.emote = emote;
         }
 
-        @Nonnull
-        public static ReactionEmote fromUnicode(@Nonnull String name, @Nonnull JDA api)
+        @NotNull
+        public static ReactionEmote fromUnicode(@NotNull String name, @NotNull JDA api)
         {
             return new ReactionEmote(name, api);
         }
 
-        @Nonnull
-        public static ReactionEmote fromCustom(@Nonnull Emote emote)
+        @NotNull
+        public static ReactionEmote fromCustom(@NotNull Emote emote)
         {
             return new ReactionEmote(emote);
         }
@@ -499,7 +499,7 @@ public class MessageReaction
          *
          * @return The name for this emote/emoji
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             return name;
@@ -513,7 +513,7 @@ public class MessageReaction
          *
          * @return String containing the codepoint representation of the reaction emoji
          */
-        @Nonnull
+        @NotNull
         public String getAsCodepoints()
         {
             if (!isEmoji())
@@ -536,7 +536,7 @@ public class MessageReaction
          *
          * @return The unicode if it is an emoji, or the name and id in the format {@code <name>:<id>}
          */
-        @Nonnull
+        @NotNull
         public String getAsReactionCode()
         {
             return emote != null
@@ -552,7 +552,7 @@ public class MessageReaction
          *
          * @return The unicode for the emoji
          */
-        @Nonnull
+        @NotNull
         public String getEmoji()
         {
             if (!isEmoji())
@@ -569,7 +569,7 @@ public class MessageReaction
          *
          * @return The Emote for the Reaction instance
          */
-        @Nonnull
+        @NotNull
         public Emote getEmote()
         {
             if (!isEmote())
@@ -582,7 +582,7 @@ public class MessageReaction
          *
          * @return The JDA instance of the Reaction
          */
-        @Nonnull
+        @NotNull
         public JDA getJDA()
         {
             return api;

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageSticker.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageSticker.java
@@ -15,7 +15,8 @@
  */
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Set;
 
 /**
@@ -60,7 +61,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return the name of the sticker
      */
-    @Nonnull
+    @NotNull
     public String getName()
     {
         return name;
@@ -71,7 +72,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return the description of the sticker
      */
-    @Nonnull
+    @NotNull
     public String getDescription()
     {
         return description;
@@ -82,7 +83,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return the ID of the pack the sticker is from
      */
-    @Nonnull
+    @NotNull
     public String getPackId()
     {
         return Long.toUnsignedString(getPackIdLong());
@@ -104,7 +105,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return the Discord hash-id of the sticker
      */
-    @Nonnull
+    @NotNull
     public String getAssetHash()
     {
         return asset;
@@ -118,7 +119,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return the url of the sticker
      */
-    @Nonnull
+    @NotNull
     public String getAssetUrl()
     {
         return String.format(ASSET_URL, id, asset, formatType.getExtension());
@@ -129,7 +130,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return the format of the sticker
      */
-    @Nonnull
+    @NotNull
     public StickerFormat getFormatType()
     {
         return formatType;
@@ -140,7 +141,7 @@ public class MessageSticker implements ISnowflake
      *
      * @return Possibly-empty unmodifiable Set of tags of the sticker
      */
-    @Nonnull
+    @NotNull
     public Set<String> getTags()
     {
         return tags;
@@ -185,7 +186,7 @@ public class MessageSticker implements ISnowflake
          *
          * @return The file extension for this format
          */
-        @Nonnull
+        @NotNull
         public String getExtension()
         {
             if (this == UNKNOWN)
@@ -201,7 +202,7 @@ public class MessageSticker implements ISnowflake
          *
          * @return The representative StickerFormat or UNKNOWN if it can't be resolved
          */
-        @Nonnull
+        @NotNull
         public static MessageSticker.StickerFormat fromId(int id)
         {
             for (MessageSticker.StickerFormat stickerFormat : values())

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
@@ -15,7 +15,7 @@
  */
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents the different types of {@link net.dv8tion.jda.api.entities.Message Messages} that can be received from Discord.
@@ -169,7 +169,7 @@ public enum MessageType
      *
      * @return A MessageType with the same Discord id key as the one provided, or {@link #UNKNOWN}.
      */
-    @Nonnull
+    @NotNull
     public static MessageType fromId(int id)
     {
         for (MessageType type : values())

--- a/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PermissionOverride.java
@@ -19,10 +19,10 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.PermissionOverrideAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 /**
@@ -70,7 +70,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return Possibly-empty set of allowed {@link net.dv8tion.jda.api.Permission Permissions}.
      */
-    @Nonnull
+    @NotNull
     EnumSet<Permission> getAllowed();
 
     /**
@@ -79,7 +79,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return Possibly-empty set of unaffected {@link net.dv8tion.jda.api.Permission Permissions}.
      */
-    @Nonnull
+    @NotNull
     EnumSet<Permission> getInherit();
 
     /**
@@ -88,7 +88,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return Possibly-empty set of denied {@link net.dv8tion.jda.api.Permission Permissions}.
      */
-    @Nonnull
+    @NotNull
     EnumSet<Permission> getDenied();
 
     /**
@@ -96,7 +96,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return Never-null {@link net.dv8tion.jda.api.JDA JDA} instance.
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -142,7 +142,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return Never-null related {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} that this override is part of.
      */
-    @Nonnull
+    @NotNull
     GuildChannel getChannel();
 
     /**
@@ -152,7 +152,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return Never-null related {@link net.dv8tion.jda.api.entities.Guild Guild}.
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -184,7 +184,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return The PermissionOverrideAction of this override.
      */
-    @Nonnull
+    @NotNull
     PermissionOverrideAction getManager();
 
     /**
@@ -207,7 +207,7 @@ public interface PermissionOverride extends ISnowflake
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/PrivateChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PrivateChannel.java
@@ -17,9 +17,9 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 /**
  * Represents the connection used for direct messaging.
@@ -33,7 +33,7 @@ public interface PrivateChannel extends MessageChannel, IFakeable
      *
      * @return A non-null {@link net.dv8tion.jda.api.entities.User User}.
      */
-    @Nonnull
+    @NotNull
     User getUser();
 
     /**
@@ -41,7 +41,7 @@ public interface PrivateChannel extends MessageChannel, IFakeable
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -51,7 +51,7 @@ public interface PrivateChannel extends MessageChannel, IFakeable
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Void
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<Void> close();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/RichPresence.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/RichPresence.java
@@ -17,9 +17,9 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Objects;
 
@@ -45,7 +45,7 @@ public interface RichPresence extends Activity
      *
      * @return The ID for the application
      */
-    @Nonnull
+    @NotNull
     String getApplicationId();
 
     /**
@@ -149,7 +149,7 @@ public interface RichPresence extends Activity
          *
          * @return The key for this image
          */
-        @Nonnull
+        @NotNull
         public String getKey()
         {
             return key;
@@ -171,7 +171,7 @@ public interface RichPresence extends Activity
          *
          * @return URL for this image
          */
-        @Nonnull
+        @NotNull
         public String getUrl()
         {
             if (key.startsWith("spotify:"))

--- a/src/main/java/net/dv8tion/jda/api/entities/Role.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Role.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.managers.RoleManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.RoleAction;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 
 /**
@@ -73,7 +73,7 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      *
      * @return Never-null String containing the name of this {@link net.dv8tion.jda.api.entities.Role Role}.
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -147,14 +147,14 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      *
      * @return True, if this role can interact with the specified role
      */
-    boolean canInteract(@Nonnull Role role);
+    boolean canInteract(@NotNull Role role);
 
     /**
      * Returns the {@link net.dv8tion.jda.api.entities.Guild Guild} this Role exists in
      *
      * @return the Guild containing this Role
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -187,9 +187,9 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      * @return {@link RoleAction RoleAction}
      *         <br>RoleAction with already copied values from the specified {@link net.dv8tion.jda.api.entities.Role Role}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RoleAction createCopy(@Nonnull Guild guild);
+    RoleAction createCopy(@NotNull Guild guild);
 
     /**
      * Creates a new {@link net.dv8tion.jda.api.entities.Role Role} in this {@link net.dv8tion.jda.api.entities.Guild Guild}
@@ -216,7 +216,7 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      * @return {@link RoleAction RoleAction}
      *         <br>RoleAction with already copied values from the specified {@link net.dv8tion.jda.api.entities.Role Role}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RoleAction createCopy()
     {
@@ -238,7 +238,7 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      *
      * @return The RoleManager of this Role
      */
-    @Nonnull
+    @NotNull
     RoleManager getManager();
 
     /**
@@ -264,7 +264,7 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 
@@ -273,7 +273,7 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -288,7 +288,7 @@ public interface Role extends IMentionable, IPermissionHolder, Comparable<Role>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     RoleTags getTags();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/SelfUser.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/SelfUser.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.exceptions.AccountTypeException;
 import net.dv8tion.jda.api.managers.AccountManager;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents the currently logged in account.
@@ -61,7 +60,7 @@ public interface SelfUser extends User
      *
      * @deprecated This is no longer supported
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
@@ -152,6 +151,6 @@ public interface SelfUser extends User
      *
      * @return An AccountManager instance for the current account
      */
-    @Nonnull
+    @NotNull
     AccountManager getManager();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/TeamMember.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TeamMember.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Member of a {@link net.dv8tion.jda.api.entities.ApplicationTeam}.
@@ -32,7 +32,7 @@ public interface TeamMember
      *
      * @return The user
      */
-    @Nonnull
+    @NotNull
     User getUser();
 
     /**
@@ -42,7 +42,7 @@ public interface TeamMember
      *
      * @return The {@link net.dv8tion.jda.api.entities.TeamMember.MembershipState}, or {@link net.dv8tion.jda.api.entities.TeamMember.MembershipState#UNKNOWN UNKNOWN}
      */
-    @Nonnull
+    @NotNull
     MembershipState getMembershipState();
 
     /**
@@ -50,7 +50,7 @@ public interface TeamMember
      *
      * @return The team id.
      */
-    @Nonnull
+    @NotNull
     default String getTeamId()
     {
         return Long.toUnsignedString(getTeamIdLong());
@@ -100,7 +100,7 @@ public interface TeamMember
          *
          * @return The MembershipState, or {@link #UNKNOWN}
          */
-        @Nonnull
+        @NotNull
         public static MembershipState fromKey(int key)
         {
             for (MembershipState state : values())

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -27,10 +27,10 @@ import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.FormattableFlags;
 import java.util.Formatter;
@@ -104,11 +104,11 @@ public interface TextChannel extends GuildChannel, MessageChannel
      */
     int getSlowmode();
 
-    @Nonnull
+    @NotNull
     @Override
-    ChannelAction<TextChannel> createCopy(@Nonnull Guild guild);
+    ChannelAction<TextChannel> createCopy(@NotNull Guild guild);
 
-    @Nonnull
+    @NotNull
     @Override
     ChannelAction<TextChannel> createCopy();
 
@@ -127,7 +127,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      * @return {@link net.dv8tion.jda.api.requests.RestAction} - Type: List{@literal <}{@link net.dv8tion.jda.api.entities.Webhook Webhook}{@literal >}
      *         <br>Retrieved an immutable list of Webhooks attached to this channel
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<List<Webhook>> retrieveWebhooks();
 
@@ -159,9 +159,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      * @return A specific {@link WebhookAction WebhookAction}
      *         <br>This action allows to set fields for the new webhook before creating it
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    WebhookAction createWebhook(@Nonnull String name);
+    WebhookAction createWebhook(@NotNull String name);
 
     /**
      * Subscribes to the crossposted messages in this channel.
@@ -191,9 +191,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Webhook.WebhookReference> follow(@Nonnull String targetChannelId);
+    RestAction<Webhook.WebhookReference> follow(@NotNull String targetChannelId);
 
     /**
      * Subscribes to the crossposted messages in this channel.
@@ -221,7 +221,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Webhook.WebhookReference> follow(long targetChannelId)
     {
@@ -258,9 +258,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Webhook.WebhookReference> follow(@Nonnull TextChannel targetChannel)
+    default RestAction<Webhook.WebhookReference> follow(@NotNull TextChannel targetChannel)
     {
         Checks.notNull(targetChannel, "Target Channel");
         Member selfMember = targetChannel.getGuild().getSelfMember();
@@ -314,9 +314,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      * @see    #deleteMessagesByIds(Collection)
      * @see    #purgeMessages(List)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> deleteMessages(@Nonnull Collection<Message> messages);
+    RestAction<Void> deleteMessages(@NotNull Collection<Message> messages);
 
     /**
      * Bulk deletes a list of messages.
@@ -364,9 +364,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      * @see    #deleteMessages(Collection)
      * @see    #purgeMessagesById(List)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> deleteMessagesByIds(@Nonnull Collection<String> messageIds);
+    RestAction<Void> deleteMessagesByIds(@NotNull Collection<String> messageIds);
 
     /**
      * Deletes a {@link net.dv8tion.jda.api.entities.Webhook Webhook} attached to this channel
@@ -400,9 +400,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> deleteWebhookById(@Nonnull String id);
+    AuditableRestAction<Void> deleteWebhookById(@NotNull String id);
 
     /**
      * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
@@ -435,9 +435,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> clearReactionsById(@Nonnull String messageId);
+    RestAction<Void> clearReactionsById(@NotNull String messageId);
 
     /**
      * Attempts to remove all reactions from a message with the specified {@code messageId} in this TextChannel
@@ -468,7 +468,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Void> clearReactionsById(long messageId)
     {
@@ -515,9 +515,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull String unicode);
+    RestAction<Void> clearReactionsById(@NotNull String messageId, @NotNull String unicode);
 
     /**
      * Removes all reactions for the specified emoji.
@@ -549,9 +549,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote);
+    RestAction<Void> clearReactionsById(@NotNull String messageId, @NotNull Emote emote);
 
     /**
      * Removes all reactions for the specified emoji.
@@ -593,9 +593,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> clearReactionsById(long messageId, @Nonnull String unicode)
+    default RestAction<Void> clearReactionsById(long messageId, @NotNull String unicode)
     {
         return clearReactionsById(Long.toUnsignedString(messageId), unicode);
     }
@@ -630,9 +630,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> clearReactionsById(long messageId, @Nonnull Emote emote)
+    default RestAction<Void> clearReactionsById(long messageId, @NotNull Emote emote)
     {
         return clearReactionsById(Long.toUnsignedString(messageId), emote);
     }
@@ -696,9 +696,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode, @Nonnull User user);
+    RestAction<Void> removeReactionById(@NotNull String messageId, @NotNull String unicode, @NotNull User user);
 
     /**
      * Attempts to remove the reaction from a message represented by the specified {@code messageId}
@@ -759,9 +759,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(long messageId, @Nonnull String unicode, @Nonnull User user)
+    default RestAction<Void> removeReactionById(long messageId, @NotNull String unicode, @NotNull User user)
     {
         return removeReactionById(Long.toUnsignedString(messageId), unicode, user);
     }
@@ -819,9 +819,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull Emote emote, @Nonnull User user)
+    default RestAction<Void> removeReactionById(@NotNull String messageId, @NotNull Emote emote, @NotNull User user)
     {
         Checks.notNull(emote, "Emote");
         return removeReactionById(messageId, emote.getName() + ":" + emote.getId(), user);
@@ -880,9 +880,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction}
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Void> removeReactionById(long messageId, @Nonnull Emote emote, @Nonnull User user)
+    default RestAction<Void> removeReactionById(long messageId, @NotNull Emote emote, @NotNull User user)
     {
         return removeReactionById(Long.toUnsignedString(messageId), emote, user);
     }
@@ -928,9 +928,9 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<Message> crosspostMessageById(@Nonnull String messageId)
+    default RestAction<Message> crosspostMessageById(@NotNull String messageId)
     {
         if (!isNews())
             throw new IllegalStateException("You can only crosspost messages in news channels!");
@@ -981,7 +981,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Message> crosspostMessageById(long messageId)
     {
@@ -1009,7 +1009,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *
      * @return True, if the specified member is able to read and send messages in this channel
      */
-    boolean canTalk(@Nonnull Member member);
+    boolean canTalk(@NotNull Member member);
 
     @Override
     default void formatTo(Formatter formatter, int flags, int width, int precision)

--- a/src/main/java/net/dv8tion/jda/api/entities/User.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/User.java
@@ -24,10 +24,10 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.entities.UserById;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -98,7 +98,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     static User fromId(long id)
     {
         return new UserById(id);
@@ -120,8 +120,8 @@ public interface User extends IMentionable, IFakeable
      *
      * @since  4.2.1
      */
-    @Nonnull
-    static User fromId(@Nonnull String id)
+    @NotNull
+    static User fromId(@NotNull String id)
     {
         return fromId(MiscUtil.parseSnowflake(id));
     }
@@ -134,7 +134,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return Never-null String containing the {@link net.dv8tion.jda.api.entities.User User}'s username.
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -147,7 +147,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return Never-null String containing the {@link net.dv8tion.jda.api.entities.User User} discriminator.
      */
-    @Nonnull
+    @NotNull
     String getDiscriminator();
 
     /**
@@ -186,7 +186,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return Never-null String containing the {@link net.dv8tion.jda.api.entities.User User} default avatar id.
      */
-    @Nonnull
+    @NotNull
     String getDefaultAvatarId();
 
     /**
@@ -197,7 +197,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return Never-null String containing the {@link net.dv8tion.jda.api.entities.User User} default avatar url.
      */
-    @Nonnull
+    @NotNull
     default String getDefaultAvatarUrl()
     {
         return String.format(DEFAULT_AVATAR_URL, getDefaultAvatarId());
@@ -213,7 +213,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return  Never-null String containing the {@link net.dv8tion.jda.api.entities.User User} effective avatar url.
      */
-    @Nonnull
+    @NotNull
     default String getEffectiveAvatarUrl()
     {
         String avatarUrl = getAvatarUrl();
@@ -229,7 +229,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return Never-null String containing the tag for this user, for example DV8FromTheWorld#6297
      */
-    @Nonnull
+    @NotNull
     String getAsTag();
 
     /**
@@ -275,7 +275,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @see    JDA#openPrivateChannelById(long)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RestAction<PrivateChannel> openPrivateChannel();
 
@@ -288,7 +288,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return Immutable list of all {@link net.dv8tion.jda.api.entities.Guild Guilds} that this user is a member of.
      */
-    @Nonnull
+    @NotNull
     List<Guild> getMutualGuilds();
 
     /**
@@ -320,7 +320,7 @@ public interface User extends IMentionable, IFakeable
      *
      * @return the corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -331,7 +331,7 @@ public interface User extends IMentionable, IFakeable
      * 
      * @return EnumSet containing the flags of the user.
      */
-    @Nonnull
+    @NotNull
     EnumSet<UserFlag> getFlags();
 
     /**
@@ -382,7 +382,7 @@ public interface User extends IMentionable, IFakeable
         private final int raw;
         private final String name;
 
-        UserFlag(int offset, @Nonnull String name)
+        UserFlag(int offset, @NotNull String name)
         {
             this.offset = offset;
             this.raw = 1 << offset;
@@ -394,7 +394,7 @@ public interface User extends IMentionable, IFakeable
          * 
          * @return The readable name of this UserFlag.
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             return this.name;
@@ -431,7 +431,7 @@ public interface User extends IMentionable, IFakeable
          *         
          * @return UserFlag relating to the provided offset.
          */
-        @Nonnull
+        @NotNull
         public static UserFlag getFromOffset(int offset)
         {
             for (UserFlag flag : values())
@@ -451,7 +451,7 @@ public interface User extends IMentionable, IFakeable
          *         
          * @return Possibly-empty EnumSet of UserFlags.
          */
-        @Nonnull
+        @NotNull
         public static EnumSet<UserFlag> getFlags(int flags)
         {
             final EnumSet<UserFlag> foundFlags = EnumSet.noneOf(UserFlag.class);
@@ -480,7 +480,7 @@ public interface User extends IMentionable, IFakeable
          *         
          * @return bitmask representing the provided flags.
          */
-        public static int getRaw(@Nonnull UserFlag... flags){
+        public static int getRaw(@NotNull UserFlag... flags){
             Checks.noneNull(flags, "UserFlags");
             
             int raw = 0;
@@ -508,7 +508,7 @@ public interface User extends IMentionable, IFakeable
          * 
          * @see java.util.EnumSet EnumSet
          */
-        public static int getRaw(@Nonnull Collection<UserFlag> flags)
+        public static int getRaw(@NotNull Collection<UserFlag> flags)
         {
             Checks.notNull(flags, "Flag Collection");
             

--- a/src/main/java/net/dv8tion/jda/api/entities/VanityInvite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/VanityInvite.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Objects;
 
 /**
@@ -29,7 +30,7 @@ public class VanityInvite
     private final String code;
     private final int uses;
 
-    public VanityInvite(@Nonnull String code, int uses)
+    public VanityInvite(@NotNull String code, int uses)
     {
         this.code = code;
         this.uses = uses;
@@ -40,7 +41,7 @@ public class VanityInvite
      *
      * @return The code
      */
-    @Nonnull
+    @NotNull
     public String getCode()
     {
         return code;
@@ -62,7 +63,7 @@ public class VanityInvite
      *
      * @return The invite url
      */
-    @Nonnull
+    @NotNull
     public String getUrl()
     {
         return "https://discord.gg/" + getCode();

--- a/src/main/java/net/dv8tion/jda/api/entities/VoiceChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/VoiceChannel.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a Discord Voice GuildChannel.
@@ -58,11 +57,11 @@ public interface VoiceChannel extends GuildChannel
      */
     int getBitrate();
 
-    @Nonnull
+    @NotNull
     @Override
-    ChannelAction<VoiceChannel> createCopy(@Nonnull Guild guild);
+    ChannelAction<VoiceChannel> createCopy(@NotNull Guild guild);
 
-    @Nonnull
+    @NotNull
     @Override
     ChannelAction<VoiceChannel> createCopy();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Webhook.java
@@ -22,10 +22,10 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * An object representing Webhooks in Discord
@@ -43,7 +43,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The current JDA instance of this Webhook
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -52,7 +52,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The {@link WebhookType}
      */
-    @Nonnull
+    @NotNull
     WebhookType getType();
 
     /**
@@ -73,7 +73,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The current Guild of this Webhook
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -85,7 +85,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The current TextChannel of this Webhook
      */
-    @Nonnull
+    @NotNull
     TextChannel getChannel();
 
     /**
@@ -123,7 +123,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @see    <a href="https://discord.com/developers/docs/resources/webhook#execute-webhook">Execute Webhook Docs</a>
      */
-    @Nonnull
+    @NotNull
     User getDefaultUser();
 
     /**
@@ -135,7 +135,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The name of this Webhook
      */
-    @Nonnull
+    @NotNull
     String getName();
 
     /**
@@ -167,7 +167,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The execution route for this Webhook.
      */
-    @Nonnull
+    @NotNull
     String getUrl();
 
     /**
@@ -209,7 +209,7 @@ public interface Webhook extends ISnowflake, IFakeable
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *         <br>The rest action to delete this Webhook.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AuditableRestAction<Void> delete();
 
@@ -243,9 +243,9 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AuditableRestAction<Void> delete(@Nonnull String token);
+    AuditableRestAction<Void> delete(@NotNull String token);
 
     /**
      * The {@link WebhookManager WebhookManager} for this Webhook.
@@ -259,7 +259,7 @@ public interface Webhook extends ISnowflake, IFakeable
      *
      * @return The {@link WebhookManager WebhookManager} for this Webhook
      */
-    @Nonnull
+    @NotNull
     WebhookManager getManager();
 
     /**
@@ -290,7 +290,7 @@ public interface Webhook extends ISnowflake, IFakeable
          *
          * @return The ID for the channel this webhook belongs to
          */
-        @Nonnull
+        @NotNull
         public String getChannelId()
         {
             return Long.toUnsignedString(channelId);
@@ -314,7 +314,7 @@ public interface Webhook extends ISnowflake, IFakeable
          *
          * @return {@link RestAction} - Type: {@link Webhook}
          */
-        @Nonnull
+        @NotNull
         @CheckReturnValue
         public RestAction<Webhook> resolve()
         {
@@ -349,7 +349,7 @@ public interface Webhook extends ISnowflake, IFakeable
          *
          * @return The channel name
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             return name;
@@ -381,7 +381,7 @@ public interface Webhook extends ISnowflake, IFakeable
          *
          * @return The guild name
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             return name;

--- a/src/main/java/net/dv8tion/jda/api/entities/WebhookType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/WebhookType.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.entities;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public enum WebhookType
 {
@@ -52,7 +52,7 @@ public enum WebhookType
      *
      * @return The WebhookType or {@link #UNKNOWN}
      */
-    @Nonnull
+    @NotNull
     public static WebhookType fromKey(int key)
     {
         for (WebhookType type : values())

--- a/src/main/java/net/dv8tion/jda/api/events/DisconnectEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/DisconnectEvent.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.events;
 import com.neovisionaries.ws.client.WebSocketFrame;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.CloseCode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 
 /**
@@ -40,9 +40,9 @@ public class DisconnectEvent extends Event
     protected final OffsetDateTime disconnectTime;
 
     public DisconnectEvent(
-        @Nonnull JDA api,
+        @NotNull JDA api,
         @Nullable WebSocketFrame serverCloseFrame, @Nullable WebSocketFrame clientCloseFrame,
-        boolean closedByServer, @Nonnull OffsetDateTime disconnectTime)
+        boolean closedByServer, @NotNull OffsetDateTime disconnectTime)
     {
         super(api);
         this.serverCloseFrame = serverCloseFrame;
@@ -103,7 +103,7 @@ public class DisconnectEvent extends Event
      *
      * @return Time of closure
      */
-    @Nonnull
+    @NotNull
     public OffsetDateTime getTimeDisconnected()
     {
         return disconnectTime;

--- a/src/main/java/net/dv8tion/jda/api/events/Event.java
+++ b/src/main/java/net/dv8tion/jda/api/events/Event.java
@@ -16,8 +16,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Top-level event type
@@ -41,7 +40,7 @@ public abstract class Event implements GenericEvent
      *
      * @see   #Event(net.dv8tion.jda.api.JDA)
      */
-    public Event(@Nonnull JDA api, long responseNumber)
+    public Event(@NotNull JDA api, long responseNumber)
     {
         this.api = api;
         this.responseNumber = responseNumber;
@@ -54,12 +53,12 @@ public abstract class Event implements GenericEvent
      * @param api
      *        Current JDA instance
      */
-    public Event(@Nonnull JDA api)
+    public Event(@NotNull JDA api)
     {
         this(api, api.getResponseTotal());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/ExceptionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/ExceptionEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that JDA encountered a Throwable that could not be forwarded to another end-user frontend.
@@ -33,7 +32,7 @@ public class ExceptionEvent extends Event
     protected final Throwable throwable;
     protected final boolean logged;
 
-    public ExceptionEvent(@Nonnull JDA api, @Nonnull Throwable throwable, boolean logged)
+    public ExceptionEvent(@NotNull JDA api, @NotNull Throwable throwable, boolean logged)
     {
         super(api);
         this.throwable = throwable;
@@ -55,7 +54,7 @@ public class ExceptionEvent extends Event
      *
      * @return The cause
      */
-    @Nonnull
+    @NotNull
     public Throwable getCause()
     {
         return throwable;

--- a/src/main/java/net/dv8tion/jda/api/events/GatewayPingEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/GatewayPingEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the gateway ping has been updated by the heartbeat cycle.
@@ -33,7 +32,7 @@ public class GatewayPingEvent extends Event implements UpdateEvent<JDA, Long>
     public static final String IDENTIFIER = "gateway-ping";
     private final long next, prev;
 
-    public GatewayPingEvent(@Nonnull JDA api, long old)
+    public GatewayPingEvent(@NotNull JDA api, long old)
     {
         super(api);
         this.next = api.getGatewayPing();
@@ -60,28 +59,28 @@ public class GatewayPingEvent extends Event implements UpdateEvent<JDA, Long>
         return prev;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {
         return IDENTIFIER;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getEntity()
     {
         return getJDA();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Long getOldValue()
     {
         return prev;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Long getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/GenericEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public interface GenericEvent
 {
@@ -27,7 +26,7 @@ public interface GenericEvent
      *
      * @return The corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/RawGatewayEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/RawGatewayEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.utils.data.DataObject;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Wrapper for the raw dispatch event received from discord.
@@ -44,7 +43,7 @@ public class RawGatewayEvent extends Event
 {
     private final DataObject data;
 
-    public RawGatewayEvent(@Nonnull JDA api, long responseNumber, @Nonnull DataObject data)
+    public RawGatewayEvent(@NotNull JDA api, long responseNumber, @NotNull DataObject data)
     {
         super(api, responseNumber);
         this.data = data;
@@ -62,7 +61,7 @@ public class RawGatewayEvent extends Event
      *
      * @return The data object
      */
-    @Nonnull
+    @NotNull
     public DataObject getPackage()
     {
         return data;
@@ -73,7 +72,7 @@ public class RawGatewayEvent extends Event
      *
      * @return The payload as a {@link net.dv8tion.jda.api.utils.data.DataObject} instance
      */
-    @Nonnull
+    @NotNull
     public DataObject getPayload()
     {
         return data.getObject("d");
@@ -84,7 +83,7 @@ public class RawGatewayEvent extends Event
      *
      * @return The type of event.
      */
-    @Nonnull
+    @NotNull
     public String getType()
     {
         return data.getString("t");

--- a/src/main/java/net/dv8tion/jda/api/events/ReadyEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/ReadyEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.handle.GuildSetupController;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that JDA finished loading all entities.
@@ -33,7 +32,7 @@ public class ReadyEvent extends Event
     private final int availableGuilds;
     private final int unavailableGuilds;
 
-    public ReadyEvent(@Nonnull JDA api, long responseNumber)
+    public ReadyEvent(@NotNull JDA api, long responseNumber)
     {
         super(api, responseNumber);
         this.availableGuilds = (int) getJDA().getGuildCache().size();

--- a/src/main/java/net/dv8tion/jda/api/events/ReconnectedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/ReconnectedEvent.java
@@ -16,8 +16,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates if JDA successfully re-established its connection to the gateway.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class ReconnectedEvent extends Event
 {
-    public ReconnectedEvent(@Nonnull JDA api, long responseNumber)
+    public ReconnectedEvent(@NotNull JDA api, long responseNumber)
     {
         super(api, responseNumber);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/ResumedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/ResumedEvent.java
@@ -16,8 +16,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that JDA successfully resumed its connection to the gateway.
@@ -27,7 +26,7 @@ import javax.annotation.Nonnull;
  */
 public class ResumedEvent extends Event
 {
-    public ResumedEvent(@Nonnull JDA api, long responseNumber)
+    public ResumedEvent(@NotNull JDA api, long responseNumber)
     {
         super(api, responseNumber);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/ShutdownEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/ShutdownEvent.java
@@ -17,9 +17,9 @@ package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.requests.CloseCode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 
 /**
@@ -31,7 +31,7 @@ public class ShutdownEvent extends Event
     protected final OffsetDateTime shutdownTime;
     protected final int code;
 
-    public ShutdownEvent(@Nonnull JDA api, @Nonnull OffsetDateTime shutdownTime, int code)
+    public ShutdownEvent(@NotNull JDA api, @NotNull OffsetDateTime shutdownTime, int code)
     {
         super(api);
         this.shutdownTime = shutdownTime;
@@ -44,7 +44,7 @@ public class ShutdownEvent extends Event
      * @return {@link java.time.OffsetDateTime OffsetDateTime} representing
      *         the point in time when the connection was dropped.
      */
-    @Nonnull
+    @NotNull
     public OffsetDateTime getTimeShutdown()
     {
         return shutdownTime;

--- a/src/main/java/net/dv8tion/jda/api/events/StatusChangeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/StatusChangeEvent.java
@@ -16,8 +16,7 @@
 package net.dv8tion.jda.api.events;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that our {@link net.dv8tion.jda.api.JDA.Status Status} changed. (Example: SHUTTING_DOWN {@literal ->} SHUTDOWN)
@@ -33,7 +32,7 @@ public class StatusChangeEvent extends Event implements UpdateEvent<JDA, JDA.Sta
     protected final JDA.Status newStatus;
     protected final JDA.Status oldStatus;
 
-    public StatusChangeEvent(@Nonnull JDA api, @Nonnull JDA.Status newStatus, @Nonnull JDA.Status oldStatus)
+    public StatusChangeEvent(@NotNull JDA api, @NotNull JDA.Status newStatus, @NotNull JDA.Status oldStatus)
     {
         super(api);
         this.newStatus = newStatus;
@@ -45,7 +44,7 @@ public class StatusChangeEvent extends Event implements UpdateEvent<JDA, JDA.Sta
      *
      * @return The new status
      */
-    @Nonnull
+    @NotNull
     public JDA.Status getNewStatus()
     {
         return newStatus;
@@ -56,34 +55,34 @@ public class StatusChangeEvent extends Event implements UpdateEvent<JDA, JDA.Sta
      *
      * @return The previous status
      */
-    @Nonnull
+    @NotNull
     public JDA.Status getOldStatus()
     {
         return oldStatus;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {
         return IDENTIFIER;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getEntity()
     {
         return getJDA();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA.Status getOldValue()
     {
         return oldStatus;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA.Status getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/UpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/UpdateEvent.java
@@ -16,8 +16,8 @@
 
 package net.dv8tion.jda.api.events;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a value of an entity was updated
@@ -34,7 +34,7 @@ public interface UpdateEvent<E, T> extends GenericEvent
      *
      * @return The class of the affected entity
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
     default Class<E> getEntityType()
     {
@@ -65,7 +65,7 @@ public interface UpdateEvent<E, T> extends GenericEvent
      *
      * @return The name of the updated property
      */
-    @Nonnull
+    @NotNull
     String getPropertyIdentifier();
 
     /**
@@ -73,7 +73,7 @@ public interface UpdateEvent<E, T> extends GenericEvent
      *
      * @return The affected entity
      */
-    @Nonnull
+    @NotNull
     E getEntity();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/CategoryCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/CategoryCreateEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.category;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Category Category} was created.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class CategoryCreateEvent extends GenericCategoryEvent
 {
-    public CategoryCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Category category)
+    public CategoryCreateEvent(@NotNull JDA api, long responseNumber, @NotNull Category category)
     {
         super(api, responseNumber, category);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/CategoryDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/CategoryDeleteEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.category;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Category Category} was deleted.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class CategoryDeleteEvent extends GenericCategoryEvent
 {
-    public CategoryDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Category category)
+    public CategoryDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull Category category)
     {
         super(api, responseNumber, category);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/GenericCategoryEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/GenericCategoryEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Category Category} was created/deleted/updated.
@@ -33,7 +32,7 @@ public abstract class GenericCategoryEvent extends Event
 {
     protected final Category category;
 
-    public GenericCategoryEvent(@Nonnull JDA api, long responseNumber, @Nonnull Category category)
+    public GenericCategoryEvent(@NotNull JDA api, long responseNumber, @NotNull Category category)
     {
         super(api, responseNumber);
         this.category = category;
@@ -44,7 +43,7 @@ public abstract class GenericCategoryEvent extends Event
      *
      * @return The Category
      */
-    @Nonnull
+    @NotNull
     public Category getCategory()
     {
         return category;
@@ -55,7 +54,7 @@ public abstract class GenericCategoryEvent extends Event
      *
      * @return The ID for the category
      */
-    @Nonnull
+    @NotNull
     public String getId()
     {
         return Long.toUnsignedString(getIdLong());
@@ -77,7 +76,7 @@ public abstract class GenericCategoryEvent extends Event
      *
      * @return The {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return category.getGuild();

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/update/CategoryUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/update/CategoryUpdateNameEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.category.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the name of a {@link net.dv8tion.jda.api.entities.Category Category} was updated.
@@ -32,7 +31,7 @@ public class CategoryUpdateNameEvent extends GenericCategoryUpdateEvent<String>
 {
     public static final String IDENTIFIER = "name";
 
-    public CategoryUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull Category category, @Nonnull String oldName)
+    public CategoryUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull Category category, @NotNull String oldName)
     {
         super(api, responseNumber, category, oldName, category.getName(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class CategoryUpdateNameEvent extends GenericCategoryUpdateEvent<String>
      *
      * @return The previous name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class CategoryUpdateNameEvent extends GenericCategoryUpdateEvent<String>
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/update/CategoryUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/update/CategoryUpdatePermissionsEvent.java
@@ -24,8 +24,8 @@ import net.dv8tion.jda.api.entities.IPermissionHolder;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.channel.category.GenericCategoryEvent;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -44,7 +44,7 @@ public class CategoryUpdatePermissionsEvent extends GenericCategoryEvent
 {
     protected final List<IPermissionHolder> changed;
 
-    public CategoryUpdatePermissionsEvent(@Nonnull JDA api, long responseNumber, @Nonnull Category category, @Nonnull List<IPermissionHolder> changed)
+    public CategoryUpdatePermissionsEvent(@NotNull JDA api, long responseNumber, @NotNull Category category, @NotNull List<IPermissionHolder> changed)
     {
         super(api, responseNumber, category);
         this.changed = changed;
@@ -55,7 +55,7 @@ public class CategoryUpdatePermissionsEvent extends GenericCategoryEvent
      *
      * @return Immutable list of permission holders affected by this event
      */
-    @Nonnull
+    @NotNull
     public List<IPermissionHolder> getChangedPermissionHolders()
     {
         return changed;
@@ -66,7 +66,7 @@ public class CategoryUpdatePermissionsEvent extends GenericCategoryEvent
      *
      * @return Immutable list of affected roles
      */
-    @Nonnull
+    @NotNull
     public List<Role> getChangedRoles()
     {
         return changed.stream()
@@ -80,7 +80,7 @@ public class CategoryUpdatePermissionsEvent extends GenericCategoryEvent
      *
      * @return Immutable list of affected members
      */
-    @Nonnull
+    @NotNull
     public List<Member> getChangedMembers()
     {
         return changed.stream()

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/update/CategoryUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/update/CategoryUpdatePositionEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.category.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the position of a {@link net.dv8tion.jda.api.entities.Category Category} was updated.
@@ -32,7 +31,7 @@ public class CategoryUpdatePositionEvent extends GenericCategoryUpdateEvent<Inte
 {
     public static final String IDENTIFIER = "position";
 
-    public CategoryUpdatePositionEvent(@Nonnull JDA api, long responseNumber, @Nonnull Category category, int oldPosition)
+    public CategoryUpdatePositionEvent(@NotNull JDA api, long responseNumber, @NotNull Category category, int oldPosition)
     {
         super(api, responseNumber, category, oldPosition, category.getPositionRaw(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/category/update/GenericCategoryUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/category/update/GenericCategoryUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.channel.category.GenericCategoryEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Category Category} was updated.
@@ -37,8 +36,8 @@ public abstract class GenericCategoryUpdateEvent<T> extends GenericCategoryEvent
     protected final String identifier;
 
     public GenericCategoryUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull Category category,
-        @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull Category category,
+        @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, category);
         this.previous = previous;
@@ -46,14 +45,14 @@ public abstract class GenericCategoryUpdateEvent<T> extends GenericCategoryEvent
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Category getEntity()
     {
         return getCategory();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/priv/PrivateChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/priv/PrivateChannelCreateEvent.java
@@ -21,8 +21,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.PrivateChannel Private Channel} was created.
@@ -38,7 +37,7 @@ public class PrivateChannelCreateEvent extends Event
 {
     private final PrivateChannel channel;
 
-    public PrivateChannelCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull PrivateChannel channel)
+    public PrivateChannelCreateEvent(@NotNull JDA api, long responseNumber, @NotNull PrivateChannel channel)
     {
         super(api, responseNumber);
         this.channel = channel;
@@ -50,7 +49,7 @@ public class PrivateChannelCreateEvent extends Event
      *
      * @return The User
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return channel.getUser();
@@ -61,7 +60,7 @@ public class PrivateChannelCreateEvent extends Event
      *
      * @return The PrivateChannel
      */
-    @Nonnull
+    @NotNull
     public PrivateChannel getChannel()
     {
         return channel;

--- a/src/main/java/net/dv8tion/jda/api/events/channel/priv/PrivateChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/priv/PrivateChannelDeleteEvent.java
@@ -21,8 +21,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.PrivateChannel Private Channel} was deleted.
@@ -36,7 +35,7 @@ public class PrivateChannelDeleteEvent extends Event
 {
     protected final PrivateChannel channel;
 
-    public PrivateChannelDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull PrivateChannel channel)
+    public PrivateChannelDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull PrivateChannel channel)
     {
         super(api, responseNumber);
         this.channel = channel;
@@ -48,7 +47,7 @@ public class PrivateChannelDeleteEvent extends Event
      *
      * @return The User
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return channel.getUser();
@@ -59,7 +58,7 @@ public class PrivateChannelDeleteEvent extends Event
      *
      * @return The PrivateChannel
      */
-    @Nonnull
+    @NotNull
     public PrivateChannel getChannel()
     {
         return channel;

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/GenericStoreChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/GenericStoreChannelEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.channel.store;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.StoreChannel;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel} event was fired.
@@ -32,7 +31,7 @@ public abstract class GenericStoreChannelEvent extends Event
 {
     protected final StoreChannel channel;
 
-    public GenericStoreChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel)
+    public GenericStoreChannelEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel)
     {
         super(api, responseNumber);
         this.channel = channel;
@@ -43,7 +42,7 @@ public abstract class GenericStoreChannelEvent extends Event
      *
      * @return The channel
      */
-    @Nonnull
+    @NotNull
     public StoreChannel getChannel()
     {
         return channel;

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/StoreChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/StoreChannelCreateEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.store;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.StoreChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel} has been created.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class StoreChannelCreateEvent extends GenericStoreChannelEvent
 {
-    public StoreChannelCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel)
+    public StoreChannelCreateEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel)
     {
         super(api, responseNumber, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/StoreChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/StoreChannelDeleteEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.store;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.StoreChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel} has been deleted.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class StoreChannelDeleteEvent extends GenericStoreChannelEvent
 {
-    public StoreChannelDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel)
+    public StoreChannelDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel)
     {
         super(api, responseNumber, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/update/GenericStoreChannelUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/update/GenericStoreChannelUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.StoreChannel;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.channel.store.GenericStoreChannelEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel} was updated.
@@ -36,8 +35,8 @@ public abstract class GenericStoreChannelUpdateEvent<T> extends GenericStoreChan
     protected final T next;
     protected final String identifier;
 
-    public GenericStoreChannelUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel,
-                                          @Nullable T prev, @Nullable T next, @Nonnull String identifier)
+    public GenericStoreChannelUpdateEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel,
+                                          @Nullable T prev, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, channel);
         this.prev = prev;
@@ -45,14 +44,14 @@ public abstract class GenericStoreChannelUpdateEvent<T> extends GenericStoreChan
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {
         return identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public StoreChannel getEntity()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/update/StoreChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/update/StoreChannelUpdateNameEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.store.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.StoreChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel}'s name changed.
@@ -32,8 +31,8 @@ public class StoreChannelUpdateNameEvent extends GenericStoreChannelUpdateEvent<
 {
     public static final String IDENTIFIER = "name";
 
-    public StoreChannelUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel,
-                                       @Nonnull String prev)
+    public StoreChannelUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel,
+                                       @NotNull String prev)
     {
         super(api, responseNumber, channel, prev, channel.getName(), IDENTIFIER);
     }
@@ -43,7 +42,7 @@ public class StoreChannelUpdateNameEvent extends GenericStoreChannelUpdateEvent<
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -54,20 +53,20 @@ public class StoreChannelUpdateNameEvent extends GenericStoreChannelUpdateEvent<
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/update/StoreChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/update/StoreChannelUpdatePermissionsEvent.java
@@ -24,8 +24,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.StoreChannel;
 import net.dv8tion.jda.api.events.channel.store.GenericStoreChannelEvent;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -44,7 +44,7 @@ public class StoreChannelUpdatePermissionsEvent extends GenericStoreChannelEvent
 {
     private final List<IPermissionHolder> changed;
 
-    public StoreChannelUpdatePermissionsEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel, List<IPermissionHolder> permHolders)
+    public StoreChannelUpdatePermissionsEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel, List<IPermissionHolder> permHolders)
     {
         super(api, responseNumber, channel);
         this.changed = permHolders;
@@ -58,7 +58,7 @@ public class StoreChannelUpdatePermissionsEvent extends GenericStoreChannelEvent
      * @see    #getChangedRoles()
      * @see    #getChangedMembers()
      */
-    @Nonnull
+    @NotNull
     public List<IPermissionHolder> getChangedPermissionHolders()
     {
         return changed;
@@ -69,7 +69,7 @@ public class StoreChannelUpdatePermissionsEvent extends GenericStoreChannelEvent
      *
      * @return List of affected roles
      */
-    @Nonnull
+    @NotNull
     public List<Role> getChangedRoles()
     {
         return changed.stream()
@@ -83,7 +83,7 @@ public class StoreChannelUpdatePermissionsEvent extends GenericStoreChannelEvent
      *
      * @return List of affected members
      */
-    @Nonnull
+    @NotNull
     public List<Member> getChangedMembers()
     {
         return changed.stream()

--- a/src/main/java/net/dv8tion/jda/api/events/channel/store/update/StoreChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/store/update/StoreChannelUpdatePositionEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.store.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.StoreChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel}'s position changed.
@@ -32,7 +31,7 @@ public class StoreChannelUpdatePositionEvent extends GenericStoreChannelUpdateEv
 {
     public static final String IDENTIFIER = "position";
 
-    public StoreChannelUpdatePositionEvent(@Nonnull JDA api, long responseNumber, @Nonnull StoreChannel channel, int prev)
+    public StoreChannelUpdatePositionEvent(@NotNull JDA api, long responseNumber, @NotNull StoreChannel channel, int prev)
     {
         super(api, responseNumber, channel, prev, channel.getPositionRaw(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/GenericTextChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/GenericTextChannelEvent.java
@@ -19,8 +19,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} event was fired.
@@ -32,7 +31,7 @@ public abstract class GenericTextChannelEvent extends Event
 {
     private final TextChannel channel;
 
-    public GenericTextChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel)
+    public GenericTextChannelEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel)
     {
         super(api, responseNumber);
         this.channel = channel;
@@ -43,7 +42,7 @@ public abstract class GenericTextChannelEvent extends Event
      *
      * @return The TextChannel
      */
-    @Nonnull
+    @NotNull
     public TextChannel getChannel()
     {
         return channel;
@@ -55,7 +54,7 @@ public abstract class GenericTextChannelEvent extends Event
      *
      * @return The Guild
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return channel.getGuild();

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/TextChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/TextChannelCreateEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.text;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} has been created.
@@ -27,7 +26,7 @@ import javax.annotation.Nonnull;
  */
 public class TextChannelCreateEvent extends GenericTextChannelEvent
 {
-    public TextChannelCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel)
+    public TextChannelCreateEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel)
     {
         super(api, responseNumber, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/TextChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/TextChannelDeleteEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.text;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} has been deleted.
@@ -27,7 +26,7 @@ import javax.annotation.Nonnull;
  */
 public class TextChannelDeleteEvent extends GenericTextChannelEvent
 {
-    public TextChannelDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel)
+    public TextChannelDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel)
     {
         super(api, responseNumber, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/GenericTextChannelUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/GenericTextChannelUpdateEvent.java
@@ -19,9 +19,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.channel.text.GenericTextChannelEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} was updated.
@@ -36,8 +35,8 @@ public abstract class GenericTextChannelUpdateEvent<T> extends GenericTextChanne
     protected final String identifier;
 
     public GenericTextChannelUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel,
-        @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull TextChannel channel,
+        @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, channel);
         this.previous = previous;
@@ -45,14 +44,14 @@ public abstract class GenericTextChannelUpdateEvent<T> extends GenericTextChanne
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public TextChannel getEntity()
     {
         return getChannel();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNSFWEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNSFWEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.text.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s NSFW status changed.
@@ -31,7 +30,7 @@ public class TextChannelUpdateNSFWEvent extends GenericTextChannelUpdateEvent<Bo
 {
     public static final String IDENTIFIER = "nsfw";
 
-    public TextChannelUpdateNSFWEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, boolean oldNsfw)
+    public TextChannelUpdateNSFWEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, boolean oldNsfw)
     {
         super(api, responseNumber, channel, oldNsfw, channel.isNSFW(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNameEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.text.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s name changed.
@@ -31,7 +30,7 @@ public class TextChannelUpdateNameEvent extends GenericTextChannelUpdateEvent<St
 {
     public static final String IDENTIFIER = "name";
 
-    public TextChannelUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nonnull String oldName)
+    public TextChannelUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, @NotNull String oldName)
     {
         super(api, responseNumber, channel, oldName, channel.getName(), IDENTIFIER);
     }
@@ -41,7 +40,7 @@ public class TextChannelUpdateNameEvent extends GenericTextChannelUpdateEvent<St
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -52,20 +51,20 @@ public class TextChannelUpdateNameEvent extends GenericTextChannelUpdateEvent<St
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNewsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateNewsEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.channel.text.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s has been converted into a news channel
@@ -36,19 +35,19 @@ public class TextChannelUpdateNewsEvent extends GenericTextChannelUpdateEvent<Bo
 {
     public static final String IDENTIFIER = "news";
 
-    public TextChannelUpdateNewsEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel)
+    public TextChannelUpdateNewsEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel)
     {
         super(api, responseNumber, channel, !channel.isNews(), channel.isNews(), IDENTIFIER);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateParentEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateParentEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.channel.text.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s parent changed.
@@ -34,7 +33,7 @@ public class TextChannelUpdateParentEvent extends GenericTextChannelUpdateEvent<
 {
     public static final String IDENTIFIER = "parent";
 
-    public TextChannelUpdateParentEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nullable Category oldParent)
+    public TextChannelUpdateParentEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, @Nullable Category oldParent)
     {
         super(api, responseNumber, channel, oldParent, channel.getParent(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdatePermissionsEvent.java
@@ -23,8 +23,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.channel.text.GenericTextChannelEvent;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,7 +43,7 @@ public class TextChannelUpdatePermissionsEvent extends GenericTextChannelEvent
 {
     private final List<IPermissionHolder> changed;
 
-    public TextChannelUpdatePermissionsEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nonnull List<IPermissionHolder> permHolders)
+    public TextChannelUpdatePermissionsEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, @NotNull List<IPermissionHolder> permHolders)
     {
         super(api, responseNumber, channel);
         this.changed = permHolders;
@@ -57,7 +57,7 @@ public class TextChannelUpdatePermissionsEvent extends GenericTextChannelEvent
      * @see    #getChangedRoles()
      * @see    #getChangedMembers()
      */
-    @Nonnull
+    @NotNull
     public List<IPermissionHolder> getChangedPermissionHolders()
     {
         return changed;
@@ -68,7 +68,7 @@ public class TextChannelUpdatePermissionsEvent extends GenericTextChannelEvent
      *
      * @return List of affected roles
      */
-    @Nonnull
+    @NotNull
     public List<Role> getChangedRoles()
     {
         return changed.stream()
@@ -82,7 +82,7 @@ public class TextChannelUpdatePermissionsEvent extends GenericTextChannelEvent
      *
      * @return List of affected members
      */
-    @Nonnull
+    @NotNull
     public List<Member> getChangedMembers()
     {
         return changed.stream()

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdatePositionEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.text.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s position changed.
@@ -31,7 +30,7 @@ public class TextChannelUpdatePositionEvent extends GenericTextChannelUpdateEven
 {
     public static final String IDENTIFIER = "position";
 
-    public TextChannelUpdatePositionEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, int oldPosition)
+    public TextChannelUpdatePositionEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, int oldPosition)
     {
         super(api, responseNumber, channel, oldPosition, channel.getPositionRaw(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateSlowmodeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateSlowmodeEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.text.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s slowmode changed.
@@ -31,7 +30,7 @@ public class TextChannelUpdateSlowmodeEvent extends GenericTextChannelUpdateEven
 {
     public static final String IDENTIFIER = "slowmode";
 
-    public TextChannelUpdateSlowmodeEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, int oldSlowmode)
+    public TextChannelUpdateSlowmodeEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, int oldSlowmode)
     {
         super(api, responseNumber, channel, oldSlowmode, channel.getSlowmode(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateTopicEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/text/update/TextChannelUpdateTopicEvent.java
@@ -17,9 +17,8 @@ package net.dv8tion.jda.api.events.channel.text.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}'s topic changed.
@@ -32,7 +31,7 @@ public class TextChannelUpdateTopicEvent extends GenericTextChannelUpdateEvent<S
 {
     public static final String IDENTIFIER = "topic";
 
-    public TextChannelUpdateTopicEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nullable String oldTopic)
+    public TextChannelUpdateTopicEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, @Nullable String oldTopic)
     {
         super(api, responseNumber, channel, oldTopic, channel.getTopic(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/GenericVoiceChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/GenericVoiceChannelEvent.java
@@ -19,8 +19,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} event was fired.
@@ -32,7 +31,7 @@ public abstract class GenericVoiceChannelEvent extends Event
 {
     private final VoiceChannel channel;
 
-    public GenericVoiceChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel)
+    public GenericVoiceChannelEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel)
     {
         super(api, responseNumber);
         this.channel = channel;
@@ -43,7 +42,7 @@ public abstract class GenericVoiceChannelEvent extends Event
      *
      * @return The VoiceChannel
      */
-    @Nonnull
+    @NotNull
     public VoiceChannel getChannel()
     {
         return channel;
@@ -55,7 +54,7 @@ public abstract class GenericVoiceChannelEvent extends Event
      *
      * @return The Guild
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return channel.getGuild();

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/VoiceChannelCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/VoiceChannelCreateEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} was created.
@@ -27,7 +26,7 @@ import javax.annotation.Nonnull;
  */
 public class VoiceChannelCreateEvent extends GenericVoiceChannelEvent
 {
-    public VoiceChannelCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel)
+    public VoiceChannelCreateEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel)
     {
         super(api, responseNumber, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/VoiceChannelDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/VoiceChannelDeleteEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} was deleted.
@@ -27,7 +26,7 @@ import javax.annotation.Nonnull;
  */
 public class VoiceChannelDeleteEvent extends GenericVoiceChannelEvent
 {
-    public VoiceChannelDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel)
+    public VoiceChannelDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel)
     {
         super(api, responseNumber, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/GenericVoiceChannelUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/GenericVoiceChannelUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.channel.voice.GenericVoiceChannelEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} updated.
@@ -37,8 +36,8 @@ public abstract class GenericVoiceChannelUpdateEvent<T> extends GenericVoiceChan
     private final T next;
 
     public GenericVoiceChannelUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel,
-        @Nullable T prev, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel,
+        @Nullable T prev, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, channel);
         this.prev = prev;
@@ -46,14 +45,14 @@ public abstract class GenericVoiceChannelUpdateEvent<T> extends GenericVoiceChan
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getEntity()
     {
         return getChannel();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateBitrateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateBitrateEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.voice.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link VoiceChannel VoiceChannel}'s bitrate changed.
@@ -31,7 +30,7 @@ public class VoiceChannelUpdateBitrateEvent extends GenericVoiceChannelUpdateEve
 {
     public static final String IDENTIFIER = "bitrate";
 
-    public VoiceChannelUpdateBitrateEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel, int oldBitrate)
+    public VoiceChannelUpdateBitrateEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel, int oldBitrate)
     {
         super(api, responseNumber, channel, oldBitrate, channel.getBitrate(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateNameEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.voice.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link VoiceChannel VoiceChannel}'s name changed.
@@ -31,7 +30,7 @@ public class VoiceChannelUpdateNameEvent extends GenericVoiceChannelUpdateEvent<
 {
     public static final String IDENTIFIER = "name";
 
-    public VoiceChannelUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel, @Nonnull String oldName)
+    public VoiceChannelUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel, @NotNull String oldName)
     {
         super(api, responseNumber, channel, oldName, channel.getName(), IDENTIFIER);
     }
@@ -41,7 +40,7 @@ public class VoiceChannelUpdateNameEvent extends GenericVoiceChannelUpdateEvent<
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -52,20 +51,20 @@ public class VoiceChannelUpdateNameEvent extends GenericVoiceChannelUpdateEvent<
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateParentEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateParentEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.channel.voice.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel}'s parent changed.
@@ -34,7 +33,7 @@ public class VoiceChannelUpdateParentEvent extends GenericVoiceChannelUpdateEven
 {
     public static final String IDENTIFIER = "parent";
 
-    public VoiceChannelUpdateParentEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel, @Nullable Category oldParent)
+    public VoiceChannelUpdateParentEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel, @Nullable Category oldParent)
     {
         super(api, responseNumber, channel, oldParent, channel.getParent(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdatePermissionsEvent.java
@@ -23,8 +23,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.channel.voice.GenericVoiceChannelEvent;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -43,7 +43,7 @@ public class VoiceChannelUpdatePermissionsEvent extends GenericVoiceChannelEvent
 {
     private final List<IPermissionHolder> changedPermHolders;
 
-    public VoiceChannelUpdatePermissionsEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel, @Nonnull List<IPermissionHolder> changed)
+    public VoiceChannelUpdatePermissionsEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel, @NotNull List<IPermissionHolder> changed)
     {
         super(api, responseNumber, channel);
         this.changedPermHolders = changed;
@@ -57,7 +57,7 @@ public class VoiceChannelUpdatePermissionsEvent extends GenericVoiceChannelEvent
      * @see    #getChangedRoles()
      * @see    #getChangedMembers()
      */
-    @Nonnull
+    @NotNull
     public List<IPermissionHolder> getChangedPermissionHolders()
     {
         return changedPermHolders;
@@ -68,7 +68,7 @@ public class VoiceChannelUpdatePermissionsEvent extends GenericVoiceChannelEvent
      *
      * @return List of affected roles
      */
-    @Nonnull
+    @NotNull
     public List<Role> getChangedRoles()
     {
         return changedPermHolders.stream()
@@ -82,7 +82,7 @@ public class VoiceChannelUpdatePermissionsEvent extends GenericVoiceChannelEvent
      *
      * @return List of affected members
      */
-    @Nonnull
+    @NotNull
     public List<Member> getChangedMembers()
     {
         return changedPermHolders.stream()

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdatePositionEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.voice.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link VoiceChannel VoiceChannel}'s position changed.
@@ -31,7 +30,7 @@ public class VoiceChannelUpdatePositionEvent extends GenericVoiceChannelUpdateEv
 {
     public static final String IDENTIFIER = "position";
 
-    public VoiceChannelUpdatePositionEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel, int oldPosition)
+    public VoiceChannelUpdatePositionEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel, int oldPosition)
     {
         super(api, responseNumber, channel, oldPosition, channel.getPositionRaw(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateUserLimitEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateUserLimitEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.channel.voice.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link VoiceChannel VoiceChannel}'s user limit changed.
@@ -31,7 +30,7 @@ public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateE
 {
     public static final String IDENTIFIER = "userlimit";
 
-    public VoiceChannelUpdateUserLimitEvent(@Nonnull JDA api, long responseNumber, @Nonnull VoiceChannel channel, int oldUserLimit)
+    public VoiceChannelUpdateUserLimitEvent(@NotNull JDA api, long responseNumber, @NotNull VoiceChannel channel, int oldUserLimit)
     {
         super(api, responseNumber, channel, oldUserLimit, channel.getUserLimit(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/emote/EmoteAddedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/emote/EmoteAddedEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.emote;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a new {@link net.dv8tion.jda.api.entities.Emote Emote} was added to a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -33,7 +32,7 @@ import javax.annotation.Nonnull;
  */
 public class EmoteAddedEvent extends GenericEmoteEvent
 {
-    public EmoteAddedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Emote emote)
+    public EmoteAddedEvent(@NotNull JDA api, long responseNumber, @NotNull Emote emote)
     {
         super(api, responseNumber, emote);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/emote/EmoteRemovedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/emote/EmoteRemovedEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.emote;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that an {@link net.dv8tion.jda.api.entities.Emote Emote} was removed from a Guild.
@@ -33,7 +32,7 @@ import javax.annotation.Nonnull;
  */
 public class EmoteRemovedEvent extends GenericEmoteEvent
 {
-    public EmoteRemovedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Emote emote)
+    public EmoteRemovedEvent(@NotNull JDA api, long responseNumber, @NotNull Emote emote)
     {
         super(api, responseNumber, emote);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/emote/GenericEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/emote/GenericEmoteEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that an {@link net.dv8tion.jda.api.entities.Emote Emote} was created/removed/updated.
@@ -37,7 +36,7 @@ public abstract class GenericEmoteEvent extends Event
 {
     protected final Emote emote;
 
-    public GenericEmoteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Emote emote)
+    public GenericEmoteEvent(@NotNull JDA api, long responseNumber, @NotNull Emote emote)
     {
         super(api, responseNumber);
         this.emote = emote;
@@ -48,7 +47,7 @@ public abstract class GenericEmoteEvent extends Event
      *
      * @return The origin Guild
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return emote.getGuild();
@@ -59,7 +58,7 @@ public abstract class GenericEmoteEvent extends Event
      *
      * @return The emote
      */
-    @Nonnull
+    @NotNull
     public Emote getEmote()
     {
         return emote;

--- a/src/main/java/net/dv8tion/jda/api/events/emote/update/EmoteUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/emote/update/EmoteUpdateNameEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.emote.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the name of an {@link net.dv8tion.jda.api.entities.Emote Emote} changed.
@@ -39,7 +38,7 @@ public class EmoteUpdateNameEvent extends GenericEmoteUpdateEvent<String>
 {
     public static final String IDENTIFIER = "name";
 
-    public EmoteUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull Emote emote, @Nonnull String oldName)
+    public EmoteUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull Emote emote, @NotNull String oldName)
     {
         super(api, responseNumber, emote, oldName, emote.getName(), IDENTIFIER);
     }
@@ -49,7 +48,7 @@ public class EmoteUpdateNameEvent extends GenericEmoteUpdateEvent<String>
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -60,20 +59,20 @@ public class EmoteUpdateNameEvent extends GenericEmoteUpdateEvent<String>
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/emote/update/EmoteUpdateRolesEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/emote/update/EmoteUpdateRolesEvent.java
@@ -19,8 +19,8 @@ package net.dv8tion.jda.api.events.emote.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.Role;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -41,7 +41,7 @@ public class EmoteUpdateRolesEvent extends GenericEmoteUpdateEvent<List<Role>>
 {
     public static final String IDENTIFIER = "roles";
 
-    public EmoteUpdateRolesEvent(@Nonnull JDA api, long responseNumber, @Nonnull Emote emote, @Nonnull List<Role> oldRoles)
+    public EmoteUpdateRolesEvent(@NotNull JDA api, long responseNumber, @NotNull Emote emote, @NotNull List<Role> oldRoles)
     {
         super(api, responseNumber, emote, oldRoles, emote.getRoles(), IDENTIFIER);
     }
@@ -51,7 +51,7 @@ public class EmoteUpdateRolesEvent extends GenericEmoteUpdateEvent<List<Role>>
      *
      * @return The old role whitelist
      */
-    @Nonnull
+    @NotNull
     public List<Role> getOldRoles()
     {
         return getOldValue();
@@ -62,20 +62,20 @@ public class EmoteUpdateRolesEvent extends GenericEmoteUpdateEvent<List<Role>>
      *
      * @return The new role whitelist
      */
-    @Nonnull
+    @NotNull
     public List<Role> getNewRoles()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Role> getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Role> getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/emote/update/GenericEmoteUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/emote/update/GenericEmoteUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.emote.GenericEmoteEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that an {@link net.dv8tion.jda.api.entities.Emote Emote} was updated.
@@ -41,8 +40,8 @@ public abstract class GenericEmoteUpdateEvent<T> extends GenericEmoteEvent imple
     protected final String identifier;
 
     public GenericEmoteUpdateEvent(
-            @Nonnull JDA api, long responseNumber, @Nonnull Emote emote,
-            @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+            @NotNull JDA api, long responseNumber, @NotNull Emote emote,
+            @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, emote);
         this.previous = previous;
@@ -50,14 +49,14 @@ public abstract class GenericEmoteUpdateEvent<T> extends GenericEmoteEvent imple
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Emote getEntity()
     {
         return getEmote();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GenericGuildEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GenericGuildEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} event is fired.
@@ -31,7 +30,7 @@ public abstract class GenericGuildEvent extends Event
 {
     protected final Guild guild;
 
-    public GenericGuildEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild)
+    public GenericGuildEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild)
     {
         super(api, responseNumber);
         this.guild = guild;
@@ -42,7 +41,7 @@ public abstract class GenericGuildEvent extends Event
      *
      * @return The Guild
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return guild;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildAvailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildAvailableEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} became available.
@@ -29,7 +28,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildAvailableEvent extends GenericGuildEvent
 {
-    public GuildAvailableEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild)
+    public GuildAvailableEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild)
     {
         super(api, responseNumber, guild);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildBanEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildBanEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.User User} was banned from a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -37,7 +36,7 @@ public class GuildBanEvent extends GenericGuildEvent
 {
     private final User user;
 
-    public GuildBanEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull User user)
+    public GuildBanEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull User user)
     {
         super(api, responseNumber, guild);
         this.user = user;
@@ -48,7 +47,7 @@ public class GuildBanEvent extends GenericGuildEvent
      *
      * @return The banned user
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return user;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildJoinEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that you joined a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -30,7 +29,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildJoinEvent extends GenericGuildEvent
 {
-    public GuildJoinEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild)
+    public GuildJoinEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild)
     {
         super(api, responseNumber, guild);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildLeaveEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that you left a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -30,7 +29,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildLeaveEvent extends GenericGuildEvent
 {
-    public GuildLeaveEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild)
+    public GuildLeaveEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild)
     {
         super(api, responseNumber, guild);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildReadyEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildReadyEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.ReadyEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} finished setting up
@@ -39,7 +38,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildReadyEvent extends GenericGuildEvent
 {
-    public GuildReadyEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild)
+    public GuildReadyEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild)
     {
         super(api, responseNumber, guild);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildTimeoutEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildTimeoutEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.ReadyEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a guild failed to ready up and timed out.
@@ -38,7 +37,7 @@ public class GuildTimeoutEvent extends Event
 {
     private final long guildId;
 
-    public GuildTimeoutEvent(@Nonnull JDA api, long guildId)
+    public GuildTimeoutEvent(@NotNull JDA api, long guildId)
     {
         super(api);
         this.guildId = guildId;
@@ -59,7 +58,7 @@ public class GuildTimeoutEvent extends Event
      *
      * @return The guild id
      */
-    @Nonnull
+    @NotNull
     public String getGuildId()
     {
         return Long.toUnsignedString(guildId);

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildUnavailableEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildUnavailableEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} became unavailable.
@@ -29,7 +28,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildUnavailableEvent extends GenericGuildEvent
 {
-    public GuildUnavailableEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild)
+    public GuildUnavailableEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild)
     {
         super(api, responseNumber, guild);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildUnbanEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildUnbanEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.User User} was unbanned from a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -34,7 +33,7 @@ public class GuildUnbanEvent extends GenericGuildEvent
 {
     private final User user;
 
-    public GuildUnbanEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull User user)
+    public GuildUnbanEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull User user)
     {
         super(api, responseNumber, guild);
         this.user = user;
@@ -45,7 +44,7 @@ public class GuildUnbanEvent extends GenericGuildEvent
      *
      * @return The unbanned user
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return user;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildJoinedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildJoinedEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that you joined a {@link net.dv8tion.jda.api.entities.Guild Guild} that is not yet available.
@@ -32,7 +31,7 @@ public class UnavailableGuildJoinedEvent extends Event
 {
     private final long guildId;
 
-    public UnavailableGuildJoinedEvent(@Nonnull JDA api, long responseNumber, long guildId)
+    public UnavailableGuildJoinedEvent(@NotNull JDA api, long responseNumber, long guildId)
     {
         super(api, responseNumber);
         this.guildId = guildId;
@@ -43,7 +42,7 @@ public class UnavailableGuildJoinedEvent extends Event
      *
      * @return The ID of the guild
      */
-    @Nonnull
+    @NotNull
     public String getGuildId()
     {
         return Long.toUnsignedString(guildId);

--- a/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/UnavailableGuildLeaveEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that you left a {@link net.dv8tion.jda.api.entities.Guild Guild} that is not yet available.
@@ -31,7 +30,7 @@ public class UnavailableGuildLeaveEvent extends Event
 {
     private final long guildId;
 
-    public UnavailableGuildLeaveEvent(@Nonnull JDA api, long responseNumber, long guildId)
+    public UnavailableGuildLeaveEvent(@NotNull JDA api, long responseNumber, long guildId)
     {
         super(api, responseNumber);
         this.guildId = guildId;
@@ -42,7 +41,7 @@ public class UnavailableGuildLeaveEvent extends Event
      *
      * @return The id for the guild
      */
-    @Nonnull
+    @NotNull
     public String getGuildId()
     {
         return Long.toUnsignedString(guildId);

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GenericGuildInviteEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.invite;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that an {@link Invite} was created or deleted in a {@link Guild}.
@@ -38,7 +37,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
     private final String code;
     private final GuildChannel channel;
 
-    public GenericGuildInviteEvent(@Nonnull JDA api, long responseNumber, @Nonnull String code, @Nonnull GuildChannel channel)
+    public GenericGuildInviteEvent(@NotNull JDA api, long responseNumber, @NotNull String code, @NotNull GuildChannel channel)
     {
         super(api, responseNumber, channel.getGuild());
         this.code = code;
@@ -51,7 +50,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      *
      * @return The invite code
      */
-    @Nonnull
+    @NotNull
     public String getCode()
     {
         return code;
@@ -63,7 +62,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      *
      * @return The invite url
      */
-    @Nonnull
+    @NotNull
     public String getUrl()
     {
         return "https://discord.gg/" + code;
@@ -74,7 +73,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      *
      * @return {@link GuildChannel}
      */
-    @Nonnull
+    @NotNull
     public GuildChannel getChannel()
     {
         return channel;
@@ -85,7 +84,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      *
      * @return {@link ChannelType}
      */
-    @Nonnull
+    @NotNull
     public ChannelType getChannelType()
     {
         return channel.getType();
@@ -102,7 +101,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public TextChannel getTextChannel()
     {
         if (getChannelType() != ChannelType.TEXT)
@@ -121,7 +120,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public VoiceChannel getVoiceChannel()
     {
         if (getChannelType() != ChannelType.VOICE)
@@ -140,7 +139,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public StoreChannel getStoreChannel()
     {
         if (getChannelType() != ChannelType.STORE)
@@ -159,7 +158,7 @@ public class GenericGuildInviteEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public Category getCategory()
     {
         if (getChannelType() != ChannelType.CATEGORY)

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteCreateEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.invite;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Invite;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that an {@link Invite Invite} was created in a {@link net.dv8tion.jda.api.entities.Invite.Guild Guild}.
@@ -36,7 +35,7 @@ public class GuildInviteCreateEvent extends GenericGuildInviteEvent
 {
     private final Invite invite;
 
-    public GuildInviteCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Invite invite, @Nonnull GuildChannel channel)
+    public GuildInviteCreateEvent(@NotNull JDA api, long responseNumber, @NotNull Invite invite, @NotNull GuildChannel channel)
     {
         super(api, responseNumber, invite.getCode(), channel);
         this.invite = invite;
@@ -47,7 +46,7 @@ public class GuildInviteCreateEvent extends GenericGuildInviteEvent
      *
      * @return {@link Invite}
      */
-    @Nonnull
+    @NotNull
     public Invite getInvite()
     {
         return invite;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/invite/GuildInviteDeleteEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Invite;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates than an {@link Invite} was deleted from a {@link Guild}.
@@ -35,7 +34,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildInviteDeleteEvent extends GenericGuildInviteEvent
 {
-    public GuildInviteDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull String code, @Nonnull GuildChannel channel)
+    public GuildInviteDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull String code, @NotNull GuildChannel channel)
     {
         super(api, responseNumber, code, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GenericGuildMemberEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GenericGuildMemberEvent.java
@@ -19,8 +19,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} member event is fired.
@@ -36,7 +35,7 @@ public abstract class GenericGuildMemberEvent extends GenericGuildEvent
 {
     private final Member member;
 
-    public GenericGuildMemberEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GenericGuildMemberEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member.getGuild());
         this.member = member;
@@ -48,7 +47,7 @@ public abstract class GenericGuildMemberEvent extends GenericGuildEvent
      *
      * @return The User instance
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return getMember().getUser();
@@ -59,7 +58,7 @@ public abstract class GenericGuildMemberEvent extends GenericGuildEvent
      *
      * @return The Member instance
      */
-    @Nonnull
+    @NotNull
     public Member getMember()
     {
         return member;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberJoinEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.guild.member;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} joined a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -33,7 +32,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildMemberJoinEvent extends GenericGuildMemberEvent
 {
-    public GuildMemberJoinEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildMemberJoinEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberLeaveEvent.java
@@ -19,8 +19,7 @@ import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates a {@link net.dv8tion.jda.api.entities.Member Member} left a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -41,7 +40,7 @@ import javax.annotation.Nonnull;
 @ReplaceWith("GuildMemberRemoveEvent")
 public class GuildMemberLeaveEvent extends GenericGuildMemberEvent
 {
-    public GuildMemberLeaveEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildMemberLeaveEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRemoveEvent.java
@@ -21,9 +21,8 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a user was removed from a {@link Guild}. This includes kicks, bans, and leaves respectively.
@@ -44,7 +43,7 @@ public class GuildMemberRemoveEvent extends GenericGuildEvent
     private final User user;
     private final Member member;
 
-    public GuildMemberRemoveEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull User user, @Nullable Member member)
+    public GuildMemberRemoveEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull User user, @Nullable Member member)
     {
         super(api, responseNumber, guild);
         this.user = user;
@@ -56,7 +55,7 @@ public class GuildMemberRemoveEvent extends GenericGuildEvent
      *
      * @return The user who was removed
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return user;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRoleAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRoleAddEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.guild.member;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,7 +43,7 @@ public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
 {
     private final List<Role> addedRoles;
 
-    public GuildMemberRoleAddEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull List<Role> addedRoles)
+    public GuildMemberRoleAddEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull List<Role> addedRoles)
     {
         super(api, responseNumber, member);
         this.addedRoles = Collections.unmodifiableList(addedRoles);
@@ -54,7 +54,7 @@ public class GuildMemberRoleAddEvent extends GenericGuildMemberEvent
      *
      * @return The list of roles that were added
      */
-    @Nonnull
+    @NotNull
     public List<Role> getRoles()
     {
         return addedRoles;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRoleRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberRoleRemoveEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.guild.member;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,7 +43,7 @@ public class GuildMemberRoleRemoveEvent extends GenericGuildMemberEvent
 {
     private final List<Role> removedRoles;
 
-    public GuildMemberRoleRemoveEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull List<Role> removedRoles)
+    public GuildMemberRoleRemoveEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull List<Role> removedRoles)
     {
         super(api, responseNumber, member);
         this.removedRoles = Collections.unmodifiableList(removedRoles);

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/GuildMemberUpdateEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.member;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Fired for every {@link Member} update, regardless of cache.
@@ -40,7 +39,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildMemberUpdateEvent extends GenericGuildMemberEvent
 {
-    public GuildMemberUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildMemberUpdateEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GenericGuildMemberUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GenericGuildMemberUpdateEvent.java
@@ -19,9 +19,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.guild.member.GenericGuildMemberEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} member event is fired.
@@ -47,8 +46,8 @@ public abstract class GenericGuildMemberUpdateEvent<T> extends GenericGuildMembe
     protected final String identifier;
 
     public GenericGuildMemberUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull Member member,
-        @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull Member member,
+        @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, member);
         this.previous = previous;
@@ -56,14 +55,14 @@ public abstract class GenericGuildMemberUpdateEvent<T> extends GenericGuildMembe
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {
         return identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getEntity()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateBoostTimeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateBoostTimeEvent.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.events.guild.member.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 
 /**
@@ -46,7 +46,7 @@ public class GuildMemberUpdateBoostTimeEvent extends GenericGuildMemberUpdateEve
 {
     public static final String IDENTIFIER = "boost_time";
 
-    public GuildMemberUpdateBoostTimeEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nullable OffsetDateTime previous)
+    public GuildMemberUpdateBoostTimeEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @Nullable OffsetDateTime previous)
     {
         super(api, responseNumber, member, previous, member.getTimeBoosted(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateNicknameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateNicknameEvent.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.events.guild.member.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} nickname.
@@ -44,7 +43,7 @@ public class GuildMemberUpdateNicknameEvent extends GenericGuildMemberUpdateEven
 {
     public static final String IDENTIFIER = "nick";
 
-    public GuildMemberUpdateNicknameEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nullable String oldNick)
+    public GuildMemberUpdateNicknameEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @Nullable String oldNick)
     {
         super(api, responseNumber, member, oldNick, member.getNickname(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdatePendingEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdatePendingEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.member.update;
 import net.dv8tion.jda.annotations.Incubating;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link Member Member} has agreed to Membership Screening requirements.
@@ -49,7 +48,7 @@ public class GuildMemberUpdatePendingEvent extends GenericGuildMemberUpdateEvent
 {
     public static final String IDENTIFIER = "pending";
 
-    public GuildMemberUpdatePendingEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean previous)
+    public GuildMemberUpdatePendingEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, boolean previous)
     {
         super(api, responseNumber, member, previous, member.isPending(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/override/GenericPermissionOverrideEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/override/GenericPermissionOverrideEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.override;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link PermissionOverride} for a {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel} was created, deleted, or updated.
@@ -34,7 +33,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
     protected final GuildChannel channel;
     protected final PermissionOverride override;
 
-    public GenericPermissionOverrideEvent(@Nonnull JDA api, long responseNumber, @Nonnull GuildChannel channel, @Nonnull PermissionOverride override)
+    public GenericPermissionOverrideEvent(@NotNull JDA api, long responseNumber, @NotNull GuildChannel channel, @NotNull PermissionOverride override)
     {
         super(api, responseNumber, channel.getGuild());
         this.channel = channel;
@@ -46,7 +45,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      *
      * @return The {@link ChannelType}
      */
-    @Nonnull
+    @NotNull
     public ChannelType getChannelType()
     {
         return channel.getType();
@@ -57,7 +56,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      *
      * @return The {@link GuildChannel}
      */
-    @Nonnull
+    @NotNull
     public GuildChannel getChannel()
     {
         return channel;
@@ -74,7 +73,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public TextChannel getTextChannel()
     {
         if (channel instanceof TextChannel)
@@ -93,7 +92,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public VoiceChannel getVoiceChannel()
     {
         if (channel instanceof VoiceChannel)
@@ -112,7 +111,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public StoreChannel getStoreChannel()
     {
         if (channel instanceof StoreChannel)
@@ -132,7 +131,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      * @see    #getChannel()
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public Category getCategory()
     {
         if (channel instanceof Category)
@@ -145,7 +144,7 @@ public class GenericPermissionOverrideEvent extends GenericGuildEvent
      *
      * @return The override
      */
-    @Nonnull
+    @NotNull
     public PermissionOverride getPermissionOverride()
     {
         return override;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/override/PermissionOverrideCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/override/PermissionOverrideCreateEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.override;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.PermissionOverride;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link PermissionOverride} of a {@link GuildChannel} has been created.
@@ -29,7 +28,7 @@ import javax.annotation.Nonnull;
  */
 public class PermissionOverrideCreateEvent extends GenericPermissionOverrideEvent
 {
-    public PermissionOverrideCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull GuildChannel channel, @Nonnull PermissionOverride override)
+    public PermissionOverrideCreateEvent(@NotNull JDA api, long responseNumber, @NotNull GuildChannel channel, @NotNull PermissionOverride override)
     {
         super(api, responseNumber, channel, override);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/override/PermissionOverrideDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/override/PermissionOverrideDeleteEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.override;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.PermissionOverride;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link PermissionOverride} of a {@link GuildChannel} has been deleted.
@@ -29,7 +28,7 @@ import javax.annotation.Nonnull;
  */
 public class PermissionOverrideDeleteEvent extends GenericPermissionOverrideEvent
 {
-    public PermissionOverrideDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull GuildChannel channel, @Nonnull PermissionOverride override)
+    public PermissionOverrideDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull GuildChannel channel, @NotNull PermissionOverride override)
     {
         super(api, responseNumber, channel, override);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/override/PermissionOverrideUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/override/PermissionOverrideUpdateEvent.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.PermissionOverride;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
 /**
@@ -33,7 +33,7 @@ public class PermissionOverrideUpdateEvent extends GenericPermissionOverrideEven
 {
     private final long oldAllow, oldDeny;
 
-    public PermissionOverrideUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull GuildChannel channel, @Nonnull PermissionOverride override, long oldAllow, long oldDeny)
+    public PermissionOverrideUpdateEvent(@NotNull JDA api, long responseNumber, @NotNull GuildChannel channel, @NotNull PermissionOverride override, long oldAllow, long oldDeny)
     {
         super(api, responseNumber, channel, override);
         this.oldAllow = oldAllow;
@@ -75,7 +75,7 @@ public class PermissionOverrideUpdateEvent extends GenericPermissionOverrideEven
      *
      * @return The old allowed permissions
      */
-    @Nonnull
+    @NotNull
     public EnumSet<Permission> getOldAllow()
     {
         return Permission.getPermissions(oldAllow);
@@ -86,7 +86,7 @@ public class PermissionOverrideUpdateEvent extends GenericPermissionOverrideEven
      *
      * @return The old denied permissions
      */
-    @Nonnull
+    @NotNull
     public EnumSet<Permission> getOldDeny()
     {
         return Permission.getPermissions(oldDeny);
@@ -97,7 +97,7 @@ public class PermissionOverrideUpdateEvent extends GenericPermissionOverrideEven
      *
      * @return The old inherited permissions
      */
-    @Nonnull
+    @NotNull
     public EnumSet<Permission> getOldInherited()
     {
         return Permission.getPermissions(getOldInheritedRaw());

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GenericGuildUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GenericGuildUpdateEvent.java
@@ -19,9 +19,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} was updated.
@@ -35,8 +34,8 @@ public abstract class GenericGuildUpdateEvent<T> extends GenericGuildEvent imple
     protected final String identifier;
 
     public GenericGuildUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull Guild guild,
-        @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull Guild guild,
+        @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, guild);
         this.previous = previous;
@@ -44,14 +43,14 @@ public abstract class GenericGuildUpdateEvent<T> extends GenericGuildEvent imple
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getEntity()
     {
         return getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateAfkChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateAfkChannelEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the afk-channel of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -34,7 +33,7 @@ public class GuildUpdateAfkChannelEvent extends GenericGuildUpdateEvent<VoiceCha
 {
     public static final String IDENTIFIER = "afk_channel";
 
-    public GuildUpdateAfkChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable VoiceChannel oldAfkChannel)
+    public GuildUpdateAfkChannelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable VoiceChannel oldAfkChannel)
     {
         super(api, responseNumber, guild, oldAfkChannel, guild.getAfkChannel(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateAfkTimeoutEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateAfkTimeoutEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild.Timeout AFK-Timeout} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateAfkTimeoutEvent extends GenericGuildUpdateEvent<Guild.Ti
 {
     public static final String IDENTIFIER = "afk_timeout";
 
-    public GuildUpdateAfkTimeoutEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.Timeout oldAfkTimeout)
+    public GuildUpdateAfkTimeoutEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Guild.Timeout oldAfkTimeout)
     {
         super(api, responseNumber, guild, oldAfkTimeout, guild.getAfkTimeout(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class GuildUpdateAfkTimeoutEvent extends GenericGuildUpdateEvent<Guild.Ti
      *
      * @return The old AFK-Timeout
      */
-    @Nonnull
+    @NotNull
     public Guild.Timeout getOldAfkTimeout()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class GuildUpdateAfkTimeoutEvent extends GenericGuildUpdateEvent<Guild.Ti
      *
      * @return The new AFK-Timeout
      */
-    @Nonnull
+    @NotNull
     public Guild.Timeout getNewAfkTimeout()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.Timeout getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.Timeout getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBannerEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBannerEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getBannerId() banner} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -35,7 +34,7 @@ public class GuildUpdateBannerEvent extends GenericGuildUpdateEvent<String>
 {
     public static final String IDENTIFIER = "banner";
 
-    public GuildUpdateBannerEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable String previous)
+    public GuildUpdateBannerEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable String previous)
     {
         super(api, responseNumber, guild, previous, guild.getBannerId(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBoostCountEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBoostCountEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getBoostCount() boost count} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateBoostCountEvent extends GenericGuildUpdateEvent<Integer>
 {
     public static final String IDENTIFIER = "boost_count";
 
-    public GuildUpdateBoostCountEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, int previous)
+    public GuildUpdateBoostCountEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, int previous)
     {
         super(api, responseNumber, guild, previous, guild.getBoostCount(), IDENTIFIER);
     }
@@ -57,14 +56,14 @@ public class GuildUpdateBoostCountEvent extends GenericGuildUpdateEvent<Integer>
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBoostTierEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateBoostTierEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getBoostTier() boost tier} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateBoostTierEvent extends GenericGuildUpdateEvent<Guild.Boo
 {
     public static final String IDENTIFIER = "boost_tier";
 
-    public GuildUpdateBoostTierEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.BoostTier previous)
+    public GuildUpdateBoostTierEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Guild.BoostTier previous)
     {
         super(api, responseNumber, guild, previous, guild.getBoostTier(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class GuildUpdateBoostTierEvent extends GenericGuildUpdateEvent<Guild.Boo
      *
      * @return The old BoostTier
      */
-    @Nonnull
+    @NotNull
     public Guild.BoostTier getOldBoostTier()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class GuildUpdateBoostTierEvent extends GenericGuildUpdateEvent<Guild.Boo
      *
      * @return The new BoostTier
      */
-    @Nonnull
+    @NotNull
     public Guild.BoostTier getNewBoostTier()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.BoostTier getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.BoostTier getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateCommunityUpdatesChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateCommunityUpdatesChannelEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the community updates channel of a {@link Guild Guild} changed.
@@ -34,7 +33,7 @@ public class GuildUpdateCommunityUpdatesChannelEvent extends GenericGuildUpdateE
 {
     public static final String IDENTIFIER = "community_updates_channel";
 
-    public GuildUpdateCommunityUpdatesChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable TextChannel oldCommunityUpdatesChannel)
+    public GuildUpdateCommunityUpdatesChannelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable TextChannel oldCommunityUpdatesChannel)
     {
         super(api, responseNumber, guild, oldCommunityUpdatesChannel, guild.getCommunityUpdatesChannel(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateDescriptionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateDescriptionEvent.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getDescription() description} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -33,7 +32,7 @@ public class GuildUpdateDescriptionEvent extends GenericGuildUpdateEvent<String>
 {
     public static final String IDENTIFIER = "description";
 
-    public GuildUpdateDescriptionEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable String previous)
+    public GuildUpdateDescriptionEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable String previous)
     {
         super(api, responseNumber, guild, previous, guild.getDescription(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateExplicitContentLevelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateExplicitContentLevelEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild.ExplicitContentLevel ExplicitContentLevel} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateExplicitContentLevelEvent extends GenericGuildUpdateEven
 {
     public static final String IDENTIFIER = "explicit_content_filter";
 
-    public GuildUpdateExplicitContentLevelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.ExplicitContentLevel oldLevel)
+    public GuildUpdateExplicitContentLevelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Guild.ExplicitContentLevel oldLevel)
     {
         super(api, responseNumber, guild, oldLevel, guild.getExplicitContentLevel(), IDENTIFIER);
     }
@@ -43,7 +42,7 @@ public class GuildUpdateExplicitContentLevelEvent extends GenericGuildUpdateEven
      *
      * @return The old explicit content level
      */
-    @Nonnull
+    @NotNull
     public Guild.ExplicitContentLevel getOldLevel()
     {
         return getOldValue();
@@ -55,20 +54,20 @@ public class GuildUpdateExplicitContentLevelEvent extends GenericGuildUpdateEven
      *
      * @return The new explicit content level
      */
-    @Nonnull
+    @NotNull
     public Guild.ExplicitContentLevel getNewLevel()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.ExplicitContentLevel getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.ExplicitContentLevel getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateFeaturesEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateFeaturesEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 /**
@@ -33,7 +33,7 @@ public class GuildUpdateFeaturesEvent extends GenericGuildUpdateEvent<Set<String
 {
     public static final String IDENTIFIER = "features";
 
-    public GuildUpdateFeaturesEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Set<String> oldFeatures)
+    public GuildUpdateFeaturesEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Set<String> oldFeatures)
     {
         super(api, responseNumber, guild, oldFeatures, guild.getFeatures(), IDENTIFIER);
     }
@@ -43,7 +43,7 @@ public class GuildUpdateFeaturesEvent extends GenericGuildUpdateEvent<Set<String
      *
      * @return Never-null, unmodifiable Set of the old features
      */
-    @Nonnull
+    @NotNull
     public Set<String> getOldFeatures()
     {
         return getOldValue();
@@ -54,20 +54,20 @@ public class GuildUpdateFeaturesEvent extends GenericGuildUpdateEvent<Set<String
      *
      * @return Never-null, unmodifiable Set of the new features
      */
-    @Nonnull
+    @NotNull
     public Set<String> getNewFeatures()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<String> getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<String> getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateIconEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateIconEvent.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the Icon of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -33,7 +32,7 @@ public class GuildUpdateIconEvent extends GenericGuildUpdateEvent<String>
 {
     public static final String IDENTIFIER = "icon";
 
-    public GuildUpdateIconEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable String oldIconId)
+    public GuildUpdateIconEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable String oldIconId)
     {
         super(api, responseNumber, guild, oldIconId, guild.getIconId(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateLocaleEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateLocaleEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Locale;
 
 /**
@@ -36,19 +36,19 @@ public class GuildUpdateLocaleEvent extends GenericGuildUpdateEvent<Locale>
 {
     public static final String IDENTIFIER = "locale";
 
-    public GuildUpdateLocaleEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Locale previous)
+    public GuildUpdateLocaleEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Locale previous)
     {
         super(api, responseNumber, guild, previous, guild.getLocale(), IDENTIFIER);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Locale getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Locale getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateMFALevelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateMFALevelEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild.MFALevel MFALevel} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateMFALevelEvent extends GenericGuildUpdateEvent<Guild.MFAL
 {
     public static final String IDENTIFIER = "mfa_level";
 
-    public GuildUpdateMFALevelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.MFALevel oldMFALevel)
+    public GuildUpdateMFALevelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Guild.MFALevel oldMFALevel)
     {
         super(api, responseNumber, guild, oldMFALevel, guild.getRequiredMFALevel(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class GuildUpdateMFALevelEvent extends GenericGuildUpdateEvent<Guild.MFAL
      *
      * @return The old MFALevel
      */
-    @Nonnull
+    @NotNull
     public Guild.MFALevel getOldMFALevel()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class GuildUpdateMFALevelEvent extends GenericGuildUpdateEvent<Guild.MFAL
      *
      * @return The new MFALevel
      */
-    @Nonnull
+    @NotNull
     public Guild.MFALevel getNewMFALevel()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.MFALevel getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.MFALevel getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateMaxMembersEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateMaxMembersEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getMaxMembers() maximum member limit} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateMaxMembersEvent extends GenericGuildUpdateEvent<Integer>
 {
     public static final String IDENTIFIER = "max_members";
 
-    public GuildUpdateMaxMembersEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, int previous)
+    public GuildUpdateMaxMembersEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, int previous)
     {
         super(api, responseNumber, guild, previous, guild.getMaxMembers(), IDENTIFIER);
     }
@@ -57,14 +56,14 @@ public class GuildUpdateMaxMembersEvent extends GenericGuildUpdateEvent<Integer>
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateMaxPresencesEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateMaxPresencesEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getMaxPresences() maximum presences limit} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateMaxPresencesEvent extends GenericGuildUpdateEvent<Intege
 {
     public static final String IDENTIFIER = "max_presences";
 
-    public GuildUpdateMaxPresencesEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, int previous)
+    public GuildUpdateMaxPresencesEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, int previous)
     {
         super(api, responseNumber, guild, previous, guild.getMaxPresences(), IDENTIFIER);
     }
@@ -57,14 +56,14 @@ public class GuildUpdateMaxPresencesEvent extends GenericGuildUpdateEvent<Intege
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateNameEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the name of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateNameEvent extends GenericGuildUpdateEvent<String>
 {
     public static final String IDENTIFIER = "name";
 
-    public GuildUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull String oldName)
+    public GuildUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull String oldName)
     {
         super(api, responseNumber, guild, oldName, guild.getName(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class GuildUpdateNameEvent extends GenericGuildUpdateEvent<String>
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class GuildUpdateNameEvent extends GenericGuildUpdateEvent<String>
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateNotificationLevelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateNotificationLevelEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild.NotificationLevel NotificationLevel} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateNotificationLevelEvent extends GenericGuildUpdateEvent<G
 {
     public static final String IDENTIFIER = "notification_level";
 
-    public GuildUpdateNotificationLevelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.NotificationLevel oldNotificationLevel)
+    public GuildUpdateNotificationLevelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Guild.NotificationLevel oldNotificationLevel)
     {
         super(api, responseNumber, guild, oldNotificationLevel, guild.getDefaultNotificationLevel(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class GuildUpdateNotificationLevelEvent extends GenericGuildUpdateEvent<G
      *
      * @return The old NotificationLevel
      */
-    @Nonnull
+    @NotNull
     public Guild.NotificationLevel getOldNotificationLevel()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class GuildUpdateNotificationLevelEvent extends GenericGuildUpdateEvent<G
      *
      * @return The new NotificationLevel
      */
-    @Nonnull
+    @NotNull
     public Guild.NotificationLevel getNewNotificationLevel()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.NotificationLevel getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.NotificationLevel getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateOwnerEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateOwnerEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the owner of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -35,7 +34,7 @@ public class GuildUpdateOwnerEvent extends GenericGuildUpdateEvent<Member>
     public static final String IDENTIFIER = "owner";
     private final long prevId, nextId;
 
-    public GuildUpdateOwnerEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable Member oldOwner,
+    public GuildUpdateOwnerEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable Member oldOwner,
                                  long prevId, long nextId)
     {
         super(api, responseNumber, guild, oldOwner, guild.getOwner(), IDENTIFIER);
@@ -58,7 +57,7 @@ public class GuildUpdateOwnerEvent extends GenericGuildUpdateEvent<Member>
      *
      * @return The new owner id
      */
-    @Nonnull
+    @NotNull
     public String getNewOwnerId()
     {
         return Long.toUnsignedString(nextId);
@@ -79,7 +78,7 @@ public class GuildUpdateOwnerEvent extends GenericGuildUpdateEvent<Member>
      *
      * @return The previous owner id
      */
-    @Nonnull
+    @NotNull
     public String getOldOwnerId()
     {
         return Long.toUnsignedString(prevId);

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRegionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRegionEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.Region Region} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -36,7 +35,7 @@ public class GuildUpdateRegionEvent extends GenericGuildUpdateEvent<Region>
     private final String oldRegion;
     private final String newRegion;
 
-    public GuildUpdateRegionEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull String oldRegion)
+    public GuildUpdateRegionEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull String oldRegion)
     {
         super(api, responseNumber, guild, Region.fromKey(oldRegion), guild.getRegion(), IDENTIFIER);
         this.oldRegion = oldRegion;
@@ -51,7 +50,7 @@ public class GuildUpdateRegionEvent extends GenericGuildUpdateEvent<Region>
      *
      * @return Resolved {@link net.dv8tion.jda.api.Region Region} constant from the raw name
      */
-    @Nonnull
+    @NotNull
     public Region getOldRegion()
     {
         return getOldValue();
@@ -64,7 +63,7 @@ public class GuildUpdateRegionEvent extends GenericGuildUpdateEvent<Region>
      *
      * @return Raw name of the old voice region
      */
-    @Nonnull
+    @NotNull
     public String getOldRegionRaw()
     {
         return oldRegion;
@@ -78,7 +77,7 @@ public class GuildUpdateRegionEvent extends GenericGuildUpdateEvent<Region>
      *
      * @return Resolved {@link net.dv8tion.jda.api.Region Region} constant from the raw name
      */
-    @Nonnull
+    @NotNull
     public Region getNewRegion()
     {
         return getNewValue();
@@ -91,20 +90,20 @@ public class GuildUpdateRegionEvent extends GenericGuildUpdateEvent<Region>
      *
      * @return Raw name of the updated voice region
      */
-    @Nonnull
+    @NotNull
     public String getNewRegionRaw()
     {
         return newRegion;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Region getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Region getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRulesChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateRulesChannelEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the rules channel of a {@link Guild Guild} changed.
@@ -34,7 +33,7 @@ public class GuildUpdateRulesChannelEvent extends GenericGuildUpdateEvent<TextCh
 {
     public static final String IDENTIFIER = "rules_channel";
 
-    public GuildUpdateRulesChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable TextChannel oldRulesChannel)
+    public GuildUpdateRulesChannelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable TextChannel oldRulesChannel)
     {
         super(api, responseNumber, guild, oldRulesChannel, guild.getRulesChannel(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateSplashEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateSplashEvent.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the splash of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -33,7 +32,7 @@ public class GuildUpdateSplashEvent extends GenericGuildUpdateEvent<String>
 {
     public static final String IDENTIFIER = "splash";
 
-    public GuildUpdateSplashEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable String oldSplashId)
+    public GuildUpdateSplashEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable String oldSplashId)
     {
         super(api, responseNumber, guild, oldSplashId, guild.getSplashId(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateSystemChannelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateSystemChannelEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the system channel of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -35,7 +34,7 @@ public class GuildUpdateSystemChannelEvent extends GenericGuildUpdateEvent<TextC
 {
     public static final String IDENTIFIER = "system_channel";
 
-    public GuildUpdateSystemChannelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable TextChannel oldSystemChannel)
+    public GuildUpdateSystemChannelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable TextChannel oldSystemChannel)
     {
         super(api, responseNumber, guild, oldSystemChannel, guild.getSystemChannel(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateVanityCodeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateVanityCodeEvent.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild#getVanityUrl() vanity url} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -33,7 +32,7 @@ public class GuildUpdateVanityCodeEvent extends GenericGuildUpdateEvent<String>
 {
     public static final String IDENTIFIER = "vanity_code";
 
-    public GuildUpdateVanityCodeEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nullable String previous)
+    public GuildUpdateVanityCodeEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @Nullable String previous)
     {
         super(api, responseNumber, guild, previous, guild.getVanityCode(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateVerificationLevelEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/update/GuildUpdateVerificationLevelEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link net.dv8tion.jda.api.entities.Guild.VerificationLevel VerificationLevel} of a {@link net.dv8tion.jda.api.entities.Guild Guild} changed.
@@ -32,7 +31,7 @@ public class GuildUpdateVerificationLevelEvent extends GenericGuildUpdateEvent<G
 {
     public static final String IDENTIFIER = "verification_level";
 
-    public GuildUpdateVerificationLevelEvent(@Nonnull JDA api, long responseNumber, @Nonnull Guild guild, @Nonnull Guild.VerificationLevel oldVerificationLevel)
+    public GuildUpdateVerificationLevelEvent(@NotNull JDA api, long responseNumber, @NotNull Guild guild, @NotNull Guild.VerificationLevel oldVerificationLevel)
     {
         super(api, responseNumber, guild, oldVerificationLevel, guild.getVerificationLevel(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class GuildUpdateVerificationLevelEvent extends GenericGuildUpdateEvent<G
      *
      * @return The old VerificationLevel
      */
-    @Nonnull
+    @NotNull
     public Guild.VerificationLevel getOldVerificationLevel()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class GuildUpdateVerificationLevelEvent extends GenericGuildUpdateEvent<G
      *
      * @return The new VerificationLevel
      */
-    @Nonnull
+    @NotNull
     public Guild.VerificationLevel getNewVerificationLevel()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.VerificationLevel getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild.VerificationLevel getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GenericGuildVoiceEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GenericGuildVoiceEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Guild Guild} voice event is fired.
@@ -45,7 +44,7 @@ public abstract class GenericGuildVoiceEvent extends GenericGuildEvent
 {
     protected final Member member;
 
-    public GenericGuildVoiceEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GenericGuildVoiceEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member.getGuild());
         this.member = member;
@@ -56,7 +55,7 @@ public abstract class GenericGuildVoiceEvent extends GenericGuildEvent
      *
      * @return The affected Member
      */
-    @Nonnull
+    @NotNull
     public Member getMember()
     {
         return member;
@@ -68,7 +67,7 @@ public abstract class GenericGuildVoiceEvent extends GenericGuildEvent
      *
      * @return The {@link net.dv8tion.jda.api.entities.GuildVoiceState GuildVoiceState} of the member
      */
-    @Nonnull
+    @NotNull
     public GuildVoiceState getVoiceState()
     {
         return member.getVoiceState();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GenericGuildVoiceUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GenericGuildVoiceUpdateEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.guild.voice;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * <h2>Requirements</h2>
@@ -41,7 +40,7 @@ public class GenericGuildVoiceUpdateEvent extends GenericGuildVoiceEvent impleme
     protected final VoiceChannel joined, left;
 
     public GenericGuildVoiceUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nullable VoiceChannel left, @Nullable VoiceChannel joined)
+        @NotNull JDA api, long responseNumber, @NotNull Member member, @Nullable VoiceChannel left, @Nullable VoiceChannel joined)
     {
         super(api, responseNumber, member);
         this.left = left;
@@ -62,14 +61,14 @@ public class GenericGuildVoiceUpdateEvent extends GenericGuildVoiceEvent impleme
         return joined;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {
         return IDENTIFIER;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getEntity()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceDeafenEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} was (un-)deafened.
@@ -44,7 +43,7 @@ public class GuildVoiceDeafenEvent extends GenericGuildVoiceEvent
 {
     protected final boolean deafened;
 
-    public GuildVoiceDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceDeafenEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.deafened = member.getVoiceState().isDeafened();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildDeafenEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} was (un-)deafened by a moderator.
@@ -42,7 +41,7 @@ public class GuildVoiceGuildDeafenEvent extends GenericGuildVoiceEvent
 {
     protected final boolean guildDeafened;
 
-    public GuildVoiceGuildDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceGuildDeafenEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.guildDeafened = member.getVoiceState().isGuildDeafened();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildMuteEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} was (un-)muted by a moderator.
@@ -42,7 +41,7 @@ public class GuildVoiceGuildMuteEvent extends GenericGuildVoiceEvent
 {
     protected final boolean guildMuted;
 
-    public GuildVoiceGuildMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceGuildMuteEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.guildMuted = member.getVoiceState().isGuildMuted();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceJoinEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceJoinEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} connected to a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel}.
@@ -43,19 +42,19 @@ import javax.annotation.Nonnull;
  */
 public class GuildVoiceJoinEvent extends GenericGuildVoiceUpdateEvent
 {
-    public GuildVoiceJoinEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceJoinEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member, null, member.getVoiceState().getChannel());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getChannelJoined()
     {
         return super.getChannelJoined();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceLeaveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceLeaveEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} disconnected from a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel}.
@@ -45,19 +44,19 @@ import javax.annotation.Nonnull;
  */
 public class GuildVoiceLeaveEvent extends GenericGuildVoiceUpdateEvent
 {
-    public GuildVoiceLeaveEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull VoiceChannel channelLeft)
+    public GuildVoiceLeaveEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull VoiceChannel channelLeft)
     {
         super(api, responseNumber, member, channelLeft, null);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getChannelLeft()
     {
         return super.getChannelLeft();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getOldValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMoveEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} moves between {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}.
@@ -45,33 +44,33 @@ import javax.annotation.Nonnull;
  */
 public class GuildVoiceMoveEvent extends GenericGuildVoiceUpdateEvent
 {
-    public GuildVoiceMoveEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull VoiceChannel channelLeft)
+    public GuildVoiceMoveEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull VoiceChannel channelLeft)
     {
         super(api, responseNumber, member, channelLeft, member.getVoiceState().getChannel());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getChannelLeft()
     {
         return super.getChannelLeft();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getChannelJoined()
     {
         return super.getChannelJoined();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VoiceChannel getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMuteEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} was (un-)muted.
@@ -44,7 +43,7 @@ public class GuildVoiceMuteEvent extends GenericGuildVoiceEvent
 {
     protected final boolean muted;
 
-    public GuildVoiceMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceMuteEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.muted = member.getVoiceState().isMuted();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfDeafenEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} (un-)deafened itself.
@@ -42,7 +41,7 @@ public class GuildVoiceSelfDeafenEvent extends GenericGuildVoiceEvent
 {
     protected final boolean selfDeafened;
 
-    public GuildVoiceSelfDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceSelfDeafenEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.selfDeafened = member.getVoiceState().isSelfDeafened();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfMuteEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} (un-)muted itself.
@@ -42,7 +41,7 @@ public class GuildVoiceSelfMuteEvent extends GenericGuildVoiceEvent
 {
     protected final boolean selfMuted;
 
-    public GuildVoiceSelfMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceSelfMuteEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.selfMuted = member.getVoiceState().isSelfMuted();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceStreamEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceStreamEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} started or ended a stream.
@@ -42,7 +41,7 @@ public class GuildVoiceStreamEvent extends GenericGuildVoiceEvent
 {
     private final boolean stream;
 
-    public GuildVoiceStreamEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean stream)
+    public GuildVoiceStreamEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, boolean stream)
     {
         super(api, responseNumber, member);
         this.stream = stream;

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSuppressEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSuppressEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} was (un-)suppressed.
@@ -44,7 +43,7 @@ public class GuildVoiceSuppressEvent extends GenericGuildVoiceEvent
 {
     protected final boolean suppressed;
 
-    public GuildVoiceSuppressEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member)
+    public GuildVoiceSuppressEvent(@NotNull JDA api, long responseNumber, @NotNull Member member)
     {
         super(api, responseNumber, member);
         this.suppressed = member.getVoiceState().isSuppressed();

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceUpdateEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.guild.voice;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.events.UpdateEvent;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} joined or left a {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel}.

--- a/src/main/java/net/dv8tion/jda/api/events/http/HttpRequestEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/http/HttpRequestEvent.java
@@ -26,9 +26,9 @@ import net.dv8tion.jda.internal.requests.Route.CompiledRoute;
 import okhttp3.Headers;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -41,7 +41,7 @@ public class HttpRequestEvent extends Event
     private final Request<?> request;
     private final Response response;
 
-    public HttpRequestEvent(@Nonnull final Request<?> request, @Nonnull final Response response)
+    public HttpRequestEvent(@NotNull final Request<?> request, @NotNull final Response response)
     {
         super(request.getJDA());
 
@@ -49,7 +49,7 @@ public class HttpRequestEvent extends Event
         this.response = response;
     }
 
-    @Nonnull
+    @NotNull
     public Request<?> getRequest()
     {
         return this.request;
@@ -121,19 +121,19 @@ public class HttpRequestEvent extends Event
         return this.response.getRawResponse();
     }
 
-    @Nonnull
+    @NotNull
     public Set<String> getCFRays()
     {
         return this.response.getCFRays();
     }
 
-    @Nonnull
+    @NotNull
     public RestAction<?> getRestAction()
     {
         return this.request.getRestAction();
     }
 
-    @Nonnull
+    @NotNull
     public CompiledRoute getRoute()
     {
         return this.request.getRoute();

--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Message Message} was created/deleted/changed.
@@ -40,7 +39,7 @@ public abstract class GenericMessageEvent extends Event
     protected final long messageId;
     protected final MessageChannel channel;
 
-    public GenericMessageEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull MessageChannel channel)
+    public GenericMessageEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull MessageChannel channel)
     {
         super(api, responseNumber);
         this.messageId = messageId;
@@ -52,7 +51,7 @@ public abstract class GenericMessageEvent extends Event
      *
      * @return The MessageChannel
      */
-    @Nonnull
+    @NotNull
     public MessageChannel getChannel()
     {
         return channel;
@@ -63,7 +62,7 @@ public abstract class GenericMessageEvent extends Event
      *
      * @return The id for this message
      */
-    @Nonnull
+    @NotNull
     public String getMessageId()
     {
         return Long.toUnsignedString(messageId);
@@ -87,7 +86,7 @@ public abstract class GenericMessageEvent extends Event
      *
      * @return True, if the message is from the specified channel type
      */
-    public boolean isFromType(@Nonnull ChannelType type)
+    public boolean isFromType(@NotNull ChannelType type)
     {
         return channel.getType() == type;
     }
@@ -108,7 +107,7 @@ public abstract class GenericMessageEvent extends Event
      *
      * @return The ChannelType
      */
-    @Nonnull
+    @NotNull
     public ChannelType getChannelType()
     {
         return channel.getType();
@@ -128,7 +127,7 @@ public abstract class GenericMessageEvent extends Event
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return getTextChannel().getGuild();
@@ -148,7 +147,7 @@ public abstract class GenericMessageEvent extends Event
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public TextChannel getTextChannel()
     {
         if (!isFromType(ChannelType.TEXT))
@@ -170,7 +169,7 @@ public abstract class GenericMessageEvent extends Event
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
      */
-    @Nonnull
+    @NotNull
     public PrivateChannel getPrivateChannel()
     {
         if (!isFromType(ChannelType.PRIVATE))

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageBulkDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageBulkDeleteEvent.java
@@ -19,8 +19,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.Event;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -43,7 +43,7 @@ public class MessageBulkDeleteEvent extends Event
     protected final TextChannel channel;
     protected final List<String> messageIds;
 
-    public MessageBulkDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nonnull List<String> messageIds)
+    public MessageBulkDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, @NotNull List<String> messageIds)
     {
         super(api, responseNumber);
         this.channel = channel;
@@ -55,7 +55,7 @@ public class MessageBulkDeleteEvent extends Event
      *
      * @return The TextChannel
      */
-    @Nonnull
+    @NotNull
     public TextChannel getChannel()
     {
         return channel;
@@ -66,7 +66,7 @@ public class MessageBulkDeleteEvent extends Event
      *
      * @return The Guild
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return channel.getGuild();
@@ -77,7 +77,7 @@ public class MessageBulkDeleteEvent extends Event
      *
      * @return The list of message ids
      */
-    @Nonnull
+    @NotNull
     public List<String> getMessageIds()
     {
         return messageIds;

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageDeleteEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.message;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a Message was deleted in a {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
@@ -38,7 +37,7 @@ import javax.annotation.Nonnull;
  */
 public class MessageDeleteEvent extends GenericMessageEvent
 {
-    public MessageDeleteEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull MessageChannel channel)
+    public MessageDeleteEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull MessageChannel channel)
     {
         super(api, responseNumber, messageId, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageEmbedEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.message;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class MessageEmbedEvent extends GenericMessageEvent
 {
     private final List<MessageEmbed> embeds;
 
-    public MessageEmbedEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull MessageChannel channel, @Nonnull List<MessageEmbed> embeds)
+    public MessageEmbedEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull MessageChannel channel, @NotNull List<MessageEmbed> embeds)
     {
         super(api, responseNumber, messageId, channel);
         this.embeds = Collections.unmodifiableList(embeds);
@@ -52,7 +52,7 @@ public class MessageEmbedEvent extends GenericMessageEvent
      *
      * @return The list of MessageEmbeds
      */
-    @Nonnull
+    @NotNull
     public List<MessageEmbed> getMessageEmbeds()
     {
         return embeds;

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageReceivedEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.Webhook;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a Message was received in a {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
@@ -43,7 +42,7 @@ public class MessageReceivedEvent extends GenericMessageEvent
 {
     private final Message message;
 
-    public MessageReceivedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public MessageReceivedEvent(@NotNull JDA api, long responseNumber, @NotNull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getChannel());
         this.message = message;
@@ -54,7 +53,7 @@ public class MessageReceivedEvent extends GenericMessageEvent
      *
      * @return The received {@link net.dv8tion.jda.api.entities.Message Message} object.
      */
-    @Nonnull
+    @NotNull
     public Message getMessage()
     {
         return message;
@@ -69,7 +68,7 @@ public class MessageReceivedEvent extends GenericMessageEvent
      *
      * @see #isWebhookMessage()
      */
-    @Nonnull
+    @NotNull
     public User getAuthor()
     {
         return message.getAuthor();

--- a/src/main/java/net/dv8tion/jda/api/events/message/MessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/MessageUpdateEvent.java
@@ -19,9 +19,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a Message was edited in a {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}.
@@ -44,7 +43,7 @@ public class MessageUpdateEvent extends GenericMessageEvent
 {
     private final Message message;
 
-    public MessageUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public MessageUpdateEvent(@NotNull JDA api, long responseNumber, @NotNull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getChannel());
         this.message = message;
@@ -56,7 +55,7 @@ public class MessageUpdateEvent extends GenericMessageEvent
      *
      * @return The updated Message
      */
-    @Nonnull
+    @NotNull
     public Message getMessage()
     {
         return message;
@@ -69,7 +68,7 @@ public class MessageUpdateEvent extends GenericMessageEvent
      *
      * @see    net.dv8tion.jda.api.entities.User User
      */
-    @Nonnull
+    @NotNull
     public User getAuthor()
     {
         return message.getAuthor();

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GenericGuildMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GenericGuildMessageEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Message Message} event is fired from a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
@@ -36,7 +35,7 @@ public abstract class GenericGuildMessageEvent extends GenericGuildEvent
     protected final long messageId;
     protected final TextChannel channel;
 
-    public GenericGuildMessageEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull TextChannel channel)
+    public GenericGuildMessageEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull TextChannel channel)
     {
         super(api, responseNumber, channel.getGuild());
         this.messageId = messageId;
@@ -48,7 +47,7 @@ public abstract class GenericGuildMessageEvent extends GenericGuildEvent
      *
      * @return The message id
      */
-    @Nonnull
+    @NotNull
     public String getMessageId()
     {
         return Long.toUnsignedString(messageId);
@@ -69,7 +68,7 @@ public abstract class GenericGuildMessageEvent extends GenericGuildEvent
      *
      * @return The TextChannel for this message
      */
-    @Nonnull
+    @NotNull
     public TextChannel getChannel()
     {
         return channel;

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageDeleteEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.message.guild;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a Guild Message was deleted.
@@ -31,7 +30,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildMessageDeleteEvent extends GenericGuildMessageEvent
 {
-    public GuildMessageDeleteEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull TextChannel channel)
+    public GuildMessageDeleteEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull TextChannel channel)
     {
         super(api, responseNumber, messageId, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageEmbedEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.message.guild;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.TextChannel;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -35,7 +35,7 @@ public class GuildMessageEmbedEvent extends GenericGuildMessageEvent
 {
     private final List<MessageEmbed> embeds;
 
-    public GuildMessageEmbedEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull TextChannel channel, @Nonnull List<MessageEmbed> embeds)
+    public GuildMessageEmbedEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull TextChannel channel, @NotNull List<MessageEmbed> embeds)
     {
         super(api, responseNumber, messageId, channel);
         this.embeds = embeds;
@@ -46,7 +46,7 @@ public class GuildMessageEmbedEvent extends GenericGuildMessageEvent
      *
      * @return The MessageEmbeds
      */
-    @Nonnull
+    @NotNull
     public List<MessageEmbed> getMessageEmbeds()
     {
         return embeds;

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageReceivedEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.Webhook;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a Message is received in a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
@@ -37,7 +36,7 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
 {
     private final Message message;
 
-    public GuildMessageReceivedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public GuildMessageReceivedEvent(@NotNull JDA api, long responseNumber, @NotNull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getTextChannel());
         this.message = message;
@@ -48,7 +47,7 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
      *
      * @return The received {@link net.dv8tion.jda.api.entities.Message Message} object.
      */
-    @Nonnull
+    @NotNull
     public Message getMessage()
     {
         return message;
@@ -63,7 +62,7 @@ public class GuildMessageReceivedEvent extends GenericGuildMessageEvent
      *
      * @see    #isWebhookMessage()
      */
-    @Nonnull
+    @NotNull
     public User getAuthor()
     {
         return message.getAuthor();

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageUpdateEvent.java
@@ -19,9 +19,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a Message was edited in a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
@@ -36,7 +35,7 @@ public class GuildMessageUpdateEvent extends GenericGuildMessageEvent
 {
     private final Message message;
 
-    public GuildMessageUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public GuildMessageUpdateEvent(@NotNull JDA api, long responseNumber, @NotNull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getTextChannel());
         this.message = message;
@@ -47,7 +46,7 @@ public class GuildMessageUpdateEvent extends GenericGuildMessageEvent
      *
      * @return The Message
      */
-    @Nonnull
+    @NotNull
     public Message getMessage()
     {
         return message;
@@ -60,7 +59,7 @@ public class GuildMessageUpdateEvent extends GenericGuildMessageEvent
      *
      * @see    net.dv8tion.jda.api.entities.User User
      */
-    @Nonnull
+    @NotNull
     public User getAuthor()
     {
         return message.getAuthor();

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GenericGuildMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GenericGuildMessageReactionEvent.java
@@ -21,10 +21,10 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.guild.GenericGuildMessageEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} was added or removed in a TextChannel.
@@ -41,7 +41,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
     protected final Member issuer;
     protected final MessageReaction reaction;
 
-    public GenericGuildMessageReactionEvent(@Nonnull JDA api, long responseNumber, @Nullable Member user, @Nonnull MessageReaction reaction, long userId)
+    public GenericGuildMessageReactionEvent(@NotNull JDA api, long responseNumber, @Nullable Member user, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, reaction.getMessageIdLong(), (TextChannel) reaction.getChannel());
         this.issuer = user;
@@ -54,7 +54,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
      *
      * @return The user id
      */
-    @Nonnull
+    @NotNull
     public String getUserId()
     {
         return Long.toUnsignedString(userId);
@@ -103,7 +103,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
      *
      * @return The message reaction
      */
-    @Nonnull
+    @NotNull
     public MessageReaction getReaction()
     {
         return reaction;
@@ -115,7 +115,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
      *
      * @return The reaction emote
      */
-    @Nonnull
+    @NotNull
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();
@@ -129,7 +129,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<User> retrieveUser()
     {
@@ -150,7 +150,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<Member> retrieveMember()
     {
@@ -170,7 +170,7 @@ public abstract class GenericGuildMessageReactionEvent extends GenericGuildMessa
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<Message> retrieveMessage()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionAddEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} was added to a Message in a Guild
@@ -34,7 +33,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildMessageReactionAddEvent extends GenericGuildMessageReactionEvent
 {
-    public GuildMessageReactionAddEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull MessageReaction reaction)
+    public GuildMessageReactionAddEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull MessageReaction reaction)
     {
         super(api, responseNumber, member, reaction, member.getIdLong());
     }
@@ -46,7 +45,7 @@ public class GuildMessageReactionAddEvent extends GenericGuildMessageReactionEve
      *
      * @see    #getUserIdLong()
      */
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("ConstantConditions")
     public User getUser()
@@ -59,7 +58,7 @@ public class GuildMessageReactionAddEvent extends GenericGuildMessageReactionEve
      *
      * @return The member instance for the reacting user
      */
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("ConstantConditions")
     public Member getMember()

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveAllEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveAllEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.message.guild.react;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.guild.GenericGuildMessageEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the reactions for a {@link net.dv8tion.jda.api.entities.Message Message} were cleared by a moderator in a guild.
@@ -33,7 +32,7 @@ import javax.annotation.Nonnull;
  */
 public class GuildMessageReactionRemoveAllEvent extends GenericGuildMessageEvent
 {
-    public GuildMessageReactionRemoveAllEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull TextChannel channel)
+    public GuildMessageReactionRemoveAllEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull TextChannel channel)
     {
         super(api, responseNumber, messageId, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEmoteEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.guild.GenericGuildMessageEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that all reactions for a specific emoji/emote were removed by a moderator.
@@ -38,7 +37,7 @@ public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEve
 {
     private final MessageReaction reaction;
 
-    public GuildMessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, @Nonnull TextChannel channel, @Nonnull MessageReaction reaction, long messageId)
+    public GuildMessageReactionRemoveEmoteEvent(@NotNull JDA api, long responseNumber, @NotNull TextChannel channel, @NotNull MessageReaction reaction, long messageId)
     {
         super(api, responseNumber, messageId, channel);
 
@@ -50,7 +49,7 @@ public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEve
      *
      * @return The TextChannel
      */
-    @Nonnull
+    @NotNull
     public TextChannel getChannel()
     {
         return channel;
@@ -61,7 +60,7 @@ public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEve
      *
      * @return The removed MessageReaction
      */
-    @Nonnull
+    @NotNull
     public MessageReaction getReaction()
     {
         return reaction;
@@ -73,7 +72,7 @@ public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEve
      *
      * @return The ReactionEmote
      */
-    @Nonnull
+    @NotNull
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();
@@ -94,7 +93,7 @@ public class GuildMessageReactionRemoveEmoteEvent extends GenericGuildMessageEve
      *
      * @return The id of the message
      */
-    @Nonnull
+    @NotNull
     public String getMessageId()
     {
         return Long.toUnsignedString(messageId);

--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/react/GuildMessageReactionRemoveEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.message.guild.react;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageReaction;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} was removed from a Message in a Guild
@@ -34,7 +33,7 @@ import javax.annotation.Nullable;
  */
 public class GuildMessageReactionRemoveEvent extends GenericGuildMessageReactionEvent
 {
-    public GuildMessageReactionRemoveEvent(@Nonnull JDA api, long responseNumber, @Nullable Member member, @Nonnull MessageReaction reaction, long userId)
+    public GuildMessageReactionRemoveEvent(@NotNull JDA api, long responseNumber, @Nullable Member member, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, member, reaction, userId);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/GenericPrivateMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/GenericPrivateMessageEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message.priv;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Message Message} event is fired from a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}.
@@ -36,7 +35,7 @@ public abstract class GenericPrivateMessageEvent extends Event
     protected final long messageId;
     protected final PrivateChannel channel;
 
-    public GenericPrivateMessageEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull PrivateChannel channel)
+    public GenericPrivateMessageEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull PrivateChannel channel)
     {
         super(api, responseNumber);
         this.messageId = messageId;
@@ -48,7 +47,7 @@ public abstract class GenericPrivateMessageEvent extends Event
      *
      * @return The PrivateChannel
      */
-    @Nonnull
+    @NotNull
     public PrivateChannel getChannel()
     {
         return channel;
@@ -59,7 +58,7 @@ public abstract class GenericPrivateMessageEvent extends Event
      *
      * @return The id for this message
      */
-    @Nonnull
+    @NotNull
     public String getMessageId()
     {
         return Long.toUnsignedString(messageId);

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageDeleteEvent.java
@@ -17,8 +17,7 @@ package net.dv8tion.jda.api.events.message.priv;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.PrivateChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a Message was deleted in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}.
@@ -31,7 +30,7 @@ import javax.annotation.Nonnull;
  */
 public class PrivateMessageDeleteEvent extends GenericPrivateMessageEvent
 {
-    public PrivateMessageDeleteEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull PrivateChannel channel)
+    public PrivateMessageDeleteEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull PrivateChannel channel)
     {
         super(api, responseNumber, messageId, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageEmbedEvent.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.events.message.priv;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.PrivateChannel;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -35,7 +35,7 @@ public class PrivateMessageEmbedEvent extends GenericPrivateMessageEvent
 {
     private final List<MessageEmbed> embeds;
 
-    public PrivateMessageEmbedEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull PrivateChannel channel, @Nonnull List<MessageEmbed> embeds)
+    public PrivateMessageEmbedEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull PrivateChannel channel, @NotNull List<MessageEmbed> embeds)
     {
         super(api, responseNumber, messageId, channel);
         this.embeds = embeds;
@@ -46,7 +46,7 @@ public class PrivateMessageEmbedEvent extends GenericPrivateMessageEvent
      *
      * @return The MessageEmbeds
      */
-    @Nonnull
+    @NotNull
     public List<MessageEmbed> getMessageEmbeds()
     {
         return embeds;

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageReceivedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageReceivedEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message.priv;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a Message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}.
@@ -34,7 +33,7 @@ public class PrivateMessageReceivedEvent extends GenericPrivateMessageEvent
 {
     private final Message message;
 
-    public PrivateMessageReceivedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public PrivateMessageReceivedEvent(@NotNull JDA api, long responseNumber, @NotNull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getPrivateChannel());
         this.message = message;
@@ -45,7 +44,7 @@ public class PrivateMessageReceivedEvent extends GenericPrivateMessageEvent
      *
      * @return The Message
      */
-    @Nonnull
+    @NotNull
     public Message getMessage()
     {
         return message;
@@ -58,7 +57,7 @@ public class PrivateMessageReceivedEvent extends GenericPrivateMessageEvent
      *
      * @see    net.dv8tion.jda.api.entities.User User
      */
-    @Nonnull
+    @NotNull
     public User getAuthor()
     {
         return message.getAuthor();

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/PrivateMessageUpdateEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message.priv;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a Message was edited in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}.
@@ -34,7 +33,7 @@ public class PrivateMessageUpdateEvent extends GenericPrivateMessageEvent
 {
     private final Message message;
 
-    public PrivateMessageUpdateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Message message)
+    public PrivateMessageUpdateEvent(@NotNull JDA api, long responseNumber, @NotNull Message message)
     {
         super(api, responseNumber, message.getIdLong(), message.getPrivateChannel());
         this.message = message;
@@ -45,7 +44,7 @@ public class PrivateMessageUpdateEvent extends GenericPrivateMessageEvent
      *
      * @return The Message
      */
-    @Nonnull
+    @NotNull
     public Message getMessage()
     {
         return message;
@@ -58,7 +57,7 @@ public class PrivateMessageUpdateEvent extends GenericPrivateMessageEvent
      *
      * @see    net.dv8tion.jda.api.entities.User User
      */
-    @Nonnull
+    @NotNull
     public User getAuthor()
     {
         return message.getAuthor();

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/react/GenericPrivateMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/react/GenericPrivateMessageReactionEvent.java
@@ -21,9 +21,8 @@ import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.priv.GenericPrivateMessageEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} was added or removed.
@@ -39,7 +38,7 @@ public class GenericPrivateMessageReactionEvent extends GenericPrivateMessageEve
     protected final long userId;
     protected final MessageReaction reaction;
 
-    public GenericPrivateMessageReactionEvent(@Nonnull JDA api, long responseNumber, @Nonnull MessageReaction reaction, long userId)
+    public GenericPrivateMessageReactionEvent(@NotNull JDA api, long responseNumber, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, reaction.getMessageIdLong(), (PrivateChannel) reaction.getChannel());
         this.userId = userId;
@@ -51,7 +50,7 @@ public class GenericPrivateMessageReactionEvent extends GenericPrivateMessageEve
      *
      * @return The user id
      */
-    @Nonnull
+    @NotNull
     public String getUserId()
     {
         return Long.toUnsignedString(userId);
@@ -86,7 +85,7 @@ public class GenericPrivateMessageReactionEvent extends GenericPrivateMessageEve
      *
      * @return The message reaction
      */
-    @Nonnull
+    @NotNull
     public MessageReaction getReaction()
     {
         return reaction;
@@ -98,7 +97,7 @@ public class GenericPrivateMessageReactionEvent extends GenericPrivateMessageEve
      *
      * @return The message reaction emote
      */
-    @Nonnull
+    @NotNull
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/react/PrivateMessageReactionAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/react/PrivateMessageReactionAddEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message.priv.react;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageReaction;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} was added to a Message in a PrivateChannel.
@@ -32,7 +31,7 @@ import javax.annotation.Nonnull;
  */
 public class PrivateMessageReactionAddEvent extends GenericPrivateMessageReactionEvent
 {
-    public PrivateMessageReactionAddEvent(@Nonnull JDA api, long responseNumber, @Nonnull MessageReaction reaction, long userId)
+    public PrivateMessageReactionAddEvent(@NotNull JDA api, long responseNumber, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, reaction, userId);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/priv/react/PrivateMessageReactionRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/priv/react/PrivateMessageReactionRemoveEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.message.priv.react;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageReaction;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.MessageReaction MessageReaction} was removed from a Message in a PrivateChannel.
@@ -32,7 +31,7 @@ import javax.annotation.Nonnull;
  */
 public class PrivateMessageReactionRemoveEvent extends GenericPrivateMessageReactionEvent
 {
-    public PrivateMessageReactionRemoveEvent(@Nonnull JDA api, long responseNumber, @Nonnull MessageReaction reaction, long userId)
+    public PrivateMessageReactionRemoveEvent(@NotNull JDA api, long responseNumber, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, reaction, userId);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
@@ -21,10 +21,10 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Indicates that a MessageReaction was added/removed.
@@ -47,8 +47,8 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
     protected Member member;
     protected MessageReaction reaction;
 
-    public GenericMessageReactionEvent(@Nonnull JDA api, long responseNumber, @Nullable User user,
-                                       @Nullable Member member, @Nonnull MessageReaction reaction, long userId)
+    public GenericMessageReactionEvent(@NotNull JDA api, long responseNumber, @Nullable User user,
+                                       @Nullable Member member, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, reaction.getMessageIdLong(), reaction.getChannel());
         this.userId = userId;
@@ -62,7 +62,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      *
      * @return The user id
      */
-    @Nonnull
+    @NotNull
     public String getUserId()
     {
         return Long.toUnsignedString(userId);
@@ -118,7 +118,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      *
      * @return The MessageReaction
      */
-    @Nonnull
+    @NotNull
     public MessageReaction getReaction()
     {
         return reaction;
@@ -130,7 +130,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      *
      * @return The ReactionEmote instance
      */
-    @Nonnull
+    @NotNull
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();
@@ -144,7 +144,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<User> retrieveUser()
     {
@@ -169,7 +169,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<Member> retrieveMember()
     {
@@ -189,7 +189,7 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public RestAction<Message> retrieveMessage()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionAddEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionAddEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a user added a reaction to a message
@@ -40,8 +39,8 @@ import javax.annotation.Nullable;
  */
 public class MessageReactionAddEvent extends GenericMessageReactionEvent
 {
-    public MessageReactionAddEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user,
-                                   @Nullable Member member, @Nonnull MessageReaction reaction, long userId)
+    public MessageReactionAddEvent(@NotNull JDA api, long responseNumber, @NotNull User user,
+                                   @Nullable Member member, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, user, member, reaction, userId);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveAllEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveAllEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.message.react;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates the the reactions of a message have been cleared by a moderator
@@ -37,7 +36,7 @@ import javax.annotation.Nonnull;
  */
 public class MessageReactionRemoveAllEvent extends GenericMessageEvent
 {
-    public MessageReactionRemoveAllEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull MessageChannel channel)
+    public MessageReactionRemoveAllEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull MessageChannel channel)
     {
         super(api, responseNumber, messageId, channel);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEmoteEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that all reactions for a specific emoji/emote were removed by a moderator.
@@ -42,7 +41,7 @@ public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
 {
     private final MessageReaction reaction;
 
-    public MessageReactionRemoveEmoteEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull MessageChannel channel, @Nonnull MessageReaction reaction)
+    public MessageReactionRemoveEmoteEvent(@NotNull JDA api, long responseNumber, long messageId, @NotNull MessageChannel channel, @NotNull MessageReaction reaction)
     {
         super(api, responseNumber, messageId, channel);
         this.reaction = reaction;
@@ -53,7 +52,7 @@ public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
      *
      * @return The removed MessageReaction
      */
-    @Nonnull
+    @NotNull
     public MessageReaction getReaction()
     {
         return reaction;
@@ -65,7 +64,7 @@ public class MessageReactionRemoveEmoteEvent extends GenericMessageEvent
      *
      * @return The ReactionEmote
      */
-    @Nonnull
+    @NotNull
     public MessageReaction.ReactionEmote getReactionEmote()
     {
         return reaction.getReactionEmote();

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/MessageReactionRemoveEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a user removed the reaction on a message
@@ -39,8 +38,8 @@ import javax.annotation.Nullable;
  */
 public class MessageReactionRemoveEvent extends GenericMessageReactionEvent
 {
-    public MessageReactionRemoveEvent(@Nonnull JDA api, long responseNumber, @Nullable User user,
-                                      @Nullable Member member, @Nonnull MessageReaction reaction, long userId)
+    public MessageReactionRemoveEvent(@NotNull JDA api, long responseNumber, @Nullable User user,
+                                      @Nullable Member member, @NotNull MessageReaction reaction, long userId)
     {
         super(api, responseNumber, user, member, reaction, userId);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/role/GenericRoleEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/GenericRoleEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} was created/deleted/changed.
@@ -33,7 +32,7 @@ public abstract class GenericRoleEvent extends Event
 {
     protected final Role role;
 
-    public GenericRoleEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role)
+    public GenericRoleEvent(@NotNull JDA api, long responseNumber, @NotNull Role role)
     {
         super(api, responseNumber);
         this.role = role;
@@ -44,7 +43,7 @@ public abstract class GenericRoleEvent extends Event
      *
      * @return The role for this event
      */
-    @Nonnull
+    @NotNull
     public Role getRole()
     {
         return role;
@@ -55,7 +54,7 @@ public abstract class GenericRoleEvent extends Event
      *
      * @return The guild of the role
      */
-    @Nonnull
+    @NotNull
     public Guild getGuild()
     {
         return role.getGuild();

--- a/src/main/java/net/dv8tion/jda/api/events/role/RoleCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/RoleCreateEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.role;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} was created.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class RoleCreateEvent extends GenericRoleEvent
 {
-    public RoleCreateEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role createdRole)
+    public RoleCreateEvent(@NotNull JDA api, long responseNumber, @NotNull Role createdRole)
     {
         super(api, responseNumber, createdRole);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/role/RoleDeleteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/RoleDeleteEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.role;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} was deleted.
@@ -28,7 +27,7 @@ import javax.annotation.Nonnull;
  */
 public class RoleDeleteEvent extends GenericRoleEvent
 {
-    public RoleDeleteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role deletedRole)
+    public RoleDeleteEvent(@NotNull JDA api, long responseNumber, @NotNull Role deletedRole)
     {
         super(api, responseNumber, deletedRole);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/GenericRoleUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/GenericRoleUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.role.GenericRoleEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} was updated.
@@ -37,8 +36,8 @@ public abstract class GenericRoleUpdateEvent<T> extends GenericRoleEvent impleme
     protected final String identifier;
 
     public GenericRoleUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull Role role,
-        @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull Role role,
+        @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, role);
         this.previous = previous;
@@ -46,14 +45,14 @@ public abstract class GenericRoleUpdateEvent<T> extends GenericRoleEvent impleme
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Role getEntity()
     {
         return role;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateColorEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateColorEvent.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.events.role.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 
 /**
@@ -34,7 +34,7 @@ public class RoleUpdateColorEvent extends GenericRoleUpdateEvent<Integer>
 {
     public static final String IDENTIFIER = "color";
 
-    public RoleUpdateColorEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role, int oldColor)
+    public RoleUpdateColorEvent(@NotNull JDA api, long responseNumber, @NotNull Role role, int oldColor)
     {
         super(api, responseNumber, role, oldColor, role.getColorRaw(), IDENTIFIER);
     }
@@ -81,14 +81,14 @@ public class RoleUpdateColorEvent extends GenericRoleUpdateEvent<Integer>
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateHoistedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateHoistedEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.role.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} updated its hoist state.
@@ -32,7 +31,7 @@ public class RoleUpdateHoistedEvent extends GenericRoleUpdateEvent<Boolean>
 {
     public static final String IDENTIFIER = "hoist";
 
-    public RoleUpdateHoistedEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role, boolean wasHoisted)
+    public RoleUpdateHoistedEvent(@NotNull JDA api, long responseNumber, @NotNull Role role, boolean wasHoisted)
     {
         super(api, responseNumber, role, wasHoisted, !wasHoisted, IDENTIFIER);
     }
@@ -47,14 +46,14 @@ public class RoleUpdateHoistedEvent extends GenericRoleUpdateEvent<Boolean>
         return getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateMentionableEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateMentionableEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.role.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} updated its mentionable state.
@@ -32,7 +31,7 @@ public class RoleUpdateMentionableEvent extends GenericRoleUpdateEvent<Boolean>
 {
     public static final String IDENTIFIER = "mentionable";
 
-    public RoleUpdateMentionableEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role, boolean wasMentionable)
+    public RoleUpdateMentionableEvent(@NotNull JDA api, long responseNumber, @NotNull Role role, boolean wasMentionable)
     {
         super(api, responseNumber, role, wasMentionable, !wasMentionable, IDENTIFIER);
     }
@@ -47,14 +46,14 @@ public class RoleUpdateMentionableEvent extends GenericRoleUpdateEvent<Boolean>
         return getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdateNameEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.role.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} updated its name.
@@ -32,7 +31,7 @@ public class RoleUpdateNameEvent extends GenericRoleUpdateEvent<String>
 {
     public static final String IDENTIFIER = "name";
 
-    public RoleUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role, @Nonnull String oldName)
+    public RoleUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull Role role, @NotNull String oldName)
     {
         super(api, responseNumber, role, oldName, role.getName(), IDENTIFIER);
     }
@@ -42,7 +41,7 @@ public class RoleUpdateNameEvent extends GenericRoleUpdateEvent<String>
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -53,20 +52,20 @@ public class RoleUpdateNameEvent extends GenericRoleUpdateEvent<String>
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdatePermissionsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdatePermissionsEvent.java
@@ -19,8 +19,8 @@ package net.dv8tion.jda.api.events.role.update;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Role;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
 /**
@@ -37,7 +37,7 @@ public class RoleUpdatePermissionsEvent extends GenericRoleUpdateEvent<EnumSet<P
     private final long oldPermissionsRaw;
     private final long newPermissionsRaw;
 
-    public RoleUpdatePermissionsEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role, long oldPermissionsRaw)
+    public RoleUpdatePermissionsEvent(@NotNull JDA api, long responseNumber, @NotNull Role role, long oldPermissionsRaw)
     {
         super(api, responseNumber, role, Permission.getPermissions(oldPermissionsRaw), role.getPermissions(), IDENTIFIER);
         this.oldPermissionsRaw = oldPermissionsRaw;
@@ -49,7 +49,7 @@ public class RoleUpdatePermissionsEvent extends GenericRoleUpdateEvent<EnumSet<P
      *
      * @return The old permissions
      */
-    @Nonnull
+    @NotNull
     public EnumSet<Permission> getOldPermissions()
     {
         return getOldValue();
@@ -70,7 +70,7 @@ public class RoleUpdatePermissionsEvent extends GenericRoleUpdateEvent<EnumSet<P
      *
      * @return The new permissions
      */
-    @Nonnull
+    @NotNull
     public EnumSet<Permission> getNewPermissions()
     {
         return getNewValue();
@@ -86,14 +86,14 @@ public class RoleUpdatePermissionsEvent extends GenericRoleUpdateEvent<EnumSet<P
         return newPermissionsRaw;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdatePositionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/RoleUpdatePositionEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.role.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Role Role} updated its position.
@@ -35,7 +34,7 @@ public class RoleUpdatePositionEvent extends GenericRoleUpdateEvent<Integer>
     private final int oldPositionRaw;
     private final int newPositionRaw;
 
-    public RoleUpdatePositionEvent(@Nonnull JDA api, long responseNumber, @Nonnull Role role, int oldPosition, int oldPositionRaw)
+    public RoleUpdatePositionEvent(@NotNull JDA api, long responseNumber, @NotNull Role role, int oldPosition, int oldPositionRaw)
     {
         super(api, responseNumber, role, oldPosition, role.getPosition(), IDENTIFIER);
         this.oldPositionRaw = oldPositionRaw;
@@ -82,14 +81,14 @@ public class RoleUpdatePositionEvent extends GenericRoleUpdateEvent<Integer>
         return newPositionRaw;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Integer getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/GenericSelfUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/GenericSelfUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.SelfUser;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.UpdateEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.SelfUser SelfUser} changed or started an activity.
@@ -37,8 +36,8 @@ public abstract class GenericSelfUpdateEvent<T> extends Event implements UpdateE
     protected final String identifier;
 
     public GenericSelfUpdateEvent(
-            @Nonnull JDA api, long responseNumber,
-            @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+            @NotNull JDA api, long responseNumber,
+            @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber);
         this.previous = previous;
@@ -51,20 +50,20 @@ public abstract class GenericSelfUpdateEvent<T> extends Event implements UpdateE
      *
      * @return The {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}
      */
-    @Nonnull
+    @NotNull
     public SelfUser getSelfUser()
     {
         return api.getSelfUser();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SelfUser getEntity()
     {
         return getSelfUser();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateAvatarEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateAvatarEvent.java
@@ -17,9 +17,8 @@
 package net.dv8tion.jda.api.events.self;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the avatar of the current user changed.
@@ -33,7 +32,7 @@ public class SelfUpdateAvatarEvent extends GenericSelfUpdateEvent<String>
     public static final String IDENTIFIER = "avatar";
     private static final String AVATAR_URL = "https://cdn.discordapp.com/avatars/%s/%s%s";
 
-    public SelfUpdateAvatarEvent(@Nonnull JDA api, long responseNumber, @Nullable String oldAvatarId)
+    public SelfUpdateAvatarEvent(@NotNull JDA api, long responseNumber, @Nullable String oldAvatarId)
     {
         super(api, responseNumber, oldAvatarId, api.getSelfUser().getAvatarId(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateDiscriminatorEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateDiscriminatorEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events.self;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the discriminator of the current user changed.
@@ -31,7 +30,7 @@ public class SelfUpdateDiscriminatorEvent extends GenericSelfUpdateEvent<String>
 {
     public static final String IDENTIFIER = "discriminator";
 
-    public SelfUpdateDiscriminatorEvent(@Nonnull JDA api, long responseNumber, @Nonnull String oldDiscriminator)
+    public SelfUpdateDiscriminatorEvent(@NotNull JDA api, long responseNumber, @NotNull String oldDiscriminator)
     {
         super(api, responseNumber, oldDiscriminator, api.getSelfUser().getDiscriminator(), IDENTIFIER);
     }
@@ -41,7 +40,7 @@ public class SelfUpdateDiscriminatorEvent extends GenericSelfUpdateEvent<String>
      *
      * @return The old discriminator
      */
-    @Nonnull
+    @NotNull
     public String getOldDiscriminator()
     {
         return getOldValue();
@@ -52,20 +51,20 @@ public class SelfUpdateDiscriminatorEvent extends GenericSelfUpdateEvent<String>
      *
      * @return The new discriminator
      */
-    @Nonnull
+    @NotNull
     public String getNewDiscriminator()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateEmailEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateEmailEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.self;
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the email of the current user changed. (client-only)
@@ -38,7 +37,7 @@ public class SelfUpdateEmailEvent extends GenericSelfUpdateEvent<String>
 {
     public static final String IDENTIFIER = "email";
 
-    public SelfUpdateEmailEvent(@Nonnull JDA api, long responseNumber, @Nonnull String oldEmail)
+    public SelfUpdateEmailEvent(@NotNull JDA api, long responseNumber, @NotNull String oldEmail)
     {
         super(api, responseNumber, oldEmail, api.getSelfUser().getEmail(), IDENTIFIER);
     }
@@ -48,7 +47,7 @@ public class SelfUpdateEmailEvent extends GenericSelfUpdateEvent<String>
      *
      * @return The old email
      */
-    @Nonnull
+    @NotNull
     public String getOldEmail()
     {
         return getOldValue();
@@ -59,20 +58,20 @@ public class SelfUpdateEmailEvent extends GenericSelfUpdateEvent<String>
      *
      * @return The new email
      */
-    @Nonnull
+    @NotNull
     public String getNewEmail()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateMFAEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateMFAEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events.self;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the mfa level of the current user changed.
@@ -32,7 +31,7 @@ public class SelfUpdateMFAEvent extends GenericSelfUpdateEvent<Boolean>
 {
     public static final String IDENTIFIER = "mfa_enabled";
 
-    public SelfUpdateMFAEvent(@Nonnull JDA api, long responseNumber, boolean wasMfaEnabled)
+    public SelfUpdateMFAEvent(@NotNull JDA api, long responseNumber, boolean wasMfaEnabled)
     {
         super(api, responseNumber, wasMfaEnabled, !wasMfaEnabled, IDENTIFIER);
     }
@@ -47,14 +46,14 @@ public class SelfUpdateMFAEvent extends GenericSelfUpdateEvent<Boolean>
         return getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateMobileEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateMobileEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.self;
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that you login to your discord account with a mobile device for the first time. (client-only)
@@ -38,7 +37,7 @@ public class SelfUpdateMobileEvent extends GenericSelfUpdateEvent<Boolean>
 {
     public static final String IDENTIFIER = "mobile";
 
-    public SelfUpdateMobileEvent(@Nonnull JDA api, long responseNumber, boolean wasMobile)
+    public SelfUpdateMobileEvent(@NotNull JDA api, long responseNumber, boolean wasMobile)
     {
         super(api, responseNumber, wasMobile, !wasMobile, IDENTIFIER);
     }
@@ -53,14 +52,14 @@ public class SelfUpdateMobileEvent extends GenericSelfUpdateEvent<Boolean>
         return getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateNameEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events.self;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the name of the current user changed.
@@ -31,7 +30,7 @@ public class SelfUpdateNameEvent extends GenericSelfUpdateEvent<String>
 {
     public static final String IDENTIFIER = "name";
 
-    public SelfUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull String oldName)
+    public SelfUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull String oldName)
     {
         super(api, responseNumber, oldName, api.getSelfUser().getName(), IDENTIFIER);
     }
@@ -41,7 +40,7 @@ public class SelfUpdateNameEvent extends GenericSelfUpdateEvent<String>
      *
      * @return The old name
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -52,20 +51,20 @@ public class SelfUpdateNameEvent extends GenericSelfUpdateEvent<String>
      *
      * @return The new name
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateNitroEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateNitroEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.self;
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the current user subscribed to nitro or the active nitro subscription ran out. (client-only)
@@ -38,7 +37,7 @@ public class SelfUpdateNitroEvent extends GenericSelfUpdateEvent<Boolean>
 {
     public static final String IDENTIFIER = "nitro";
 
-    public SelfUpdateNitroEvent(@Nonnull JDA api, long responseNumber, boolean wasNitro)
+    public SelfUpdateNitroEvent(@NotNull JDA api, long responseNumber, boolean wasNitro)
     {
         super(api, responseNumber, wasNitro, !wasNitro, IDENTIFIER);
     }
@@ -53,14 +52,14 @@ public class SelfUpdateNitroEvent extends GenericSelfUpdateEvent<Boolean>
         return getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdatePhoneNumberEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdatePhoneNumberEvent.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.events.self;
 import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the phone number associated with your account changed. (client-only)
@@ -39,7 +38,7 @@ public class SelfUpdatePhoneNumberEvent extends GenericSelfUpdateEvent<String>
 {
     public static final String IDENTIFIER = "phone";
 
-    public SelfUpdatePhoneNumberEvent(@Nonnull JDA api, long responseNumber, @Nullable String oldPhoneNumber)
+    public SelfUpdatePhoneNumberEvent(@NotNull JDA api, long responseNumber, @Nullable String oldPhoneNumber)
     {
         super(api, responseNumber, oldPhoneNumber, api.getSelfUser().getPhoneNumber(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateVerifiedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/self/SelfUpdateVerifiedEvent.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.events.self;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the verification state of the current user changed. (client-only)
@@ -31,7 +30,7 @@ public class SelfUpdateVerifiedEvent extends GenericSelfUpdateEvent<Boolean>
 {
     public static final String IDENTIFIER = "verified";
 
-    public SelfUpdateVerifiedEvent(@Nonnull JDA api, long responseNumber, boolean wasVerified)
+    public SelfUpdateVerifiedEvent(@NotNull JDA api, long responseNumber, boolean wasVerified)
     {
         super(api, responseNumber, wasVerified, !wasVerified, IDENTIFIER);
     }
@@ -46,14 +45,14 @@ public class SelfUpdateVerifiedEvent extends GenericSelfUpdateEvent<Boolean>
         return getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Boolean getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/GenericUserEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/GenericUserEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.user;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.Event;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.User User} changed or started an activity.
@@ -31,7 +30,7 @@ public abstract class GenericUserEvent extends Event
 {
     private final User user;
 
-    public GenericUserEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user)
+    public GenericUserEvent(@NotNull JDA api, long responseNumber, @NotNull User user)
     {
         super(api, responseNumber);
         this.user = user;
@@ -42,7 +41,7 @@ public abstract class GenericUserEvent extends Event
      *
      * @return The user instance related to this event
      */
-    @Nonnull
+    @NotNull
     public User getUser()
     {
         return user;

--- a/src/main/java/net/dv8tion/jda/api/events/user/UserActivityEndEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/UserActivityEndEvent.java
@@ -22,8 +22,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.user.update.GenericUserPresenceEvent;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.User User} has stopped an {@link Activity}
@@ -60,7 +59,7 @@ public class UserActivityEndEvent extends GenericUserEvent implements GenericUse
     private final Activity oldActivity;
     private final Member member;
 
-    public UserActivityEndEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull Activity oldActivity)
+    public UserActivityEndEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull Activity oldActivity)
     {
         super(api, responseNumber, member.getUser());
         this.oldActivity = oldActivity;
@@ -72,20 +71,20 @@ public class UserActivityEndEvent extends GenericUserEvent implements GenericUse
      *
      * @return The old activity
      */
-    @Nonnull
+    @NotNull
     public Activity getOldActivity()
     {
         return oldActivity;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return member.getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getMember()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/UserActivityStartEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/UserActivityStartEvent.java
@@ -22,8 +22,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.user.update.GenericUserPresenceEvent;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.User User} has started an {@link Activity}
@@ -55,7 +54,7 @@ public class UserActivityStartEvent extends GenericUserEvent implements GenericU
     private final Activity newActivity;
     private final Member member;
 
-    public UserActivityStartEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull Activity newActivity)
+    public UserActivityStartEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull Activity newActivity)
     {
         super(api, responseNumber, member.getUser());
         this.newActivity = newActivity;
@@ -72,14 +71,14 @@ public class UserActivityStartEvent extends GenericUserEvent implements GenericU
         return newActivity;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return member.getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getMember()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/UserTypingEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/UserTypingEvent.java
@@ -17,9 +17,9 @@ package net.dv8tion.jda.api.events.user;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 
 /**
@@ -40,7 +40,7 @@ public class UserTypingEvent extends GenericUserEvent
     private final MessageChannel channel;
     private final OffsetDateTime timestamp;
 
-    public UserTypingEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, @Nonnull MessageChannel channel, @Nonnull OffsetDateTime timestamp, @Nullable Member member)
+    public UserTypingEvent(@NotNull JDA api, long responseNumber, @NotNull User user, @NotNull MessageChannel channel, @NotNull OffsetDateTime timestamp, @Nullable Member member)
     {
         super(api, responseNumber, user);
         this.member = member;
@@ -53,7 +53,7 @@ public class UserTypingEvent extends GenericUserEvent
      *
      * @return The time when the typing started
      */
-    @Nonnull
+    @NotNull
     public OffsetDateTime getTimestamp()
     {
         return timestamp;
@@ -64,7 +64,7 @@ public class UserTypingEvent extends GenericUserEvent
      *
      * @return The channel
      */
-    @Nonnull
+    @NotNull
     public MessageChannel getChannel()
     {
         return channel;
@@ -78,7 +78,7 @@ public class UserTypingEvent extends GenericUserEvent
      *
      * @return True, if the user started typing in a channel of the specified type
      */
-    public boolean isFromType(@Nonnull ChannelType type)
+    public boolean isFromType(@NotNull ChannelType type)
     {
         return channel.getType() == type;
     }
@@ -88,7 +88,7 @@ public class UserTypingEvent extends GenericUserEvent
      *
      * @return The {@link net.dv8tion.jda.api.entities.ChannelType ChannelType}
      */
-    @Nonnull
+    @NotNull
     public ChannelType getType()
     {
         return channel.getType();

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/GenericUserPresenceEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/GenericUserPresenceEvent.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.events.user.update;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.GenericEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the presence of a {@link net.dv8tion.jda.api.entities.User User} has changed.
@@ -47,7 +46,7 @@ public interface GenericUserPresenceEvent extends GenericEvent
      *
      * @return The guild
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -55,6 +54,6 @@ public interface GenericUserPresenceEvent extends GenericEvent
      *
      * @return The member
      */
-    @Nonnull
+    @NotNull
     Member getMember();
 }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/GenericUserUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/GenericUserUpdateEvent.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.UpdateEvent;
 import net.dv8tion.jda.api.events.user.GenericUserEvent;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that a user has updated their presence on discord.
@@ -49,8 +48,8 @@ public abstract class GenericUserUpdateEvent<T> extends GenericUserEvent impleme
     protected final String identifier;
 
     public GenericUserUpdateEvent(
-        @Nonnull JDA api, long responseNumber, @Nonnull User user,
-        @Nullable T previous, @Nullable T next, @Nonnull String identifier)
+        @NotNull JDA api, long responseNumber, @NotNull User user,
+        @Nullable T previous, @Nullable T next, @NotNull String identifier)
     {
         super(api, responseNumber, user);
         this.previous = previous;
@@ -58,14 +57,14 @@ public abstract class GenericUserUpdateEvent<T> extends GenericUserEvent impleme
         this.identifier = identifier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getEntity()
     {
         return getUser();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getPropertyIdentifier()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateActivitiesEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateActivitiesEvent.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -55,20 +55,20 @@ public class UserUpdateActivitiesEvent extends GenericUserUpdateEvent<List<Activ
     public static final String IDENTIFIER = "activities";
     private final Member member;
 
-    public UserUpdateActivitiesEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nullable List<Activity> previous)
+    public UserUpdateActivitiesEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @Nullable List<Activity> previous)
     {
         super(api, responseNumber, member.getUser(), previous, member.getActivities(), IDENTIFIER);
         this.member = member;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return member.getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getMember()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateActivityOrderEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateActivityOrderEvent.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.internal.JDAImpl;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -48,34 +48,34 @@ public class UserUpdateActivityOrderEvent extends GenericUserUpdateEvent<List<Ac
 
     private final Member member;
 
-    public UserUpdateActivityOrderEvent(@Nonnull JDAImpl api, long responseNumber, @Nonnull List<Activity> previous, @Nonnull Member member)
+    public UserUpdateActivityOrderEvent(@NotNull JDAImpl api, long responseNumber, @NotNull List<Activity> previous, @NotNull Member member)
     {
         super(api, responseNumber, member.getUser(), previous, member.getActivities(), IDENTIFIER);
         this.member = member;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return member.getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getMember()
     {
         return member;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Activity> getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Activity> getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateAvatarEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateAvatarEvent.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.events.user.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the Avatar of a {@link net.dv8tion.jda.api.entities.User User} changed.
@@ -44,7 +43,7 @@ public class UserUpdateAvatarEvent extends GenericUserUpdateEvent<String>
 {
     public static final String IDENTIFIER = "avatar";
 
-    public UserUpdateAvatarEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, @Nullable String oldAvatar)
+    public UserUpdateAvatarEvent(@NotNull JDA api, long responseNumber, @NotNull User user, @Nullable String oldAvatar)
     {
         super(api, responseNumber, user, oldAvatar, user.getAvatarId(), IDENTIFIER);
     }

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateDiscriminatorEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateDiscriminatorEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.user.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the discriminator of a {@link net.dv8tion.jda.api.entities.User User} changed.
@@ -43,7 +42,7 @@ public class UserUpdateDiscriminatorEvent extends GenericUserUpdateEvent<String>
 {
     public static final String IDENTIFIER = "discriminator";
 
-    public UserUpdateDiscriminatorEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, @Nonnull String oldDiscriminator)
+    public UserUpdateDiscriminatorEvent(@NotNull JDA api, long responseNumber, @NotNull User user, @NotNull String oldDiscriminator)
     {
         super(api, responseNumber, user, oldDiscriminator, user.getDiscriminator(), IDENTIFIER);
     }
@@ -53,7 +52,7 @@ public class UserUpdateDiscriminatorEvent extends GenericUserUpdateEvent<String>
      *
      * @return The old discriminator
      */
-    @Nonnull
+    @NotNull
     public String getOldDiscriminator()
     {
         return getOldValue();
@@ -64,20 +63,20 @@ public class UserUpdateDiscriminatorEvent extends GenericUserUpdateEvent<String>
      *
      * @return The new discriminator
      */
-    @Nonnull
+    @NotNull
     public String getNewDiscriminator()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateFlagsEvent.java
@@ -17,8 +17,8 @@ package net.dv8tion.jda.api.events.user.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
 /**
@@ -43,7 +43,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
 {
     public static final String IDENTIFIER = "public_flags";
     
-    public UserUpdateFlagsEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, @Nonnull EnumSet<User.UserFlag> oldFlags)
+    public UserUpdateFlagsEvent(@NotNull JDA api, long responseNumber, @NotNull User user, @NotNull EnumSet<User.UserFlag> oldFlags)
     {
         super(api, responseNumber, user, oldFlags, user.getFlags(), IDENTIFIER);
     }
@@ -53,7 +53,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
      * 
      * @return {@link EnumSet} of the old {@link net.dv8tion.jda.api.entities.User.UserFlag UserFlags}
      */
-    @Nonnull
+    @NotNull
     public EnumSet<User.UserFlag> getOldFlags()
     {
         return getOldValue();
@@ -74,7 +74,7 @@ public class UserUpdateFlagsEvent extends GenericUserUpdateEvent<EnumSet<User.Us
      *
      * @return The new {@code EnumSet<{@link net.dv8tion.jda.api.entities.User.UserFlag UserFlag}>} representation of the User's flags.
      */
-    @Nonnull
+    @NotNull
     public EnumSet<User.UserFlag> getNewFlags()
     {
         return getNewValue();

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateNameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateNameEvent.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.events.user.update;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the username of a {@link net.dv8tion.jda.api.entities.User User} changed. (Not Nickname)
@@ -43,7 +42,7 @@ public class UserUpdateNameEvent extends GenericUserUpdateEvent<String>
 {
     public static final String IDENTIFIER = "name";
 
-    public UserUpdateNameEvent(@Nonnull JDA api, long responseNumber, @Nonnull User user, @Nonnull String oldName)
+    public UserUpdateNameEvent(@NotNull JDA api, long responseNumber, @NotNull User user, @NotNull String oldName)
     {
         super(api, responseNumber, user, oldName, user.getName(), IDENTIFIER);
     }
@@ -53,7 +52,7 @@ public class UserUpdateNameEvent extends GenericUserUpdateEvent<String>
      *
      * @return The old username
      */
-    @Nonnull
+    @NotNull
     public String getOldName()
     {
         return getOldValue();
@@ -64,20 +63,20 @@ public class UserUpdateNameEvent extends GenericUserUpdateEvent<String>
      *
      * @return The new username
      */
-    @Nonnull
+    @NotNull
     public String getNewName()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getNewValue()
     {

--- a/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateOnlineStatusEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/user/update/UserUpdateOnlineStatusEvent.java
@@ -20,8 +20,7 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the {@link OnlineStatus OnlineStatus} of a {@link net.dv8tion.jda.api.entities.User User} changed.
@@ -48,21 +47,21 @@ public class UserUpdateOnlineStatusEvent extends GenericUserUpdateEvent<OnlineSt
     private final Guild guild;
     private final Member member;
 
-    public UserUpdateOnlineStatusEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, @Nonnull OnlineStatus oldOnlineStatus)
+    public UserUpdateOnlineStatusEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @NotNull OnlineStatus oldOnlineStatus)
     {
         super(api, responseNumber, member.getUser(), oldOnlineStatus, member.getOnlineStatus(), IDENTIFIER);
         this.guild = member.getGuild();
         this.member = member;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getMember()
     {
@@ -74,7 +73,7 @@ public class UserUpdateOnlineStatusEvent extends GenericUserUpdateEvent<OnlineSt
      *
      * @return The old status
      */
-    @Nonnull
+    @NotNull
     public OnlineStatus getOldOnlineStatus()
     {
         return getOldValue();
@@ -85,20 +84,20 @@ public class UserUpdateOnlineStatusEvent extends GenericUserUpdateEvent<OnlineSt
      *
      * @return The new status
      */
-    @Nonnull
+    @NotNull
     public OnlineStatus getNewOnlineStatus()
     {
         return getNewValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public OnlineStatus getOldValue()
     {
         return super.getOldValue();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public OnlineStatus getNewValue() {
         return super.getNewValue();

--- a/src/main/java/net/dv8tion/jda/api/exceptions/ContextException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ContextException.java
@@ -17,8 +17,8 @@
 package net.dv8tion.jda.api.exceptions;
 
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
 /**
@@ -33,7 +33,7 @@ public class ContextException extends Exception
      *
      * @return Wrapping failure consumer around {@code Throwable::printStackTrace}
      */
-    @Nonnull
+    @NotNull
     public static Consumer<Throwable> herePrintingTrace()
     {
         return here(Throwable::printStackTrace);
@@ -48,8 +48,8 @@ public class ContextException extends Exception
      *
      * @return Wrapper of the provided consumer that will append a context with the current stack-trace
      */
-    @Nonnull
-    public static Consumer<Throwable> here(@Nonnull Consumer<? super Throwable> acceptor)
+    @NotNull
+    public static Consumer<Throwable> here(@NotNull Consumer<? super Throwable> acceptor)
     {
         return new ContextConsumer(new ContextException(), acceptor);
     }

--- a/src/main/java/net/dv8tion/jda/api/exceptions/ErrorHandler.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ErrorHandler.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.api.exceptions;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -73,7 +73,7 @@ public class ErrorHandler implements Consumer<Throwable>
      * @param base
      *        The base {@link Consumer}
      */
-    public ErrorHandler(@Nonnull Consumer<? super Throwable> base)
+    public ErrorHandler(@NotNull Consumer<? super Throwable> base)
     {
         Checks.notNull(base, "Consumer");
         this.base = base;
@@ -103,8 +103,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied ignore cases
      */
-    @Nonnull
-    public ErrorHandler ignore(@Nonnull ErrorResponse ignored, @Nonnull ErrorResponse... errorResponses)
+    @NotNull
+    public ErrorHandler ignore(@NotNull ErrorResponse ignored, @NotNull ErrorResponse... errorResponses)
     {
         Checks.notNull(ignored, "ErrorResponse");
         Checks.noneNull(errorResponses, "ErrorResponse");
@@ -134,8 +134,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied ignore cases
      */
-    @Nonnull
-    public ErrorHandler ignore(@Nonnull Collection<ErrorResponse> errorResponses)
+    @NotNull
+    public ErrorHandler ignore(@NotNull Collection<ErrorResponse> errorResponses)
     {
         return handle(errorResponses, empty);
     }
@@ -163,8 +163,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @see    java.net.SocketTimeoutException
      */
-    @Nonnull
-    public ErrorHandler ignore(@Nonnull Class<?> clazz, @Nonnull Class<?>... classes)
+    @NotNull
+    public ErrorHandler ignore(@NotNull Class<?> clazz, @NotNull Class<?>... classes)
     {
         Checks.notNull(clazz, "Classes");
         Checks.noneNull(classes, "Classes");
@@ -201,8 +201,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @see    ErrorResponseException
      */
-    @Nonnull
-    public ErrorHandler ignore(@Nonnull Predicate<? super Throwable> condition)
+    @NotNull
+    public ErrorHandler ignore(@NotNull Predicate<? super Throwable> condition)
     {
         return handle(condition, empty);
     }
@@ -232,8 +232,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied handler
      */
-    @Nonnull
-    public ErrorHandler handle(@Nonnull ErrorResponse response, @Nonnull Consumer<? super ErrorResponseException> handler)
+    @NotNull
+    public ErrorHandler handle(@NotNull ErrorResponse response, @NotNull Consumer<? super ErrorResponseException> handler)
     {
         Checks.notNull(response, "ErrorResponse");
         return handle(EnumSet.of(response), handler);
@@ -264,8 +264,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied handler
      */
-    @Nonnull
-    public ErrorHandler handle(@Nonnull Collection<ErrorResponse> errorResponses, @Nonnull Consumer<? super ErrorResponseException> handler)
+    @NotNull
+    public ErrorHandler handle(@NotNull Collection<ErrorResponse> errorResponses, @NotNull Consumer<? super ErrorResponseException> handler)
     {
         Checks.notNull(handler, "Handler");
         Checks.noneNull(errorResponses, "ErrorResponse");
@@ -295,8 +295,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied handler
      */
-    @Nonnull
-    public <T> ErrorHandler handle(@Nonnull Class<T> clazz, @Nonnull Consumer<? super T> handler)
+    @NotNull
+    public <T> ErrorHandler handle(@NotNull Class<T> clazz, @NotNull Consumer<? super T> handler)
     {
         Checks.notNull(clazz, "Class");
         Checks.notNull(handler, "Handler");
@@ -329,8 +329,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied handler
      */
-    @Nonnull
-    public <T> ErrorHandler handle(@Nonnull Class<T> clazz, @Nonnull Predicate<? super T> condition, @Nonnull Consumer<? super T> handler)
+    @NotNull
+    public <T> ErrorHandler handle(@NotNull Class<T> clazz, @NotNull Predicate<? super T> condition, @NotNull Consumer<? super T> handler)
     {
         Checks.notNull(clazz, "Class");
         Checks.notNull(handler, "Handler");
@@ -362,8 +362,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied handler
      */
-    @Nonnull
-    public ErrorHandler handle(@Nonnull Collection<Class<?>> clazz, @Nullable Predicate<? super Throwable> condition, @Nonnull Consumer<? super Throwable> handler)
+    @NotNull
+    public ErrorHandler handle(@NotNull Collection<Class<?>> clazz, @Nullable Predicate<? super Throwable> condition, @NotNull Consumer<? super Throwable> handler)
     {
         Checks.noneNull(clazz, "Class");
         Checks.notNull(handler, "Handler");
@@ -392,8 +392,8 @@ public class ErrorHandler implements Consumer<Throwable>
      *
      * @return This ErrorHandler with the applied handler
      */
-    @Nonnull
-    public ErrorHandler handle(@Nonnull Predicate<? super Throwable> condition, @Nonnull Consumer<? super Throwable> handler)
+    @NotNull
+    public ErrorHandler handle(@NotNull Predicate<? super Throwable> condition, @NotNull Consumer<? super Throwable> handler)
     {
         Checks.notNull(condition, "Condition");
         Checks.notNull(handler, "Handler");

--- a/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
@@ -24,8 +24,8 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -128,7 +128,7 @@ public class ErrorResponseException extends RuntimeException
      *
      * @return Possibly-empty list of {@link SchemaError SchemaError}
      */
-    @Nonnull
+    @NotNull
     public List<SchemaError> getSchemaErrors()
     {
         return schemaErrors;
@@ -246,8 +246,8 @@ public class ErrorResponseException extends RuntimeException
      * @return {@link Consumer} decorator for {@link RestAction#getDefaultFailure()}
      *         which ignores the specified {@link ErrorResponse ErrorResponses}
      */
-    @Nonnull
-    public static Consumer<Throwable> ignore(@Nonnull Collection<ErrorResponse> set)
+    @NotNull
+    public static Consumer<Throwable> ignore(@NotNull Collection<ErrorResponse> set)
     {
         return ignore(RestAction.getDefaultFailure(), set);
     }
@@ -276,8 +276,8 @@ public class ErrorResponseException extends RuntimeException
      * @return {@link Consumer} decorator for {@link RestAction#getDefaultFailure()}
      *         which ignores the specified {@link ErrorResponse ErrorResponses}
      */
-    @Nonnull
-    public static Consumer<Throwable> ignore(@Nonnull ErrorResponse ignored, @Nonnull ErrorResponse... errorResponses)
+    @NotNull
+    public static Consumer<Throwable> ignore(@NotNull ErrorResponse ignored, @NotNull ErrorResponse... errorResponses)
     {
         return ignore(RestAction.getDefaultFailure(), ignored, errorResponses);
     }
@@ -308,8 +308,8 @@ public class ErrorResponseException extends RuntimeException
      * @return {@link Consumer} decorator for the provided callback
      *         which ignores the specified {@link ErrorResponse ErrorResponses}
      */
-    @Nonnull
-    public static Consumer<Throwable> ignore(@Nonnull Consumer<? super Throwable> orElse, @Nonnull ErrorResponse ignored, @Nonnull ErrorResponse... errorResponses)
+    @NotNull
+    public static Consumer<Throwable> ignore(@NotNull Consumer<? super Throwable> orElse, @NotNull ErrorResponse ignored, @NotNull ErrorResponse... errorResponses)
     {
         return ignore(orElse, EnumSet.of(ignored, errorResponses));
     }
@@ -338,8 +338,8 @@ public class ErrorResponseException extends RuntimeException
      * @return {@link Consumer} decorator for the provided callback
      *         which ignores the specified {@link ErrorResponse ErrorResponses}
      */
-    @Nonnull
-    public static Consumer<Throwable> ignore(@Nonnull Consumer<? super Throwable> orElse, @Nonnull Collection<ErrorResponse> set)
+    @NotNull
+    public static Consumer<Throwable> ignore(@NotNull Consumer<? super Throwable> orElse, @NotNull Collection<ErrorResponse> set)
     {
         Checks.notNull(orElse, "Callback");
         Checks.notEmpty(set, "Ignored collection");
@@ -368,7 +368,7 @@ public class ErrorResponseException extends RuntimeException
          *
          * @return The error code
          */
-        @Nonnull
+        @NotNull
         public String getCode()
         {
             return code;
@@ -379,7 +379,7 @@ public class ErrorResponseException extends RuntimeException
          *
          * @return The message
          */
-        @Nonnull
+        @NotNull
         public String getMessage()
         {
             return message;
@@ -415,7 +415,7 @@ public class ErrorResponseException extends RuntimeException
          *
          * @return The JSON-path location
          */
-        @Nonnull
+        @NotNull
         public String getLocation()
         {
             return location;
@@ -426,7 +426,7 @@ public class ErrorResponseException extends RuntimeException
          *
          * @return The error codes
          */
-        @Nonnull
+        @NotNull
         public List<ErrorCode> getErrors()
         {
             return errors;

--- a/src/main/java/net/dv8tion/jda/api/exceptions/InsufficientPermissionException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/InsufficientPermissionException.java
@@ -22,9 +22,8 @@ import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.internal.utils.Checks;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Indicates that the user is missing a {@link Permission} for some action.
@@ -38,27 +37,27 @@ public class InsufficientPermissionException extends PermissionException
     private final long channelId;
     private final ChannelType channelType;
 
-    public InsufficientPermissionException(@Nonnull Guild guild, @Nonnull Permission permission)
+    public InsufficientPermissionException(@NotNull Guild guild, @NotNull Permission permission)
     {
         this(guild, null, permission);
     }
 
-    public InsufficientPermissionException(@Nonnull Guild guild, @Nonnull Permission permission, @Nonnull String reason)
+    public InsufficientPermissionException(@NotNull Guild guild, @NotNull Permission permission, @NotNull String reason)
     {
         this(guild, null, permission, reason);
     }
 
-    public InsufficientPermissionException(@Nonnull GuildChannel channel, @Nonnull Permission permission)
+    public InsufficientPermissionException(@NotNull GuildChannel channel, @NotNull Permission permission)
     {
         this(channel.getGuild(), channel, permission);
     }
 
-    public InsufficientPermissionException(@Nonnull GuildChannel channel, @Nonnull Permission permission, @Nonnull String reason)
+    public InsufficientPermissionException(@NotNull GuildChannel channel, @NotNull Permission permission, @NotNull String reason)
     {
         this(channel.getGuild(), channel, permission, reason);
     }
 
-    private InsufficientPermissionException(@Nonnull Guild guild, @Nullable GuildChannel channel, @Nonnull Permission permission)
+    private InsufficientPermissionException(@NotNull Guild guild, @Nullable GuildChannel channel, @NotNull Permission permission)
     {
         super(permission, "Cannot perform action due to a lack of Permission. Missing permission: " + permission.toString());
         this.guildId = guild.getIdLong();
@@ -66,7 +65,7 @@ public class InsufficientPermissionException extends PermissionException
         this.channelType = channel == null ? ChannelType.UNKNOWN : channel.getType();
     }
 
-    private InsufficientPermissionException(@Nonnull Guild guild, @Nullable GuildChannel channel, @Nonnull Permission permission, @Nonnull String reason)
+    private InsufficientPermissionException(@NotNull Guild guild, @Nullable GuildChannel channel, @NotNull Permission permission, @NotNull String reason)
     {
         super(permission, reason);
         this.guildId = guild.getIdLong();
@@ -109,7 +108,7 @@ public class InsufficientPermissionException extends PermissionException
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     public ChannelType getChannelType()
     {
         return channelType;
@@ -129,7 +128,7 @@ public class InsufficientPermissionException extends PermissionException
      * @return The Guild instance or null
      */
     @Nullable
-    public Guild getGuild(@Nonnull JDA api)
+    public Guild getGuild(@NotNull JDA api)
     {
         Checks.notNull(api, "JDA");
         return api.getGuildById(guildId);
@@ -149,7 +148,7 @@ public class InsufficientPermissionException extends PermissionException
      * @return The GuildChannel instance or null
      */
     @Nullable
-    public GuildChannel getChannel(@Nonnull JDA api)
+    public GuildChannel getChannel(@NotNull JDA api)
     {
         Checks.notNull(api, "JDA");
         return api.getGuildChannelById(channelType, channelId);

--- a/src/main/java/net/dv8tion/jda/api/exceptions/MissingAccessException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/MissingAccessException.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.exceptions;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.GuildChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicates that the user is missing the {@link Permission#VIEW_CHANNEL VIEW_CHANNEL}
@@ -31,12 +30,12 @@ import javax.annotation.Nonnull;
  */
 public class MissingAccessException extends InsufficientPermissionException
 {
-    public MissingAccessException(@Nonnull GuildChannel channel, @Nonnull Permission permission)
+    public MissingAccessException(@NotNull GuildChannel channel, @NotNull Permission permission)
     {
         super(channel, permission);
     }
 
-    public MissingAccessException(@Nonnull GuildChannel channel, @Nonnull Permission permission, @Nonnull String reason)
+    public MissingAccessException(@NotNull GuildChannel channel, @NotNull Permission permission, @NotNull String reason)
     {
         super(channel, permission, reason);
     }

--- a/src/main/java/net/dv8tion/jda/api/hooks/AnnotatedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/AnnotatedEventManager.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.hooks;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.ClassWalker;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -55,7 +55,7 @@ public class AnnotatedEventManager implements IEventManager
     private final Map<Class<?>, Map<Object, List<Method>>> methods = new ConcurrentHashMap<>();
 
     @Override
-    public void register(@Nonnull Object listener)
+    public void register(@NotNull Object listener)
     {
         if (listeners.add(listener))
         {
@@ -64,7 +64,7 @@ public class AnnotatedEventManager implements IEventManager
     }
 
     @Override
-    public void unregister(@Nonnull Object listener)
+    public void unregister(@NotNull Object listener)
     {
         if (listeners.remove(listener))
         {
@@ -72,7 +72,7 @@ public class AnnotatedEventManager implements IEventManager
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Object> getRegisteredListeners()
     {
@@ -80,7 +80,7 @@ public class AnnotatedEventManager implements IEventManager
     }
 
     @Override
-    public void handle(@Nonnull GenericEvent event)
+    public void handle(@NotNull GenericEvent event)
     {
         for (Class<?> eventClass : ClassWalker.walk(event.getClass()))
         {

--- a/src/main/java/net/dv8tion/jda/api/hooks/EventListener.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/EventListener.java
@@ -16,8 +16,7 @@
 package net.dv8tion.jda.api.hooks;
 
 import net.dv8tion.jda.api.events.GenericEvent;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * JDA pushes {@link net.dv8tion.jda.api.events.GenericEvent GenericEvents} to the registered EventListeners.
@@ -47,5 +46,5 @@ public interface EventListener
      * @param  event
      *         The Event to handle.
      */
-    void onEvent(@Nonnull GenericEvent event);
+    void onEvent(@NotNull GenericEvent event);
 }

--- a/src/main/java/net/dv8tion/jda/api/hooks/IEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/IEventManager.java
@@ -16,8 +16,8 @@
 package net.dv8tion.jda.api.hooks;
 
 import net.dv8tion.jda.api.events.GenericEvent;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
@@ -55,7 +55,7 @@ public interface IEventManager
      * @throws java.lang.UnsupportedOperationException
      *         If the implementation does not support this method
      */
-    void register(@Nonnull Object listener);
+    void register(@NotNull Object listener);
 
     /**
      * Removes the specified listener
@@ -66,7 +66,7 @@ public interface IEventManager
      * @throws java.lang.UnsupportedOperationException
      *         If the implementation does not support this method
      */
-    void unregister(@Nonnull Object listener);
+    void unregister(@NotNull Object listener);
 
     /**
      * Handles the provided {@link net.dv8tion.jda.api.events.GenericEvent GenericEvent}.
@@ -77,7 +77,7 @@ public interface IEventManager
      * @param event
      *        The event to handle
      */
-    void handle(@Nonnull GenericEvent event);
+    void handle(@NotNull GenericEvent event);
 
     /**
      * The currently registered listeners
@@ -87,6 +87,6 @@ public interface IEventManager
      *
      * @return A list of listeners that have already been registered
      */
-    @Nonnull
+    @NotNull
     List<Object> getRegisteredListeners();
 }

--- a/src/main/java/net/dv8tion/jda/api/hooks/InterfacedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/InterfacedEventManager.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.hooks;
 import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,7 +55,7 @@ public class InterfacedEventManager implements IEventManager
      *         If the provided listener does not implement {@link net.dv8tion.jda.api.hooks.EventListener EventListener}
      */
     @Override
-    public void register(@Nonnull Object listener)
+    public void register(@NotNull Object listener)
     {
         if (!(listener instanceof EventListener))
         {
@@ -65,7 +65,7 @@ public class InterfacedEventManager implements IEventManager
     }
 
     @Override
-    public void unregister(@Nonnull Object listener)
+    public void unregister(@NotNull Object listener)
     {
         if (!(listener instanceof EventListener))
         {
@@ -79,7 +79,7 @@ public class InterfacedEventManager implements IEventManager
         listeners.remove(listener);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Object> getRegisteredListeners()
     {
@@ -87,7 +87,7 @@ public class InterfacedEventManager implements IEventManager
     }
 
     @Override
-    public void handle(@Nonnull GenericEvent event)
+    public void handle(@NotNull GenericEvent event)
     {
         for (EventListener listener : listeners)
         {

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -84,8 +84,8 @@ import net.dv8tion.jda.api.events.user.UserActivityStartEvent;
 import net.dv8tion.jda.api.events.user.UserTypingEvent;
 import net.dv8tion.jda.api.events.user.update.*;
 import net.dv8tion.jda.internal.utils.ClassWalker;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -127,146 +127,146 @@ public abstract class ListenerAdapter implements EventListener
     @ForRemoval
     @DeprecatedSince("4.2.0")
     @ReplaceWith("onPermissionOverrideUpdate(), onPermissionOverrideCreate(), and onPermissionOverrideDelete()")
-    public void onTextChannelUpdatePermissions(@Nonnull TextChannelUpdatePermissionsEvent event) {}
+    public void onTextChannelUpdatePermissions(@NotNull TextChannelUpdatePermissionsEvent event) {}
 
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
     @ReplaceWith("onPermissionOverrideUpdate(), onPermissionOverrideCreate(), and onPermissionOverrideDelete()")
-    public void onStoreChannelUpdatePermissions(@Nonnull StoreChannelUpdatePermissionsEvent event) {}
+    public void onStoreChannelUpdatePermissions(@NotNull StoreChannelUpdatePermissionsEvent event) {}
 
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
     @ReplaceWith("onPermissionOverrideUpdate(), onPermissionOverrideCreate(), and onPermissionOverrideDelete()")
-    public void onVoiceChannelUpdatePermissions(@Nonnull VoiceChannelUpdatePermissionsEvent event) {}
+    public void onVoiceChannelUpdatePermissions(@NotNull VoiceChannelUpdatePermissionsEvent event) {}
 
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
     @ReplaceWith("onPermissionOverrideUpdate(), onPermissionOverrideCreate(), and onPermissionOverrideDelete()")
-    public void onCategoryUpdatePermissions(@Nonnull CategoryUpdatePermissionsEvent event) {}
+    public void onCategoryUpdatePermissions(@NotNull CategoryUpdatePermissionsEvent event) {}
 
     @Deprecated
     @DeprecatedSince("4.2.0")
     @ReplaceWith("onGuildMemberRemove(GuildMemberRemoveEvent)")
-    public void onGuildMemberLeave(@Nonnull GuildMemberLeaveEvent event) {}
+    public void onGuildMemberLeave(@NotNull GuildMemberLeaveEvent event) {}
 
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    public void onSelfUpdateEmail(@Nonnull SelfUpdateEmailEvent event) {}
+    public void onSelfUpdateEmail(@NotNull SelfUpdateEmailEvent event) {}
 
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.1")
     @ReplaceWith("onResumed(ResumedEvent)")
-    public void onResume(@Nonnull ResumedEvent event) {}
+    public void onResume(@NotNull ResumedEvent event) {}
 
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.1")
     @ReplaceWith("onReconnected(ReconnectedEvent)")
-    public void onReconnect(@Nonnull ReconnectedEvent event) {}
+    public void onReconnect(@NotNull ReconnectedEvent event) {}
 
-    public void onGenericEvent(@Nonnull GenericEvent event) {}
-    public void onGenericUpdate(@Nonnull UpdateEvent<?, ?> event) {}
-    public void onRawGateway(@Nonnull RawGatewayEvent event) {}
-    public void onGatewayPing(@Nonnull GatewayPingEvent event) {}
+    public void onGenericEvent(@NotNull GenericEvent event) {}
+    public void onGenericUpdate(@NotNull UpdateEvent<?, ?> event) {}
+    public void onRawGateway(@NotNull RawGatewayEvent event) {}
+    public void onGatewayPing(@NotNull GatewayPingEvent event) {}
 
     //JDA Events
-    public void onReady(@Nonnull ReadyEvent event) {}
-    public void onResumed(@Nonnull ResumedEvent event) {}
-    public void onReconnected(@Nonnull ReconnectedEvent event) {}
-    public void onDisconnect(@Nonnull DisconnectEvent event) {}
-    public void onShutdown(@Nonnull ShutdownEvent event) {}
-    public void onStatusChange(@Nonnull StatusChangeEvent event) {}
-    public void onException(@Nonnull ExceptionEvent event) {}
+    public void onReady(@NotNull ReadyEvent event) {}
+    public void onResumed(@NotNull ResumedEvent event) {}
+    public void onReconnected(@NotNull ReconnectedEvent event) {}
+    public void onDisconnect(@NotNull DisconnectEvent event) {}
+    public void onShutdown(@NotNull ShutdownEvent event) {}
+    public void onStatusChange(@NotNull StatusChangeEvent event) {}
+    public void onException(@NotNull ExceptionEvent event) {}
 
     //User Events
-    public void onUserUpdateName(@Nonnull UserUpdateNameEvent event) {}
-    public void onUserUpdateDiscriminator(@Nonnull UserUpdateDiscriminatorEvent event) {}
-    public void onUserUpdateAvatar(@Nonnull UserUpdateAvatarEvent event) {}
-    public void onUserUpdateOnlineStatus(@Nonnull UserUpdateOnlineStatusEvent event) {}
-    public void onUserUpdateActivityOrder(@Nonnull UserUpdateActivityOrderEvent event) {}
-    public void onUserUpdateFlags(@Nonnull UserUpdateFlagsEvent event) {}
-    public void onUserTyping(@Nonnull UserTypingEvent event) {}
-    public void onUserActivityStart(@Nonnull UserActivityStartEvent event) {}
-    public void onUserActivityEnd(@Nonnull UserActivityEndEvent event) {}
-    public void onUserUpdateActivities(@Nonnull UserUpdateActivitiesEvent event) {}
+    public void onUserUpdateName(@NotNull UserUpdateNameEvent event) {}
+    public void onUserUpdateDiscriminator(@NotNull UserUpdateDiscriminatorEvent event) {}
+    public void onUserUpdateAvatar(@NotNull UserUpdateAvatarEvent event) {}
+    public void onUserUpdateOnlineStatus(@NotNull UserUpdateOnlineStatusEvent event) {}
+    public void onUserUpdateActivityOrder(@NotNull UserUpdateActivityOrderEvent event) {}
+    public void onUserUpdateFlags(@NotNull UserUpdateFlagsEvent event) {}
+    public void onUserTyping(@NotNull UserTypingEvent event) {}
+    public void onUserActivityStart(@NotNull UserActivityStartEvent event) {}
+    public void onUserActivityEnd(@NotNull UserActivityEndEvent event) {}
+    public void onUserUpdateActivities(@NotNull UserUpdateActivitiesEvent event) {}
 
     //Self Events. Fires only in relation to the currently logged in account.
-    public void onSelfUpdateAvatar(@Nonnull SelfUpdateAvatarEvent event) {}
-    public void onSelfUpdateMFA(@Nonnull SelfUpdateMFAEvent event) {}
-    public void onSelfUpdateName(@Nonnull SelfUpdateNameEvent event) {}
-    public void onSelfUpdateVerified(@Nonnull SelfUpdateVerifiedEvent event) {}
+    public void onSelfUpdateAvatar(@NotNull SelfUpdateAvatarEvent event) {}
+    public void onSelfUpdateMFA(@NotNull SelfUpdateMFAEvent event) {}
+    public void onSelfUpdateName(@NotNull SelfUpdateNameEvent event) {}
+    public void onSelfUpdateVerified(@NotNull SelfUpdateVerifiedEvent event) {}
 
     //Message Events
     //Guild (TextChannel) Message Events
-    public void onGuildMessageReceived(@Nonnull GuildMessageReceivedEvent event) {}
-    public void onGuildMessageUpdate(@Nonnull GuildMessageUpdateEvent event) {}
-    public void onGuildMessageDelete(@Nonnull GuildMessageDeleteEvent event) {}
-    public void onGuildMessageEmbed(@Nonnull GuildMessageEmbedEvent event) {}
-    public void onGuildMessageReactionAdd(@Nonnull GuildMessageReactionAddEvent event) {}
-    public void onGuildMessageReactionRemove(@Nonnull GuildMessageReactionRemoveEvent event) {}
-    public void onGuildMessageReactionRemoveAll(@Nonnull GuildMessageReactionRemoveAllEvent event) {}
-    public void onGuildMessageReactionRemoveEmote(@Nonnull GuildMessageReactionRemoveEmoteEvent event) {}
+    public void onGuildMessageReceived(@NotNull GuildMessageReceivedEvent event) {}
+    public void onGuildMessageUpdate(@NotNull GuildMessageUpdateEvent event) {}
+    public void onGuildMessageDelete(@NotNull GuildMessageDeleteEvent event) {}
+    public void onGuildMessageEmbed(@NotNull GuildMessageEmbedEvent event) {}
+    public void onGuildMessageReactionAdd(@NotNull GuildMessageReactionAddEvent event) {}
+    public void onGuildMessageReactionRemove(@NotNull GuildMessageReactionRemoveEvent event) {}
+    public void onGuildMessageReactionRemoveAll(@NotNull GuildMessageReactionRemoveAllEvent event) {}
+    public void onGuildMessageReactionRemoveEmote(@NotNull GuildMessageReactionRemoveEmoteEvent event) {}
 
     //Private Message Events
-    public void onPrivateMessageReceived(@Nonnull PrivateMessageReceivedEvent event) {}
-    public void onPrivateMessageUpdate(@Nonnull PrivateMessageUpdateEvent event) {}
-    public void onPrivateMessageDelete(@Nonnull PrivateMessageDeleteEvent event) {}
-    public void onPrivateMessageEmbed(@Nonnull PrivateMessageEmbedEvent event) {}
-    public void onPrivateMessageReactionAdd(@Nonnull PrivateMessageReactionAddEvent event) {}
-    public void onPrivateMessageReactionRemove(@Nonnull PrivateMessageReactionRemoveEvent event) {}
+    public void onPrivateMessageReceived(@NotNull PrivateMessageReceivedEvent event) {}
+    public void onPrivateMessageUpdate(@NotNull PrivateMessageUpdateEvent event) {}
+    public void onPrivateMessageDelete(@NotNull PrivateMessageDeleteEvent event) {}
+    public void onPrivateMessageEmbed(@NotNull PrivateMessageEmbedEvent event) {}
+    public void onPrivateMessageReactionAdd(@NotNull PrivateMessageReactionAddEvent event) {}
+    public void onPrivateMessageReactionRemove(@NotNull PrivateMessageReactionRemoveEvent event) {}
 
     //Combined Message Events (Combines Guild and Private message into 1 event)
-    public void onMessageReceived(@Nonnull MessageReceivedEvent event) {}
-    public void onMessageUpdate(@Nonnull MessageUpdateEvent event) {}
-    public void onMessageDelete(@Nonnull MessageDeleteEvent event) {}
-    public void onMessageBulkDelete(@Nonnull MessageBulkDeleteEvent event) {}
-    public void onMessageEmbed(@Nonnull MessageEmbedEvent event) {}
-    public void onMessageReactionAdd(@Nonnull MessageReactionAddEvent event) {}
-    public void onMessageReactionRemove(@Nonnull MessageReactionRemoveEvent event) {}
-    public void onMessageReactionRemoveAll(@Nonnull MessageReactionRemoveAllEvent event) {}
-    public void onMessageReactionRemoveEmote(@Nonnull MessageReactionRemoveEmoteEvent event) {}
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {}
+    public void onMessageUpdate(@NotNull MessageUpdateEvent event) {}
+    public void onMessageDelete(@NotNull MessageDeleteEvent event) {}
+    public void onMessageBulkDelete(@NotNull MessageBulkDeleteEvent event) {}
+    public void onMessageEmbed(@NotNull MessageEmbedEvent event) {}
+    public void onMessageReactionAdd(@NotNull MessageReactionAddEvent event) {}
+    public void onMessageReactionRemove(@NotNull MessageReactionRemoveEvent event) {}
+    public void onMessageReactionRemoveAll(@NotNull MessageReactionRemoveAllEvent event) {}
+    public void onMessageReactionRemoveEmote(@NotNull MessageReactionRemoveEmoteEvent event) {}
 
     //PermissionOverride Events
-    public void onPermissionOverrideDelete(@Nonnull PermissionOverrideDeleteEvent event) {}
-    public void onPermissionOverrideUpdate(@Nonnull PermissionOverrideUpdateEvent event) {}
-    public void onPermissionOverrideCreate(@Nonnull PermissionOverrideCreateEvent event) {}
+    public void onPermissionOverrideDelete(@NotNull PermissionOverrideDeleteEvent event) {}
+    public void onPermissionOverrideUpdate(@NotNull PermissionOverrideUpdateEvent event) {}
+    public void onPermissionOverrideCreate(@NotNull PermissionOverrideCreateEvent event) {}
 
     //StoreChannel Events
-    public void onStoreChannelDelete(@Nonnull StoreChannelDeleteEvent event) {}
-    public void onStoreChannelUpdateName(@Nonnull StoreChannelUpdateNameEvent event) {}
-    public void onStoreChannelUpdatePosition(@Nonnull StoreChannelUpdatePositionEvent event) {}
-    public void onStoreChannelCreate(@Nonnull StoreChannelCreateEvent event) {}
+    public void onStoreChannelDelete(@NotNull StoreChannelDeleteEvent event) {}
+    public void onStoreChannelUpdateName(@NotNull StoreChannelUpdateNameEvent event) {}
+    public void onStoreChannelUpdatePosition(@NotNull StoreChannelUpdatePositionEvent event) {}
+    public void onStoreChannelCreate(@NotNull StoreChannelCreateEvent event) {}
 
     //TextChannel Events
-    public void onTextChannelDelete(@Nonnull TextChannelDeleteEvent event) {}
-    public void onTextChannelUpdateName(@Nonnull TextChannelUpdateNameEvent event) {}
-    public void onTextChannelUpdateTopic(@Nonnull TextChannelUpdateTopicEvent event) {}
-    public void onTextChannelUpdatePosition(@Nonnull TextChannelUpdatePositionEvent event) {}
-    public void onTextChannelUpdateNSFW(@Nonnull TextChannelUpdateNSFWEvent event) {}
-    public void onTextChannelUpdateParent(@Nonnull TextChannelUpdateParentEvent event) {}
-    public void onTextChannelUpdateSlowmode(@Nonnull TextChannelUpdateSlowmodeEvent event) {}
-    public void onTextChannelUpdateNews(@Nonnull TextChannelUpdateNewsEvent event) {}
-    public void onTextChannelCreate(@Nonnull TextChannelCreateEvent event) {}
+    public void onTextChannelDelete(@NotNull TextChannelDeleteEvent event) {}
+    public void onTextChannelUpdateName(@NotNull TextChannelUpdateNameEvent event) {}
+    public void onTextChannelUpdateTopic(@NotNull TextChannelUpdateTopicEvent event) {}
+    public void onTextChannelUpdatePosition(@NotNull TextChannelUpdatePositionEvent event) {}
+    public void onTextChannelUpdateNSFW(@NotNull TextChannelUpdateNSFWEvent event) {}
+    public void onTextChannelUpdateParent(@NotNull TextChannelUpdateParentEvent event) {}
+    public void onTextChannelUpdateSlowmode(@NotNull TextChannelUpdateSlowmodeEvent event) {}
+    public void onTextChannelUpdateNews(@NotNull TextChannelUpdateNewsEvent event) {}
+    public void onTextChannelCreate(@NotNull TextChannelCreateEvent event) {}
 
     //VoiceChannel Events
-    public void onVoiceChannelDelete(@Nonnull VoiceChannelDeleteEvent event) {}
-    public void onVoiceChannelUpdateName(@Nonnull VoiceChannelUpdateNameEvent event) {}
-    public void onVoiceChannelUpdatePosition(@Nonnull VoiceChannelUpdatePositionEvent event) {}
-    public void onVoiceChannelUpdateUserLimit(@Nonnull VoiceChannelUpdateUserLimitEvent event) {}
-    public void onVoiceChannelUpdateBitrate(@Nonnull VoiceChannelUpdateBitrateEvent event) {}
-    public void onVoiceChannelUpdateParent(@Nonnull VoiceChannelUpdateParentEvent event) {}
-    public void onVoiceChannelCreate(@Nonnull VoiceChannelCreateEvent event) {}
+    public void onVoiceChannelDelete(@NotNull VoiceChannelDeleteEvent event) {}
+    public void onVoiceChannelUpdateName(@NotNull VoiceChannelUpdateNameEvent event) {}
+    public void onVoiceChannelUpdatePosition(@NotNull VoiceChannelUpdatePositionEvent event) {}
+    public void onVoiceChannelUpdateUserLimit(@NotNull VoiceChannelUpdateUserLimitEvent event) {}
+    public void onVoiceChannelUpdateBitrate(@NotNull VoiceChannelUpdateBitrateEvent event) {}
+    public void onVoiceChannelUpdateParent(@NotNull VoiceChannelUpdateParentEvent event) {}
+    public void onVoiceChannelCreate(@NotNull VoiceChannelCreateEvent event) {}
 
     //Category Events
-    public void onCategoryDelete(@Nonnull CategoryDeleteEvent event) {}
-    public void onCategoryUpdateName(@Nonnull CategoryUpdateNameEvent event) {}
-    public void onCategoryUpdatePosition(@Nonnull CategoryUpdatePositionEvent event) {}
-    public void onCategoryCreate(@Nonnull CategoryCreateEvent event) {}
+    public void onCategoryDelete(@NotNull CategoryDeleteEvent event) {}
+    public void onCategoryUpdateName(@NotNull CategoryUpdateNameEvent event) {}
+    public void onCategoryUpdatePosition(@NotNull CategoryUpdatePositionEvent event) {}
+    public void onCategoryCreate(@NotNull CategoryCreateEvent event) {}
 
     //PrivateChannel Events
 
@@ -276,131 +276,131 @@ public abstract class ListenerAdapter implements EventListener
     @Deprecated
     @ForRemoval(deadline = "4.4.0")
     @DeprecatedSince("4.3.0")
-    public void onPrivateChannelCreate(@Nonnull PrivateChannelCreateEvent event) {}
+    public void onPrivateChannelCreate(@NotNull PrivateChannelCreateEvent event) {}
     @Deprecated
     @ForRemoval(deadline = "4.4.0")
     @DeprecatedSince("4.3.0")
-    public void onPrivateChannelDelete(@Nonnull PrivateChannelDeleteEvent event) {}
+    public void onPrivateChannelDelete(@NotNull PrivateChannelDeleteEvent event) {}
 
     //Guild Events
-    public void onGuildReady(@Nonnull GuildReadyEvent event) {}
-    public void onGuildTimeout(@Nonnull GuildTimeoutEvent event) {}
-    public void onGuildJoin(@Nonnull GuildJoinEvent event) {}
-    public void onGuildLeave(@Nonnull GuildLeaveEvent event) {}
-    public void onGuildAvailable(@Nonnull GuildAvailableEvent event) {}
-    public void onGuildUnavailable(@Nonnull GuildUnavailableEvent event) {}
-    public void onUnavailableGuildJoined(@Nonnull UnavailableGuildJoinedEvent event) {}
-    public void onUnavailableGuildLeave(@Nonnull UnavailableGuildLeaveEvent event) {}
-    public void onGuildBan(@Nonnull GuildBanEvent event) {}
-    public void onGuildUnban(@Nonnull GuildUnbanEvent event) {}
-    public void onGuildMemberRemove(@Nonnull GuildMemberRemoveEvent event) {}
+    public void onGuildReady(@NotNull GuildReadyEvent event) {}
+    public void onGuildTimeout(@NotNull GuildTimeoutEvent event) {}
+    public void onGuildJoin(@NotNull GuildJoinEvent event) {}
+    public void onGuildLeave(@NotNull GuildLeaveEvent event) {}
+    public void onGuildAvailable(@NotNull GuildAvailableEvent event) {}
+    public void onGuildUnavailable(@NotNull GuildUnavailableEvent event) {}
+    public void onUnavailableGuildJoined(@NotNull UnavailableGuildJoinedEvent event) {}
+    public void onUnavailableGuildLeave(@NotNull UnavailableGuildLeaveEvent event) {}
+    public void onGuildBan(@NotNull GuildBanEvent event) {}
+    public void onGuildUnban(@NotNull GuildUnbanEvent event) {}
+    public void onGuildMemberRemove(@NotNull GuildMemberRemoveEvent event) {}
 
     //Guild Update Events
-    public void onGuildUpdateAfkChannel(@Nonnull GuildUpdateAfkChannelEvent event) {}
-    public void onGuildUpdateSystemChannel(@Nonnull GuildUpdateSystemChannelEvent event) {}
-    public void onGuildUpdateRulesChannel(@Nonnull GuildUpdateRulesChannelEvent event) {}
-    public void onGuildUpdateCommunityUpdatesChannel(@Nonnull GuildUpdateCommunityUpdatesChannelEvent event) {}
-    public void onGuildUpdateAfkTimeout(@Nonnull GuildUpdateAfkTimeoutEvent event) {}
-    public void onGuildUpdateExplicitContentLevel(@Nonnull GuildUpdateExplicitContentLevelEvent event) {}
-    public void onGuildUpdateIcon(@Nonnull GuildUpdateIconEvent event) {}
-    public void onGuildUpdateMFALevel(@Nonnull GuildUpdateMFALevelEvent event) {}
-    public void onGuildUpdateName(@Nonnull GuildUpdateNameEvent event){}
-    public void onGuildUpdateNotificationLevel(@Nonnull GuildUpdateNotificationLevelEvent event) {}
-    public void onGuildUpdateOwner(@Nonnull GuildUpdateOwnerEvent event) {}
-    public void onGuildUpdateRegion(@Nonnull GuildUpdateRegionEvent event) {}
-    public void onGuildUpdateSplash(@Nonnull GuildUpdateSplashEvent event) {}
-    public void onGuildUpdateVerificationLevel(@Nonnull GuildUpdateVerificationLevelEvent event) {}
-    public void onGuildUpdateLocale(@Nonnull GuildUpdateLocaleEvent event) {}
-    public void onGuildUpdateFeatures(@Nonnull GuildUpdateFeaturesEvent event) {}
-    public void onGuildUpdateVanityCode(@Nonnull GuildUpdateVanityCodeEvent event) {}
-    public void onGuildUpdateBanner(@Nonnull GuildUpdateBannerEvent event) {}
-    public void onGuildUpdateDescription(@Nonnull GuildUpdateDescriptionEvent event) {}
-    public void onGuildUpdateBoostTier(@Nonnull GuildUpdateBoostTierEvent event) {}
-    public void onGuildUpdateBoostCount(@Nonnull GuildUpdateBoostCountEvent event) {}
-    public void onGuildUpdateMaxMembers(@Nonnull GuildUpdateMaxMembersEvent event) {}
-    public void onGuildUpdateMaxPresences(@Nonnull GuildUpdateMaxPresencesEvent event) {}
+    public void onGuildUpdateAfkChannel(@NotNull GuildUpdateAfkChannelEvent event) {}
+    public void onGuildUpdateSystemChannel(@NotNull GuildUpdateSystemChannelEvent event) {}
+    public void onGuildUpdateRulesChannel(@NotNull GuildUpdateRulesChannelEvent event) {}
+    public void onGuildUpdateCommunityUpdatesChannel(@NotNull GuildUpdateCommunityUpdatesChannelEvent event) {}
+    public void onGuildUpdateAfkTimeout(@NotNull GuildUpdateAfkTimeoutEvent event) {}
+    public void onGuildUpdateExplicitContentLevel(@NotNull GuildUpdateExplicitContentLevelEvent event) {}
+    public void onGuildUpdateIcon(@NotNull GuildUpdateIconEvent event) {}
+    public void onGuildUpdateMFALevel(@NotNull GuildUpdateMFALevelEvent event) {}
+    public void onGuildUpdateName(@NotNull GuildUpdateNameEvent event){}
+    public void onGuildUpdateNotificationLevel(@NotNull GuildUpdateNotificationLevelEvent event) {}
+    public void onGuildUpdateOwner(@NotNull GuildUpdateOwnerEvent event) {}
+    public void onGuildUpdateRegion(@NotNull GuildUpdateRegionEvent event) {}
+    public void onGuildUpdateSplash(@NotNull GuildUpdateSplashEvent event) {}
+    public void onGuildUpdateVerificationLevel(@NotNull GuildUpdateVerificationLevelEvent event) {}
+    public void onGuildUpdateLocale(@NotNull GuildUpdateLocaleEvent event) {}
+    public void onGuildUpdateFeatures(@NotNull GuildUpdateFeaturesEvent event) {}
+    public void onGuildUpdateVanityCode(@NotNull GuildUpdateVanityCodeEvent event) {}
+    public void onGuildUpdateBanner(@NotNull GuildUpdateBannerEvent event) {}
+    public void onGuildUpdateDescription(@NotNull GuildUpdateDescriptionEvent event) {}
+    public void onGuildUpdateBoostTier(@NotNull GuildUpdateBoostTierEvent event) {}
+    public void onGuildUpdateBoostCount(@NotNull GuildUpdateBoostCountEvent event) {}
+    public void onGuildUpdateMaxMembers(@NotNull GuildUpdateMaxMembersEvent event) {}
+    public void onGuildUpdateMaxPresences(@NotNull GuildUpdateMaxPresencesEvent event) {}
 
     //Guild Invite Events
-    public void onGuildInviteCreate(@Nonnull GuildInviteCreateEvent event) {}
-    public void onGuildInviteDelete(@Nonnull GuildInviteDeleteEvent event) {}
+    public void onGuildInviteCreate(@NotNull GuildInviteCreateEvent event) {}
+    public void onGuildInviteDelete(@NotNull GuildInviteDeleteEvent event) {}
 
     //Guild Member Events
-    public void onGuildMemberJoin(@Nonnull GuildMemberJoinEvent event) {}
-    public void onGuildMemberRoleAdd(@Nonnull GuildMemberRoleAddEvent event) {}
-    public void onGuildMemberRoleRemove(@Nonnull GuildMemberRoleRemoveEvent event) {}
+    public void onGuildMemberJoin(@NotNull GuildMemberJoinEvent event) {}
+    public void onGuildMemberRoleAdd(@NotNull GuildMemberRoleAddEvent event) {}
+    public void onGuildMemberRoleRemove(@NotNull GuildMemberRoleRemoveEvent event) {}
 
     //Guild Member Update Events
-    public void onGuildMemberUpdate(@Nonnull GuildMemberUpdateEvent event) {}
-    public void onGuildMemberUpdateNickname(@Nonnull GuildMemberUpdateNicknameEvent event) {}
-    public void onGuildMemberUpdateBoostTime(@Nonnull GuildMemberUpdateBoostTimeEvent event) {}
-    public void onGuildMemberUpdatePending(@Nonnull GuildMemberUpdatePendingEvent event) {}
+    public void onGuildMemberUpdate(@NotNull GuildMemberUpdateEvent event) {}
+    public void onGuildMemberUpdateNickname(@NotNull GuildMemberUpdateNicknameEvent event) {}
+    public void onGuildMemberUpdateBoostTime(@NotNull GuildMemberUpdateBoostTimeEvent event) {}
+    public void onGuildMemberUpdatePending(@NotNull GuildMemberUpdatePendingEvent event) {}
 
     //Guild Voice Events
-    public void onGuildVoiceUpdate(@Nonnull GuildVoiceUpdateEvent event) {}
-    public void onGuildVoiceJoin(@Nonnull GuildVoiceJoinEvent event) {}
-    public void onGuildVoiceMove(@Nonnull GuildVoiceMoveEvent event) {}
-    public void onGuildVoiceLeave(@Nonnull GuildVoiceLeaveEvent event) {}
-    public void onGuildVoiceMute(@Nonnull GuildVoiceMuteEvent event) {}
-    public void onGuildVoiceDeafen(@Nonnull GuildVoiceDeafenEvent event) {}
-    public void onGuildVoiceGuildMute(@Nonnull GuildVoiceGuildMuteEvent event) {}
-    public void onGuildVoiceGuildDeafen(@Nonnull GuildVoiceGuildDeafenEvent event) {}
-    public void onGuildVoiceSelfMute(@Nonnull GuildVoiceSelfMuteEvent event) {}
-    public void onGuildVoiceSelfDeafen(@Nonnull GuildVoiceSelfDeafenEvent event) {}
-    public void onGuildVoiceSuppress(@Nonnull GuildVoiceSuppressEvent event) {}
-    public void onGuildVoiceStream(@Nonnull GuildVoiceStreamEvent event) {}
+    public void onGuildVoiceUpdate(@NotNull GuildVoiceUpdateEvent event) {}
+    public void onGuildVoiceJoin(@NotNull GuildVoiceJoinEvent event) {}
+    public void onGuildVoiceMove(@NotNull GuildVoiceMoveEvent event) {}
+    public void onGuildVoiceLeave(@NotNull GuildVoiceLeaveEvent event) {}
+    public void onGuildVoiceMute(@NotNull GuildVoiceMuteEvent event) {}
+    public void onGuildVoiceDeafen(@NotNull GuildVoiceDeafenEvent event) {}
+    public void onGuildVoiceGuildMute(@NotNull GuildVoiceGuildMuteEvent event) {}
+    public void onGuildVoiceGuildDeafen(@NotNull GuildVoiceGuildDeafenEvent event) {}
+    public void onGuildVoiceSelfMute(@NotNull GuildVoiceSelfMuteEvent event) {}
+    public void onGuildVoiceSelfDeafen(@NotNull GuildVoiceSelfDeafenEvent event) {}
+    public void onGuildVoiceSuppress(@NotNull GuildVoiceSuppressEvent event) {}
+    public void onGuildVoiceStream(@NotNull GuildVoiceStreamEvent event) {}
 
     //Role events
-    public void onRoleCreate(@Nonnull RoleCreateEvent event) {}
-    public void onRoleDelete(@Nonnull RoleDeleteEvent event) {}
+    public void onRoleCreate(@NotNull RoleCreateEvent event) {}
+    public void onRoleDelete(@NotNull RoleDeleteEvent event) {}
 
     //Role Update Events
-    public void onRoleUpdateColor(@Nonnull RoleUpdateColorEvent event) {}
-    public void onRoleUpdateHoisted(@Nonnull RoleUpdateHoistedEvent event) {}
-    public void onRoleUpdateMentionable(@Nonnull RoleUpdateMentionableEvent event) {}
-    public void onRoleUpdateName(@Nonnull RoleUpdateNameEvent event) {}
-    public void onRoleUpdatePermissions(@Nonnull RoleUpdatePermissionsEvent event) {}
-    public void onRoleUpdatePosition(@Nonnull RoleUpdatePositionEvent event) {}
+    public void onRoleUpdateColor(@NotNull RoleUpdateColorEvent event) {}
+    public void onRoleUpdateHoisted(@NotNull RoleUpdateHoistedEvent event) {}
+    public void onRoleUpdateMentionable(@NotNull RoleUpdateMentionableEvent event) {}
+    public void onRoleUpdateName(@NotNull RoleUpdateNameEvent event) {}
+    public void onRoleUpdatePermissions(@NotNull RoleUpdatePermissionsEvent event) {}
+    public void onRoleUpdatePosition(@NotNull RoleUpdatePositionEvent event) {}
 
     //Emote Events
-    public void onEmoteAdded(@Nonnull EmoteAddedEvent event) {}
-    public void onEmoteRemoved(@Nonnull EmoteRemovedEvent event) {}
+    public void onEmoteAdded(@NotNull EmoteAddedEvent event) {}
+    public void onEmoteRemoved(@NotNull EmoteRemovedEvent event) {}
 
     //Emote Update Events
-    public void onEmoteUpdateName(@Nonnull EmoteUpdateNameEvent event) {}
-    public void onEmoteUpdateRoles(@Nonnull EmoteUpdateRolesEvent event) {}
+    public void onEmoteUpdateName(@NotNull EmoteUpdateNameEvent event) {}
+    public void onEmoteUpdateRoles(@NotNull EmoteUpdateRolesEvent event) {}
 
     // Debug Events
-    public void onHttpRequest(@Nonnull HttpRequestEvent event) {}
+    public void onHttpRequest(@NotNull HttpRequestEvent event) {}
 
     //Generic Events
-    public void onGenericMessage(@Nonnull GenericMessageEvent event) {}
-    public void onGenericMessageReaction(@Nonnull GenericMessageReactionEvent event) {}
-    public void onGenericGuildMessage(@Nonnull GenericGuildMessageEvent event) {}
-    public void onGenericGuildMessageReaction(@Nonnull GenericGuildMessageReactionEvent event) {}
-    public void onGenericPrivateMessage(@Nonnull GenericPrivateMessageEvent event) {}
-    public void onGenericPrivateMessageReaction(@Nonnull GenericPrivateMessageReactionEvent event) {}
-    public void onGenericUser(@Nonnull GenericUserEvent event) {}
-    public void onGenericUserPresence(@Nonnull GenericUserPresenceEvent event) {}
-    public void onGenericSelfUpdate(@Nonnull GenericSelfUpdateEvent event) {}
-    public void onGenericStoreChannel(@Nonnull GenericStoreChannelEvent event) {}
-    public void onGenericStoreChannelUpdate(@Nonnull GenericStoreChannelUpdateEvent event) {}
-    public void onGenericTextChannel(@Nonnull GenericTextChannelEvent event) {}
-    public void onGenericTextChannelUpdate(@Nonnull GenericTextChannelUpdateEvent event) {}
-    public void onGenericVoiceChannel(@Nonnull GenericVoiceChannelEvent event) {}
-    public void onGenericVoiceChannelUpdate(@Nonnull GenericVoiceChannelUpdateEvent event) {}
-    public void onGenericCategory(@Nonnull GenericCategoryEvent event) {}
-    public void onGenericCategoryUpdate(@Nonnull GenericCategoryUpdateEvent event) {}
-    public void onGenericGuild(@Nonnull GenericGuildEvent event) {}
-    public void onGenericGuildUpdate(@Nonnull GenericGuildUpdateEvent event) {}
-    public void onGenericGuildInvite(@Nonnull GenericGuildInviteEvent event) {}
-    public void onGenericGuildMember(@Nonnull GenericGuildMemberEvent event) {}
-    public void onGenericGuildMemberUpdate(@Nonnull GenericGuildMemberUpdateEvent event) {}
-    public void onGenericGuildVoice(@Nonnull GenericGuildVoiceEvent event) {}
-    public void onGenericRole(@Nonnull GenericRoleEvent event) {}
-    public void onGenericRoleUpdate(@Nonnull GenericRoleUpdateEvent event) {}
-    public void onGenericEmote(@Nonnull GenericEmoteEvent event) {}
-    public void onGenericEmoteUpdate(@Nonnull GenericEmoteUpdateEvent event) {}
-    public void onGenericPermissionOverride(@Nonnull GenericPermissionOverrideEvent event) {}
+    public void onGenericMessage(@NotNull GenericMessageEvent event) {}
+    public void onGenericMessageReaction(@NotNull GenericMessageReactionEvent event) {}
+    public void onGenericGuildMessage(@NotNull GenericGuildMessageEvent event) {}
+    public void onGenericGuildMessageReaction(@NotNull GenericGuildMessageReactionEvent event) {}
+    public void onGenericPrivateMessage(@NotNull GenericPrivateMessageEvent event) {}
+    public void onGenericPrivateMessageReaction(@NotNull GenericPrivateMessageReactionEvent event) {}
+    public void onGenericUser(@NotNull GenericUserEvent event) {}
+    public void onGenericUserPresence(@NotNull GenericUserPresenceEvent event) {}
+    public void onGenericSelfUpdate(@NotNull GenericSelfUpdateEvent event) {}
+    public void onGenericStoreChannel(@NotNull GenericStoreChannelEvent event) {}
+    public void onGenericStoreChannelUpdate(@NotNull GenericStoreChannelUpdateEvent event) {}
+    public void onGenericTextChannel(@NotNull GenericTextChannelEvent event) {}
+    public void onGenericTextChannelUpdate(@NotNull GenericTextChannelUpdateEvent event) {}
+    public void onGenericVoiceChannel(@NotNull GenericVoiceChannelEvent event) {}
+    public void onGenericVoiceChannelUpdate(@NotNull GenericVoiceChannelUpdateEvent event) {}
+    public void onGenericCategory(@NotNull GenericCategoryEvent event) {}
+    public void onGenericCategoryUpdate(@NotNull GenericCategoryUpdateEvent event) {}
+    public void onGenericGuild(@NotNull GenericGuildEvent event) {}
+    public void onGenericGuildUpdate(@NotNull GenericGuildUpdateEvent event) {}
+    public void onGenericGuildInvite(@NotNull GenericGuildInviteEvent event) {}
+    public void onGenericGuildMember(@NotNull GenericGuildMemberEvent event) {}
+    public void onGenericGuildMemberUpdate(@NotNull GenericGuildMemberUpdateEvent event) {}
+    public void onGenericGuildVoice(@NotNull GenericGuildVoiceEvent event) {}
+    public void onGenericRole(@NotNull GenericRoleEvent event) {}
+    public void onGenericRoleUpdate(@NotNull GenericRoleUpdateEvent event) {}
+    public void onGenericEmote(@NotNull GenericEmoteEvent event) {}
+    public void onGenericEmoteUpdate(@NotNull GenericEmoteUpdateEvent event) {}
+    public void onGenericPermissionOverride(@NotNull GenericPermissionOverrideEvent event) {}
 
     private static final MethodHandles.Lookup lookup = MethodHandles.lookup();
     private static final ConcurrentMap<Class<?>, MethodHandle> methods = new ConcurrentHashMap<>();
@@ -417,7 +417,7 @@ public abstract class ListenerAdapter implements EventListener
     }
 
     @Override
-    public final void onEvent(@Nonnull GenericEvent event)
+    public final void onEvent(@NotNull GenericEvent event)
     {
         onGenericEvent(event);
         if (event instanceof UpdateEvent)

--- a/src/main/java/net/dv8tion/jda/api/hooks/VoiceDispatchInterceptor.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/VoiceDispatchInterceptor.java
@@ -23,9 +23,8 @@ import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.api.managers.DirectAudioController;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Interceptor used to handle critical voice dispatches.
@@ -43,7 +42,7 @@ public interface VoiceDispatchInterceptor
      * @param update
      *        The {@link VoiceServerUpdate} to handle
      */
-    void onVoiceServerUpdate(@Nonnull VoiceServerUpdate update);
+    void onVoiceServerUpdate(@NotNull VoiceServerUpdate update);
 
     /**
      * Handles the <b>VOICE_STATE_UPDATE</b>.
@@ -54,7 +53,7 @@ public interface VoiceDispatchInterceptor
      *
      * @return True, if a connection was previously established
      */
-    boolean onVoiceStateUpdate(@Nonnull VoiceStateUpdate update);
+    boolean onVoiceStateUpdate(@NotNull VoiceStateUpdate update);
 
     /**
      * Abstraction for all relevant voice updates
@@ -69,7 +68,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The guild
          */
-        @Nonnull
+        @NotNull
         Guild getGuild();
 
         /**
@@ -77,7 +76,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The raw JSON object
          */
-        @Nonnull
+        @NotNull
         @Override
         DataObject toData();
 
@@ -86,7 +85,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The {@link DirectAudioController} for this JDA instance
          */
-        @Nonnull
+        @NotNull
         default DirectAudioController getAudioController()
         {
             return getJDA().getDirectAudioController();
@@ -107,7 +106,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The guild id
          */
-        @Nonnull
+        @NotNull
         default String getGuildId()
         {
             return Long.toUnsignedString(getGuildIdLong());
@@ -118,7 +117,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The JDA instance
          */
-        @Nonnull
+        @NotNull
         default JDA getJDA()
         {
             return getGuild().getJDA();
@@ -156,14 +155,14 @@ public interface VoiceDispatchInterceptor
             this.json = json;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Guild getGuild()
         {
             return guild;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public DataObject toData()
         {
@@ -175,7 +174,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The endpoint
          */
-        @Nonnull
+        @NotNull
         public String getEndpoint()
         {
             return endpoint;
@@ -186,7 +185,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The access token
          */
-        @Nonnull
+        @NotNull
         public String getToken()
         {
             return token;
@@ -197,7 +196,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The session id
          */
-        @Nonnull
+        @NotNull
         public String getSessionId()
         {
             return sessionId;
@@ -220,14 +219,14 @@ public interface VoiceDispatchInterceptor
             this.json = json;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Guild getGuild()
         {
             return voiceState.getGuild();
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public DataObject toData()
         {
@@ -250,7 +249,7 @@ public interface VoiceDispatchInterceptor
          *
          * @return The voice state
          */
-        @Nonnull
+        @NotNull
         public GuildVoiceState getVoiceState()
         {
             return voiceState;

--- a/src/main/java/net/dv8tion/jda/api/managers/AccountManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/AccountManager.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.annotations.DeprecatedSince;
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.entities.Icon;
 import net.dv8tion.jda.api.entities.SelfUser;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Manager providing functionality to update one or more fields for the logged in account.
@@ -56,7 +56,7 @@ public interface AccountManager extends Manager<AccountManager>
      *
      * @return The corresponding SelfUser
      */
-    @Nonnull
+    @NotNull
     SelfUser getSelfUser();
 
     /**
@@ -75,7 +75,7 @@ public interface AccountManager extends Manager<AccountManager>
      *
      * @return AccountManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     AccountManager reset(long fields);
@@ -96,7 +96,7 @@ public interface AccountManager extends Manager<AccountManager>
      *
      * @return AccountManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     AccountManager reset(long... fields);
@@ -116,9 +116,9 @@ public interface AccountManager extends Manager<AccountManager>
      *
      * @return AccountManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    AccountManager setName(@Nonnull String name);
+    AccountManager setName(@NotNull String name);
 
     /**
      * Sets the username for the currently logged in account
@@ -145,9 +145,9 @@ public interface AccountManager extends Manager<AccountManager>
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AccountManager setName(@Nonnull String name, @Nullable String currentPassword)
+    default AccountManager setName(@NotNull String name, @Nullable String currentPassword)
     {
         throw new UnsupportedOperationException();
     }
@@ -161,7 +161,7 @@ public interface AccountManager extends Manager<AccountManager>
      *
      * @return AccountManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     AccountManager setAvatar(@Nullable Icon avatar);
 
@@ -186,7 +186,7 @@ public interface AccountManager extends Manager<AccountManager>
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default AccountManager setAvatar(@Nullable Icon avatar, @Nullable String currentPassword)
     {
@@ -216,9 +216,9 @@ public interface AccountManager extends Manager<AccountManager>
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AccountManager setEmail(@Nonnull String email, @Nonnull String currentPassword)
+    default AccountManager setEmail(@NotNull String email, @NotNull String currentPassword)
     {
         throw new UnsupportedOperationException();
     }
@@ -244,9 +244,9 @@ public interface AccountManager extends Manager<AccountManager>
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.2.0")
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default AccountManager setPassword(@Nonnull String newPassword, @Nonnull String currentPassword)
+    default AccountManager setPassword(@NotNull String newPassword, @NotNull String currentPassword)
     {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/AudioManager.java
@@ -29,10 +29,10 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.VoiceChannel;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -105,7 +105,7 @@ public interface AudioManager
      * @see    #setSpeakingMode(SpeakingMode...)
      */
     @Incubating
-    void setSpeakingMode(@Nonnull Collection<SpeakingMode> mode);
+    void setSpeakingMode(@NotNull Collection<SpeakingMode> mode);
 
     /**
      * The {@link SpeakingMode} that should be used when sending audio via
@@ -123,7 +123,7 @@ public interface AudioManager
      * @see    #getSpeakingMode()
      */
     @Incubating
-    default void setSpeakingMode(@Nonnull SpeakingMode... mode)
+    default void setSpeakingMode(@NotNull SpeakingMode... mode)
     {
         Checks.notNull(mode, "Speaking Mode");
         setSpeakingMode(Arrays.asList(mode));
@@ -140,7 +140,7 @@ public interface AudioManager
      *
      * @see    #setSpeakingMode(Collection)
      */
-    @Nonnull
+    @NotNull
     @Incubating
     EnumSet<SpeakingMode> getSpeakingMode();
 
@@ -168,7 +168,7 @@ public interface AudioManager
      *
      * @return The corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -176,7 +176,7 @@ public interface AudioManager
      *
      * @return The Guild that this AudioManager manages.
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -327,7 +327,7 @@ public interface AudioManager
      *
      * @return The current {@link net.dv8tion.jda.api.audio.hooks.ConnectionStatus ConnectionStatus}.
      */
-    @Nonnull
+    @NotNull
     ConnectionStatus getConnectionStatus();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
@@ -18,10 +18,10 @@ package net.dv8tion.jda.api.managers;
 
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**
@@ -89,7 +89,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     ChannelManager reset(long fields);
 
@@ -115,7 +115,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     ChannelManager reset(long... fields);
 
@@ -125,7 +125,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return The {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}
      */
-    @Nonnull
+    @NotNull
     GuildChannel getChannel();
 
     /**
@@ -133,7 +133,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return The ChannelType
      */
-    @Nonnull
+    @NotNull
     default ChannelType getType()
     {
         return getChannel().getType();
@@ -146,7 +146,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getChannel().getGuild();
@@ -157,7 +157,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager clearOverridesAdded();
 
@@ -166,7 +166,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager clearOverridesRemoved();
 
@@ -193,9 +193,9 @@ public interface ChannelManager extends Manager<ChannelManager>
      * @see    #putPermissionOverride(IPermissionHolder, Collection, Collection)
      * @see    net.dv8tion.jda.api.Permission#getRaw(Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelManager putPermissionOverride(@Nonnull IPermissionHolder permHolder, long allow, long deny);
+    ChannelManager putPermissionOverride(@NotNull IPermissionHolder permHolder, long allow, long deny);
 
     /**
      * Adds an override for the specified {@link net.dv8tion.jda.api.entities.IPermissionHolder IPermissionHolder}
@@ -221,9 +221,9 @@ public interface ChannelManager extends Manager<ChannelManager>
      * @see    #putPermissionOverride(IPermissionHolder, long, long)
      * @see    java.util.EnumSet EnumSet
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelManager putPermissionOverride(@Nonnull IPermissionHolder permHolder, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
+    default ChannelManager putPermissionOverride(@NotNull IPermissionHolder permHolder, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
     {
         long allowRaw = allow == null ? 0 : Permission.getRaw(allow);
         long denyRaw  = deny  == null ? 0 : Permission.getRaw(deny);
@@ -246,9 +246,9 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelManager removePermissionOverride(@Nonnull IPermissionHolder permHolder);
+    ChannelManager removePermissionOverride(@NotNull IPermissionHolder permHolder);
 
     /**
      * Syncs all {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} of this GuildChannel with
@@ -270,7 +270,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @see     <a href="https://discord.com/developers/docs/topics/permissions#permission-syncing" target="_blank">Discord Documentation - Permission Syncing</a>
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default ChannelManager sync()
     {
@@ -302,9 +302,9 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @see     <a href="https://discord.com/developers/docs/topics/permissions#permission-syncing" target="_blank">Discord Documentation - Permission Syncing</a>
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelManager sync(@Nonnull GuildChannel syncSource);
+    ChannelManager sync(@NotNull GuildChannel syncSource);
 
     /**
      * Sets the <b><u>name</u></b> of the selected {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}.
@@ -323,9 +323,9 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelManager setName(@Nonnull String name);
+    ChannelManager setName(@NotNull String name);
 
     /**
      * Sets the <b><u>{@link net.dv8tion.jda.api.entities.Category Parent Category}</u></b>
@@ -344,7 +344,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @since  3.4.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setParent(@Nullable Category category);
 
@@ -360,7 +360,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setPosition(int position);
 
@@ -381,7 +381,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setTopic(@Nullable String topic);
 
@@ -396,7 +396,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setNSFW(boolean nsfw);
 
@@ -422,7 +422,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setSlowmode(int slowmode);
 
@@ -443,7 +443,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @return ChannelManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setUserLimit(int userLimit);
 
@@ -466,7 +466,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @see    net.dv8tion.jda.api.entities.Guild#getFeatures()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setBitrate(int bitrate);
 
@@ -489,7 +489,7 @@ public interface ChannelManager extends Manager<ChannelManager>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelManager setNews(boolean news);
 }

--- a/src/main/java/net/dv8tion/jda/api/managers/DirectAudioController.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/DirectAudioController.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.managers;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Direct access to internal gateway communication.
@@ -35,7 +34,7 @@ public interface DirectAudioController
      *
      * @return The JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -46,7 +45,7 @@ public interface DirectAudioController
      *
      * @see   #reconnect(VoiceChannel)
      */
-    void connect(@Nonnull VoiceChannel channel);
+    void connect(@NotNull VoiceChannel channel);
 
     /**
      * Requests to terminate the connection to a voice channel.
@@ -56,7 +55,7 @@ public interface DirectAudioController
      *
      * @see   #reconnect(VoiceChannel)
      */
-    void disconnect(@Nonnull Guild guild);
+    void disconnect(@NotNull Guild guild);
 
     /**
      * Requests to reconnect to the voice channel in the target guild.
@@ -64,5 +63,5 @@ public interface DirectAudioController
      * @param channel
      *        The channel we were connected to
      */
-    void reconnect(@Nonnull VoiceChannel channel);
+    void reconnect(@NotNull VoiceChannel channel);
 }

--- a/src/main/java/net/dv8tion/jda/api/managers/EmoteManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/EmoteManager.java
@@ -19,10 +19,10 @@ package net.dv8tion.jda.api.managers;
 import net.dv8tion.jda.api.entities.Emote;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -64,7 +64,7 @@ public interface EmoteManager extends Manager<EmoteManager>
      *
      * @return EmoteManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     EmoteManager reset(long fields);
 
@@ -84,7 +84,7 @@ public interface EmoteManager extends Manager<EmoteManager>
      *
      * @return EmoteManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     EmoteManager reset(long... fields);
 
@@ -95,7 +95,7 @@ public interface EmoteManager extends Manager<EmoteManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getEmote().getGuild();
@@ -107,7 +107,7 @@ public interface EmoteManager extends Manager<EmoteManager>
      *
      * @return The target Emote
      */
-    @Nonnull
+    @NotNull
     Emote getEmote();
 
     /**
@@ -126,9 +126,9 @@ public interface EmoteManager extends Manager<EmoteManager>
      *
      * @return EmoteManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    EmoteManager setName(@Nonnull String name);
+    EmoteManager setName(@NotNull String name);
 
     /**
      * Sets the <b><u>restriction roles</u></b> of the selected {@link net.dv8tion.jda.api.entities.Emote Emote}.
@@ -145,7 +145,7 @@ public interface EmoteManager extends Manager<EmoteManager>
      *
      * @return EmoteManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     EmoteManager setRoles(@Nullable Set<Role> roles);
 }

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
@@ -21,10 +21,10 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Icon;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.VoiceChannel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Manager providing functionality to update one or more fields for a {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -104,7 +104,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     GuildManager reset(long fields);
 
@@ -135,7 +135,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     GuildManager reset(long... fields);
 
@@ -145,7 +145,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return The {@link net.dv8tion.jda.api.entities.Guild Guild} of this Manager
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -159,9 +159,9 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setName(@Nonnull String name);
+    GuildManager setName(@NotNull String name);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.Region Region} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -178,9 +178,9 @@ public interface GuildManager extends Manager<GuildManager>
      * @see    net.dv8tion.jda.api.Region#isVip()
      * @see    net.dv8tion.jda.api.entities.Guild#getFeatures()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setRegion(@Nonnull Region region);
+    GuildManager setRegion(@NotNull Region region);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Icon Icon} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -191,7 +191,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setIcon(@Nullable Icon icon);
 
@@ -207,7 +207,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setSplash(@Nullable Icon splash);
 
@@ -223,7 +223,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setAfkChannel(@Nullable VoiceChannel afkChannel);
 
@@ -239,7 +239,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setSystemChannel(@Nullable TextChannel systemChannel);
 
@@ -255,7 +255,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setRulesChannel(@Nullable TextChannel rulesChannel);
 
@@ -271,7 +271,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setCommunityUpdatesChannel(@Nullable TextChannel communityUpdatesChannel);
 
@@ -286,9 +286,9 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setAfkTimeout(@Nonnull Guild.Timeout timeout);
+    GuildManager setAfkTimeout(@NotNull Guild.Timeout timeout);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Guild.VerificationLevel Verification Level} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -301,9 +301,9 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setVerificationLevel(@Nonnull Guild.VerificationLevel level);
+    GuildManager setVerificationLevel(@NotNull Guild.VerificationLevel level);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Guild.NotificationLevel Notification Level} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -316,9 +316,9 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setDefaultNotificationLevel(@Nonnull Guild.NotificationLevel level);
+    GuildManager setDefaultNotificationLevel(@NotNull Guild.NotificationLevel level);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Guild.MFALevel MFA Level} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -331,9 +331,9 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setRequiredMFALevel(@Nonnull Guild.MFALevel level);
+    GuildManager setRequiredMFALevel(@NotNull Guild.MFALevel level);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Guild.ExplicitContentLevel Explicit Content Level} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -346,9 +346,9 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildManager setExplicitContentLevel(@Nonnull Guild.ExplicitContentLevel level);
+    GuildManager setExplicitContentLevel(@NotNull Guild.ExplicitContentLevel level);
 
     /**
      * Sets the Banner {@link net.dv8tion.jda.api.entities.Icon Icon} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -362,7 +362,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setBanner(@Nullable Icon banner);
 
@@ -378,7 +378,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setVanityCode(@Nullable String code);
 
@@ -394,7 +394,7 @@ public interface GuildManager extends Manager<GuildManager>
      *
      * @return GuildManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildManager setDescription(@Nullable String description);
 }

--- a/src/main/java/net/dv8tion/jda/api/managers/Manager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/Manager.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.managers;
 
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.managers.ManagerBase;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -60,23 +60,23 @@ public interface Manager<M extends Manager<M>> extends AuditableRestAction<Void>
         return ManagerBase.isPermissionChecksEnabled();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     M setCheck(BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    M timeout(long timeout, @Nonnull TimeUnit unit);
+    M timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     M deadline(long timestamp);
 
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     M reset(long fields);
 
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     M reset(long... fields);
 
@@ -85,7 +85,7 @@ public interface Manager<M extends Manager<M>> extends AuditableRestAction<Void>
      *
      * @return The current Manager with all settings reset to default
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     M reset();
 }

--- a/src/main/java/net/dv8tion/jda/api/managers/PermOverrideManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/PermOverrideManager.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.PermissionOverride;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
@@ -68,7 +68,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return PermOverrideManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     PermOverrideManager reset(long fields);
 
@@ -89,7 +89,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return PermOverrideManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     PermOverrideManager reset(long... fields);
 
@@ -100,7 +100,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getPermissionOverride().getGuild();
@@ -113,7 +113,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}
      */
-    @Nonnull
+    @NotNull
     default GuildChannel getChannel()
     {
         return getPermissionOverride().getChannel();
@@ -125,7 +125,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return The target {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride}
      */
-    @Nonnull
+    @NotNull
     PermissionOverride getPermissionOverride();
 
     /**
@@ -137,7 +137,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return PermOverrideManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermOverrideManager grant(long permissions);
 
@@ -155,9 +155,9 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermOverrideManager grant(@Nonnull Permission... permissions)
+    default PermOverrideManager grant(@NotNull Permission... permissions)
     {
         Checks.notNull(permissions, "Permissions");
         return grant(Permission.getRaw(permissions));
@@ -178,9 +178,9 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermOverrideManager grant(@Nonnull Collection<Permission> permissions)
+    default PermOverrideManager grant(@NotNull Collection<Permission> permissions)
     {
         return grant(Permission.getRaw(permissions));
     }
@@ -194,7 +194,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return PermOverrideManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermOverrideManager deny(long permissions);
 
@@ -212,9 +212,9 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermOverrideManager deny(@Nonnull Permission... permissions)
+    default PermOverrideManager deny(@NotNull Permission... permissions)
     {
         Checks.notNull(permissions, "Permissions");
         return deny(Permission.getRaw(permissions));
@@ -235,9 +235,9 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermOverrideManager deny(@Nonnull Collection<Permission> permissions)
+    default PermOverrideManager deny(@NotNull Collection<Permission> permissions)
     {
         return deny(Permission.getRaw(permissions));
     }
@@ -252,7 +252,7 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return PermOverrideManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermOverrideManager clear(long permissions);
 
@@ -269,9 +269,9 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      *
      * @return PermOverrideManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermOverrideManager clear(@Nonnull Permission... permissions)
+    default PermOverrideManager clear(@NotNull Permission... permissions)
     {
         Checks.notNull(permissions, "Permissions");
         return clear(Permission.getRaw(permissions));
@@ -293,9 +293,9 @@ public interface PermOverrideManager extends Manager<PermOverrideManager>
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermOverrideManager clear(@Nonnull Collection<Permission> permissions)
+    default PermOverrideManager clear(@NotNull Collection<Permission> permissions)
     {
         return clear(Permission.getRaw(permissions));
     }

--- a/src/main/java/net/dv8tion/jda/api/managers/Presence.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/Presence.java
@@ -19,9 +19,8 @@ package net.dv8tion.jda.api.managers;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The Presence associated with the provided JDA instance
@@ -35,7 +34,7 @@ public interface Presence
      *
      * @return The current JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -45,7 +44,7 @@ public interface Presence
      * @return The {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus}
      *         of the current session
      */
-    @Nonnull
+    @NotNull
     OnlineStatus getStatus();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/managers/RoleManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/RoleManager.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.util.Arrays;
 import java.util.Collection;
@@ -76,7 +76,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return RoleManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     RoleManager reset(long fields);
 
@@ -99,7 +99,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return RoleManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     RoleManager reset(long... fields);
 
@@ -109,7 +109,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return The target Role
      */
-    @Nonnull
+    @NotNull
     Role getRole();
 
     /**
@@ -119,7 +119,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getRole().getGuild();
@@ -138,9 +138,9 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return RoleManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RoleManager setName(@Nonnull String name);
+    RoleManager setName(@NotNull String name);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.Permission Permissions} of the selected {@link net.dv8tion.jda.api.entities.Role Role}.
@@ -159,7 +159,7 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    #setPermissions(Collection)
      * @see    #setPermissions(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleManager setPermissions(long perms);
 
@@ -183,9 +183,9 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    #setPermissions(long)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RoleManager setPermissions(@Nonnull Permission... permissions)
+    default RoleManager setPermissions(@NotNull Permission... permissions)
     {
         Checks.notNull(permissions, "Permissions");
         return setPermissions(Arrays.asList(permissions));
@@ -212,9 +212,9 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RoleManager setPermissions(@Nonnull Collection<Permission> permissions)
+    default RoleManager setPermissions(@NotNull Collection<Permission> permissions)
     {
         Checks.noneNull(permissions, "Permissions");
         return setPermissions(Permission.getRaw(permissions));
@@ -228,7 +228,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return RoleManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RoleManager setColor(@Nullable Color color)
     {
@@ -245,7 +245,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @see    Role#DEFAULT_COLOR_RAW Role.DEFAULT_COLOR_RAW
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleManager setColor(int rgb);
 
@@ -257,7 +257,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return RoleManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleManager setHoisted(boolean hoisted);
 
@@ -269,7 +269,7 @@ public interface RoleManager extends Manager<RoleManager>
      *
      * @return RoleManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleManager setMentionable(boolean mentionable);
 
@@ -291,9 +291,9 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    #setPermissions(Permission...)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RoleManager givePermissions(@Nonnull Permission... perms)
+    default RoleManager givePermissions(@NotNull Permission... perms)
     {
         Checks.notNull(perms, "Permissions");
         return givePermissions(Arrays.asList(perms));
@@ -318,9 +318,9 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RoleManager givePermissions(@Nonnull Collection<Permission> perms);
+    RoleManager givePermissions(@NotNull Collection<Permission> perms);
 
     /**
      * Revokes the specified {@link net.dv8tion.jda.api.Permission Permissions} from the selected {@link net.dv8tion.jda.api.entities.Role Role}.
@@ -340,9 +340,9 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    #setPermissions(Permission...)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RoleManager revokePermissions(@Nonnull Permission... perms)
+    default RoleManager revokePermissions(@NotNull Permission... perms)
     {
         Checks.notNull(perms, "Permissions");
         return revokePermissions(Arrays.asList(perms));
@@ -367,7 +367,7 @@ public interface RoleManager extends Manager<RoleManager>
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    RoleManager revokePermissions(@Nonnull Collection<Permission> perms);
+    RoleManager revokePermissions(@NotNull Collection<Permission> perms);
 }

--- a/src/main/java/net/dv8tion/jda/api/managers/WebhookManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/WebhookManager.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Icon;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.Webhook;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Manager providing functionality to update one or more fields for a {@link net.dv8tion.jda.api.entities.Webhook Webhook}.
@@ -67,7 +67,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return WebhookManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     WebhookManager reset(long fields);
 
@@ -88,7 +88,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return WebhookManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     WebhookManager reset(long... fields);
 
@@ -98,7 +98,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return The target {@link net.dv8tion.jda.api.entities.Webhook Webhook}
      */
-    @Nonnull
+    @NotNull
     Webhook getWebhook();
 
     /**
@@ -108,7 +108,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      */
-    @Nonnull
+    @NotNull
     default TextChannel getChannel()
     {
         return getWebhook().getChannel();
@@ -121,7 +121,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return The parent {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getWebhook().getGuild();
@@ -140,9 +140,9 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return WebhookManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    WebhookManager setName(@Nonnull String name);
+    WebhookManager setName(@NotNull String name);
 
     /**
      * Sets the <b><u>default avatar</u></b> of the selected {@link net.dv8tion.jda.api.entities.Webhook Webhook}.
@@ -154,7 +154,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return WebhookManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     WebhookManager setAvatar(@Nullable Icon icon);
 
@@ -175,7 +175,7 @@ public interface WebhookManager extends Manager<WebhookManager>
      *
      * @return WebhookManager for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    WebhookManager setChannel(@Nonnull TextChannel channel);
+    WebhookManager setChannel(@NotNull TextChannel channel);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/CloseCode.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/CloseCode.java
@@ -16,8 +16,8 @@
 
 package net.dv8tion.jda.api.requests;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Constants representing main gateway close codes with association to an explaining message.
@@ -75,7 +75,7 @@ public enum CloseCode
      *
      * @return The reason for this close
      */
-    @Nonnull
+    @NotNull
     public String getMeaning()
     {
         return meaning;

--- a/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.api.requests;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -123,7 +123,7 @@ public enum ErrorResponse
         return code;
     }
 
-    @Nonnull
+    @NotNull
     public String getMeaning()
     {
         return meaning;
@@ -152,8 +152,8 @@ public enum ErrorResponse
      *
      * @return {@link Predicate} which returns true, if the error response is equal to this
      */
-    @Nonnull
-    public static Predicate<Throwable> test(@Nonnull ErrorResponse... responses)
+    @NotNull
+    public static Predicate<Throwable> test(@NotNull ErrorResponse... responses)
     {
         Checks.noneNull(responses, "ErrorResponse");
         EnumSet<ErrorResponse> set = EnumSet.noneOf(ErrorResponse.class);
@@ -170,8 +170,8 @@ public enum ErrorResponse
      *
      * @return {@link Predicate} which returns true, if the error response is equal to this
      */
-    @Nonnull
-    public static Predicate<Throwable> test(@Nonnull Collection<ErrorResponse> responses)
+    @NotNull
+    public static Predicate<Throwable> test(@NotNull Collection<ErrorResponse> responses)
     {
         Checks.noneNull(responses, "ErrorResponse");
         EnumSet<ErrorResponse> set = EnumSet.copyOf(responses);
@@ -179,7 +179,7 @@ public enum ErrorResponse
 
     }
 
-    @Nonnull
+    @NotNull
     public static ErrorResponse fromCode(int code)
     {
         for (ErrorResponse error : values())
@@ -190,7 +190,7 @@ public enum ErrorResponse
         return SERVER_ERROR;
     }
 
-    @Nonnull
+    @NotNull
     public static ErrorResponse fromJSON(@Nullable DataObject obj)
     {
         if (obj == null || obj.isNull("code"))

--- a/src/main/java/net/dv8tion/jda/api/requests/GatewayIntent.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/GatewayIntent.java
@@ -37,8 +37,8 @@ import net.dv8tion.jda.api.events.user.update.GenericUserPresenceEvent;
 import net.dv8tion.jda.api.events.user.update.GenericUserUpdateEvent;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -209,7 +209,7 @@ public enum GatewayIntent
      *
      * @return {@link EnumSet} of intents
      */
-    @Nonnull
+    @NotNull
     public static EnumSet<GatewayIntent> getIntents(int raw)
     {
         EnumSet<GatewayIntent> set = EnumSet.noneOf(GatewayIntent.class);
@@ -232,7 +232,7 @@ public enum GatewayIntent
      *
      * @return The bitmask for this set of intents
      */
-    public static int getRaw(@Nonnull Collection<GatewayIntent> set)
+    public static int getRaw(@NotNull Collection<GatewayIntent> set)
     {
         int raw = 0;
         for (GatewayIntent intent : set)
@@ -253,7 +253,7 @@ public enum GatewayIntent
      *
      * @return The bitmask for this set of intents
      */
-    public static int getRaw(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... set)
+    public static int getRaw(@NotNull GatewayIntent intent, @NotNull GatewayIntent... set)
     {
         Checks.notNull(intent, "Intent");
         Checks.notNull(set,    "Intent");
@@ -274,8 +274,8 @@ public enum GatewayIntent
      *
      * @return {@link EnumSet} for the required intents
      */
-    @Nonnull
-    public static EnumSet<GatewayIntent> fromCacheFlags(@Nonnull CacheFlag flag, @Nonnull CacheFlag... other)
+    @NotNull
+    public static EnumSet<GatewayIntent> fromCacheFlags(@NotNull CacheFlag flag, @NotNull CacheFlag... other)
     {
         Checks.notNull(flag, "CacheFlag");
         Checks.noneNull(other, "CacheFlag");
@@ -294,8 +294,8 @@ public enum GatewayIntent
      *
      * @return {@link EnumSet} for the required intents
      */
-    @Nonnull
-    public static EnumSet<GatewayIntent> fromCacheFlags(@Nonnull Collection<CacheFlag> flags)
+    @NotNull
+    public static EnumSet<GatewayIntent> fromCacheFlags(@NotNull Collection<CacheFlag> flags)
     {
         EnumSet<GatewayIntent> intents = EnumSet.noneOf(GatewayIntent.class);
         for (CacheFlag flag : flags)
@@ -320,9 +320,9 @@ public enum GatewayIntent
      *
      * @return {@link EnumSet} for the required intents
      */
-    @Nonnull
+    @NotNull
     @SafeVarargs
-    public static EnumSet<GatewayIntent> fromEvents(@Nonnull Class<? extends GenericEvent>... events)
+    public static EnumSet<GatewayIntent> fromEvents(@NotNull Class<? extends GenericEvent>... events)
     {
         Checks.noneNull(events, "Event");
         return fromEvents(Arrays.asList(events));
@@ -339,8 +339,8 @@ public enum GatewayIntent
      *
      * @return {@link EnumSet} for the required intents
      */
-    @Nonnull
-    public static EnumSet<GatewayIntent> fromEvents(@Nonnull Collection<Class<? extends GenericEvent>> events)
+    @NotNull
+    public static EnumSet<GatewayIntent> fromEvents(@NotNull Collection<Class<? extends GenericEvent>> events)
     {
         EnumSet<GatewayIntent> intents = EnumSet.noneOf(GatewayIntent.class);
         for (Class<? extends GenericEvent> event : events)
@@ -396,8 +396,8 @@ public enum GatewayIntent
      *
      * @return {@link EnumSet} for the required intents
      */
-    @Nonnull
-    public static EnumSet<GatewayIntent> from(@Nonnull Collection<Class<? extends GenericEvent>> events, @Nonnull Collection<CacheFlag> flags)
+    @NotNull
+    public static EnumSet<GatewayIntent> from(@NotNull Collection<Class<? extends GenericEvent>> events, @NotNull Collection<CacheFlag> flags)
     {
         EnumSet<GatewayIntent> intents = fromEvents(events);
         intents.addAll(fromCacheFlags(flags));

--- a/src/main/java/net/dv8tion/jda/api/requests/Request.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/Request.java
@@ -28,9 +28,9 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import okhttp3.RequestBody;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
@@ -155,25 +155,25 @@ public class Request<T>
         onFailure(new TimeoutException("RestAction has timed out"));
     }
 
-    @Nonnull
+    @NotNull
     public JDAImpl getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     public RestAction<T> getRestAction()
     {
         return restAction;
     }
 
-    @Nonnull
+    @NotNull
     public Consumer<? super T> getOnSuccess()
     {
         return onSuccess;
     }
 
-    @Nonnull
+    @NotNull
     public Consumer<? super Throwable> getOnFailure()
     {
         return onFailure;
@@ -221,7 +221,7 @@ public class Request<T>
         return headers;
     }
 
-    @Nonnull
+    @NotNull
     public Route.CompiledRoute getRoute()
     {
         return route;
@@ -254,7 +254,7 @@ public class Request<T>
         return isCancelled;
     }
 
-    public void handleResponse(@Nonnull Response response)
+    public void handleResponse(@NotNull Response response)
     {
         restAction.handleResponse(response, this);
         api.handleEvent(new HttpRequestEvent(this, response));

--- a/src/main/java/net/dv8tion/jda/api/requests/Response.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/Response.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.utils.IOFunction;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.utils.IOUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.*;
 import java.util.Optional;
 import java.util.Set;
@@ -47,13 +47,13 @@ public class Response implements Closeable
     private boolean attemptedParsing = false;
     private Exception exception;
 
-    public Response(@Nullable final okhttp3.Response response, @Nonnull final Exception exception, @Nonnull final Set<String> cfRays)
+    public Response(@Nullable final okhttp3.Response response, @NotNull final Exception exception, @NotNull final Set<String> cfRays)
     {
         this(response, response != null ? response.code() : ERROR_CODE, ERROR_MESSAGE, -1, cfRays);
         this.exception = exception;
     }
 
-    public Response(@Nullable final okhttp3.Response response, final int code, @Nonnull final String message, final long retryAfter, @Nonnull final Set<String> cfRays)
+    public Response(@Nullable final okhttp3.Response response, final int code, @NotNull final String message, final long retryAfter, @NotNull final Set<String> cfRays)
     {
         this.rawResponse = response;
         this.code = code;
@@ -77,48 +77,48 @@ public class Response implements Closeable
         }
     }
 
-    public Response(final long retryAfter, @Nonnull final Set<String> cfRays)
+    public Response(final long retryAfter, @NotNull final Set<String> cfRays)
     {
         this(null, 429, "TOO MANY REQUESTS", retryAfter, cfRays);
     }
 
-    public Response(@Nonnull final okhttp3.Response response, final long retryAfter, @Nonnull final Set<String> cfRays)
+    public Response(@NotNull final okhttp3.Response response, final long retryAfter, @NotNull final Set<String> cfRays)
     {
         this(response, response.code(), response.message(), retryAfter, cfRays);
     }
 
-    @Nonnull
+    @NotNull
     public DataArray getArray()
     {
         return get(DataArray.class, JSON_SERIALIZE_ARRAY);
     }
 
-    @Nonnull
+    @NotNull
     public Optional<DataArray> optArray()
     {
         return parseBody(true, DataArray.class, JSON_SERIALIZE_ARRAY);
     }
 
-    @Nonnull
+    @NotNull
     public DataObject getObject()
     {
         return get(DataObject.class, JSON_SERIALIZE_OBJECT);
     }
 
-    @Nonnull
+    @NotNull
     public Optional<DataObject> optObject()
     {
         return parseBody(true, DataObject.class, JSON_SERIALIZE_OBJECT);
     }
 
-    @Nonnull
+    @NotNull
     public String getString()
     {
         return parseBody(String.class, this::readString)
             .orElseGet(() -> fallbackString == null ? "N/A" : fallbackString);
     }
 
-    @Nonnull
+    @NotNull
     public <T> T get(Class<T> clazz, IOFunction<BufferedReader, T> parser)
     {
         return parseBody(clazz, parser).orElseThrow(IllegalStateException::new);
@@ -130,7 +130,7 @@ public class Response implements Closeable
         return this.rawResponse;
     }
 
-    @Nonnull
+    @NotNull
     public Set<String> getCFRays()
     {
         return cfRays;

--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -25,10 +25,10 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.operator.*;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.ContextRunnable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -223,7 +223,7 @@ public interface RestAction<T>
      * @throws IllegalArgumentException
      *         If the provided unit is null
      */
-    static void setDefaultTimeout(long timeout, @Nonnull TimeUnit unit)
+    static void setDefaultTimeout(long timeout, @NotNull TimeUnit unit)
     {
         RestActionImpl.setDefaultTimeout(timeout, unit);
     }
@@ -246,7 +246,7 @@ public interface RestAction<T>
      *
      * @return The fallback consumer
      */
-    @Nonnull
+    @NotNull
     static Consumer<? super Throwable> getDefaultFailure()
     {
         return RestActionImpl.getDefaultFailure();
@@ -257,7 +257,7 @@ public interface RestAction<T>
      *
      * @return The fallback consumer
      */
-    @Nonnull
+    @NotNull
     static Consumer<Object> getDefaultSuccess()
     {
         return RestActionImpl.getDefaultSuccess();
@@ -285,10 +285,10 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @SafeVarargs
     @CheckReturnValue
-    static <E> RestAction<List<E>> allOf(@Nonnull RestAction<? extends E> first, @Nonnull RestAction<? extends E>... others)
+    static <E> RestAction<List<E>> allOf(@NotNull RestAction<? extends E> first, @NotNull RestAction<? extends E>... others)
     {
         Checks.notNull(first, "RestAction");
         Checks.noneNull(others, "RestAction");
@@ -318,9 +318,9 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    static <E> RestAction<List<E>> allOf(@Nonnull Collection<? extends RestAction<? extends E>> actions)
+    static <E> RestAction<List<E>> allOf(@NotNull Collection<? extends RestAction<? extends E>> actions)
     {
         return accumulate(actions, Collectors.toList());
     }
@@ -351,9 +351,9 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    static <E, A, O> RestAction<O> accumulate(@Nonnull Collection<? extends RestAction<? extends E>> actions, @Nonnull Collector<? super E, A, ? extends O> collector)
+    static <E, A, O> RestAction<O> accumulate(@NotNull Collection<? extends RestAction<? extends E>> actions, @NotNull Collector<? super E, A, ? extends O> collector)
     {
         Checks.noneNull(actions, "RestAction");
         Checks.notEmpty(actions, "RestActions");
@@ -387,7 +387,7 @@ public interface RestAction<T>
      *
      * @return The corresponding JDA instance
      */
-    @Nonnull
+    @NotNull
     JDA getJDA();
 
     /**
@@ -403,7 +403,7 @@ public interface RestAction<T>
      * @see    #getCheck()
      * @see    #addCheck(BooleanSupplier)
      */
-    @Nonnull
+    @NotNull
     RestAction<T> setCheck(@Nullable BooleanSupplier checks);
 
     /**
@@ -436,9 +436,9 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> addCheck(@Nonnull BooleanSupplier checks)
+    default RestAction<T> addCheck(@NotNull BooleanSupplier checks)
     {
         Checks.notNull(checks, "Checks");
         BooleanSupplier check = getCheck();
@@ -470,8 +470,8 @@ public interface RestAction<T>
      *
      * @see    #setDefaultTimeout(long, TimeUnit)
      */
-    @Nonnull
-    default RestAction<T> timeout(long timeout, @Nonnull TimeUnit unit)
+    @NotNull
+    default RestAction<T> timeout(long timeout, @NotNull TimeUnit unit)
     {
         Checks.notNull(unit, "TimeUnit");
         return deadline(timeout <= 0 ? 0 : System.currentTimeMillis() + unit.toMillis(timeout));
@@ -499,7 +499,7 @@ public interface RestAction<T>
      * @see    #timeout(long, TimeUnit)
      * @see    #setDefaultTimeout(long, TimeUnit)
      */
-    @Nonnull
+    @NotNull
     default RestAction<T> deadline(long timestamp)
     {
         throw new UnsupportedOperationException();
@@ -688,7 +688,7 @@ public interface RestAction<T>
      *
      * @return Never-null {@link java.util.concurrent.CompletableFuture CompletableFuture} representing the completion promise
      */
-    @Nonnull
+    @NotNull
     default CompletableFuture<T> submit()
     {
         return submit(true);
@@ -707,7 +707,7 @@ public interface RestAction<T>
      *
      * @return Never-null {@link java.util.concurrent.CompletableFuture CompletableFuture} task representing the completion promise
      */
-    @Nonnull
+    @NotNull
     CompletableFuture<T> submit(boolean shouldQueue);
 
     /**
@@ -726,7 +726,7 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<Result<T>> mapToResult()
     {
@@ -757,9 +757,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default <O> RestAction<O> map(@Nonnull Function<? super T, ? extends O> map)
+    default <O> RestAction<O> map(@NotNull Function<? super T, ? extends O> map)
     {
         Checks.notNull(map, "Function");
         return new MapRestAction<>(this, map);
@@ -791,9 +791,9 @@ public interface RestAction<T>
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> onErrorMap(@Nonnull Function<? super Throwable, ? extends T> map)
+    default RestAction<T> onErrorMap(@NotNull Function<? super Throwable, ? extends T> map)
     {
         return onErrorMap(null, map);
     }
@@ -829,9 +829,9 @@ public interface RestAction<T>
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> onErrorMap(@Nullable Predicate<? super Throwable> condition, @Nonnull Function<? super Throwable, ? extends T> map)
+    default RestAction<T> onErrorMap(@Nullable Predicate<? super Throwable> condition, @NotNull Function<? super Throwable, ? extends T> map)
     {
         Checks.notNull(map, "Function");
         return new MapErrorRestAction<>(this, condition == null ? (x) -> true : condition, map);
@@ -864,9 +864,9 @@ public interface RestAction<T>
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> onErrorFlatMap(@Nonnull Function<? super Throwable, ? extends RestAction<? extends T>> map)
+    default RestAction<T> onErrorFlatMap(@NotNull Function<? super Throwable, ? extends RestAction<? extends T>> map)
     {
         return onErrorFlatMap(null, map);
     }
@@ -903,9 +903,9 @@ public interface RestAction<T>
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> onErrorFlatMap(@Nullable Predicate<? super Throwable> condition, @Nonnull Function<? super Throwable, ? extends RestAction<? extends T>> map)
+    default RestAction<T> onErrorFlatMap(@Nullable Predicate<? super Throwable> condition, @NotNull Function<? super Throwable, ? extends RestAction<? extends T>> map)
     {
         Checks.notNull(map, "Function");
         return new FlatMapErrorRestAction<>(this, condition == null ? (x) -> true : condition, map);
@@ -940,9 +940,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default <O> RestAction<O> flatMap(@Nonnull Function<? super T, ? extends RestAction<O>> flatMap)
+    default <O> RestAction<O> flatMap(@NotNull Function<? super T, ? extends RestAction<O>> flatMap)
     {
         return flatMap(null, flatMap);
     }
@@ -986,9 +986,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default <O> RestAction<O> flatMap(@Nullable Predicate<? super T> condition, @Nonnull Function<? super T, ? extends RestAction<O>> flatMap)
+    default <O> RestAction<O> flatMap(@Nullable Predicate<? super T> condition, @NotNull Function<? super T, ? extends RestAction<O>> flatMap)
     {
         Checks.notNull(flatMap, "Function");
         return new FlatMapRestAction<>(this, condition, flatMap);
@@ -1017,9 +1017,9 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default <U, O> RestAction<O> and(@Nonnull RestAction<U> other, @Nonnull BiFunction<? super T, ? super U, ? extends O> accumulator)
+    default <U, O> RestAction<O> and(@NotNull RestAction<U> other, @NotNull BiFunction<? super T, ? super U, ? extends O> accumulator)
     {
         Checks.notNull(other, "RestAction");
         Checks.notNull(accumulator, "Accumulator");
@@ -1044,9 +1044,9 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default <U> RestAction<Void> and(@Nonnull RestAction<U> other)
+    default <U> RestAction<Void> and(@NotNull RestAction<U> other)
     {
         return and(other, (a, b) -> null);
     }
@@ -1072,10 +1072,10 @@ public interface RestAction<T>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     @SuppressWarnings("unchecked")
-    default RestAction<List<T>> zip(@Nonnull RestAction<? extends T> first, @Nonnull RestAction<? extends T>... other)
+    default RestAction<List<T>> zip(@NotNull RestAction<? extends T> first, @NotNull RestAction<? extends T>... other)
     {
         Checks.notNull(first, "RestAction");
         Checks.noneNull(other, "RestAction");
@@ -1111,9 +1111,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> delay(@Nonnull Duration duration)
+    default RestAction<T> delay(@NotNull Duration duration)
     {
         return delay(duration, null);
     }
@@ -1145,9 +1145,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> delay(@Nonnull Duration duration, @Nullable ScheduledExecutorService scheduler)
+    default RestAction<T> delay(@NotNull Duration duration, @Nullable ScheduledExecutorService scheduler)
     {
         Checks.notNull(duration, "Duration");
         return new DelayRestAction<>(this, TimeUnit.MILLISECONDS, duration.toMillis(), scheduler);
@@ -1180,9 +1180,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> delay(long delay, @Nonnull TimeUnit unit)
+    default RestAction<T> delay(long delay, @NotNull TimeUnit unit)
     {
         return delay(delay, unit, null);
     }
@@ -1216,9 +1216,9 @@ public interface RestAction<T>
      *
      * @since  4.1.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<T> delay(long delay, @Nonnull TimeUnit unit, @Nullable ScheduledExecutorService scheduler)
+    default RestAction<T> delay(long delay, @NotNull TimeUnit unit, @Nullable ScheduledExecutorService scheduler)
     {
         Checks.notNull(unit, "TimeUnit");
         return new DelayRestAction<>(this, unit, delay, scheduler);
@@ -1247,8 +1247,8 @@ public interface RestAction<T>
      * @return {@link DelayedCompletableFuture DelayedCompletableFuture}
      *         representing the delayed operation
      */
-    @Nonnull
-    default DelayedCompletableFuture<T> submitAfter(long delay, @Nonnull TimeUnit unit)
+    @NotNull
+    default DelayedCompletableFuture<T> submitAfter(long delay, @NotNull TimeUnit unit)
     {
         return submitAfter(delay, unit, null);
     }
@@ -1277,8 +1277,8 @@ public interface RestAction<T>
      * @return {@link DelayedCompletableFuture DelayedCompletableFuture}
      *         representing the delayed operation
      */
-    @Nonnull
-    default DelayedCompletableFuture<T> submitAfter(long delay, @Nonnull TimeUnit unit, @Nullable ScheduledExecutorService executor)
+    @NotNull
+    default DelayedCompletableFuture<T> submitAfter(long delay, @NotNull TimeUnit unit, @Nullable ScheduledExecutorService executor)
     {
         Checks.notNull(unit, "TimeUnit");
         if (executor == null)
@@ -1312,7 +1312,7 @@ public interface RestAction<T>
      *
      * @return The response value
      */
-    default T completeAfter(long delay, @Nonnull TimeUnit unit)
+    default T completeAfter(long delay, @NotNull TimeUnit unit)
     {
         Checks.notNull(unit, "TimeUnit");
         try
@@ -1349,8 +1349,8 @@ public interface RestAction<T>
      * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
      *         representing the delayed operation
      */
-    @Nonnull
-    default ScheduledFuture<?> queueAfter(long delay, @Nonnull TimeUnit unit)
+    @NotNull
+    default ScheduledFuture<?> queueAfter(long delay, @NotNull TimeUnit unit)
     {
         return queueAfter(delay, unit, null, null, null);
     }
@@ -1381,8 +1381,8 @@ public interface RestAction<T>
      * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
      *         representing the delayed operation
      */
-    @Nonnull
-    default ScheduledFuture<?> queueAfter(long delay, @Nonnull TimeUnit unit, @Nullable Consumer<? super T> success)
+    @NotNull
+    default ScheduledFuture<?> queueAfter(long delay, @NotNull TimeUnit unit, @Nullable Consumer<? super T> success)
     {
         return queueAfter(delay, unit, success, null, null);
     }
@@ -1415,8 +1415,8 @@ public interface RestAction<T>
      *
      * @see    net.dv8tion.jda.api.exceptions.ErrorHandler
      */
-    @Nonnull
-    default ScheduledFuture<?> queueAfter(long delay, @Nonnull TimeUnit unit, @Nullable Consumer<? super T> success, @Nullable Consumer<? super Throwable> failure)
+    @NotNull
+    default ScheduledFuture<?> queueAfter(long delay, @NotNull TimeUnit unit, @Nullable Consumer<? super T> success, @Nullable Consumer<? super Throwable> failure)
     {
         return queueAfter(delay, unit, success, failure, null);
     }
@@ -1446,8 +1446,8 @@ public interface RestAction<T>
      * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
      *         representing the delayed operation
      */
-    @Nonnull
-    default ScheduledFuture<?> queueAfter(long delay, @Nonnull TimeUnit unit, @Nullable ScheduledExecutorService executor)
+    @NotNull
+    default ScheduledFuture<?> queueAfter(long delay, @NotNull TimeUnit unit, @Nullable ScheduledExecutorService executor)
     {
         return queueAfter(delay, unit, null, null, executor);
     }
@@ -1480,8 +1480,8 @@ public interface RestAction<T>
      * @return {@link java.util.concurrent.ScheduledFuture ScheduledFuture}
      *         representing the delayed operation
      */
-    @Nonnull
-    default ScheduledFuture<?> queueAfter(long delay, @Nonnull TimeUnit unit, @Nullable Consumer<? super T> success, @Nullable ScheduledExecutorService executor)
+    @NotNull
+    default ScheduledFuture<?> queueAfter(long delay, @NotNull TimeUnit unit, @Nullable Consumer<? super T> success, @Nullable ScheduledExecutorService executor)
     {
         return queueAfter(delay, unit, success, null, executor);
     }
@@ -1516,8 +1516,8 @@ public interface RestAction<T>
      *
      * @see    net.dv8tion.jda.api.exceptions.ErrorHandler
      */
-    @Nonnull
-    default ScheduledFuture<?> queueAfter(long delay, @Nonnull TimeUnit unit, @Nullable Consumer<? super T> success, @Nullable Consumer<? super Throwable> failure, @Nullable ScheduledExecutorService executor)
+    @NotNull
+    default ScheduledFuture<?> queueAfter(long delay, @NotNull TimeUnit unit, @Nullable Consumer<? super T> success, @Nullable Consumer<? super Throwable> failure, @Nullable ScheduledExecutorService executor)
     {
         Checks.notNull(unit, "TimeUnit");
         if (executor == null)

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/AuditableRestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/AuditableRestAction.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.api.requests.restaction;
 import net.dv8tion.jda.api.audit.ThreadLocalReason;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -58,27 +58,27 @@ public interface AuditableRestAction<T> extends RestAction<T>
      *
      * @see    ThreadLocalReason
      */
-    @Nonnull
+    @NotNull
     AuditableRestAction<T> reason(@Nullable String reason);
 
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
     AuditableRestAction<T> setCheck(@Nullable BooleanSupplier checks);
 
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
-    AuditableRestAction<T> timeout(long timeout, @Nonnull TimeUnit unit);
+    AuditableRestAction<T> timeout(long timeout, @NotNull TimeUnit unit);
 
     /**
      * {@inheritDoc}
      */
-    @Nonnull
+    @NotNull
     @Override
     AuditableRestAction<T> deadline(long timestamp);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -47,15 +47,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface ChannelAction<T extends GuildChannel> extends AuditableRestAction<T>
 {
-    @Nonnull
+    @NotNull
     @Override
     ChannelAction<T> setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    ChannelAction<T> timeout(long timeout, @Nonnull TimeUnit unit);
+    ChannelAction<T> timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     ChannelAction<T> deadline(long timestamp);
 
@@ -64,7 +64,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The guild
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -72,7 +72,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The channel type
      */
-    @Nonnull
+    @NotNull
     ChannelType getType();
 
     /**
@@ -86,9 +86,9 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelAction<T> setName(@Nonnull String name);
+    ChannelAction<T> setName(@NotNull String name);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Category Category} for the new GuildChannel.
@@ -108,7 +108,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @see    #syncPermissionOverrides()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setParent(@Nullable Category category);
 
@@ -131,7 +131,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setPosition(@Nullable Integer position);
 
@@ -148,7 +148,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setTopic(@Nullable String topic);
 
@@ -163,7 +163,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setNSFW(boolean nsfw);
 
@@ -186,7 +186,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setSlowmode(int slowmode);
 
@@ -208,7 +208,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setNews(boolean news);
 
@@ -243,9 +243,9 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @see    java.util.EnumSet
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelAction<T> addPermissionOverride(@Nonnull IPermissionHolder target, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
+    default ChannelAction<T> addPermissionOverride(@NotNull IPermissionHolder target, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
     {
         final long allowRaw = allow != null ? Permission.getRaw(allow) : 0;
         final long denyRaw = deny != null ? Permission.getRaw(deny) : 0;
@@ -292,9 +292,9 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelAction<T> addPermissionOverride(@Nonnull IPermissionHolder target, long allow, long deny)
+    default ChannelAction<T> addPermissionOverride(@NotNull IPermissionHolder target, long allow, long deny)
     {
         Checks.notNull(target, "Override Role/Member");
         if (target instanceof Role)
@@ -333,7 +333,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @see    java.util.EnumSet
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default ChannelAction<T> addMemberPermissionOverride(long memberId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
     {
@@ -372,7 +372,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @see    java.util.EnumSet
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default ChannelAction<T> addRolePermissionOverride(long roleId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
     {
@@ -416,7 +416,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> addMemberPermissionOverride(long memberId, long allow, long deny);
 
@@ -454,7 +454,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> addRolePermissionOverride(long roleId, long allow, long deny);
 
@@ -467,7 +467,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> removePermissionOverride(long id);
 
@@ -483,9 +483,9 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelAction<T> removePermissionOverride(@Nonnull String id)
+    default ChannelAction<T> removePermissionOverride(@NotNull String id)
     {
         return removePermissionOverride(MiscUtil.parseSnowflake(id));
     }
@@ -502,9 +502,9 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default ChannelAction<T> removePermissionOverride(@Nonnull IPermissionHolder holder)
+    default ChannelAction<T> removePermissionOverride(@NotNull IPermissionHolder holder)
     {
         Checks.notNull(holder, "PermissionHolder");
         return removePermissionOverride(holder.getIdLong());
@@ -515,7 +515,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> clearPermissionOverrides();
 
@@ -530,7 +530,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> syncPermissionOverrides();
 
@@ -548,7 +548,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setBitrate(@Nullable Integer bitrate);
 
@@ -565,7 +565,7 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
      *
      * @return The current ChannelAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelAction<T> setUserlimit(@Nullable Integer userlimit);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/GuildAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/GuildAction.java
@@ -27,10 +27,10 @@ import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.requests.restaction.GuildActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.PermOverrideData;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.util.Collection;
 import java.util.HashSet;
@@ -49,15 +49,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface GuildAction extends RestAction<Void>
 {
-    @Nonnull
+    @NotNull
     @Override
     GuildAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    GuildAction timeout(long timeout, @Nonnull TimeUnit unit);
+    GuildAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     GuildAction deadline(long timestamp);
 
@@ -73,7 +73,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildAction setRegion(@Nullable Region region);
 
@@ -86,7 +86,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildAction setIcon(@Nullable Icon icon);
 
@@ -101,9 +101,9 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildAction setName(@Nonnull String name);
+    GuildAction setName(@NotNull String name);
 
     /**
      * Sets the {@link net.dv8tion.jda.api.entities.Guild.VerificationLevel VerificationLevel}
@@ -114,7 +114,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildAction setVerificationLevel(@Nullable Guild.VerificationLevel level);
 
@@ -127,7 +127,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildAction setNotificationLevel(@Nullable Guild.NotificationLevel level);
 
@@ -140,7 +140,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     GuildAction setExplicitContentLevel(@Nullable Guild.ExplicitContentLevel level);
 
@@ -157,9 +157,9 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildAction addChannel(@Nonnull ChannelData channel);
+    GuildAction addChannel(@NotNull ChannelData channel);
 
     /**
      * Gets the {@link ChannelData ChannelData}
@@ -173,7 +173,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelData getChannel(int index);
 
@@ -189,7 +189,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The removed object
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     ChannelData removeChannel(int index);
 
@@ -202,9 +202,9 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The current GuildAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    GuildAction removeChannel(@Nonnull ChannelData data);
+    GuildAction removeChannel(@NotNull ChannelData data);
 
     /**
      * Creates a new {@link ChannelData ChannelData}
@@ -226,9 +226,9 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return The new ChannelData instance
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    ChannelData newChannel(@Nonnull ChannelType type, @Nonnull String name);
+    ChannelData newChannel(@NotNull ChannelType type, @NotNull String name);
 
     /**
      * Retrieves the {@link RoleData RoleData} for the
@@ -239,7 +239,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return RoleData of the public role
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleData getPublicRole();
 
@@ -256,7 +256,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return RoleData of the provided index
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleData getRole(int index);
 
@@ -269,7 +269,7 @@ public interface GuildAction extends RestAction<Void>
      *
      * @return RoleData for the new Role
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleData newRole();
 
@@ -304,7 +304,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setPermissionsRaw(@Nullable Long rawPermissions)
         {
             this.permissions = rawPermissions;
@@ -322,8 +322,8 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
-        public RoleData addPermissions(@Nonnull Permission... permissions)
+        @NotNull
+        public RoleData addPermissions(@NotNull Permission... permissions)
         {
             Checks.notNull(permissions, "Permissions");
             for (Permission perm : permissions)
@@ -345,8 +345,8 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
-        public RoleData addPermissions(@Nonnull Collection<Permission> permissions)
+        @NotNull
+        public RoleData addPermissions(@NotNull Collection<Permission> permissions)
         {
             Checks.noneNull(permissions, "Permissions");
             if (this.permissions == null)
@@ -366,7 +366,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setName(@Nullable String name)
         {
             checkPublic("name");
@@ -385,7 +385,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setColor(@Nullable Color color)
         {
             checkPublic("color");
@@ -404,7 +404,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setColor(@Nullable Integer color)
         {
             checkPublic("color");
@@ -423,7 +423,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setPosition(@Nullable Integer position)
         {
             checkPublic("position");
@@ -442,7 +442,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setMentionable(@Nullable Boolean mentionable)
         {
             checkPublic("mentionable");
@@ -461,7 +461,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return The current RoleData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public RoleData setHoisted(@Nullable Boolean hoisted)
         {
             checkPublic("hoisted");
@@ -469,7 +469,7 @@ public interface GuildAction extends RestAction<Void>
             return this;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public DataObject toData()
         {
@@ -559,7 +559,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public ChannelData setTopic(@Nullable String topic)
         {
             if (topic != null && topic.length() > 1024)
@@ -577,7 +577,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public ChannelData setNSFW(@Nullable Boolean nsfw)
         {
             this.nsfw = nsfw;
@@ -596,7 +596,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public ChannelData setBitrate(@Nullable Integer bitrate)
         {
             if (bitrate != null)
@@ -620,7 +620,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public ChannelData setUserlimit(@Nullable Integer userlimit)
         {
             if (userlimit != null && (userlimit < 0 || userlimit > 99))
@@ -637,7 +637,7 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
+        @NotNull
         public ChannelData setPosition(@Nullable Integer position)
         {
             this.position = position;
@@ -661,8 +661,8 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
-        public ChannelData addPermissionOverride(@Nonnull GuildActionImpl.RoleData role, long allow, long deny)
+        @NotNull
+        public ChannelData addPermissionOverride(@NotNull GuildActionImpl.RoleData role, long allow, long deny)
         {
             Checks.notNull(role, "Role");
             this.overrides.add(new PermOverrideData(PermOverrideData.ROLE_TYPE, role.id, allow, deny));
@@ -689,8 +689,8 @@ public interface GuildAction extends RestAction<Void>
          *
          * @return This ChannelData instance for chaining convenience
          */
-        @Nonnull
-        public ChannelData addPermissionOverride(@Nonnull GuildActionImpl.RoleData role, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
+        @NotNull
+        public ChannelData addPermissionOverride(@NotNull GuildActionImpl.RoleData role, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
         {
             long allowRaw = 0;
             long denyRaw = 0;
@@ -707,7 +707,7 @@ public interface GuildAction extends RestAction<Void>
             return addPermissionOverride(role, allowRaw, denyRaw);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public DataObject toData()
         {

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/InviteAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/InviteAction.java
@@ -18,10 +18,10 @@ package net.dv8tion.jda.api.requests.restaction;
 
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Invite;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -33,15 +33,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface InviteAction extends AuditableRestAction<Invite>
 {
-    @Nonnull
+    @NotNull
     @Override
     InviteAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    InviteAction timeout(long timeout, @Nonnull TimeUnit unit);
+    InviteAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     InviteAction deadline(long timestamp);
 
@@ -57,7 +57,7 @@ public interface InviteAction extends AuditableRestAction<Invite>
      *
      * @return The current InviteAction for chaining.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     InviteAction setMaxAge(@Nullable final Integer maxAge);
 
@@ -75,9 +75,9 @@ public interface InviteAction extends AuditableRestAction<Invite>
      *
      * @return The current InviteAction for chaining.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    InviteAction setMaxAge(@Nullable final Long maxAge, @Nonnull final TimeUnit timeUnit);
+    InviteAction setMaxAge(@Nullable final Long maxAge, @NotNull final TimeUnit timeUnit);
 
     /**
      * Sets the max uses for the invite. Set this to {@code 0} if the invite should have unlimited uses. Default is {@code 0}.
@@ -91,7 +91,7 @@ public interface InviteAction extends AuditableRestAction<Invite>
      *
      * @return The current InviteAction for chaining.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     InviteAction setMaxUses(@Nullable final Integer maxUses);
 
@@ -103,7 +103,7 @@ public interface InviteAction extends AuditableRestAction<Invite>
      *
      * @return The current InviteAction for chaining.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     InviteAction setTemporary(@Nullable final Boolean temporary);
 
@@ -115,7 +115,7 @@ public interface InviteAction extends AuditableRestAction<Invite>
      *
      * @return The current InviteAction for chaining.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     InviteAction setUnique(@Nullable final Boolean unique);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MemberAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MemberAction.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -42,15 +42,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface MemberAction extends RestAction<Void>
 {
-    @Nonnull
+    @NotNull
     @Override
     MemberAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    MemberAction timeout(long timeout, @Nonnull TimeUnit unit);
+    MemberAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     MemberAction deadline(long timestamp);
 
@@ -59,7 +59,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The access token
      */
-    @Nonnull
+    @NotNull
     String getAccessToken();
 
     /**
@@ -67,7 +67,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The id of the user
      */
-    @Nonnull
+    @NotNull
     String getUserId();
 
     /**
@@ -84,7 +84,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The Guild
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -99,7 +99,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The current MemberAction for chaining
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MemberAction setNickname(@Nullable String nick);
 
@@ -115,7 +115,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The current MemberAction for chaining
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MemberAction setRoles(@Nullable Collection<Role> roles);
 
@@ -131,7 +131,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The current MemberAction for chaining
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MemberAction setRoles(@Nullable Role... roles);
 
@@ -144,7 +144,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The current MemberAction for chaining
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MemberAction setMute(boolean mute);
 
@@ -157,7 +157,7 @@ public interface MemberAction extends RestAction<Void>
      *
      * @return The current MemberAction for chaining
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MemberAction setDeafen(boolean deaf);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -26,10 +26,10 @@ import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -119,7 +119,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Default mentions set by MessageAction.setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     static EnumSet<Message.MentionType> getDefaultMentions()
     {
         return MessageActionImpl.getDefaultMentions();
@@ -179,15 +179,15 @@ public interface MessageAction extends RestAction<Message>, Appendable
         return MessageActionImpl.isDefaultFailOnInvalidReply();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     MessageAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    MessageAction timeout(long timeout, @Nonnull TimeUnit unit);
+    MessageAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     MessageAction deadline(long timestamp);
 
@@ -196,7 +196,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return The target channel
      */
-    @Nonnull
+    @NotNull
     MessageChannel getChannel();
 
     /**
@@ -233,7 +233,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction apply(@Nullable final Message message);
 
@@ -259,7 +259,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction referenceById(long messageId);
 
@@ -285,9 +285,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction referenceById(@Nonnull String messageId)
+    default MessageAction referenceById(@NotNull String messageId)
     {
         return referenceById(MiscUtil.parseSnowflake(messageId));
     }
@@ -314,9 +314,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction reference(@Nonnull Message message)
+    default MessageAction reference(@NotNull Message message)
     {
         Checks.notNull(message, "Message");
         return referenceById(message.getIdLong());
@@ -335,7 +335,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction mentionRepliedUser(boolean mention);
 
@@ -352,7 +352,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction failOnInvalidReply(boolean fail);
 
@@ -365,7 +365,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction tts(final boolean isTTS);
 
@@ -378,7 +378,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction reset();
 
@@ -397,7 +397,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    net.dv8tion.jda.api.MessageBuilder#setNonce(String)
      * @see    <a href="https://en.wikipedia.org/wiki/Cryptographic_nonce" target="_blank">Cryptographic Nonce - Wikipedia</a>
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction nonce(@Nullable final String nonce);
 
@@ -414,7 +414,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction content(@Nullable final String content);
 
@@ -434,7 +434,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction embed(@Nullable final MessageEmbed embed);
 
@@ -446,10 +446,10 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    default MessageAction append(@Nonnull final CharSequence csq)
+    default MessageAction append(@NotNull final CharSequence csq)
     {
         return append(csq, 0, csq.length());
     }
@@ -462,7 +462,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     MessageAction append(@Nullable final CharSequence csq, final int start, final int end);
@@ -475,7 +475,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     MessageAction append(final char c);
@@ -504,9 +504,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction appendFormat(@Nonnull final String format, final Object... args)
+    default MessageAction appendFormat(@NotNull final String format, final Object... args)
     {
         return append(String.format(format, args));
     }
@@ -537,9 +537,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction addFile(@Nonnull final InputStream data, @Nonnull final String name, @Nonnull AttachmentOption... options);
+    MessageAction addFile(@NotNull final InputStream data, @NotNull final String name, @NotNull AttachmentOption... options);
 
     /**
      * Adds the provided byte[] as file data.
@@ -569,9 +569,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction addFile(@Nonnull final byte[] data, @Nonnull final String name, @Nonnull AttachmentOption... options)
+    default MessageAction addFile(@NotNull final byte[] data, @NotNull final String name, @NotNull AttachmentOption... options)
     {
         Checks.notNull(data, "Data");
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
@@ -601,9 +601,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction addFile(@Nonnull final File file, @Nonnull AttachmentOption... options)
+    default MessageAction addFile(@NotNull final File file, @NotNull AttachmentOption... options)
     {
         Checks.notNull(file, "File");
         return addFile(file, file.getName(), options);
@@ -639,9 +639,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @see    net.dv8tion.jda.api.entities.SelfUser#getAllowedFileSize() SelfUser.getAllowedFileSize()
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction addFile(@Nonnull final File file, @Nonnull final String name, @Nonnull AttachmentOption... options);
+    MessageAction addFile(@NotNull final File file, @NotNull final String name, @NotNull AttachmentOption... options);
 
     /**
      * Clears all previously added files
@@ -652,7 +652,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @see    #clearFiles(BiConsumer)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction clearFiles();
 
@@ -667,9 +667,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @see    java.io.Closeable
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction clearFiles(@Nonnull BiConsumer<String, InputStream> finalizer);
+    MessageAction clearFiles(@NotNull BiConsumer<String, InputStream> finalizer);
 
     /**
      * Clears all previously added files
@@ -683,9 +683,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @see    java.io.Closeable
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction clearFiles(@Nonnull Consumer<InputStream> finalizer);
+    MessageAction clearFiles(@NotNull Consumer<InputStream> finalizer);
 
     /**
      * Whether all fields should be considered when editing a message
@@ -695,7 +695,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction override(final boolean bool);
 
@@ -714,7 +714,7 @@ public interface MessageAction extends RestAction<Message>, Appendable
      *
      * @return Updated MessageAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     MessageAction allowedMentions(@Nullable Collection<Message.MentionType> allowedMentions);
 
@@ -739,9 +739,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    #allowedMentions(Collection)
      * @see    #setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction mention(@Nonnull IMentionable... mentions);
+    MessageAction mention(@NotNull IMentionable... mentions);
 
     /**
      * Used to provide a whitelist for {@link net.dv8tion.jda.api.entities.User Users}, {@link net.dv8tion.jda.api.entities.Member Members}
@@ -764,9 +764,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    #allowedMentions(Collection)
      * @see    #setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction mention(@Nonnull Collection<? extends IMentionable> mentions)
+    default MessageAction mention(@NotNull Collection<? extends IMentionable> mentions)
     {
         Checks.noneNull(mentions, "Mention");
         return mention(mentions.toArray(new IMentionable[0]));
@@ -791,9 +791,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    #allowedMentions(Collection)
      * @see    #setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction mentionUsers(@Nonnull String... userIds);
+    MessageAction mentionUsers(@NotNull String... userIds);
 
     /**
      * Used to provide a whitelist of {@link net.dv8tion.jda.api.entities.User Users} that should be pinged,
@@ -814,9 +814,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    #allowedMentions(Collection)
      * @see    #setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction mentionUsers(@Nonnull long... userIds)
+    default MessageAction mentionUsers(@NotNull long... userIds)
     {
         Checks.notNull(userIds, "UserId array");
         String[] stringIds = new String[userIds.length];
@@ -846,9 +846,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    #allowedMentions(Collection)
      * @see    #setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    MessageAction mentionRoles(@Nonnull String... roleIds);
+    MessageAction mentionRoles(@NotNull String... roleIds);
 
     /**
      * Used to provide a whitelist of {@link net.dv8tion.jda.api.entities.Role Roles} that should be pinged,
@@ -869,9 +869,9 @@ public interface MessageAction extends RestAction<Message>, Appendable
      * @see    #allowedMentions(Collection)
      * @see    #setDefaultMentions(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default MessageAction mentionRoles(@Nonnull long... roleIds)
+    default MessageAction mentionRoles(@NotNull long... roleIds)
     {
         Checks.notNull(roleIds, "RoleId array");
         String[] stringIds = new String[roleIds.length];

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/PermissionOverrideAction.java
@@ -19,10 +19,10 @@ package net.dv8tion.jda.api.requests.restaction;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
@@ -43,15 +43,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface PermissionOverrideAction extends AuditableRestAction<PermissionOverride>
 {
-    @Nonnull
+    @NotNull
     @Override
     PermissionOverrideAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    PermissionOverrideAction timeout(long timeout, @Nonnull TimeUnit unit);
+    PermissionOverrideAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     PermissionOverrideAction deadline(long timestamp);
 
@@ -61,7 +61,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     default PermissionOverrideAction reset()
     {
         return resetAllow().resetDeny();
@@ -73,7 +73,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     PermissionOverrideAction resetAllow();
 
     /**
@@ -82,7 +82,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     PermissionOverrideAction resetDeny();
 
     /**
@@ -90,7 +90,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The channel
      */
-    @Nonnull
+    @NotNull
     GuildChannel getChannel();
 
     /**
@@ -114,7 +114,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The guild
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getChannel().getGuild();
@@ -139,7 +139,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return set of granted {@link net.dv8tion.jda.api.Permission Permissions}
      */
-    @Nonnull
+    @NotNull
     default EnumSet<Permission> getAllowedPermissions()
     {
         return Permission.getPermissions(getAllow());
@@ -164,7 +164,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return set of denied {@link net.dv8tion.jda.api.Permission Permissions}
      */
-    @Nonnull
+    @NotNull
     default EnumSet<Permission> getDeniedPermissions()
     {
         return Permission.getPermissions(getDeny());
@@ -194,7 +194,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @see    #getInherited()
      */
-    @Nonnull
+    @NotNull
     default EnumSet<Permission> getInheritedPermissions()
     {
         return Permission.getPermissions(getInherited());
@@ -242,7 +242,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @see    #setAllow(java.util.Collection) setAllow(Collection)
      * @see    #setAllow(net.dv8tion.jda.api.Permission...) setAllow(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermissionOverrideAction setAllow(long allowBits);
 
@@ -269,7 +269,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @see    java.util.EnumSet EnumSet
      * @see    #setAllow(net.dv8tion.jda.api.Permission...) setAllow(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default PermissionOverrideAction setAllow(@Nullable Collection<Permission> permissions)
     {
@@ -297,7 +297,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default PermissionOverrideAction setAllow(@Nullable Permission... permissions)
     {
@@ -320,7 +320,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermissionOverrideAction grant(long allowBits);
 
@@ -339,9 +339,9 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction grant(@Nonnull Collection<Permission> permissions)
+    default PermissionOverrideAction grant(@NotNull Collection<Permission> permissions)
     {
         return grant(Permission.getRaw(permissions));
     }
@@ -361,9 +361,9 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction grant(@Nonnull Permission... permissions)
+    default PermissionOverrideAction grant(@NotNull Permission... permissions)
     {
         return grant(Permission.getRaw(permissions));
     }
@@ -391,7 +391,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @see    #setDeny(java.util.Collection) setDeny(Collection)
      * @see    #setDeny(net.dv8tion.jda.api.Permission...) setDeny(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermissionOverrideAction setDeny(long denyBits);
 
@@ -418,7 +418,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @see    java.util.EnumSet EnumSet
      * @see    #setDeny(net.dv8tion.jda.api.Permission...) setDeny(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default PermissionOverrideAction setDeny(@Nullable Collection<Permission> permissions)
     {
@@ -446,7 +446,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default PermissionOverrideAction setDeny(@Nullable Permission... permissions)
     {
@@ -469,7 +469,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermissionOverrideAction deny(long denyBits);
 
@@ -488,9 +488,9 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction deny(@Nonnull Collection<Permission> permissions)
+    default PermissionOverrideAction deny(@NotNull Collection<Permission> permissions)
     {
         return deny(Permission.getRaw(permissions));
     }
@@ -510,9 +510,9 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction deny(@Nonnull Permission... permissions)
+    default PermissionOverrideAction deny(@NotNull Permission... permissions)
     {
         return deny(Permission.getRaw(permissions));
     }
@@ -531,7 +531,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermissionOverrideAction clear(long inheritedBits);
 
@@ -551,9 +551,9 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction clear(@Nonnull Collection<Permission> permissions)
+    default PermissionOverrideAction clear(@NotNull Collection<Permission> permissions)
     {
         return clear(Permission.getRaw(permissions));
     }
@@ -574,9 +574,9 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      *
      * @return The current PermissionOverrideAction - for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default PermissionOverrideAction clear(@Nonnull Permission... permissions)
+    default PermissionOverrideAction clear(@NotNull Permission... permissions)
     {
         return clear(Permission.getRaw(permissions));
     }
@@ -603,7 +603,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection)  Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     PermissionOverrideAction setPermissions(long allowBits, long denyBits);
 
@@ -632,7 +632,7 @@ public interface PermissionOverrideAction extends AuditableRestAction<Permission
      * @see    java.util.EnumSet EnumSet
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default PermissionOverrideAction setPermissions(@Nullable Collection<Permission> grantPermissions, @Nullable Collection<Permission> denyPermissions)
     {

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/RoleAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/RoleAction.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -43,15 +43,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface RoleAction extends AuditableRestAction<Role>
 {
-    @Nonnull
+    @NotNull
     @Override
     RoleAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    RoleAction timeout(long timeout, @Nonnull TimeUnit unit);
+    RoleAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     RoleAction deadline(long timestamp);
 
@@ -60,7 +60,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @return The guild
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -74,7 +74,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @return The current RoleAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleAction setName(@Nullable String name);
 
@@ -86,7 +86,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @return The current RoleAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleAction setHoisted(@Nullable Boolean hoisted);
 
@@ -99,7 +99,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @return The current RoleAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleAction setMentionable(@Nullable Boolean mentionable);
 
@@ -111,7 +111,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @return The current RoleAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RoleAction setColor(@Nullable Color color)
     {
@@ -128,7 +128,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @return The current RoleAction, for chaining convenience
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleAction setColor(@Nullable Integer rgb);
 
@@ -149,7 +149,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      *
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...) Permission.getRaw(Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RoleAction setPermissions(@Nullable Permission... permissions)
     {
@@ -177,7 +177,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection) Permission.getRaw(Collection)
      * @see    java.util.EnumSet EnumSet
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RoleAction setPermissions(@Nullable Collection<Permission> permissions)
     {
@@ -205,7 +205,7 @@ public interface RoleAction extends AuditableRestAction<Role>
      * @see    net.dv8tion.jda.api.Permission#getRaw(java.util.Collection)
      * @see    net.dv8tion.jda.api.Permission#getRaw(net.dv8tion.jda.api.Permission...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     RoleAction setPermissions(@Nullable Long permissions);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/WebhookAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/WebhookAction.java
@@ -20,10 +20,10 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Icon;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.Webhook;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -35,15 +35,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface WebhookAction extends AuditableRestAction<Webhook>
 {
-    @Nonnull
+    @NotNull
     @Override
     WebhookAction setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    WebhookAction timeout(long timeout, @Nonnull TimeUnit unit);
+    WebhookAction timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     WebhookAction deadline(long timestamp);
 
@@ -52,7 +52,7 @@ public interface WebhookAction extends AuditableRestAction<Webhook>
      *
      * @return The channel
      */
-    @Nonnull
+    @NotNull
     TextChannel getChannel();
 
     /**
@@ -60,7 +60,7 @@ public interface WebhookAction extends AuditableRestAction<Webhook>
      *
      * @return The guild
      */
-    @Nonnull
+    @NotNull
     default Guild getGuild()
     {
         return getChannel().getGuild();
@@ -77,9 +77,9 @@ public interface WebhookAction extends AuditableRestAction<Webhook>
      *
      * @return The current WebhookAction for chaining convenience.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    WebhookAction setName(@Nonnull String name);
+    WebhookAction setName(@NotNull String name);
 
     /**
      * Sets the <b>Avatar</b> for the custom Webhook User
@@ -90,7 +90,7 @@ public interface WebhookAction extends AuditableRestAction<Webhook>
      *
      * @return The current WebhookAction for chaining convenience.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     WebhookAction setAvatar(@Nullable Icon icon);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/CategoryOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/CategoryOrderAction.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.requests.restaction.order;
 
 import net.dv8tion.jda.api.entities.Category;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An extension of {@link ChannelOrderAction ChannelOrderAction} with
@@ -42,6 +41,6 @@ public interface CategoryOrderAction extends ChannelOrderAction
      * @return The {@link net.dv8tion.jda.api.entities.Category Category}
      *         of this CategoryOrderAction.
      */
-    @Nonnull
+    @NotNull
     Category getCategory();
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/ChannelOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/ChannelOrderAction.java
@@ -19,8 +19,8 @@ package net.dv8tion.jda.api.requests.restaction.order;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildChannel;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 
 /**
@@ -47,7 +47,7 @@ public interface ChannelOrderAction extends OrderAction<GuildChannel, ChannelOrd
      *
      * @return The corresponding {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 
     /**
@@ -66,7 +66,7 @@ public interface ChannelOrderAction extends OrderAction<GuildChannel, ChannelOrd
      *
      * @see    net.dv8tion.jda.api.entities.ChannelType#fromSortBucket(int)
      */
-    @Nonnull
+    @NotNull
     default EnumSet<ChannelType> getChannelTypes()
     {
         return ChannelType.fromSortBucket(getSortBucket());

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/OrderAction.java
@@ -17,9 +17,9 @@
 package net.dv8tion.jda.api.requests.restaction.order;
 
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -45,15 +45,15 @@ import java.util.function.BooleanSupplier;
  */
 public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<Void>
 {
-    @Nonnull
+    @NotNull
     @Override
     M setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    M timeout(long timeout, @Nonnull TimeUnit unit);
+    M timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     M deadline(long timestamp);
 
@@ -71,7 +71,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @return Immutable List representing the current order
      */
-    @Nonnull
+    @NotNull
     List<T> getCurrentOrder();
 
     /**
@@ -90,7 +90,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      * @see    #getSelectedPosition()
      * @see    #getSelectedEntity()
      */
-    @Nonnull
+    @NotNull
     M selectPosition(int selectedPosition);
 
     /**
@@ -108,8 +108,8 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      * @see    #getSelectedPosition()
      * @see    #getSelectedEntity()
      */
-    @Nonnull
-    M selectPosition(@Nonnull T selectedEntity);
+    @NotNull
+    M selectPosition(@NotNull T selectedEntity);
 
     /**
      * The currently selected position
@@ -127,7 +127,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @return The currently selected entity
      */
-    @Nonnull
+    @NotNull
     T getSelectedEntity();
 
     /**
@@ -146,7 +146,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @see    #moveTo(int)
      */
-    @Nonnull
+    @NotNull
     M moveUp(int amount);
 
     /**
@@ -165,7 +165,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @see    #moveTo(int)
      */
-    @Nonnull
+    @NotNull
     M moveDown(int amount);
 
     /**
@@ -186,7 +186,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      * @see    #moveDown(int)
      * @see    #moveUp(int)
      */
-    @Nonnull
+    @NotNull
     M moveTo(int position);
 
     /**
@@ -203,7 +203,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @return The current OrderAction sub-implementation instance
      */
-    @Nonnull
+    @NotNull
     M swapPosition(int swapPosition);
 
     /**
@@ -224,8 +224,8 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @see    #swapPosition(int)
      */
-    @Nonnull
-    M swapPosition(@Nonnull T swapEntity);
+    @NotNull
+    M swapPosition(@NotNull T swapEntity);
 
     /**
      * Reverses the {@link #getCurrentOrder() current order} by using
@@ -235,7 +235,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @see    java.util.Collections#reverse(java.util.List)
      */
-    @Nonnull
+    @NotNull
     M reverseOrder();
 
     /**
@@ -246,7 +246,7 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @see    java.util.Collections#shuffle(java.util.List)
      */
-    @Nonnull
+    @NotNull
     M shuffleOrder();
 
     /**
@@ -264,6 +264,6 @@ public interface OrderAction<T, M extends OrderAction<T, M>> extends RestAction<
      *
      * @see    java.util.ArrayList#sort(java.util.Comparator)
      */
-    @Nonnull
-    M sortOrder(@Nonnull final Comparator<T> comparator);
+    @NotNull
+    M sortOrder(@NotNull final Comparator<T> comparator);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/order/RoleOrderAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/order/RoleOrderAction.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.api.requests.restaction.order;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Implementation of {@link OrderAction OrderAction}
@@ -45,6 +44,6 @@ public interface RoleOrderAction extends OrderAction<Role, RoleOrderAction>
      *
      * @return The corresponding {@link net.dv8tion.jda.api.entities.Guild Guild}
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/AuditLogPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/AuditLogPaginationAction.java
@@ -20,9 +20,8 @@ import net.dv8tion.jda.api.audit.ActionType;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link PaginationAction PaginationAction} that paginates the audit logs endpoint.
@@ -73,7 +72,7 @@ public interface AuditLogPaginationAction extends PaginationAction<AuditLogEntry
      *
      * @return The never-null target Guild
      */
-    @Nonnull
+    @NotNull
     Guild getGuild();
     
     /**
@@ -85,7 +84,7 @@ public interface AuditLogPaginationAction extends PaginationAction<AuditLogEntry
      *
      * @return The current AuditLogPaginationAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     AuditLogPaginationAction type(@Nullable ActionType type);
 
     /**
@@ -98,7 +97,7 @@ public interface AuditLogPaginationAction extends PaginationAction<AuditLogEntry
      *
      * @return The current AuditLogPaginationAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     AuditLogPaginationAction user(@Nullable User user);
 
     /**
@@ -114,7 +113,7 @@ public interface AuditLogPaginationAction extends PaginationAction<AuditLogEntry
      *
      * @return The current AuditLogPaginationAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     AuditLogPaginationAction user(@Nullable String userId);
 
     /**
@@ -126,6 +125,6 @@ public interface AuditLogPaginationAction extends PaginationAction<AuditLogEntry
      *
      * @return The current AuditLogPaginationAction for chaining convenience
      */
-    @Nonnull
+    @NotNull
     AuditLogPaginationAction user(long userId);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/MessagePaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/MessagePaginationAction.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.api.requests.restaction.pagination;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * {@link PaginationAction PaginationAction} that paginates the message history endpoint.
@@ -66,7 +65,7 @@ public interface MessagePaginationAction extends PaginationAction<Message, Messa
      *
      * @return {@link net.dv8tion.jda.api.entities.ChannelType ChannelType}
      */
-    @Nonnull
+    @NotNull
     default ChannelType getType()
     {
         return getChannel().getType();
@@ -77,6 +76,6 @@ public interface MessagePaginationAction extends PaginationAction<Message, Messa
      *
      * @return The MessageChannel instance
      */
-    @Nonnull
+    @NotNull
     MessageChannel getChannel();
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/PaginationAction.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.Procedure;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -121,7 +121,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    java.util.concurrent.TimeUnit
      * @see    net.dv8tion.jda.api.utils.TimeUtil
      */
-    @Nonnull
+    @NotNull
     M skipTo(long id);
 
     /**
@@ -134,15 +134,15 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      */
     long getLastKey();
 
-    @Nonnull
+    @NotNull
     @Override
     M setCheck(@Nullable BooleanSupplier checks);
 
-    @Nonnull
+    @NotNull
     @Override
-    M timeout(long timeout, @Nonnull TimeUnit unit);
+    M timeout(long timeout, @NotNull TimeUnit unit);
 
-    @Nonnull
+    @NotNull
     @Override
     M deadline(long timestamp);
 
@@ -171,7 +171,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return Immutable {@link java.util.List List} containing all currently cached entities for this PaginationAction
      */
-    @Nonnull
+    @NotNull
     List<T> getCached();
 
     /**
@@ -182,7 +182,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return The most recent cached entity
      */
-    @Nonnull
+    @NotNull
     T getLast();
 
     /**
@@ -193,7 +193,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return The very first cached entity
      */
-    @Nonnull
+    @NotNull
     T getFirst();
 
     /**
@@ -218,7 +218,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return The current PaginationAction implementation instance
      */
-    @Nonnull
+    @NotNull
     M limit(final int limit);
 
     /**
@@ -235,7 +235,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return The current PaginationAction implementation instance
      */
-    @Nonnull
+    @NotNull
     M cache(final boolean enableCache);
 
     /**
@@ -298,8 +298,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(int, Predicate)
      * @see    #takeUntilAsync(Predicate)
      */
-    @Nonnull
-    default CompletableFuture<List<T>> takeWhileAsync(@Nonnull final Predicate<? super T> rule)
+    @NotNull
+    default CompletableFuture<List<T>> takeWhileAsync(@NotNull final Predicate<? super T> rule)
     {
         Checks.notNull(rule, "Rule");
         return takeUntilAsync(rule.negate());
@@ -323,8 +323,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
      */
-    @Nonnull
-    default CompletableFuture<List<T>> takeWhileAsync(int limit, @Nonnull final Predicate<? super T> rule)
+    @NotNull
+    default CompletableFuture<List<T>> takeWhileAsync(int limit, @NotNull final Predicate<? super T> rule)
     {
         Checks.notNull(rule, "Rule");
         return takeUntilAsync(limit, rule.negate());
@@ -346,8 +346,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
      */
-    @Nonnull
-    default CompletableFuture<List<T>> takeUntilAsync(@Nonnull final Predicate<? super T> rule)
+    @NotNull
+    default CompletableFuture<List<T>> takeUntilAsync(@NotNull final Predicate<? super T> rule)
     {
         return takeUntilAsync(0, rule);
     }
@@ -370,8 +370,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      * @see    #takeWhileAsync(Predicate)
      * @see    #takeUntilAsync(int, Predicate)
      */
-    @Nonnull
-    default CompletableFuture<List<T>> takeUntilAsync(int limit, @Nonnull final Predicate<? super T> rule)
+    @NotNull
+    default CompletableFuture<List<T>> takeUntilAsync(int limit, @NotNull final Predicate<? super T> rule)
     {
         Checks.notNull(rule, "Rule");
         Checks.notNegative(limit, "Limit");
@@ -403,7 +403,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @see    #forEachAsync(Procedure)
      */
-    @Nonnull
+    @NotNull
     CompletableFuture<List<T>> takeAsync(int amount);
 
     /**
@@ -417,7 +417,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @see    #forEachRemainingAsync(Procedure)
      */
-    @Nonnull
+    @NotNull
     CompletableFuture<List<T>> takeRemainingAsync(int amount);
 
     /**
@@ -454,8 +454,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    @Nonnull
-    default CompletableFuture<?> forEachAsync(@Nonnull final Procedure<? super T> action)
+    @NotNull
+    default CompletableFuture<?> forEachAsync(@NotNull final Procedure<? super T> action)
     {
         return forEachAsync(action, RestActionImpl.getDefaultFailure());
     }
@@ -497,8 +497,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    @Nonnull
-    CompletableFuture<?> forEachAsync(@Nonnull final Procedure<? super T> action, @Nonnull final Consumer<? super Throwable> failure);
+    @NotNull
+    CompletableFuture<?> forEachAsync(@NotNull final Procedure<? super T> action, @NotNull final Consumer<? super Throwable> failure);
 
     /**
      * Iterates over all remaining entities until the provided action returns {@code false}!
@@ -535,8 +535,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    @Nonnull
-    default CompletableFuture<?> forEachRemainingAsync(@Nonnull final Procedure<? super T> action)
+    @NotNull
+    default CompletableFuture<?> forEachRemainingAsync(@NotNull final Procedure<? super T> action)
     {
         return forEachRemainingAsync(action, RestActionImpl.getDefaultFailure());
     }
@@ -578,8 +578,8 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return {@link java.util.concurrent.Future Future} that can be cancelled to stop iteration from outside!
      */
-    @Nonnull
-    CompletableFuture<?> forEachRemainingAsync(@Nonnull final Procedure<? super T> action, @Nonnull final Consumer<? super Throwable> failure);
+    @NotNull
+    CompletableFuture<?> forEachRemainingAsync(@NotNull final Procedure<? super T> action, @NotNull final Consumer<? super Throwable> failure);
 
     /**
      * Iterates over all remaining entities until the provided action returns {@code false}!
@@ -591,7 +591,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *         The {@link net.dv8tion.jda.api.utils.Procedure Procedure}
      *         which should return {@code true} to continue iterating
      */
-    void forEachRemaining(@Nonnull final Procedure<? super T> action);
+    void forEachRemaining(@NotNull final Procedure<? super T> action);
 
     @Override
     default Spliterator<T> spliterator()
@@ -604,7 +604,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return a sequential {@code Stream} over the elements in this PaginationAction
      */
-    @Nonnull
+    @NotNull
     default Stream<T> stream()
     {
         return StreamSupport.stream(spliterator(), false);
@@ -616,7 +616,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return a sequential {@code Stream} over the elements in this PaginationAction
      */
-    @Nonnull
+    @NotNull
     default Stream<T> parallelStream()
     {
         return StreamSupport.stream(spliterator(), true);
@@ -628,7 +628,7 @@ public interface PaginationAction<T, M extends PaginationAction<T, M>> extends R
      *
      * @return new PaginationIterator
      */
-    @Nonnull
+    @NotNull
     @Override
     PaginationIterator<T> iterator();
 

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/ReactionPaginationAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/pagination/ReactionPaginationAction.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.requests.restaction.pagination;
 
 import net.dv8tion.jda.api.entities.*;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * {@link PaginationAction PaginationAction} that paginates the reaction users endpoint.
@@ -65,6 +64,6 @@ public interface ReactionPaginationAction extends PaginationAction<User, Reactio
      *
      * @return The current MessageReaction
      */
-    @Nonnull
+    @NotNull
     MessageReaction getReaction();
 }

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManager.java
@@ -41,10 +41,10 @@ import net.dv8tion.jda.internal.utils.config.SessionConfig;
 import net.dv8tion.jda.internal.utils.config.ThreadingConfig;
 import net.dv8tion.jda.internal.utils.config.sharding.*;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.security.auth.login.LoginException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -146,18 +146,18 @@ public class DefaultShardManager implements ShardManager
      */
     protected final ChunkingFilter chunkingFilter;
 
-    public DefaultShardManager(@Nonnull String token)
+    public DefaultShardManager(@NotNull String token)
     {
         this(token, null);
     }
 
-    public DefaultShardManager(@Nonnull String token, @Nullable Collection<Integer> shardIds)
+    public DefaultShardManager(@NotNull String token, @Nullable Collection<Integer> shardIds)
     {
         this(token, shardIds, null, null, null, null, null, null, null);
     }
 
     public DefaultShardManager(
-        @Nonnull String token, @Nullable Collection<Integer> shardIds,
+        @NotNull String token, @Nullable Collection<Integer> shardIds,
         @Nullable ShardingConfig shardingConfig, @Nullable EventConfig eventConfig,
         @Nullable PresenceProviderConfig presenceConfig, @Nullable ThreadingProviderConfig threadingConfig,
         @Nullable ShardingSessionConfig sessionConfig, @Nullable ShardingMetaConfig metaConfig,
@@ -193,7 +193,7 @@ public class DefaultShardManager implements ShardManager
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<GatewayIntent> getGatewayIntents()
     {
@@ -201,7 +201,7 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void addEventListener(@Nonnull final Object... listeners)
+    public void addEventListener(@NotNull final Object... listeners)
     {
         ShardManager.super.addEventListener(listeners);
         for (Object o : listeners)
@@ -209,7 +209,7 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void removeEventListener(@Nonnull final Object... listeners)
+    public void removeEventListener(@NotNull final Object... listeners)
     {
         ShardManager.super.removeEventListener(listeners);
         for (Object o : listeners)
@@ -217,14 +217,14 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void addEventListeners(@Nonnull IntFunction<Object> eventListenerProvider)
+    public void addEventListeners(@NotNull IntFunction<Object> eventListenerProvider)
     {
         ShardManager.super.addEventListeners(eventListenerProvider);
         eventConfig.addEventListenerProvider(eventListenerProvider);
     }
 
     @Override
-    public void removeEventListenerProvider(@Nonnull IntFunction<Object> eventListenerProvider)
+    public void removeEventListenerProvider(@NotNull IntFunction<Object> eventListenerProvider)
     {
         eventConfig.removeEventListenerProvider(eventListenerProvider);
     }
@@ -249,7 +249,7 @@ public class DefaultShardManager implements ShardManager
         return shard == null ? null : shard.getGuildById(id);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ShardCacheView getShardCache()
     {
@@ -612,7 +612,7 @@ public class DefaultShardManager implements ShardManager
     }
 
     @Override
-    public void setIdleProvider(@Nonnull IntFunction<Boolean> idleProvider)
+    public void setIdleProvider(@NotNull IntFunction<Boolean> idleProvider)
     {
         ShardManager.super.setIdleProvider(idleProvider);
         presenceConfig.setIdleProvider(idleProvider);

--- a/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/DefaultShardManagerBuilder.java
@@ -39,10 +39,10 @@ import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import net.dv8tion.jda.internal.utils.config.flags.ShardingConfigFlag;
 import net.dv8tion.jda.internal.utils.config.sharding.*;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.security.auth.login.LoginException;
 import java.util.*;
 import java.util.concurrent.*;
@@ -140,7 +140,7 @@ public class  DefaultShardManagerBuilder
     @ForRemoval(deadline="4.3.0")
     @DeprecatedSince("4.2.0")
     @ReplaceWith("DefaultShardManager.create(String, EnumSet)")
-    public DefaultShardManagerBuilder(@Nonnull String token)
+    public DefaultShardManagerBuilder(@NotNull String token)
     {
         throw new UnsupportedOperationException("You cannot use the deprecated constructor anymore. Please use create(...), createDefault(...), or createLight(...) instead.");
     }
@@ -170,7 +170,7 @@ public class  DefaultShardManagerBuilder
      * @see    #disableIntents(GatewayIntent, GatewayIntent...)
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public static DefaultShardManagerBuilder createDefault(@Nullable String token)
     {
@@ -211,9 +211,9 @@ public class  DefaultShardManagerBuilder
      *
      * @return The new DefaultShardManagerBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder createDefault(@Nullable String token, @Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static DefaultShardManagerBuilder createDefault(@Nullable String token, @NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -252,9 +252,9 @@ public class  DefaultShardManagerBuilder
      *
      * @return The new DefaultShardManagerBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder createDefault(@Nullable String token, @Nonnull Collection<GatewayIntent> intents)
+    public static DefaultShardManagerBuilder createDefault(@Nullable String token, @NotNull Collection<GatewayIntent> intents)
     {
         return create(token, intents).applyDefault();
     }
@@ -286,7 +286,7 @@ public class  DefaultShardManagerBuilder
      * @see    #disableIntents(GatewayIntent, GatewayIntent...)
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public static DefaultShardManagerBuilder createLight(@Nullable String token)
     {
@@ -324,9 +324,9 @@ public class  DefaultShardManagerBuilder
      *
      * @return The new DefaultShardManagerBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder createLight(@Nullable String token, @Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static DefaultShardManagerBuilder createLight(@Nullable String token, @NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -362,9 +362,9 @@ public class  DefaultShardManagerBuilder
      *
      * @return The new DefaultShardManagerBuilder
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder createLight(@Nullable String token, @Nonnull Collection<GatewayIntent> intents)
+    public static DefaultShardManagerBuilder createLight(@Nullable String token, @NotNull Collection<GatewayIntent> intents)
     {
         return create(token, intents).applyLight();
     }
@@ -406,9 +406,9 @@ public class  DefaultShardManagerBuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder create(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static DefaultShardManagerBuilder create(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         return create(null, intent, intents);
     }
@@ -438,9 +438,9 @@ public class  DefaultShardManagerBuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder create(@Nonnull Collection<GatewayIntent> intents)
+    public static DefaultShardManagerBuilder create(@NotNull Collection<GatewayIntent> intents)
     {
         return create(null, intents);
     }
@@ -472,9 +472,9 @@ public class  DefaultShardManagerBuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder create(@Nullable String token, @Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    public static DefaultShardManagerBuilder create(@Nullable String token, @NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         return new DefaultShardManagerBuilder(token, GatewayIntent.getRaw(intent, intents)).applyIntents();
     }
@@ -503,9 +503,9 @@ public class  DefaultShardManagerBuilder
      *
      * @see   #setToken(String)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static DefaultShardManagerBuilder create(@Nullable String token, @Nonnull Collection<GatewayIntent> intents)
+    public static DefaultShardManagerBuilder create(@Nullable String token, @NotNull Collection<GatewayIntent> intents)
     {
         return new DefaultShardManagerBuilder(token, GatewayIntent.getRaw(intents)).applyIntents();
     }
@@ -546,8 +546,8 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.1
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setGatewayEncoding(@Nonnull GatewayEncoding encoding)
+    @NotNull
+    public DefaultShardManagerBuilder setGatewayEncoding(@NotNull GatewayEncoding encoding)
     {
         Checks.notNull(encoding, "GatewayEncoding");
         this.encoding = encoding;
@@ -565,7 +565,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setRawEventsEnabled(boolean enable)
     {
         return setFlag(ConfigFlag.RAW_EVENTS, enable);
@@ -590,7 +590,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.1.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setRelativeRateLimit(boolean enable)
     {
         return setFlag(ConfigFlag.USE_RELATIVE_RATELIMIT, enable);
@@ -612,7 +612,7 @@ public class  DefaultShardManagerBuilder
      *             You should use {@link #enableCache(Collection)} and {@link #disableCache(Collection)} instead,
      *             to disable and enable cache flags without side-effects that may break in future versions.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ReplaceWith("enableCache(flags) and disableCache(flags)")
     @DeprecatedSince("4.2.0")
@@ -637,8 +637,8 @@ public class  DefaultShardManagerBuilder
      * @see    #enableCache(CacheFlag, CacheFlag...)
      * @see    #disableCache(Collection)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder enableCache(@Nonnull Collection<CacheFlag> flags)
+    @NotNull
+    public DefaultShardManagerBuilder enableCache(@NotNull Collection<CacheFlag> flags)
     {
         Checks.noneNull(flags, "CacheFlags");
         cacheFlags.addAll(flags);
@@ -662,8 +662,8 @@ public class  DefaultShardManagerBuilder
      * @see    #enableCache(Collection)
      * @see    #disableCache(CacheFlag, CacheFlag...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder enableCache(@Nonnull CacheFlag flag, @Nonnull CacheFlag... flags)
+    @NotNull
+    public DefaultShardManagerBuilder enableCache(@NotNull CacheFlag flag, @NotNull CacheFlag... flags)
     {
         Checks.notNull(flag, "CacheFlag");
         Checks.noneNull(flags, "CacheFlag");
@@ -685,7 +685,7 @@ public class  DefaultShardManagerBuilder
      *             You should use {@link #enableCache(Collection)} and {@link #disableCache(Collection)} instead,
      *             to disable and enable cache flags without side-effects that may break in future versions.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ReplaceWith("enableCache(flags) and disableCache(flags)")
     @DeprecatedSince("4.2.0")
@@ -709,8 +709,8 @@ public class  DefaultShardManagerBuilder
      * @see    #disableCache(CacheFlag, CacheFlag...)
      * @see    #enableCache(Collection)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder disableCache(@Nonnull Collection<CacheFlag> flags)
+    @NotNull
+    public DefaultShardManagerBuilder disableCache(@NotNull Collection<CacheFlag> flags)
     {
         Checks.noneNull(flags, "CacheFlags");
         automaticallyDisabled.removeAll(flags);
@@ -735,8 +735,8 @@ public class  DefaultShardManagerBuilder
      * @see    #disableCache(Collection)
      * @see    #enableCache(CacheFlag, CacheFlag...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder disableCache(@Nonnull CacheFlag flag, @Nonnull CacheFlag... flags)
+    @NotNull
+    public DefaultShardManagerBuilder disableCache(@NotNull CacheFlag flag, @NotNull CacheFlag... flags)
     {
         Checks.notNull(flag, "CacheFlag");
         Checks.noneNull(flags, "CacheFlag");
@@ -781,7 +781,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setMemberCachePolicy(@Nullable MemberCachePolicy policy)
     {
         if (policy == null)
@@ -803,7 +803,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.utils.SessionControllerAdapter SessionControllerAdapter
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setSessionController(@Nullable SessionController controller)
     {
         this.sessionController = controller;
@@ -822,7 +822,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    VoiceDispatchInterceptor
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setVoiceDispatchInterceptor(@Nullable VoiceDispatchInterceptor interceptor)
     {
         this.voiceDispatchInterceptor = interceptor;
@@ -845,7 +845,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    <a href="https://www.slf4j.org/api/org/slf4j/MDC.html" target="_blank">MDC Javadoc</a>
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setContextMap(@Nullable IntFunction<? extends ConcurrentMap<String, String>> provider)
     {
         this.contextProvider = provider;
@@ -866,7 +866,7 @@ public class  DefaultShardManagerBuilder
      * @see    <a href="https://www.slf4j.org/api/org/slf4j/MDC.html" target="_blank">MDC Javadoc</a>
      * @see    #setContextMap(java.util.function.IntFunction)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setContextEnabled(boolean enable)
     {
         return setFlag(ConfigFlag.MDC_CONTEXT, enable);
@@ -892,8 +892,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    <a href="https://discord.com/developers/docs/topics/gateway#transport-compression" target="_blank">Official Discord Documentation - Transport Compression</a>
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setCompression(@Nonnull Compression compression)
+    @NotNull
+    public DefaultShardManagerBuilder setCompression(@NotNull Compression compression)
     {
         Checks.notNull(compression, "Compression");
         this.compression = compression;
@@ -916,8 +916,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    DefaultShardManager#addEventListener(Object...) JDA.addEventListeners(Object...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder addEventListeners(@Nonnull final Object... listeners)
+    @NotNull
+    public DefaultShardManagerBuilder addEventListeners(@NotNull final Object... listeners)
     {
         return this.addEventListeners(Arrays.asList(listeners));
     }
@@ -938,8 +938,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    DefaultShardManager#addEventListener(Object...) JDA.addEventListeners(Object...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder addEventListeners(@Nonnull final Collection<Object> listeners)
+    @NotNull
+    public DefaultShardManagerBuilder addEventListeners(@NotNull final Collection<Object> listeners)
     {
         Checks.noneNull(listeners, "listeners");
 
@@ -957,8 +957,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.JDA#removeEventListener(Object...) JDA.removeEventListeners(Object...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder removeEventListeners(@Nonnull final Object... listeners)
+    @NotNull
+    public DefaultShardManagerBuilder removeEventListeners(@NotNull final Object... listeners)
     {
         return this.removeEventListeners(Arrays.asList(listeners));
     }
@@ -973,8 +973,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.JDA#removeEventListener(Object...) JDA.removeEventListeners(Object...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder removeEventListeners(@Nonnull final Collection<Object> listeners)
+    @NotNull
+    public DefaultShardManagerBuilder removeEventListeners(@NotNull final Collection<Object> listeners)
     {
         Checks.noneNull(listeners, "listeners");
 
@@ -999,8 +999,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder addEventListenerProvider(@Nonnull final IntFunction<Object> listenerProvider)
+    @NotNull
+    public DefaultShardManagerBuilder addEventListenerProvider(@NotNull final IntFunction<Object> listenerProvider)
     {
         return this.addEventListenerProviders(Collections.singleton(listenerProvider));
     }
@@ -1022,8 +1022,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder addEventListenerProviders(@Nonnull final Collection<IntFunction<Object>> listenerProviders)
+    @NotNull
+    public DefaultShardManagerBuilder addEventListenerProviders(@NotNull final Collection<IntFunction<Object>> listenerProviders)
     {
         Checks.noneNull(listenerProviders, "listener providers");
 
@@ -1039,8 +1039,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder removeEventListenerProvider(@Nonnull final IntFunction<Object> listenerProvider)
+    @NotNull
+    public DefaultShardManagerBuilder removeEventListenerProvider(@NotNull final IntFunction<Object> listenerProvider)
     {
         return this.removeEventListenerProviders(Collections.singleton(listenerProvider));
     }
@@ -1053,8 +1053,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder removeEventListenerProviders(@Nonnull final Collection<IntFunction<Object>> listenerProviders)
+    @NotNull
+    public DefaultShardManagerBuilder removeEventListenerProviders(@NotNull final Collection<IntFunction<Object>> listenerProviders)
     {
         Checks.noneNull(listenerProviders, "listener providers");
 
@@ -1073,7 +1073,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setAudioSendFactory(@Nullable final IAudioSendFactory factory)
     {
         this.audioSendFactory = factory;
@@ -1091,7 +1091,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setAutoReconnect(final boolean autoReconnect)
     {
         return setFlag(ConfigFlag.AUTO_RECONNECT, autoReconnect);
@@ -1109,7 +1109,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setBulkDeleteSplittingEnabled(final boolean enabled)
     {
         return setFlag(ConfigFlag.BULK_DELETE_SPLIT, enabled);
@@ -1127,7 +1127,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setEnableShutdownHook(final boolean enable)
     {
         return setFlag(ConfigFlag.SHUTDOWN_HOOK, enable);
@@ -1153,11 +1153,11 @@ public class  DefaultShardManagerBuilder
      *
      * @deprecated Use {@link #setEventManagerProvider(IntFunction)} instead
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @DeprecatedSince("3.8.1")
     @ReplaceWith("setEventManagerProvider((id) -> manager)")
-    public DefaultShardManagerBuilder setEventManager(@Nonnull final IEventManager manager)
+    public DefaultShardManagerBuilder setEventManager(@NotNull final IEventManager manager)
     {
         Checks.notNull(manager, "manager");
 
@@ -1182,8 +1182,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setEventManagerProvider(@Nonnull final IntFunction<? extends IEventManager> eventManagerProvider)
+    @NotNull
+    public DefaultShardManagerBuilder setEventManagerProvider(@NotNull final IntFunction<? extends IEventManager> eventManagerProvider)
     {
         Checks.notNull(eventManagerProvider, "eventManagerProvider");
         this.eventManagerProvider = eventManagerProvider;
@@ -1205,7 +1205,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setActivity(net.dv8tion.jda.api.entities.Activity)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setActivity(@Nullable final Activity activity)
     {
         return this.setActivityProvider(id -> activity);
@@ -1226,7 +1226,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setActivity(net.dv8tion.jda.api.entities.Activity)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setActivityProvider(@Nullable final IntFunction<? extends Activity> activityProvider)
     {
         this.activityProvider = activityProvider;
@@ -1245,7 +1245,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setIdle(boolean)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setIdle(final boolean idle)
     {
         return this.setIdleProvider(id -> idle);
@@ -1263,7 +1263,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setIdle(boolean)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setIdleProvider(@Nullable final IntFunction<Boolean> idleProvider)
     {
         this.idleProvider = idleProvider;
@@ -1284,7 +1284,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setStatus(OnlineStatus) Presence.setStatusProvider(OnlineStatus)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setStatus(@Nullable final OnlineStatus status)
     {
         Checks.notNull(status, "status");
@@ -1307,7 +1307,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    net.dv8tion.jda.api.managers.Presence#setStatus(OnlineStatus) Presence.setStatusProvider(OnlineStatus)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setStatusProvider(@Nullable final IntFunction<OnlineStatus> statusProvider)
     {
         this.statusProvider = statusProvider;
@@ -1324,7 +1324,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setThreadFactory(@Nullable final ThreadFactory threadFactory)
     {
         this.threadFactory = threadFactory;
@@ -1340,7 +1340,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setHttpClientBuilder(@Nullable OkHttpClient.Builder builder)
     {
         this.httpClientBuilder = builder;
@@ -1356,7 +1356,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setHttpClient(@Nullable OkHttpClient client)
     {
         this.httpClient = client;
@@ -1382,7 +1382,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setRateLimitPool(@Nullable ScheduledExecutorService pool)
     {
         return setRateLimitPool(pool, pool == null);
@@ -1407,7 +1407,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setRateLimitPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
     {
         return setRateLimitPoolProvider(pool == null ? null : new ThreadPoolProviderImpl<>(pool, automaticShutdown));
@@ -1429,7 +1429,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setRateLimitPoolProvider(@Nullable ThreadPoolProvider<? extends ScheduledExecutorService> provider)
     {
         this.rateLimitPoolProvider = provider;
@@ -1462,7 +1462,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setGatewayPool(@Nullable ScheduledExecutorService pool)
     {
         return setGatewayPool(pool, pool == null);
@@ -1494,7 +1494,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setGatewayPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
     {
         return setGatewayPoolProvider(pool == null ? null : new ThreadPoolProviderImpl<>(pool, automaticShutdown));
@@ -1523,7 +1523,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setGatewayPoolProvider(@Nullable ThreadPoolProvider<? extends ScheduledExecutorService> provider)
     {
         this.gatewayPoolProvider = provider;
@@ -1548,7 +1548,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setCallbackPool(@Nullable ExecutorService executor)
     {
         return setCallbackPool(executor, executor == null);
@@ -1572,7 +1572,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setCallbackPool(@Nullable ExecutorService executor, boolean automaticShutdown)
     {
         return setCallbackPoolProvider(executor == null ? null : new ThreadPoolProviderImpl<>(executor, automaticShutdown));
@@ -1594,7 +1594,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setCallbackPoolProvider(@Nullable ThreadPoolProvider<? extends ExecutorService> provider)
     {
         this.callbackPoolProvider = provider;
@@ -1615,7 +1615,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setEventPool(@Nullable ExecutorService executor)
     {
         return setEventPool(executor, executor == null);
@@ -1634,7 +1634,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setEventPool(@Nullable ExecutorService executor, boolean automaticShutdown)
     {
         return setEventPoolProvider(executor == null ? null : new ThreadPoolProviderImpl<>(executor, automaticShutdown));
@@ -1658,7 +1658,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setEventPoolProvider(@Nullable ThreadPoolProvider<? extends ExecutorService> provider)
     {
         this.eventPoolProvider = provider;
@@ -1679,7 +1679,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since 4.2.1
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setAudioPool(@Nullable ScheduledExecutorService pool)
     {
         return setAudioPool(pool, pool == null);
@@ -1701,7 +1701,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since 4.2.1
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setAudioPool(@Nullable ScheduledExecutorService pool, boolean automaticShutdown)
     {
         return setAudioPoolProvider(pool == null ? null : new ThreadPoolProviderImpl<>(pool, automaticShutdown));
@@ -1721,7 +1721,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since 4.2.1
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setAudioPoolProvider(@Nullable ThreadPoolProvider<? extends ScheduledExecutorService> provider)
     {
         this.audioPoolProvider = provider;
@@ -1742,7 +1742,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setMaxReconnectDelay(final int maxReconnectDelay)
     {
         Checks.check(maxReconnectDelay >= 32, "Max reconnect delay must be 32 seconds or greater. You provided %d.", maxReconnectDelay);
@@ -1763,7 +1763,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setRequestTimeoutRetry(boolean retryOnTimeout)
     {
         return setFlag(ConfigFlag.RETRY_TIMEOUT, retryOnTimeout);
@@ -1779,7 +1779,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setShards(final int... shardIds)
     {
         Checks.notNull(shardIds, "shardIds");
@@ -1812,7 +1812,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setShards(final int minShardId, final int maxShardId)
     {
         Checks.notNegative(minShardId, "minShardId");
@@ -1843,8 +1843,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setShards(@Nonnull Collection<Integer> shardIds)
+    @NotNull
+    public DefaultShardManagerBuilder setShards(@NotNull Collection<Integer> shardIds)
     {
         Checks.notNull(shardIds, "shardIds");
         for (Integer id : shardIds)
@@ -1869,7 +1869,7 @@ public class  DefaultShardManagerBuilder
      *
      * @see    #setShards(int, int)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setShardsTotal(final int shardsTotal)
     {
         Checks.check(shardsTotal == -1 || shardsTotal > 0, "shardsTotal must either be -1 or greater than 0");
@@ -1898,8 +1898,8 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setToken(@Nonnull final String token)
+    @NotNull
+    public DefaultShardManagerBuilder setToken(@NotNull final String token)
     {
         Checks.notBlank(token, "token");
 
@@ -1921,7 +1921,7 @@ public class  DefaultShardManagerBuilder
      * @see net.dv8tion.jda.api.JDA#shutdown()
      * @see net.dv8tion.jda.api.JDA#shutdownNow()
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setUseShutdownNow(final boolean useShutdownNow)
     {
         return setFlag(ShardingConfigFlag.SHUTDOWN_NOW, useShutdownNow);
@@ -1936,7 +1936,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setWebsocketFactory(@Nullable WebSocketFactory factory)
     {
         this.wsFactory = factory;
@@ -1960,7 +1960,7 @@ public class  DefaultShardManagerBuilder
      * @see    ChunkingFilter#include(long...)
      * @see    ChunkingFilter#exclude(long...)
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setChunkingFilter(@Nullable ChunkingFilter filter)
     {
         this.chunkingFilter = filter;
@@ -1988,7 +1988,7 @@ public class  DefaultShardManagerBuilder
      * @deprecated This is now superceded by {@link #setDisabledIntents(Collection)} and {@link #setMemberCachePolicy(MemberCachePolicy)}.
      *             To get identical behavior you can do {@code setMemberCachePolicy(VOICE).setDisabledIntents(GatewayIntent.GUILD_PRESENCES, GatewayIntent.GUILD_MESSAGE_TYPING, GatewayIntent.GUILD_MEMBERS)}
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ReplaceWith("setDisabledIntents(...).setMemberCachePolicy(...)")
     @DeprecatedSince("4.2.0")
@@ -2027,8 +2027,8 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setDisabledIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public DefaultShardManagerBuilder setDisabledIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "Intent");
         Checks.noneNull(intents, "Intent");
@@ -2056,7 +2056,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setDisabledIntents(@Nullable Collection<GatewayIntent> intents)
     {
         this.intents = GatewayIntent.ALL_INTENTS;
@@ -2083,8 +2083,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    #enableIntents(Collection)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder disableIntents(@Nonnull Collection<GatewayIntent> intents)
+    @NotNull
+    public DefaultShardManagerBuilder disableIntents(@NotNull Collection<GatewayIntent> intents)
     {
         Checks.noneNull(intents, "GatewayIntent");
         int raw = GatewayIntent.getRaw(intents);
@@ -2112,8 +2112,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder disableIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public DefaultShardManagerBuilder disableIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -2147,8 +2147,8 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
-    public DefaultShardManagerBuilder setEnabledIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public DefaultShardManagerBuilder setEnabledIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "Intent");
         Checks.noneNull(intents, "Intent");
@@ -2176,7 +2176,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.2.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setEnabledIntents(@Nullable Collection<GatewayIntent> intents)
     {
         if (intents == null || intents.isEmpty())
@@ -2202,8 +2202,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    #disableIntents(Collection)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder enableIntents(@Nonnull Collection<GatewayIntent> intents)
+    @NotNull
+    public DefaultShardManagerBuilder enableIntents(@NotNull Collection<GatewayIntent> intents)
     {
         Checks.noneNull(intents, "GatewayIntent");
         int raw = GatewayIntent.getRaw(intents);
@@ -2227,8 +2227,8 @@ public class  DefaultShardManagerBuilder
      *
      * @see    #enableIntents(GatewayIntent, GatewayIntent...)
      */
-    @Nonnull
-    public DefaultShardManagerBuilder enableIntents(@Nonnull GatewayIntent intent, @Nonnull GatewayIntent... intents)
+    @NotNull
+    public DefaultShardManagerBuilder enableIntents(@NotNull GatewayIntent intent, @NotNull GatewayIntent... intents)
     {
         Checks.notNull(intent, "GatewayIntent");
         Checks.noneNull(intents, "GatewayIntent");
@@ -2250,7 +2250,7 @@ public class  DefaultShardManagerBuilder
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setLargeThreshold(int threshold)
     {
         this.largeThreshold = Math.max(50, Math.min(250, threshold)); // enforce 50 <= t <= 250
@@ -2273,7 +2273,7 @@ public class  DefaultShardManagerBuilder
      *
      * @return The DefaultShardManagerBuilder instance. Useful for chaining.
      */
-    @Nonnull
+    @NotNull
     public DefaultShardManagerBuilder setMaxBufferSize(int bufferSize)
     {
         Checks.notNegative(bufferSize, "The buffer size");
@@ -2300,7 +2300,7 @@ public class  DefaultShardManagerBuilder
      * @return A {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager} instance that has started the login process. It is unknown as
      *         to whether or not loading has finished when this returns.
      */
-    @Nonnull
+    @NotNull
     public ShardManager build() throws LoginException, IllegalArgumentException
     {
         checkIntents();

--- a/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ShardManager.java
@@ -32,10 +32,10 @@ import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -65,7 +65,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If either listeners or one of it's objects is {@code null}.
      */
-    default void addEventListener(@Nonnull final Object... listeners)
+    default void addEventListener(@NotNull final Object... listeners)
     {
         Checks.noneNull(listeners, "listeners");
         this.getShardCache().forEach(jda -> jda.addEventListener(listeners));
@@ -80,7 +80,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If either listeners or one of it's objects is {@code null}.
      */
-    default void removeEventListener(@Nonnull final Object... listeners)
+    default void removeEventListener(@NotNull final Object... listeners)
     {
         Checks.noneNull(listeners, "listeners");
         this.getShardCache().forEach(jda -> jda.removeEventListener(listeners));
@@ -99,7 +99,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If the provided listener provider or any of the listeners or provides are {@code null}.
      */
-    default void addEventListeners(@Nonnull final IntFunction<Object> eventListenerProvider)
+    default void addEventListeners(@NotNull final IntFunction<Object> eventListenerProvider)
     {
         Checks.notNull(eventListenerProvider, "event listener provider");
         this.getShardCache().forEach(jda ->
@@ -121,7 +121,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If the provided event listeners provider is {@code null}.
      */
-    default void removeEventListeners(@Nonnull final IntFunction<Collection<Object>> eventListenerProvider)
+    default void removeEventListeners(@NotNull final IntFunction<Collection<Object>> eventListenerProvider)
     {
         Checks.notNull(eventListenerProvider, "event listener provider");
         this.getShardCache().forEach(jda ->
@@ -142,7 +142,7 @@ public interface ShardManager
      * @throws java.lang.IllegalArgumentException
      *         If the provided listener provider is {@code null}.
      */
-    default void removeEventListenerProvider(@Nonnull IntFunction<Object> eventListenerProvider)
+    default void removeEventListenerProvider(@NotNull IntFunction<Object> eventListenerProvider)
     {
     }
 
@@ -179,7 +179,7 @@ public interface ShardManager
      *
      * @return {@link EnumSet} of active gateway intents
      */
-    @Nonnull
+    @NotNull
     default EnumSet<GatewayIntent> getGatewayIntents()
     {
         //noinspection ConstantConditions
@@ -198,7 +198,7 @@ public interface ShardManager
      *
      * @return The Application registry for this bot.
      */
-    @Nonnull
+    @NotNull
     default RestAction<ApplicationInfo> retrieveApplicationInfo()
     {
         return this.getShardCache().stream()
@@ -236,7 +236,7 @@ public interface ShardManager
      *
      * @return An immutable list of all visible {@link net.dv8tion.jda.api.entities.Category Categories}.
      */
-    @Nonnull
+    @NotNull
     default List<Category> getCategories()
     {
         return this.getCategoryCache().asList();
@@ -256,8 +256,8 @@ public interface ShardManager
      *
      * @return Immutable list of all categories matching the provided name
      */
-    @Nonnull
-    default List<Category> getCategoriesByName(@Nonnull final String name, final boolean ignoreCase)
+    @NotNull
+    default List<Category> getCategoriesByName(@NotNull final String name, final boolean ignoreCase)
     {
         return this.getCategoryCache().getElementsByName(name, ignoreCase);
     }
@@ -289,7 +289,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Category Category} for the provided ID.
      */
     @Nullable
-    default Category getCategoryById(@Nonnull final String id)
+    default Category getCategoryById(@NotNull final String id)
     {
         return this.getCategoryCache().getElementById(id);
     }
@@ -300,7 +300,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<Category> getCategoryCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getCategoryCache));
@@ -338,7 +338,7 @@ public interface ShardManager
      *         our cache.
      */
     @Nullable
-    default Emote getEmoteById(@Nonnull final String id)
+    default Emote getEmoteById(@NotNull final String id)
     {
         return this.getEmoteCache().getElementById(id);
     }
@@ -350,7 +350,7 @@ public interface ShardManager
      *
      * @return Unified {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<Emote> getEmoteCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getEmoteCache));
@@ -372,7 +372,7 @@ public interface ShardManager
      *
      * @return An immutable list of Emotes (which may or may not be available to usage).
      */
-    @Nonnull
+    @NotNull
     default List<Emote> getEmotes()
     {
         return this.getEmoteCache().asList();
@@ -394,8 +394,8 @@ public interface ShardManager
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.Emote Emotes} that all have the same
      *         name as the provided name.
      */
-    @Nonnull
-    default List<Emote> getEmotesByName(@Nonnull final String name, final boolean ignoreCase)
+    @NotNull
+    default List<Emote> getEmotesByName(@NotNull final String name, final boolean ignoreCase)
     {
         return this.getEmoteCache().getElementsByName(name, ignoreCase);
     }
@@ -425,7 +425,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Guild Guild} with matching id.
      */
     @Nullable
-    default Guild getGuildById(@Nonnull final String id)
+    default Guild getGuildById(@NotNull final String id)
     {
         return getGuildById(MiscUtil.parseSnowflake(id));
     }
@@ -441,8 +441,8 @@ public interface ShardManager
      *
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.Guild Guilds} that all have the same name as the provided name.
      */
-    @Nonnull
-    default List<Guild> getGuildsByName(@Nonnull final String name, final boolean ignoreCase)
+    @NotNull
+    default List<Guild> getGuildsByName(@NotNull final String name, final boolean ignoreCase)
     {
         return this.getGuildCache().getElementsByName(name, ignoreCase);
     }
@@ -453,7 +453,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<Guild> getGuildCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getGuildCache));
@@ -471,7 +471,7 @@ public interface ShardManager
      *
      * @return Possibly-empty list of all the {@link net.dv8tion.jda.api.entities.Guild Guilds} that this account is connected to.
      */
-    @Nonnull
+    @NotNull
     default List<Guild> getGuilds()
     {
         return this.getGuildCache().asList();
@@ -485,8 +485,8 @@ public interface ShardManager
      *
      * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
      */
-    @Nonnull
-    default List<Guild> getMutualGuilds(@Nonnull final Collection<User> users)
+    @NotNull
+    default List<Guild> getMutualGuilds(@NotNull final Collection<User> users)
     {
         Checks.noneNull(users, "users");
         return Collections.unmodifiableList(
@@ -504,8 +504,8 @@ public interface ShardManager
      *
      * @return Unmodifiable list of all {@link net.dv8tion.jda.api.entities.Guild Guild} instances which have all {@link net.dv8tion.jda.api.entities.User Users} in them.
      */
-    @Nonnull
-    default List<Guild> getMutualGuilds(@Nonnull final User... users)
+    @NotNull
+    default List<Guild> getMutualGuilds(@NotNull final User... users)
     {
         Checks.notNull(users, "users");
         return this.getMutualGuilds(Arrays.asList(users));
@@ -534,9 +534,9 @@ public interface ShardManager
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.User User}
      *         <br>On request, gets the User with id matching provided id from Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    default RestAction<User> retrieveUserById(@Nonnull String id)
+    default RestAction<User> retrieveUserById(@NotNull String id)
     {
         return retrieveUserById(MiscUtil.parseSnowflake(id));
     }
@@ -562,7 +562,7 @@ public interface ShardManager
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link net.dv8tion.jda.api.entities.User User}
      *         <br>On request, gets the User with id matching provided id from Discord.
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     default RestAction<User> retrieveUserById(long id)
     {
@@ -606,7 +606,7 @@ public interface ShardManager
      * @return The {@link net.dv8tion.jda.api.entities.User} for the discord tag or null if no user has the provided tag
      */
     @Nullable
-    default User getUserByTag(@Nonnull String tag)
+    default User getUserByTag(@NotNull String tag)
     {
         return getShardCache().applyStream(stream ->
             stream.map(jda -> jda.getUserByTag(tag))
@@ -639,7 +639,7 @@ public interface ShardManager
      * @return The {@link net.dv8tion.jda.api.entities.User} for the discord tag or null if no user has the provided tag
      */
     @Nullable
-    default User getUserByTag(@Nonnull String username, @Nonnull String discriminator)
+    default User getUserByTag(@NotNull String username, @NotNull String discriminator)
     {
         return getShardCache().applyStream(stream ->
             stream.map(jda -> jda.getUserByTag(username, discriminator))
@@ -679,7 +679,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel} with matching id.
      */
     @Nullable
-    default PrivateChannel getPrivateChannelById(@Nonnull final String id)
+    default PrivateChannel getPrivateChannelById(@NotNull final String id)
     {
         return this.getPrivateChannelCache().getElementById(id);
     }
@@ -690,7 +690,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<PrivateChannel> getPrivateChannelCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getPrivateChannelCache));
@@ -706,7 +706,7 @@ public interface ShardManager
      *
      * @return Possibly-empty list of all {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<PrivateChannel> getPrivateChannels()
     {
         return this.getPrivateChannelCache().asList();
@@ -742,7 +742,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.Role Role} for the specified ID
      */
     @Nullable
-    default Role getRoleById(@Nonnull final String id)
+    default Role getRoleById(@NotNull final String id)
     {
         return this.getRoleCache().getElementById(id);
     }
@@ -753,7 +753,7 @@ public interface ShardManager
      *
      * @return Unified {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<Role> getRoleCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getRoleCache));
@@ -771,7 +771,7 @@ public interface ShardManager
      *
      * @return Immutable List of all visible Roles
      */
-    @Nonnull
+    @NotNull
     default List<Role> getRoles()
     {
         return this.getRoleCache().asList();
@@ -789,8 +789,8 @@ public interface ShardManager
      *
      * @return Immutable List of all Roles matching the parameters provided.
      */
-    @Nonnull
-    default List<Role> getRolesByName(@Nonnull final String name, final boolean ignoreCase)
+    @NotNull
+    default List<Role> getRolesByName(@NotNull final String name, final boolean ignoreCase)
     {
         return this.getRoleCache().getElementsByName(name, ignoreCase);
     }
@@ -818,7 +818,7 @@ public interface ShardManager
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull String id)
+    default GuildChannel getGuildChannelById(@NotNull String id)
     {
         return getGuildChannelById(MiscUtil.parseSnowflake(id));
     }
@@ -882,7 +882,7 @@ public interface ShardManager
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, @Nonnull String id)
+    default GuildChannel getGuildChannelById(@NotNull ChannelType type, @NotNull String id)
     {
         return getGuildChannelById(type, MiscUtil.parseSnowflake(id));
     }
@@ -911,7 +911,7 @@ public interface ShardManager
      * @return The GuildChannel or null
      */
     @Nullable
-    default GuildChannel getGuildChannelById(@Nonnull ChannelType type, long id)
+    default GuildChannel getGuildChannelById(@NotNull ChannelType type, long id)
     {
         Checks.notNull(type, "ChannelType");
         GuildChannel channel;
@@ -952,7 +952,7 @@ public interface ShardManager
      *         {@code null} if no shard has the given id
      */
     @Nullable
-    default JDA getShardById(@Nonnull final String id)
+    default JDA getShardById(@NotNull final String id)
     {
         return this.getShardCache().getElementById(id);
     }
@@ -963,7 +963,7 @@ public interface ShardManager
      *
      * @return Unified {@link ShardCacheView ShardCacheView}
      */
-    @Nonnull
+    @NotNull
     ShardCacheView getShardCache();
 
     /**
@@ -976,7 +976,7 @@ public interface ShardManager
      *
      * @return An immutable list of all managed {@link net.dv8tion.jda.api.JDA JDA} instances.
      */
-    @Nonnull
+    @NotNull
     default List<JDA> getShards()
     {
         return this.getShardCache().asList();
@@ -1004,7 +1004,7 @@ public interface ShardManager
      *
      * @return All current shard statuses.
      */
-    @Nonnull
+    @NotNull
     default Map<JDA, Status> getStatuses()
     {
         return Collections.unmodifiableMap(this.getShardCache().stream()
@@ -1050,7 +1050,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} with matching id.
      */
     @Nullable
-    default TextChannel getTextChannelById(@Nonnull final String id)
+    default TextChannel getTextChannelById(@NotNull final String id)
     {
         return this.getTextChannelCache().getElementById(id);
     }
@@ -1061,7 +1061,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<TextChannel> getTextChannelCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getTextChannelCache));
@@ -1084,7 +1084,7 @@ public interface ShardManager
      *
      * @return Possibly-empty list of all known {@link net.dv8tion.jda.api.entities.TextChannel TextChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<TextChannel> getTextChannels()
     {
         return this.getTextChannelCache().asList();
@@ -1117,7 +1117,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannel} with matching id.
      */
     @Nullable
-    default StoreChannel getStoreChannelById(@Nonnull final String id)
+    default StoreChannel getStoreChannelById(@NotNull final String id)
     {
         return this.getStoreChannelCache().getElementById(id);
     }
@@ -1128,7 +1128,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<StoreChannel> getStoreChannelCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getStoreChannelCache));
@@ -1145,7 +1145,7 @@ public interface ShardManager
      *
      * @return Possibly-empty list of all known {@link net.dv8tion.jda.api.entities.StoreChannel StoreChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<StoreChannel> getStoreChannels()
     {
         return this.getStoreChannelCache().asList();
@@ -1176,7 +1176,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.User User} with matching id.
      */
     @Nullable
-    default User getUserById(@Nonnull final String id)
+    default User getUserById(@NotNull final String id)
     {
         return this.getUserCache().getElementById(id);
     }
@@ -1187,7 +1187,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<User> getUserCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getUserCache));
@@ -1209,7 +1209,7 @@ public interface ShardManager
      *
      * @return List of all {@link net.dv8tion.jda.api.entities.User Users} that are visible to JDA.
      */
-    @Nonnull
+    @NotNull
     default List<User> getUsers()
     {
         return this.getUserCache().asList();
@@ -1241,7 +1241,7 @@ public interface ShardManager
      * @return Possibly-null {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannel} with matching id.
      */
     @Nullable
-    default VoiceChannel getVoiceChannelById(@Nonnull final String id)
+    default VoiceChannel getVoiceChannelById(@NotNull final String id)
     {
         return this.getVoiceChannelCache().getElementById(id);
     }
@@ -1252,7 +1252,7 @@ public interface ShardManager
      *
      * @return {@link net.dv8tion.jda.api.utils.cache.SnowflakeCacheView SnowflakeCacheView}
      */
-    @Nonnull
+    @NotNull
     default SnowflakeCacheView<VoiceChannel> getVoiceChannelCache()
     {
         return CacheView.allSnowflakes(() -> this.getShardCache().stream().map(JDA::getVoiceChannelCache));
@@ -1269,7 +1269,7 @@ public interface ShardManager
      *
      * @return Possible-empty list of all known {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}.
      */
-    @Nonnull
+    @NotNull
     default List<VoiceChannel> getVoiceChannels()
     {
         return this.getVoiceChannelCache().asList();
@@ -1385,7 +1385,7 @@ public interface ShardManager
      * @param idleProvider
      *        Provider for a boolean
      */
-    default void setIdleProvider(@Nonnull final IntFunction<Boolean> idleProvider)
+    default void setIdleProvider(@NotNull final IntFunction<Boolean> idleProvider)
     {
         this.getShardCache().forEach(jda -> jda.getPresence().setIdle(idleProvider.apply(jda.getShardInfo().getShardId())));
     }

--- a/src/main/java/net/dv8tion/jda/api/sharding/ThreadPoolProvider.java
+++ b/src/main/java/net/dv8tion/jda/api/sharding/ThreadPoolProvider.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.api.sharding;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.concurrent.ExecutorService;
 
 /**

--- a/src/main/java/net/dv8tion/jda/api/utils/ChunkingFilter.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/ChunkingFilter.java
@@ -17,8 +17,7 @@
 package net.dv8tion.jda.api.utils;
 
 import net.dv8tion.jda.internal.utils.Checks;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Filter function for member chunking of guilds.
@@ -65,8 +64,8 @@ public interface ChunkingFilter
      *
      * @return The resulting filter
      */
-    @Nonnull
-    static ChunkingFilter include(@Nonnull long... ids)
+    @NotNull
+    static ChunkingFilter include(@NotNull long... ids)
     {
         Checks.notNull(ids, "ID array");
         if (ids.length == 0)
@@ -93,8 +92,8 @@ public interface ChunkingFilter
      *
      * @return The resulting filter
      */
-    @Nonnull
-    static ChunkingFilter exclude(@Nonnull long... ids)
+    @NotNull
+    static ChunkingFilter exclude(@NotNull long... ids)
     {
         Checks.notNull(ids, "ID array");
         if (ids.length == 0)

--- a/src/main/java/net/dv8tion/jda/api/utils/ConcurrentSessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/ConcurrentSessionController.java
@@ -20,8 +20,8 @@ import com.neovisionaries.ws.client.OpeningHandshakeException;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.NoSuchElementException;
@@ -58,13 +58,13 @@ public class ConcurrentSessionController extends SessionControllerAdapter implem
     }
 
     @Override
-    public void appendSession(@Nonnull SessionConnectNode node)
+    public void appendSession(@NotNull SessionConnectNode node)
     {
         getWorker(node).enqueue(node);
     }
 
     @Override
-    public void removeSession(@Nonnull SessionConnectNode node)
+    public void removeSession(@NotNull SessionConnectNode node)
     {
         getWorker(node).dequeue(node);
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/LockIterator.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/LockIterator.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.api.utils;
 
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.locks.Lock;
@@ -55,7 +55,7 @@ public class LockIterator<T> implements ClosableIterator<T>
     private final Iterator<? extends T> it;
     private Lock lock;
 
-    public LockIterator(@Nonnull Iterator<? extends T> it, Lock lock)
+    public LockIterator(@NotNull Iterator<? extends T> it, Lock lock)
     {
         this.it = it;
         this.lock = lock;
@@ -80,7 +80,7 @@ public class LockIterator<T> implements ClosableIterator<T>
         return hasNext;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public T next()
     {

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.api.utils;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.regex.Pattern;
 
 /**
@@ -116,8 +116,8 @@ public class MarkdownSanitizer
      *
      * @return The sanitized string
      */
-    @Nonnull
-    public static String sanitize(@Nonnull String sequence)
+    @NotNull
+    public static String sanitize(@NotNull String sequence)
     {
         return sanitize(sequence, SanitizationStrategy.REMOVE);
     }
@@ -138,8 +138,8 @@ public class MarkdownSanitizer
      * @see    MarkdownSanitizer#MarkdownSanitizer()
      * @see    #withIgnored(int)
      */
-    @Nonnull
-    public static String sanitize(@Nonnull String sequence, @Nonnull SanitizationStrategy strategy)
+    @NotNull
+    public static String sanitize(@NotNull String sequence, @NotNull SanitizationStrategy strategy)
     {
         Checks.notNull(sequence, "String");
         Checks.notNull(strategy, "Strategy");
@@ -159,8 +159,8 @@ public class MarkdownSanitizer
      *
      * @see    #escape(String, int)
      */
-    @Nonnull
-    public static String escape(@Nonnull String sequence)
+    @NotNull
+    public static String escape(@NotNull String sequence)
     {
         return escape(sequence, NORMAL);
     }
@@ -179,8 +179,8 @@ public class MarkdownSanitizer
      *
      * @return The string with escaped markdown
      */
-    @Nonnull
-    public static String escape(@Nonnull String sequence, int ignored)
+    @NotNull
+    public static String escape(@NotNull String sequence, int ignored)
     {
         return new MarkdownSanitizer()
                 .withIgnored(ignored)
@@ -199,8 +199,8 @@ public class MarkdownSanitizer
      *
      * @return The current sanitizer instance with the new strategy
      */
-    @Nonnull
-    public MarkdownSanitizer withStrategy(@Nonnull SanitizationStrategy strategy)
+    @NotNull
+    public MarkdownSanitizer withStrategy(@NotNull SanitizationStrategy strategy)
     {
         Checks.notNull(strategy, "Strategy");
         this.strategy = strategy;
@@ -216,14 +216,14 @@ public class MarkdownSanitizer
      *
      * @return The current sanitizer instance with the new ignored regions
      */
-    @Nonnull
+    @NotNull
     public MarkdownSanitizer withIgnored(int ignored)
     {
         this.ignored |= ignored;
         return this;
     }
 
-    private int getRegion(int index, @Nonnull String sequence)
+    private int getRegion(int index, @NotNull String sequence)
     {
         if (sequence.length() - index >= 3)
         {
@@ -266,14 +266,14 @@ public class MarkdownSanitizer
         return NORMAL;
     }
 
-    private boolean hasCollision(int index, @Nonnull String sequence, char c)
+    private boolean hasCollision(int index, @NotNull String sequence, char c)
     {
         if (index < 0)
             return false;
         return index < sequence.length() - 1 && sequence.charAt(index + 1) == c;
     }
 
-    private int findEndIndex(int afterIndex, int region, @Nonnull String sequence)
+    private int findEndIndex(int afterIndex, int region, @NotNull String sequence)
     {
         if (isEscape(region))
             return -1;
@@ -353,8 +353,8 @@ public class MarkdownSanitizer
         return -1;
     }
 
-    @Nonnull
-    private String handleRegion(int start, int end, @Nonnull String sequence, int region)
+    @NotNull
+    private String handleRegion(int start, int end, @NotNull String sequence, int region)
     {
         String resolved = sequence.substring(start, end);
         switch (region)
@@ -401,7 +401,7 @@ public class MarkdownSanitizer
         }
     }
 
-    private void applyStrategy(int region, @Nonnull String seq, @Nonnull StringBuilder builder)
+    private void applyStrategy(int region, @NotNull String seq, @NotNull StringBuilder builder)
     {
         if (strategy == SanitizationStrategy.REMOVE)
         {
@@ -425,7 +425,7 @@ public class MarkdownSanitizer
                .append("\\").append(token);
     }
 
-    private boolean doesEscape(int index, @Nonnull String seq)
+    private boolean doesEscape(int index, @NotNull String seq)
     {
         int backslashes = 0;
         for (int i = index - 1; i > -1; i--)
@@ -460,8 +460,8 @@ public class MarkdownSanitizer
      *
      * @return The resulting string after applying the computation
      */
-    @Nonnull
-    public String compute(@Nonnull String sequence)
+    @NotNull
+    public String compute(@NotNull String sequence)
     {
         Checks.notNull(sequence, "Input");
         StringBuilder builder = new StringBuilder();
@@ -499,7 +499,7 @@ public class MarkdownSanitizer
         return builder.toString();
     }
 
-    private String handleQuote(@Nonnull String sequence, boolean newline)
+    private String handleQuote(@NotNull String sequence, boolean newline)
     {
         // Special handling for quote
         if (!isIgnored(QUOTE) && quote.matcher(sequence).matches())

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownUtil.java
@@ -16,8 +16,8 @@
 
 package net.dv8tion.jda.api.utils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class MarkdownUtil
 {
@@ -33,8 +33,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String bold(@Nonnull String input)
+    @NotNull
+    public static String bold(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.BOLD);
         return "**" + sanitized + "**";
@@ -50,8 +50,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String italics(@Nonnull String input)
+    @NotNull
+    public static String italics(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.ITALICS_U);
         return "_" + sanitized + "_";
@@ -67,8 +67,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String underline(@Nonnull String input)
+    @NotNull
+    public static String underline(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.UNDERLINE);
         return "__" + sanitized + "__";
@@ -84,8 +84,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String monospace(@Nonnull String input)
+    @NotNull
+    public static String monospace(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.MONO);
         return "`" + sanitized + "`";
@@ -101,8 +101,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String codeblock(@Nonnull String input)
+    @NotNull
+    public static String codeblock(@NotNull String input)
     {
         return codeblock(null, input);
     }
@@ -119,8 +119,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String codeblock(@Nullable String language, @Nonnull String input)
+    @NotNull
+    public static String codeblock(@Nullable String language, @NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.BLOCK);
         if (language != null)
@@ -138,8 +138,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String spoiler(@Nonnull String input)
+    @NotNull
+    public static String spoiler(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.SPOILER);
         return "||" + sanitized + "||";
@@ -155,8 +155,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String strike(@Nonnull String input)
+    @NotNull
+    public static String strike(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.STRIKE);
         return "~~" + sanitized + "~~";
@@ -172,8 +172,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String quote(@Nonnull String input)
+    @NotNull
+    public static String quote(@NotNull String input)
     {
         String sanitized = MarkdownSanitizer.escape(input, ~MarkdownSanitizer.QUOTE);
         return "> " + sanitized.replace("\n", "\n> ");
@@ -188,8 +188,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String quoteBlock(@Nonnull String input)
+    @NotNull
+    public static String quoteBlock(@NotNull String input)
     {
         return ">>> " + input;
     }
@@ -206,8 +206,8 @@ public final class MarkdownUtil
      *
      * @return The resulting output
      */
-    @Nonnull
-    public static String maskedLink(@Nonnull String text, @Nonnull String url)
+    @NotNull
+    public static String maskedLink(@NotNull String text, @NotNull String url)
     {
         return "[" + text.replace("]", "\\]") + "](" + url.replace(")", "%29") + ")";
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/MemberCachePolicy.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MemberCachePolicy.java
@@ -22,8 +22,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.internal.utils.Checks;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Policy which decides whether a member (and respective user) should be kept in cache.
@@ -117,7 +116,7 @@ public interface MemberCachePolicy
      *
      * @return True, if the member should be cached
      */
-    boolean cacheMember(@Nonnull Member member);
+    boolean cacheMember(@NotNull Member member);
 
     /**
      * Convenience method to concatenate another policy.
@@ -131,8 +130,8 @@ public interface MemberCachePolicy
      *
      * @return New policy which combines both using a logical OR
      */
-    @Nonnull
-    default MemberCachePolicy or(@Nonnull MemberCachePolicy policy)
+    @NotNull
+    default MemberCachePolicy or(@NotNull MemberCachePolicy policy)
     {
         Checks.notNull(policy, "Policy");
         return (member) -> cacheMember(member) || policy.cacheMember(member);
@@ -150,8 +149,8 @@ public interface MemberCachePolicy
      *
      * @return New policy which combines both using a logical AND
      */
-    @Nonnull
-    default MemberCachePolicy and(@Nonnull MemberCachePolicy policy)
+    @NotNull
+    default MemberCachePolicy and(@NotNull MemberCachePolicy policy)
     {
         return (member) -> cacheMember(member) && policy.cacheMember(member);
     }
@@ -167,8 +166,8 @@ public interface MemberCachePolicy
      *
      * @return New policy which combines all provided polices using a logical OR
      */
-    @Nonnull
-    static MemberCachePolicy any(@Nonnull MemberCachePolicy policy, @Nonnull MemberCachePolicy... policies)
+    @NotNull
+    static MemberCachePolicy any(@NotNull MemberCachePolicy policy, @NotNull MemberCachePolicy... policies)
     {
         Checks.notNull(policy, "Policy");
         Checks.notNull(policies, "Policy");
@@ -188,8 +187,8 @@ public interface MemberCachePolicy
      *
      * @return New policy which combines all provided polices using a logical AND
      */
-    @Nonnull
-    static MemberCachePolicy all(@Nonnull MemberCachePolicy policy, @Nonnull MemberCachePolicy... policies)
+    @NotNull
+    static MemberCachePolicy all(@NotNull MemberCachePolicy policy, @NotNull MemberCachePolicy... policies)
     {
         Checks.notNull(policy, "Policy");
         Checks.notNull(policies, "Policy");

--- a/src/main/java/net/dv8tion/jda/api/utils/Procedure.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Procedure.java
@@ -16,10 +16,10 @@
 
 package net.dv8tion.jda.api.utils;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 @FunctionalInterface
 public interface Procedure<T>
 {
-    boolean execute(@Nonnull T value);
+    boolean execute(@NotNull T value);
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/Result.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Result.java
@@ -17,10 +17,10 @@
 package net.dv8tion.jda.api.utils;
 
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -58,7 +58,7 @@ public class Result<T>
      *
      * @return Result
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public static <E> Result<E> success(@Nullable E value)
     {
@@ -78,9 +78,9 @@ public class Result<T>
      *
      * @return Result
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static <E> Result<E> failure(@Nonnull Throwable error)
+    public static <E> Result<E> failure(@NotNull Throwable error)
     {
         Checks.notNull(error, "Error");
         return new Result<>(null, error);
@@ -100,9 +100,9 @@ public class Result<T>
      *
      * @return Result instance with the supplied value or exception failure
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
-    public static <E> Result<E> defer(@Nonnull Supplier<? extends E> supplier)
+    public static <E> Result<E> defer(@NotNull Supplier<? extends E> supplier)
     {
         Checks.notNull(supplier, "Supplier");
         try
@@ -150,8 +150,8 @@ public class Result<T>
      *
      * @return The same result instance
      */
-    @Nonnull
-    public Result<T> onFailure(@Nonnull Consumer<? super Throwable> callback)
+    @NotNull
+    public Result<T> onFailure(@NotNull Consumer<? super Throwable> callback)
     {
         Checks.notNull(callback, "Callback");
         if (isFailure())
@@ -172,8 +172,8 @@ public class Result<T>
      *
      * @return The same result instance
      */
-    @Nonnull
-    public Result<T> onSuccess(@Nonnull Consumer<? super T> callback)
+    @NotNull
+    public Result<T> onSuccess(@NotNull Consumer<? super T> callback)
     {
         Checks.notNull(callback, "Callback");
         if (isSuccess())
@@ -197,10 +197,10 @@ public class Result<T>
      *
      * @see    #flatMap(Function)
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     @SuppressWarnings("unchecked")
-    public <U> Result<U> map(@Nonnull Function<? super T, ? extends U> function)
+    public <U> Result<U> map(@NotNull Function<? super T, ? extends U> function)
     {
         Checks.notNull(function, "Function");
         if (isSuccess())
@@ -222,10 +222,10 @@ public class Result<T>
      *
      * @return The mapped result
      */
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     @SuppressWarnings("unchecked")
-    public <U> Result<U> flatMap(@Nonnull Function<? super T, ? extends Result<U>> function)
+    public <U> Result<U> flatMap(@NotNull Function<? super T, ? extends Result<U>> function)
     {
         Checks.notNull(function, "Function");
         try
@@ -283,8 +283,8 @@ public class Result<T>
      *
      * @return The same result instance
      */
-    @Nonnull
-    public Result<T> expect(@Nonnull Predicate<? super Throwable> predicate)
+    @NotNull
+    public Result<T> expect(@NotNull Predicate<? super Throwable> predicate)
     {
         Checks.notNull(predicate, "Predicate");
         if (isFailure() && predicate.test(error))

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionController.java
@@ -21,8 +21,7 @@ import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Controls states and behaviour of one or multiple {@link net.dv8tion.jda.api.JDA JDA} instances.
@@ -114,7 +113,7 @@ public interface SessionController
      * @param  node
      *         The {@link net.dv8tion.jda.api.utils.SessionController.SessionConnectNode SessionConnectNode}
      */
-    void appendSession(@Nonnull SessionConnectNode node);
+    void appendSession(@NotNull SessionConnectNode node);
 
     /**
      * Called by a JDA session when a shutdown has been requested.
@@ -124,7 +123,7 @@ public interface SessionController
      * @param node
      *        The {@link net.dv8tion.jda.api.utils.SessionController.SessionConnectNode SessionConnectNode} to remove from the queue.
      */
-    void removeSession(@Nonnull SessionConnectNode node);
+    void removeSession(@NotNull SessionConnectNode node);
 
     /**
      * Provides the cross-session global REST ratelimit it received through {@link #setGlobalRatelimit(long)}.
@@ -150,8 +149,8 @@ public interface SessionController
      *
      * @return The gateway endpoint
      */
-    @Nonnull
-    String getGateway(@Nonnull JDA api);
+    @NotNull
+    String getGateway(@NotNull JDA api);
 
     /**
      * Called by {@link net.dv8tion.jda.api.sharding.DefaultShardManager DefaultShardManager}
@@ -169,13 +168,13 @@ public interface SessionController
      *         Use {@link #getShardedGateway(JDA)} instead, an implementation for this is ignored
      *         if {@link #getShardedGateway(JDA)} is implemented instead.
      */
-    @Nonnull
+    @NotNull
     @Deprecated
     @ForRemoval
     @DeprecatedSince("4.0.0")
     @ReplaceWith("getShardedGateway(api)")
     @SuppressWarnings("DeprecatedIsStillUsed")
-    Pair<String, Integer> getGatewayBot(@Nonnull JDA api);
+    Pair<String, Integer> getGatewayBot(@NotNull JDA api);
 
     /**
      * Called by {@link net.dv8tion.jda.api.sharding.DefaultShardManager DefaultShardManager}
@@ -189,9 +188,9 @@ public interface SessionController
      *
      * @see    #getGateway(net.dv8tion.jda.api.JDA)
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    default ShardedGateway getShardedGateway(@Nonnull JDA api)
+    default ShardedGateway getShardedGateway(@NotNull JDA api)
     {
         Pair<String, Integer> tuple = getGatewayBot(api);
         return new ShardedGateway(tuple.getLeft(), tuple.getRight());
@@ -281,7 +280,7 @@ public interface SessionController
          *
          * @return The JDA instance
          */
-        @Nonnull
+        @NotNull
         JDA getJDA();
 
         /**
@@ -290,7 +289,7 @@ public interface SessionController
          *
          * @return The ShardInfo
          */
-        @Nonnull
+        @NotNull
         JDA.ShardInfo getShardInfo();
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/utils/SessionControllerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/SessionControllerAdapter.java
@@ -27,9 +27,9 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
 import javax.security.auth.login.LoginException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -52,7 +52,7 @@ public class SessionControllerAdapter implements SessionController
     }
 
     @Override
-    public void appendSession(@Nonnull SessionConnectNode node)
+    public void appendSession(@NotNull SessionConnectNode node)
     {
         removeSession(node);
         connectQueue.add(node);
@@ -60,7 +60,7 @@ public class SessionControllerAdapter implements SessionController
     }
 
     @Override
-    public void removeSession(@Nonnull SessionConnectNode node)
+    public void removeSession(@NotNull SessionConnectNode node)
     {
         connectQueue.remove(node);
     }
@@ -77,18 +77,18 @@ public class SessionControllerAdapter implements SessionController
         globalRatelimit.set(ratelimit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public String getGateway(@Nonnull JDA api)
+    public String getGateway(@NotNull JDA api)
     {
         Route.CompiledRoute route = Route.Misc.GATEWAY.compile();
         return new RestActionImpl<String>(api, route,
                 (response, request) -> response.getObject().getString("url")).priority().complete();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ShardedGateway getShardedGateway(@Nonnull JDA api)
+    public ShardedGateway getShardedGateway(@NotNull JDA api)
     {
         AccountTypeException.check(api.getAccountType(), AccountType.BOT);
         return new RestActionImpl<ShardedGateway>(api, Route.Misc.GATEWAY_BOT.compile())
@@ -119,10 +119,10 @@ public class SessionControllerAdapter implements SessionController
         }.priority().complete();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public Pair<String, Integer> getGatewayBot(@Nonnull JDA api)
+    public Pair<String, Integer> getGatewayBot(@NotNull JDA api)
     {
         ShardedGateway bot = getShardedGateway(api);
         return Pair.of(bot.getUrl(), bot.getShardTotal());

--- a/src/main/java/net/dv8tion/jda/api/utils/TimeUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/TimeUtil.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.api.utils;
 
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
@@ -54,7 +54,7 @@ public class TimeUtil
      *
      * @return The creation time of the JDA entity as OffsetDateTime
      */
-    @Nonnull
+    @NotNull
     public static OffsetDateTime getTimeCreated(long entityId)
     {
         long timestamp = (entityId >>> TIMESTAMP_OFFSET) + DISCORD_EPOCH;
@@ -75,8 +75,8 @@ public class TimeUtil
      *
      * @return The creation time of the JDA entity as OffsetDateTime
      */
-    @Nonnull
-    public static OffsetDateTime getTimeCreated(@Nonnull ISnowflake entity)
+    @NotNull
+    public static OffsetDateTime getTimeCreated(@NotNull ISnowflake entity)
     {
         Checks.notNull(entity, "Entity");
         return getTimeCreated(entity.getIdLong());
@@ -90,8 +90,8 @@ public class TimeUtil
      *
      * @return The String of the formatted OffsetDateTime
      */
-    @Nonnull
-    public static String getDateTimeString(@Nonnull OffsetDateTime time)
+    @NotNull
+    public static String getDateTimeString(@NotNull OffsetDateTime time)
     {
         return time.format(dtFormatter);
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
@@ -30,9 +30,9 @@ import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -66,8 +66,8 @@ public class WidgetUtil
      *
      * @return A String containing the URL of the banner image
      */
-    @Nonnull
-    public static String getWidgetBanner(@Nonnull Guild guild, @Nonnull BannerType type)
+    @NotNull
+    public static String getWidgetBanner(@NotNull Guild guild, @NotNull BannerType type)
     {
         Checks.notNull(guild, "Guild");
         return getWidgetBanner(guild.getId(), type);
@@ -86,8 +86,8 @@ public class WidgetUtil
      *
      * @return A String containing the URL of the banner image
      */
-    @Nonnull
-    public static String getWidgetBanner(@Nonnull String guildId, @Nonnull BannerType type)
+    @NotNull
+    public static String getWidgetBanner(@NotNull String guildId, @NotNull BannerType type)
     {
         Checks.notNull(guildId, "GuildId");
         Checks.notNull(type, "BannerType");
@@ -110,8 +110,8 @@ public class WidgetUtil
      *
      * @return a String containing the pre-made widget with the supplied settings
      */
-    @Nonnull
-    public static String getPremadeWidgetHtml(@Nonnull Guild guild, @Nonnull WidgetTheme theme, int width, int height)
+    @NotNull
+    public static String getPremadeWidgetHtml(@NotNull Guild guild, @NotNull WidgetTheme theme, int width, int height)
     {
         Checks.notNull(guild, "Guild");
         return getPremadeWidgetHtml(guild.getId(), theme, width, height);
@@ -134,8 +134,8 @@ public class WidgetUtil
      *
      * @return a String containing the pre-made widget with the supplied settings
      */
-    @Nonnull
-    public static String getPremadeWidgetHtml(@Nonnull String guildId, @Nonnull WidgetTheme theme, int width, int height)
+    @NotNull
+    public static String getPremadeWidgetHtml(@NotNull String guildId, @NotNull WidgetTheme theme, int width, int height)
     {
         Checks.notNull(guildId, "GuildId");
         Checks.notNull(theme, "WidgetTheme");
@@ -170,7 +170,7 @@ public class WidgetUtil
      *         in question has the widget enabled.
      */
     @Nullable
-    public static Widget getWidget(@Nonnull String guildId) throws RateLimitedException
+    public static Widget getWidget(@NotNull String guildId) throws RateLimitedException
     {
         return getWidget(MiscUtil.parseSnowflake(guildId));
     }
@@ -313,7 +313,7 @@ public class WidgetUtil
          * @param json
          *        The {@link net.dv8tion.jda.api.utils.data.DataObject DataObject} to construct the Widget from
          */
-        private Widget(@Nonnull DataObject json)
+        private Widget(@NotNull DataObject json)
         {
             String inviteCode = json.getString("instant_invite", null);
             if (inviteCode != null)
@@ -380,7 +380,7 @@ public class WidgetUtil
          *
          * @return the name of the guild
          */
-        @Nonnull
+        @NotNull
         public String getName()
         {
             checkAvailable();
@@ -413,7 +413,7 @@ public class WidgetUtil
          *
          * @return the list of voice channels in the guild
          */
-        @Nonnull
+        @NotNull
         public List<VoiceChannel> getVoiceChannels()
         {
             checkAvailable();
@@ -469,7 +469,7 @@ public class WidgetUtil
          *
          * @return the list of members
          */
-        @Nonnull
+        @NotNull
         public List<Member> getMembers()
         {
             checkAvailable();
@@ -555,7 +555,7 @@ public class WidgetUtil
             private final Widget widget;
             private VoiceState state;
             
-            private Member(@Nonnull DataObject json, @Nonnull Widget widget)
+            private Member(@NotNull DataObject json, @NotNull Widget widget)
             {
                 this.widget = widget;
                 this.bot = json.getBoolean("bot");
@@ -588,7 +588,7 @@ public class WidgetUtil
              * 
              * @return the username of the member
              */
-            @Nonnull
+            @NotNull
             public String getName()
             {
                 return username;
@@ -600,7 +600,7 @@ public class WidgetUtil
                 return id;
             }
 
-            @Nonnull
+            @NotNull
             @Override
             public String getAsMention()
             {
@@ -612,7 +612,7 @@ public class WidgetUtil
              * 
              * @return the never-null discriminator of the member
              */
-            @Nonnull
+            @NotNull
             public String getDiscriminator()
             {
                 return discriminator;
@@ -651,7 +651,7 @@ public class WidgetUtil
              * @return never-null String containing the asset id of the member's
              *         default avatar
              */
-            @Nonnull
+            @NotNull
             public String getDefaultAvatarId()
             {
                 return String.valueOf(Integer.parseInt(getDiscriminator()) % 5);
@@ -663,7 +663,7 @@ public class WidgetUtil
              * @return never-null String containing the url of the member's
              *         default avatar
              */
-            @Nonnull
+            @NotNull
             public String getDefaultAvatarUrl()
             {
                 return String.format(User.DEFAULT_AVATAR_URL, getDefaultAvatarId());
@@ -676,7 +676,7 @@ public class WidgetUtil
             * 
             * @return Never-null String containing the member's effective avatar url.
             */
-            @Nonnull
+            @NotNull
             public String getEffectiveAvatarUrl()
             {
                 String avatarUrl = getAvatarUrl();
@@ -701,7 +701,7 @@ public class WidgetUtil
              * 
              * @return never-null String containing the member's effective (visible) name
              */
-            @Nonnull
+            @NotNull
             public String getEffectiveName()
             {
                 return nickname == null ? username : nickname;
@@ -713,7 +713,7 @@ public class WidgetUtil
              * 
              * @return the {@link net.dv8tion.jda.api.OnlineStatus OnlineStatus} of the member
              */
-            @Nonnull
+            @NotNull
             public OnlineStatus getOnlineStatus()
             {
                 return status;
@@ -739,7 +739,7 @@ public class WidgetUtil
              * 
              * @return never-null VoiceState of the member
              */
-            @Nonnull
+            @NotNull
             public VoiceState getVoiceState()
             {
                 return state == null ? new VoiceState(this, widget) : state;
@@ -750,7 +750,7 @@ public class WidgetUtil
              * 
              * @return the Widget that holds this member
              */
-            @Nonnull
+            @NotNull
             public Widget getWidget()
             {
                 return widget;
@@ -784,7 +784,7 @@ public class WidgetUtil
             private final List<Member> members;
             private final Widget widget;
             
-            private VoiceChannel(@Nonnull DataObject json, @Nonnull Widget widget)
+            private VoiceChannel(@NotNull DataObject json, @NotNull Widget widget)
             {
                 this.widget = widget;
                 this.position = json.getInt("position");
@@ -793,7 +793,7 @@ public class WidgetUtil
                 this.members = new ArrayList<>();
             }
             
-            private void addMember(@Nonnull Member member)
+            private void addMember(@NotNull Member member)
             {
                 members.add(member);
             }
@@ -819,7 +819,7 @@ public class WidgetUtil
              * 
              * @return name of the channel
              */
-            @Nonnull
+            @NotNull
             public String getName()
             {
                 return name;
@@ -830,7 +830,7 @@ public class WidgetUtil
              * 
              * @return never-null, possibly-empty list of members in the channel
              */
-            @Nonnull
+            @NotNull
             public List<Member> getMembers()
             {
                 return members;
@@ -841,7 +841,7 @@ public class WidgetUtil
              * 
              * @return the Widget object that holds this voice channel
              */
-            @Nonnull
+            @NotNull
             public Widget getWidget()
             {
                 return widget;
@@ -878,12 +878,12 @@ public class WidgetUtil
             private final Member member;
             private final Widget widget;
             
-            private VoiceState(@Nonnull Member member, @Nonnull Widget widget)
+            private VoiceState(@NotNull Member member, @NotNull Widget widget)
             {
                 this(null, false, false, false, false, false, member, widget);
             }
             
-            private VoiceState(@Nullable VoiceChannel channel, boolean muted, boolean deafened, boolean suppress, boolean selfMute, boolean selfDeaf, @Nonnull Member member, @Nonnull Widget widget)
+            private VoiceState(@Nullable VoiceChannel channel, boolean muted, boolean deafened, boolean suppress, boolean selfMute, boolean selfDeaf, @NotNull Member member, @NotNull Widget widget)
             {
                 this.channel = channel;
                 this.muted = muted;
@@ -987,13 +987,13 @@ public class WidgetUtil
                 return selfDeaf || deafened;
             }
 
-            @Nonnull
+            @NotNull
             public Member getMember()
             {
                 return member;
             }
 
-            @Nonnull
+            @NotNull
             public Widget getWidget()
             {
                 return widget;

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheFlag.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheFlag.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 /**
@@ -115,7 +115,7 @@ public enum CacheFlag
      *
      * @return {@link EnumSet} of the cache flags that require the privileged intents
      */
-    @Nonnull
+    @NotNull
     public static EnumSet<CacheFlag> getPrivileged()
     {
         return EnumSet.copyOf(privileged);

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
@@ -23,9 +23,9 @@ import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.ShardCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.UnifiedCacheViewImpl;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -69,7 +69,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Immutable list of cached elements
      */
-    @Nonnull
+    @NotNull
     List<T> asList();
 
     /**
@@ -78,7 +78,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Immutable set of cached elements
      */
-    @Nonnull
+    @NotNull
     Set<T> asSet();
 
     /**
@@ -93,7 +93,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     ClosableIterator<T> lockedIterator();
 
     /**
@@ -108,7 +108,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @since  4.0.0
      */
-    default void forEachUnordered(@Nonnull final Consumer<? super T> action)
+    default void forEachUnordered(@NotNull final Consumer<? super T> action)
     {
         forEach(action);
     }
@@ -141,7 +141,7 @@ public interface CacheView<T> extends Iterable<T>
      * @see    #acceptStream(Consumer)
      */
     @Nullable
-    default <R> R applyStream(@Nonnull Function<? super Stream<T>, ? extends R> action)
+    default <R> R applyStream(@NotNull Function<? super Stream<T>, ? extends R> action)
     {
         Checks.notNull(action, "Action");
         try (ClosableIterator<T> it = lockedIterator())
@@ -174,7 +174,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @see    #applyStream(Function)
      */
-    default void acceptStream(@Nonnull Consumer<? super Stream<T>> action)
+    default void acceptStream(@NotNull Consumer<? super Stream<T>> action)
     {
         Checks.notNull(action, "Action");
         try (ClosableIterator<T> it = lockedIterator())
@@ -224,8 +224,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Immutable list of elements with the given name
      */
-    @Nonnull
-    List<T> getElementsByName(@Nonnull String name, boolean ignoreCase);
+    @NotNull
+    List<T> getElementsByName(@NotNull String name, boolean ignoreCase);
 
     /**
      * Creates an immutable list of all elements matching the given name.
@@ -240,8 +240,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Immutable list of elements with the given name
      */
-    @Nonnull
-    default List<T> getElementsByName(@Nonnull String name)
+    @NotNull
+    default List<T> getElementsByName(@NotNull String name)
     {
         return getElementsByName(name, false);
     }
@@ -252,7 +252,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Stream of elements
      */
-    @Nonnull
+    @NotNull
     Stream<T> stream();
 
     /**
@@ -261,7 +261,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Parallel Stream of elements
      */
-    @Nonnull
+    @NotNull
     Stream<T> parallelStream();
 
     /**
@@ -282,8 +282,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Resulting collections
      */
-    @Nonnull
-    default <R, A> R collect(@Nonnull Collector<? super T, A, R> collector)
+    @NotNull
+    default <R, A> R collect(@NotNull Collector<? super T, A, R> collector)
     {
         return stream().collect(collector);
     }
@@ -301,8 +301,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined CacheView spanning over all provided implementation instances
      */
-    @Nonnull
-    static <E> CacheView<E> all(@Nonnull Collection<? extends CacheView<E>> cacheViews)
+    @NotNull
+    static <E> CacheView<E> all(@NotNull Collection<? extends CacheView<E>> cacheViews)
     {
         Checks.noneNull(cacheViews, "Collection");
         return new UnifiedCacheViewImpl<>(cacheViews::stream);
@@ -321,8 +321,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined CacheView spanning over all provided implementation instances
      */
-    @Nonnull
-    static <E> CacheView<E> all(@Nonnull Supplier<? extends Stream<? extends CacheView<E>>> generator)
+    @NotNull
+    static <E> CacheView<E> all(@NotNull Supplier<? extends Stream<? extends CacheView<E>>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl<>(generator);
@@ -337,8 +337,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined ShardCacheView spanning over all provided implementation instances
      */
-    @Nonnull
-    static ShardCacheView allShards(@Nonnull Collection<ShardCacheView> cacheViews)
+    @NotNull
+    static ShardCacheView allShards(@NotNull Collection<ShardCacheView> cacheViews)
     {
         Checks.noneNull(cacheViews, "Collection");
         return new ShardCacheViewImpl.UnifiedShardCacheViewImpl(cacheViews::stream);
@@ -353,8 +353,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined ShardCacheView spanning over all provided implementation instances
      */
-    @Nonnull
-    static ShardCacheView allShards(@Nonnull Supplier<? extends Stream<? extends ShardCacheView>> generator)
+    @NotNull
+    static ShardCacheView allShards(@NotNull Supplier<? extends Stream<? extends ShardCacheView>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new ShardCacheViewImpl.UnifiedShardCacheViewImpl(generator);
@@ -373,8 +373,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined SnowflakeCacheView spanning over all provided implementation instances
      */
-    @Nonnull
-    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(@Nonnull Collection<? extends SnowflakeCacheView<E>> cacheViews)
+    @NotNull
+    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(@NotNull Collection<? extends SnowflakeCacheView<E>> cacheViews)
     {
         Checks.noneNull(cacheViews, "Collection");
         return new UnifiedCacheViewImpl.UnifiedSnowflakeCacheView<>(cacheViews::stream);
@@ -393,8 +393,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined SnowflakeCacheView spanning over all provided implementation instances
      */
-    @Nonnull
-    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(@Nonnull Supplier<? extends Stream<? extends SnowflakeCacheView<E>>> generator)
+    @NotNull
+    static <E extends ISnowflake> SnowflakeCacheView<E> allSnowflakes(@NotNull Supplier<? extends Stream<? extends SnowflakeCacheView<E>>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl.UnifiedSnowflakeCacheView<>(generator);
@@ -410,8 +410,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined MemberCacheView spanning over all provided instances
      */
-    @Nonnull
-    static UnifiedMemberCacheView allMembers(@Nonnull Collection<? extends MemberCacheView> cacheViews)
+    @NotNull
+    static UnifiedMemberCacheView allMembers(@NotNull Collection<? extends MemberCacheView> cacheViews)
     {
         Checks.noneNull(cacheViews, "Collection");
         return new UnifiedCacheViewImpl.UnifiedMemberCacheViewImpl(cacheViews::stream);
@@ -427,8 +427,8 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return Combined MemberCacheView spanning over all provided instances
      */
-    @Nonnull
-    static UnifiedMemberCacheView allMembers(@Nonnull Supplier<? extends Stream<? extends MemberCacheView>> generator)
+    @NotNull
+    static UnifiedMemberCacheView allMembers(@NotNull Supplier<? extends Stream<? extends MemberCacheView>> generator)
     {
         Checks.notNull(generator, "Generator");
         return new UnifiedCacheViewImpl.UnifiedMemberCacheViewImpl(generator);
@@ -443,7 +443,7 @@ public interface CacheView<T> extends Iterable<T>
      */
     class SimpleCacheView<T> extends AbstractCacheView<T>
     {
-        public SimpleCacheView(@Nonnull Class<T> type, @Nullable Function<T, String> nameMapper)
+        public SimpleCacheView(@NotNull Class<T> type, @Nullable Function<T, String> nameMapper)
         {
             super(type, nameMapper);
         }

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/MemberCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/MemberCacheView.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.api.utils.cache;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.utils.MiscUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -60,7 +60,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      * @return Possibly-null member for the specified ID
      */
     @Nullable
-    default Member getElementById(@Nonnull String id)
+    default Member getElementById(@NotNull String id)
     {
         return getElementById(MiscUtil.parseSnowflake(id));
     }
@@ -79,8 +79,8 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      *
      * @return Immutable list of members with the given username
      */
-    @Nonnull
-    List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase);
+    @NotNull
+    List<Member> getElementsByUsername(@NotNull String name, boolean ignoreCase);
 
     /**
      * Creates an immutable list of all members matching the given username.
@@ -94,8 +94,8 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      *
      * @return Immutable list of members with the given username
      */
-    @Nonnull
-    default List<Member> getElementsByUsername(@Nonnull String name)
+    @NotNull
+    default List<Member> getElementsByUsername(@NotNull String name)
     {
         return getElementsByUsername(name, false);
     }
@@ -113,7 +113,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      *
      * @return Immutable list of members with the given nickname
      */
-    @Nonnull
+    @NotNull
     List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase);
 
     /**
@@ -127,7 +127,7 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      *
      * @return Immutable list of members with the given nickname
      */
-    @Nonnull
+    @NotNull
     default List<Member> getElementsByNickname(@Nullable String name)
     {
         return getElementsByNickname(name, false);
@@ -145,8 +145,8 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      *
      * @return Immutable list of members with the given roles
      */
-    @Nonnull
-    List<Member> getElementsWithRoles(@Nonnull Role... roles);
+    @NotNull
+    List<Member> getElementsWithRoles(@NotNull Role... roles);
 
     /**
      * Creates an immutable list of all members that hold all
@@ -160,6 +160,6 @@ public interface MemberCacheView extends SnowflakeCacheView<Member>
      *
      * @return Immutable list of members with the given roles
      */
-    @Nonnull
-    List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles);
+    @NotNull
+    List<Member> getElementsWithRoles(@NotNull Collection<Role> roles);
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/ShardCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/ShardCacheView.java
@@ -16,9 +16,8 @@
 package net.dv8tion.jda.api.utils.cache;
 
 import net.dv8tion.jda.api.JDA;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Read-only view on internal ShardManager cache of JDA instances.
@@ -54,7 +53,7 @@ public interface ShardCacheView extends CacheView<JDA>
      * @return Possibly-null entity for the specified shard ID
      */
     @Nullable
-    default JDA getElementById(@Nonnull String id)
+    default JDA getElementById(@NotNull String id)
     {
         return getElementById(Integer.parseUnsignedInt(id));
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/SnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/SnowflakeCacheView.java
@@ -18,9 +18,8 @@ package net.dv8tion.jda.api.utils.cache;
 
 import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.utils.MiscUtil;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * {@link net.dv8tion.jda.api.utils.cache.CacheView CacheView} implementation
@@ -54,7 +53,7 @@ public interface SnowflakeCacheView<T extends ISnowflake> extends CacheView<T>
      * @return Possibly-null entity for the specified ID
      */
     @Nullable
-    default T getElementById(@Nonnull String id)
+    default T getElementById(@NotNull String id)
     {
         return getElementById(MiscUtil.parseSnowflake(id));
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/SortedSnowflakeCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/SortedSnowflakeCacheView.java
@@ -17,8 +17,8 @@
 package net.dv8tion.jda.api.utils.cache;
 
 import net.dv8tion.jda.api.entities.ISnowflake;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.NavigableSet;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -47,9 +47,9 @@ public interface SortedSnowflakeCacheView<T extends Comparable<? super T> & ISno
      *
      * @since  4.0.0
      */
-    void forEachUnordered(@Nonnull final Consumer<? super T> action);
+    void forEachUnordered(@NotNull final Consumer<? super T> action);
 
-    @Nonnull
+    @NotNull
     @Override
     NavigableSet<T> asSet();
 
@@ -60,7 +60,7 @@ public interface SortedSnowflakeCacheView<T extends Comparable<? super T> & ISno
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     Stream<T> streamUnordered();
 
     /**
@@ -70,6 +70,6 @@ public interface SortedSnowflakeCacheView<T extends Comparable<? super T> & ISno
      *
      * @since  4.0.0
      */
-    @Nonnull
+    @NotNull
     Stream<T> parallelStreamUnordered();
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/cache/UnifiedMemberCacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/UnifiedMemberCacheView.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.api.utils.cache;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.utils.MiscUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -44,7 +44,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Possibly-empty unmodifiable list of member for the specified ID
      */
-    @Nonnull
+    @NotNull
     List<Member> getElementsById(long id);
 
     /**
@@ -59,8 +59,8 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Possibly-empty unmodifiable list of member for the specified ID
      */
-    @Nonnull
-    default List<Member> getElementsById(@Nonnull String id)
+    @NotNull
+    default List<Member> getElementsById(@NotNull String id)
     {
         return getElementsById(MiscUtil.parseSnowflake(id));
     }
@@ -79,8 +79,8 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Immutable list of members with the given username
      */
-    @Nonnull
-    List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase);
+    @NotNull
+    List<Member> getElementsByUsername(@NotNull String name, boolean ignoreCase);
 
     /**
      * Creates an immutable list of all members matching the given username.
@@ -94,8 +94,8 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Immutable list of members with the given username
      */
-    @Nonnull
-    default List<Member> getElementsByUsername(@Nonnull String name)
+    @NotNull
+    default List<Member> getElementsByUsername(@NotNull String name)
     {
         return getElementsByUsername(name, false);
     }
@@ -113,7 +113,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Immutable list of members with the given nickname
      */
-    @Nonnull
+    @NotNull
     List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase);
 
     /**
@@ -127,7 +127,7 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Immutable list of members with the given nickname
      */
-    @Nonnull
+    @NotNull
     default List<Member> getElementsByNickname(@Nullable String name)
     {
         return getElementsByNickname(name, false);
@@ -145,8 +145,8 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Immutable list of members with the given roles
      */
-    @Nonnull
-    List<Member> getElementsWithRoles(@Nonnull Role... roles);
+    @NotNull
+    List<Member> getElementsWithRoles(@NotNull Role... roles);
 
     /**
      * Creates an immutable list of all members that hold all
@@ -160,6 +160,6 @@ public interface UnifiedMemberCacheView extends CacheView<Member>
      *
      * @return Immutable list of members with the given roles
      */
-    @Nonnull
-    List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles);
+    @NotNull
+    List<Member> getElementsWithRoles(@NotNull Collection<Role> roles);
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/concurrent/DelayedCompletableFuture.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/concurrent/DelayedCompletableFuture.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.api.utils.concurrent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.concurrent.*;
 import java.util.function.Function;
 
@@ -53,8 +54,8 @@ public class DelayedCompletableFuture<T> extends CompletableFuture<T> implements
      *
      * @return DelayedCompletableFuture for the specified runnable
      */
-    @Nonnull
-    public static <E> DelayedCompletableFuture<E> make(@Nonnull ScheduledExecutorService executor, long delay, @Nonnull TimeUnit unit, @Nonnull Function<? super DelayedCompletableFuture<E>, ? extends Runnable> mapping)
+    @NotNull
+    public static <E> DelayedCompletableFuture<E> make(@NotNull ScheduledExecutorService executor, long delay, @NotNull TimeUnit unit, @NotNull Function<? super DelayedCompletableFuture<E>, ? extends Runnable> mapping)
     {
         DelayedCompletableFuture<E> handle = new DelayedCompletableFuture<>();
         ScheduledFuture<?> future = executor.schedule(mapping.apply(handle), delay, unit);
@@ -91,13 +92,13 @@ public class DelayedCompletableFuture<T> extends CompletableFuture<T> implements
     }
 
     @Override
-    public long getDelay(@Nonnull TimeUnit unit)
+    public long getDelay(@NotNull TimeUnit unit)
     {
         return future.getDelay(unit);
     }
 
     @Override
-    public int compareTo(@Nonnull Delayed o)
+    public int compareTo(@NotNull Delayed o)
     {
         return future.compareTo(o);
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/concurrent/Task.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/concurrent/Task.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.api.utils.concurrent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.function.Consumer;
 
 /**
@@ -50,8 +51,8 @@ public interface Task<T>
      *
      * @return The current Task instance for chaining
      */
-    @Nonnull
-    Task<T> onError(@Nonnull Consumer<? super Throwable> callback);
+    @NotNull
+    Task<T> onError(@NotNull Consumer<? super Throwable> callback);
 
     /**
      * Provide a callback for success handling.
@@ -65,8 +66,8 @@ public interface Task<T>
      *
      * @return The current Task instance for chaining
      */
-    @Nonnull
-    Task<T> onSuccess(@Nonnull Consumer<? super T> callback);
+    @NotNull
+    Task<T> onSuccess(@NotNull Consumer<? super T> callback);
 
     /**
      * Blocks the current thread until the result is ready.
@@ -82,7 +83,7 @@ public interface Task<T>
      *
      * @return The result value
      */
-    @Nonnull
+    @NotNull
     T get();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -26,11 +26,11 @@ import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -79,7 +79,7 @@ public class DataArray implements Iterable<Object>
      *
      * @see    #add(Object)
      */
-    @Nonnull
+    @NotNull
     public static DataArray empty()
     {
         return new DataArray(new ArrayList<>());
@@ -94,8 +94,8 @@ public class DataArray implements Iterable<Object>
      *
      * @return A new DataArray populated with the contents of the collection
      */
-    @Nonnull
-    public static DataArray fromCollection(@Nonnull Collection<?> col)
+    @NotNull
+    public static DataArray fromCollection(@NotNull Collection<?> col)
     {
         return empty().addAll(col);
     }
@@ -111,8 +111,8 @@ public class DataArray implements Iterable<Object>
      *
      * @return A new DataArray instance for the provided array
      */
-    @Nonnull
-    public static DataArray fromJson(@Nonnull String json)
+    @NotNull
+    public static DataArray fromJson(@NotNull String json)
     {
         try
         {
@@ -135,8 +135,8 @@ public class DataArray implements Iterable<Object>
      *
      * @return A new DataArray instance for the provided array
      */
-    @Nonnull
-    public static DataArray fromJson(@Nonnull InputStream json)
+    @NotNull
+    public static DataArray fromJson(@NotNull InputStream json)
     {
         try
         {
@@ -159,8 +159,8 @@ public class DataArray implements Iterable<Object>
      *
      * @return A new DataArray instance for the provided array
      */
-    @Nonnull
-    public static DataArray fromJson(@Nonnull Reader json)
+    @NotNull
+    public static DataArray fromJson(@NotNull Reader json)
     {
         try
         {
@@ -188,8 +188,8 @@ public class DataArray implements Iterable<Object>
      *
      * @since  4.2.1
      */
-    @Nonnull
-    public static DataArray fromETF(@Nonnull byte[] data)
+    @NotNull
+    public static DataArray fromETF(@NotNull byte[] data)
     {
         Checks.notNull(data, "Data");
         try
@@ -229,7 +229,7 @@ public class DataArray implements Iterable<Object>
      *
      * @see    net.dv8tion.jda.api.utils.data.DataType#isType(Object) DataType.isType(Object)
      */
-    public boolean isType(int index, @Nonnull DataType type)
+    public boolean isType(int index, @NotNull DataType type)
     {
         return type.isType(data.get(index));
     }
@@ -265,7 +265,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return The resolved DataObject
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
     public DataObject getObject(int index)
     {
@@ -294,7 +294,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return The resolved DataArray
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
     public DataArray getArray(int index)
     {
@@ -323,7 +323,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return The resolved String
      */
-    @Nonnull
+    @NotNull
     public String getString(int index)
     {
         String value = get(String.class, index, UnaryOperator.identity(), String::valueOf);
@@ -547,7 +547,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return A DataArray with the value inserted at the end
      */
-    @Nonnull
+    @NotNull
     public DataArray add(@Nullable Object value)
     {
         if (value instanceof SerializableData)
@@ -567,8 +567,8 @@ public class DataArray implements Iterable<Object>
      *
      * @return A DataArray with the values inserted at the end
      */
-    @Nonnull
-    public DataArray addAll(@Nonnull Collection<?> values)
+    @NotNull
+    public DataArray addAll(@NotNull Collection<?> values)
     {
         values.forEach(this::add);
         return this;
@@ -582,8 +582,8 @@ public class DataArray implements Iterable<Object>
      *
      * @return A DataArray with the values inserted at the end
      */
-    @Nonnull
-    public DataArray addAll(@Nonnull DataArray array)
+    @NotNull
+    public DataArray addAll(@NotNull DataArray array)
     {
         return addAll(array.data);
     }
@@ -598,7 +598,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return A DataArray with the value inserted at the specified index
      */
-    @Nonnull
+    @NotNull
     public DataArray insert(int index, @Nullable Object value)
     {
         if (value instanceof SerializableData)
@@ -618,7 +618,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return A DataArray with the value removed
      */
-    @Nonnull
+    @NotNull
     public DataArray remove(int index)
     {
         data.remove(index);
@@ -633,7 +633,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return A DataArray with the value removed
      */
-    @Nonnull
+    @NotNull
     public DataArray remove(@Nullable Object value)
     {
         data.remove(value);
@@ -645,7 +645,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return byte array containing the JSON representation of this object
      */
-    @Nonnull
+    @NotNull
     public byte[] toJson()
     {
         try
@@ -667,7 +667,7 @@ public class DataArray implements Iterable<Object>
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     public byte[] toETF()
     {
         ByteBuffer buffer = ExTermEncoder.pack(data);
@@ -692,7 +692,7 @@ public class DataArray implements Iterable<Object>
      *
      * @return The resulting list
      */
-    @Nonnull
+    @NotNull
     public List<Object> toList()
     {
         return data;
@@ -704,13 +704,13 @@ public class DataArray implements Iterable<Object>
     }
 
     @Nullable
-    private <T> T get(@Nonnull Class<T> type, int index)
+    private <T> T get(@NotNull Class<T> type, int index)
     {
         return get(type, index, null, null);
     }
 
     @Nullable
-    private <T> T get(@Nonnull Class<T> type, int index, @Nullable Function<String, T> stringMapper, @Nullable Function<Number, T> numberMapper)
+    private <T> T get(@NotNull Class<T> type, int index, @Nullable Function<String, T> stringMapper, @Nullable Function<Number, T> numberMapper)
     {
         Object value = data.get(index);
         if (value == null)
@@ -727,14 +727,14 @@ public class DataArray implements Iterable<Object>
                                                       index, type.getSimpleName(), value, value.getClass().getSimpleName()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<Object> iterator()
     {
         return data.iterator();
     }
 
-    @Nonnull
+    @NotNull
     public <T> Stream<T> stream(BiFunction<? super DataArray, Integer, ? extends T> mapper)
     {
         return IntStream.range(0, length())

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataObject.java
@@ -26,11 +26,11 @@ import net.dv8tion.jda.api.utils.data.etf.ExTermEncoder;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.*;
@@ -41,7 +41,7 @@ import java.util.function.UnaryOperator;
  * Represents a map of values used in communication with the Discord API.
  *
  * <p>Throws {@link java.lang.NullPointerException},
- * if a parameter annotated with {@link javax.annotation.Nonnull} is provided with {@code null}.
+ * if a parameter annotated with {@link org.jetbrains.annotations.NotNull} is provided with {@code null}.
  *
  * <p>This class is not Thread-Safe.
  */
@@ -64,7 +64,7 @@ public class DataObject implements SerializableData
 
     protected final Map<String, Object> data;
 
-    protected DataObject(@Nonnull Map<String, Object> data)
+    protected DataObject(@NotNull Map<String, Object> data)
     {
         this.data = data;
     }
@@ -76,7 +76,7 @@ public class DataObject implements SerializableData
      *
      * @see    #put(String, Object)
      */
-    @Nonnull
+    @NotNull
     public static DataObject empty()
     {
         return new DataObject(new HashMap<>());
@@ -93,8 +93,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject instance for the provided payload
      */
-    @Nonnull
-    public static DataObject fromJson(@Nonnull byte[] data)
+    @NotNull
+    public static DataObject fromJson(@NotNull byte[] data)
     {
         try
         {
@@ -118,8 +118,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject instance for the provided payload
      */
-    @Nonnull
-    public static DataObject fromJson(@Nonnull String json)
+    @NotNull
+    public static DataObject fromJson(@NotNull String json)
     {
         try
         {
@@ -143,8 +143,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject instance for the provided payload
      */
-    @Nonnull
-    public static DataObject fromJson(@Nonnull InputStream stream)
+    @NotNull
+    public static DataObject fromJson(@NotNull InputStream stream)
     {
         try
         {
@@ -168,8 +168,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject instance for the provided payload
      */
-    @Nonnull
-    public static DataObject fromJson(@Nonnull Reader stream)
+    @NotNull
+    public static DataObject fromJson(@NotNull Reader stream)
     {
         try
         {
@@ -198,8 +198,8 @@ public class DataObject implements SerializableData
      *
      * @since  4.2.1
      */
-    @Nonnull
-    public static DataObject fromETF(@Nonnull byte[] data)
+    @NotNull
+    public static DataObject fromETF(@NotNull byte[] data)
     {
         Checks.notNull(data, "Data");
         try
@@ -222,7 +222,7 @@ public class DataObject implements SerializableData
      *
      * @return True, if the specified key is present
      */
-    public boolean hasKey(@Nonnull String key)
+    public boolean hasKey(@NotNull String key)
     {
         return data.containsKey(key);
     }
@@ -235,7 +235,7 @@ public class DataObject implements SerializableData
      *
      * @return True, if the specified key is null or missing
      */
-    public boolean isNull(@Nonnull String key)
+    public boolean isNull(@NotNull String key)
     {
         return data.get(key) == null;
     }
@@ -252,7 +252,7 @@ public class DataObject implements SerializableData
      *
      * @see    net.dv8tion.jda.api.utils.data.DataType#isType(Object) DataType.isType(Object)
      */
-    public boolean isType(@Nonnull String key, @Nonnull DataType type)
+    public boolean isType(@NotNull String key, @NotNull DataType type)
     {
         return type.isType(data.get(key));
     }
@@ -268,8 +268,8 @@ public class DataObject implements SerializableData
      *
      * @return The resolved instance of DataObject for the key
      */
-    @Nonnull
-    public DataObject getObject(@Nonnull String key)
+    @NotNull
+    public DataObject getObject(@NotNull String key)
     {
         return optObject(key).orElseThrow(() -> valueError(key, "DataObject"));
     }
@@ -285,9 +285,9 @@ public class DataObject implements SerializableData
      *
      * @return The resolved instance of DataObject for the key, wrapped in {@link java.util.Optional}
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
-    public Optional<DataObject> optObject(@Nonnull String key)
+    public Optional<DataObject> optObject(@NotNull String key)
     {
         Map<String, Object> child = null;
         try
@@ -312,8 +312,8 @@ public class DataObject implements SerializableData
      *
      * @return The resolved instance of DataArray for the key
      */
-    @Nonnull
-    public DataArray getArray(@Nonnull String key)
+    @NotNull
+    public DataArray getArray(@NotNull String key)
     {
         return optArray(key).orElseThrow(() -> valueError(key, "DataArray"));
     }
@@ -329,9 +329,9 @@ public class DataObject implements SerializableData
      *
      * @return The resolved instance of DataArray for the key, wrapped in {@link java.util.Optional}
      */
-    @Nonnull
+    @NotNull
     @SuppressWarnings("unchecked")
-    public Optional<DataArray> optArray(@Nonnull String key)
+    public Optional<DataArray> optArray(@NotNull String key)
     {
         List<Object> child = null;
         try
@@ -353,8 +353,8 @@ public class DataObject implements SerializableData
      *
      * @return {@link java.util.Optional} with a possible value
      */
-    @Nonnull
-    public Optional<Object> opt(@Nonnull String key)
+    @NotNull
+    public Optional<Object> opt(@NotNull String key)
     {
         return Optional.ofNullable(data.get(key));
     }
@@ -372,8 +372,8 @@ public class DataObject implements SerializableData
      *
      * @see    #opt(String)
      */
-    @Nonnull
-    public Object get(@Nonnull String key)
+    @NotNull
+    public Object get(@NotNull String key)
     {
         Object value = data.get(key);
         if (value == null)
@@ -392,8 +392,8 @@ public class DataObject implements SerializableData
      *
      * @return The String value
      */
-    @Nonnull
-    public String getString(@Nonnull String key)
+    @NotNull
+    public String getString(@NotNull String key)
     {
         String value = getString(key, null);
         if (value == null)
@@ -412,7 +412,7 @@ public class DataObject implements SerializableData
      * @return The String value, or null if provided with null defaultValue
      */
     @Contract("_, !null -> !null")
-    public String getString(@Nonnull String key, @Nullable String defaultValue)
+    public String getString(@NotNull String key, @Nullable String defaultValue)
     {
         String value = get(String.class, key, UnaryOperator.identity(), String::valueOf);
         return value == null ? defaultValue : value;
@@ -429,7 +429,7 @@ public class DataObject implements SerializableData
      *
      * @return True, if the value is present and set to true. False if the value is missing or set to false.
      */
-    public boolean getBoolean(@Nonnull String key)
+    public boolean getBoolean(@NotNull String key)
     {
         return getBoolean(key, false);
     }
@@ -447,7 +447,7 @@ public class DataObject implements SerializableData
      *
      * @return True, if the value is present and set to true. False if the value is set to false. defaultValue if it is missing.
      */
-    public boolean getBoolean(@Nonnull String key, boolean defaultValue)
+    public boolean getBoolean(@NotNull String key, boolean defaultValue)
     {
         Boolean value = get(Boolean.class, key, Boolean::parseBoolean, null);
         return value == null ? defaultValue : value;
@@ -464,7 +464,7 @@ public class DataObject implements SerializableData
      *
      * @return The long value for the key
      */
-    public long getLong(@Nonnull String key)
+    public long getLong(@NotNull String key)
     {
         Long value = get(Long.class, key, Long::parseLong, Number::longValue);
         if (value == null)
@@ -485,7 +485,7 @@ public class DataObject implements SerializableData
      *
      * @return The long value for the key
      */
-    public long getLong(@Nonnull String key, long defaultValue)
+    public long getLong(@NotNull String key, long defaultValue)
     {
         Long value = get(Long.class, key, Long::parseLong, Number::longValue);
         return value == null ? defaultValue : value;
@@ -502,7 +502,7 @@ public class DataObject implements SerializableData
      *
      * @return The unsigned long value for the key
      */
-    public long getUnsignedLong(@Nonnull String key)
+    public long getUnsignedLong(@NotNull String key)
     {
         Long value = get(Long.class, key, Long::parseUnsignedLong, Number::longValue);
         if (value == null)
@@ -523,7 +523,7 @@ public class DataObject implements SerializableData
      *
      * @return The unsigned long value for the key
      */
-    public long getUnsignedLong(@Nonnull String key, long defaultValue)
+    public long getUnsignedLong(@NotNull String key, long defaultValue)
     {
         Long value = get(Long.class, key, Long::parseUnsignedLong, Number::longValue);
         return value == null ? defaultValue : value;
@@ -540,7 +540,7 @@ public class DataObject implements SerializableData
      *
      * @return The int value for the key
      */
-    public int getInt(@Nonnull String key)
+    public int getInt(@NotNull String key)
     {
         Integer value = get(Integer.class, key, Integer::parseInt, Number::intValue);
         if (value == null)
@@ -561,7 +561,7 @@ public class DataObject implements SerializableData
      *
      * @return The int value for the key
      */
-    public int getInt(@Nonnull String key, int defaultValue)
+    public int getInt(@NotNull String key, int defaultValue)
     {
         Integer value = get(Integer.class, key, Integer::parseInt, Number::intValue);
         return value == null ? defaultValue : value;
@@ -578,7 +578,7 @@ public class DataObject implements SerializableData
      *
      * @return The unsigned int value for the key
      */
-    public int getUnsignedInt(@Nonnull String key)
+    public int getUnsignedInt(@NotNull String key)
     {
         Integer value = get(Integer.class, key, Integer::parseUnsignedInt, Number::intValue);
         if (value == null)
@@ -599,7 +599,7 @@ public class DataObject implements SerializableData
      *
      * @return The unsigned int value for the key
      */
-    public int getUnsignedInt(@Nonnull String key, int defaultValue)
+    public int getUnsignedInt(@NotNull String key, int defaultValue)
     {
         Integer value = get(Integer.class, key, Integer::parseUnsignedInt, Number::intValue);
         return value == null ? defaultValue : value;
@@ -614,8 +614,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject with the removed key
      */
-    @Nonnull
-    public DataObject remove(@Nonnull String key)
+    @NotNull
+    public DataObject remove(@NotNull String key)
     {
         data.remove(key);
         return this;
@@ -629,8 +629,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject with the updated value
      */
-    @Nonnull
-    public DataObject putNull(@Nonnull String key)
+    @NotNull
+    public DataObject putNull(@NotNull String key)
     {
         data.put(key, null);
         return this;
@@ -646,8 +646,8 @@ public class DataObject implements SerializableData
      *
      * @return A DataObject with the updated value
      */
-    @Nonnull
-    public DataObject put(@Nonnull String key, @Nullable Object value)
+    @NotNull
+    public DataObject put(@NotNull String key, @Nullable Object value)
     {
         if (value instanceof SerializableData)
             data.put(key, ((SerializableData) value).toData().data);
@@ -663,7 +663,7 @@ public class DataObject implements SerializableData
      *
      * @return {@link java.util.Collection} for all values
      */
-    @Nonnull
+    @NotNull
     public Collection<Object> values()
     {
         return data.values();
@@ -674,7 +674,7 @@ public class DataObject implements SerializableData
      *
      * @return {@link Set} of keys
      */
-    @Nonnull
+    @NotNull
     public Set<String> keys()
     {
         return data.keySet();
@@ -685,7 +685,7 @@ public class DataObject implements SerializableData
      *
      * @return byte array containing the JSON representation of this object
      */
-    @Nonnull
+    @NotNull
     public byte[] toJson()
     {
         try
@@ -707,7 +707,7 @@ public class DataObject implements SerializableData
      *
      * @since  4.2.1
      */
-    @Nonnull
+    @NotNull
     public byte[] toETF()
     {
         ByteBuffer buffer = ExTermEncoder.pack(data);
@@ -732,13 +732,13 @@ public class DataObject implements SerializableData
      *
      * @return The resulting map
      */
-    @Nonnull
+    @NotNull
     public Map<String, Object> toMap()
     {
         return data;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public DataObject toData()
     {
@@ -751,13 +751,13 @@ public class DataObject implements SerializableData
     }
 
     @Nullable
-    private <T> T get(@Nonnull Class<T> type, @Nonnull String key)
+    private <T> T get(@NotNull Class<T> type, @NotNull String key)
     {
         return get(type, key, null, null);
     }
 
     @Nullable
-    private <T> T get(@Nonnull Class<T> type, @Nonnull String key, @Nullable Function<String, T> stringParse, @Nullable Function<Number, T> numberParse)
+    private <T> T get(@NotNull Class<T> type, @NotNull String key, @Nullable Function<String, T> stringParse, @Nullable Function<Number, T> numberParse)
     {
         Object value = data.get(key);
         if (value == null)

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataType.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataType.java
@@ -16,8 +16,9 @@
 
 package net.dv8tion.jda.api.utils.data;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ public enum DataType
      *
      * @return The DataType constant or {@link #UNKNOWN}
      */
-    @Nonnull
+    @NotNull
     public static DataType getType(@Nullable Object value)
     {
         for (DataType type : values())

--- a/src/main/java/net/dv8tion/jda/api/utils/data/SerializableData.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/SerializableData.java
@@ -16,7 +16,7 @@
 
 package net.dv8tion.jda.api.utils.data;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Allows custom serialization for JSON payloads of an object.
@@ -28,6 +28,6 @@ public interface SerializableData
      *
      * @return {@link net.dv8tion.jda.api.utils.data.DataObject}
      */
-    @Nonnull
+    @NotNull
     DataObject toData();
 }

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -67,10 +67,10 @@ import net.dv8tion.jda.internal.utils.config.MetaConfig;
 import net.dv8tion.jda.internal.utils.config.SessionConfig;
 import net.dv8tion.jda.internal.utils.config.ThreadingConfig;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
-import javax.annotation.Nonnull;
 import javax.security.auth.login.LoginException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -146,7 +146,7 @@ public class JDAImpl implements JDA
         this.eventManager = new EventManagerProxy(new InterfacedEventManager(), this.threadConfig.getEventPool());
     }
 
-    public void handleEvent(@Nonnull GenericEvent event)
+    public void handleEvent(@NotNull GenericEvent event)
     {
         eventManager.handle(event);
     }
@@ -377,7 +377,7 @@ public class JDAImpl implements JDA
         return authConfig;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getToken()
     {
@@ -412,21 +412,21 @@ public class JDAImpl implements JDA
         return sessionConfig.isAutoReconnect();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Status getStatus()
     {
         return status;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<GatewayIntent> getGatewayIntents()
     {
         return GatewayIntent.getIntents(client.getGatewayIntents());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<CacheFlag> getCacheFlags()
     {
@@ -454,9 +454,9 @@ public class JDAImpl implements JDA
         return gatewayPing;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public JDA awaitStatus(@Nonnull Status status, @Nonnull Status... failOn) throws InterruptedException
+    public JDA awaitStatus(@NotNull Status status, @NotNull Status... failOn) throws InterruptedException
     {
         Checks.notNull(status, "Status");
         Checks.check(status.isInit(), "Cannot await the status %s as it is not part of the login cycle!", status);
@@ -481,28 +481,28 @@ public class JDAImpl implements JDA
         return requester.getRateLimiter().cancelRequests();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ScheduledExecutorService getRateLimitPool()
     {
         return threadConfig.getRateLimitPool();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ScheduledExecutorService getGatewayPool()
     {
         return threadConfig.getGatewayPool();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ExecutorService getCallbackPool()
     {
         return threadConfig.getCallbackPool();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("ConstantConditions") // this can't really happen unless you pass bad configs
     public OkHttpClient getHttpClient()
@@ -510,7 +510,7 @@ public class JDAImpl implements JDA
         return sessionConfig.getHttpClient();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public DirectAudioControllerImpl getDirectAudioController()
     {
@@ -519,17 +519,17 @@ public class JDAImpl implements JDA
         return this.audioController;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Guild> getMutualGuilds(@Nonnull User... users)
+    public List<Guild> getMutualGuilds(@NotNull User... users)
     {
         Checks.notNull(users, "users");
         return getMutualGuilds(Arrays.asList(users));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Guild> getMutualGuilds(@Nonnull Collection<User> users)
+    public List<Guild> getMutualGuilds(@NotNull Collection<User> users)
     {
         Checks.notNull(users, "users");
         for(User u : users)
@@ -539,14 +539,14 @@ public class JDAImpl implements JDA
                 .collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<User> retrieveUserById(@Nonnull String id)
+    public RestAction<User> retrieveUserById(@NotNull String id)
     {
         return retrieveUserById(MiscUtil.parseSnowflake(id));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<User> retrieveUserById(long id, boolean update)
     {
@@ -563,21 +563,21 @@ public class JDAImpl implements JDA
                 });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CacheView<AudioManager> getAudioManagerCache()
     {
         return audioManagers;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<Guild> getGuildCache()
     {
         return guildCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<String> getUnavailableGuilds()
     {
@@ -593,49 +593,49 @@ public class JDAImpl implements JDA
         return guildSetupController.isUnavailable(guildId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<Role> getRoleCache()
     {
         return CacheView.allSnowflakes(() -> guildCache.stream().map(Guild::getRoleCache));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<Emote> getEmoteCache()
     {
         return CacheView.allSnowflakes(() -> guildCache.stream().map(Guild::getEmoteCache));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<Category> getCategoryCache()
     {
         return categories;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<StoreChannel> getStoreChannelCache()
     {
         return storeChannelCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<TextChannel> getTextChannelCache()
     {
         return textChannelCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<VoiceChannel> getVoiceChannelCache()
     {
         return voiceChannelCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<PrivateChannel> getPrivateChannelCache()
     {
@@ -643,7 +643,7 @@ public class JDAImpl implements JDA
     }
 
     @Override
-    public PrivateChannel getPrivateChannelById(@Nonnull String id)
+    public PrivateChannel getPrivateChannelById(@NotNull String id)
     {
         return getPrivateChannelById(MiscUtil.parseSnowflake(id));
     }
@@ -657,7 +657,7 @@ public class JDAImpl implements JDA
         return channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<PrivateChannel> openPrivateChannelById(long userId)
     {
@@ -676,7 +676,7 @@ public class JDAImpl implements JDA
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<User> getUserCache()
     {
@@ -688,7 +688,7 @@ public class JDAImpl implements JDA
         return selfUser != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SelfUser getSelfUser()
     {
@@ -774,28 +774,28 @@ public class JDAImpl implements JDA
         return sessionConfig.getMaxReconnectDelay();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ShardInfo getShardInfo()
     {
         return shardInfo == null ? ShardInfo.SINGLE : shardInfo;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Presence getPresence()
     {
         return presence;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public IEventManager getEventManager()
     {
         return eventManager.getSubject();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AccountType getAccountType()
     {
@@ -809,7 +809,7 @@ public class JDAImpl implements JDA
     }
 
     @Override
-    public void addEventListener(@Nonnull Object... listeners)
+    public void addEventListener(@NotNull Object... listeners)
     {
         Checks.noneNull(listeners, "listeners");
 
@@ -818,7 +818,7 @@ public class JDAImpl implements JDA
     }
 
     @Override
-    public void removeEventListener(@Nonnull Object... listeners)
+    public void removeEventListener(@NotNull Object... listeners)
     {
         Checks.noneNull(listeners, "listeners");
 
@@ -826,25 +826,25 @@ public class JDAImpl implements JDA
             eventManager.unregister(listener);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Object> getRegisteredListeners()
     {
         return eventManager.getRegisteredListeners();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public GuildActionImpl createGuild(@Nonnull String name)
+    public GuildActionImpl createGuild(@NotNull String name)
     {
         if (guildCache.size() >= 10)
             throw new IllegalStateException("Cannot create a Guild with a Bot in 10 or more guilds!");
         return new GuildActionImpl(this, name);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Webhook> retrieveWebhookById(@Nonnull String webhookId)
+    public RestAction<Webhook> retrieveWebhookById(@NotNull String webhookId)
     {
         Checks.isSnowflake(webhookId, "Webhook ID");
 
@@ -858,7 +858,7 @@ public class JDAImpl implements JDA
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<ApplicationInfo> retrieveApplicationInfo()
     {
@@ -872,7 +872,7 @@ public class JDAImpl implements JDA
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getInviteUrl(Permission... permissions)
     {
@@ -882,7 +882,7 @@ public class JDAImpl implements JDA
         return builder.toString();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getInviteUrl(Collection<Permission> permissions)
     {

--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioConnection.java
@@ -37,10 +37,10 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import tomp2p.opuswrapper.Opus;
 
-import javax.annotation.Nonnull;
 import java.net.*;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -628,28 +628,28 @@ public class AudioConnection
             this.boxer = boxer;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getIdentifier()
         {
             return threadIdentifier;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public VoiceChannel getConnectedChannel()
         {
             return getChannel();
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public DatagramSocket getUdpSocket()
         {
             return udpSocket;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public InetSocketAddress getSocketAddress()
         {
@@ -809,7 +809,7 @@ public class AudioConnection
         }
 
         @Override
-        public void onConnectionError(@Nonnull ConnectionStatus status)
+        public void onConnectionError(@NotNull ConnectionStatus status)
         {
             LOG.warn("IAudioSendSystem reported a connection error of: {}", status);
             LOG.warn("Shutting down AudioConnection.");

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -38,8 +38,8 @@ import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.InviteActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,7 +68,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     }
 
     @Override
-    public int compareTo(@Nonnull GuildChannel o)
+    public int compareTo(@NotNull GuildChannel o)
     {
         Checks.notNull(o, "Channel");
         if (getType().getSortBucket() != o.getType().getSortBucket()) // if bucket matters
@@ -78,32 +78,32 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return Long.compareUnsigned(id, o.getIdLong());               // last resort by id
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAsMention()
     {
         return "<#" + id + '>';
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public abstract ChannelAction<T> createCopy(@Nonnull Guild guild);
+    public abstract ChannelAction<T> createCopy(@NotNull Guild guild);
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelAction<T> createCopy()
     {
         return createCopy(getGuild());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
         return name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildImpl getGuild()
     {
@@ -125,7 +125,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return rawPosition;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
@@ -133,21 +133,21 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
     }
 
     @Override
-    public PermissionOverride getPermissionOverride(@Nonnull IPermissionHolder permissionHolder)
+    public PermissionOverride getPermissionOverride(@NotNull IPermissionHolder permissionHolder)
     {
         Checks.notNull(permissionHolder, "Permission Holder");
         Checks.check(permissionHolder.getGuild().equals(getGuild()), "Provided permission holder is not from the same guild as this channel!");
         return overrides.get(permissionHolder.getIdLong());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<PermissionOverride> getPermissionOverrides()
     {
         return Arrays.asList(overrides.values(new PermissionOverride[overrides.size()]));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<PermissionOverride> getMemberPermissionOverrides()
     {
@@ -156,7 +156,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
                 .collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<PermissionOverride> getRolePermissionOverrides()
     {
@@ -189,7 +189,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelManager getManager()
     {
@@ -198,7 +198,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return manager;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {
@@ -208,9 +208,9 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public PermissionOverrideAction createPermissionOverride(@Nonnull IPermissionHolder permissionHolder)
+    public PermissionOverrideAction createPermissionOverride(@NotNull IPermissionHolder permissionHolder)
     {
         Checks.notNull(permissionHolder, "PermissionHolder");
         if (getPermissionOverride(permissionHolder) != null)
@@ -219,9 +219,9 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return putPermissionOverride(permissionHolder);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public PermissionOverrideAction putPermissionOverride(@Nonnull IPermissionHolder permissionHolder)
+    public PermissionOverrideAction putPermissionOverride(@NotNull IPermissionHolder permissionHolder)
     {
         checkPermission(Permission.MANAGE_PERMISSIONS);
         Checks.notNull(permissionHolder, "PermissionHolder");
@@ -229,7 +229,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return new PermissionOverrideActionImpl(getJDA(), this, permissionHolder);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public InviteAction createInvite()
     {
@@ -238,7 +238,7 @@ public abstract class AbstractChannelImpl<T extends GuildChannel, M extends Abst
         return new InviteActionImpl(this.getJDA(), this.getId());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<Invite>> retrieveInvites()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -24,8 +24,8 @@ import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.dv8tion.jda.api.requests.restaction.pagination.ReactionPaginationAction;
 import net.dv8tion.jda.internal.utils.Helpers;
 import org.apache.commons.collections4.Bag;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.OffsetDateTime;
@@ -49,7 +49,7 @@ public abstract class AbstractMessage implements Message
         this.isTTS = isTTS;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getContentRaw()
     {
@@ -112,7 +112,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<User> getMentionedUsersBag()
     {
@@ -120,7 +120,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<TextChannel> getMentionedChannelsBag()
     {
@@ -128,7 +128,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<Role> getMentionedRolesBag()
     {
@@ -136,7 +136,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<User> getMentionedUsers()
     {
@@ -144,7 +144,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<TextChannel> getMentionedChannels()
     {
@@ -152,7 +152,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Role> getMentionedRoles()
     {
@@ -160,15 +160,15 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Member> getMentionedMembers(@Nonnull Guild guild)
+    public List<Member> getMentionedMembers(@NotNull Guild guild)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getMentionedMembers()
     {
@@ -176,16 +176,16 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<IMentionable> getMentions(@Nonnull MentionType... types)
+    public List<IMentionable> getMentions(@NotNull MentionType... types)
     {
         unsupported();
         return null;
     }
 
     @Override
-    public boolean isMentioned(@Nonnull IMentionable mentionable, @Nonnull MentionType... types)
+    public boolean isMentioned(@NotNull IMentionable mentionable, @NotNull MentionType... types)
     {
         unsupported();
         return false;
@@ -212,7 +212,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getAuthor()
     {
@@ -227,7 +227,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getJumpUrl()
     {
@@ -235,7 +235,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getContentDisplay()
     {
@@ -243,7 +243,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getContentStripped()
     {
@@ -251,7 +251,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<String> getInvites()
     {
@@ -260,13 +260,13 @@ public abstract class AbstractMessage implements Message
     }
 
     @Override
-    public boolean isFromType(@Nonnull ChannelType type)
+    public boolean isFromType(@NotNull ChannelType type)
     {
         unsupported();
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getChannelType()
     {
@@ -281,7 +281,7 @@ public abstract class AbstractMessage implements Message
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageChannel getChannel()
     {
@@ -289,7 +289,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PrivateChannel getPrivateChannel()
     {
@@ -297,7 +297,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public TextChannel getTextChannel()
     {
@@ -312,7 +312,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
@@ -320,7 +320,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Attachment> getAttachments()
     {
@@ -328,7 +328,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageEmbed> getEmbeds()
     {
@@ -336,7 +336,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Emote> getEmotes()
     {
@@ -344,7 +344,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<Emote> getEmotesBag()
     {
@@ -352,7 +352,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageReaction> getReactions()
     {
@@ -360,7 +360,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageSticker> getStickers()
     {
@@ -368,39 +368,39 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull CharSequence newContent)
+    public MessageAction editMessage(@NotNull CharSequence newContent)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull MessageEmbed newContent)
+    public MessageAction editMessage(@NotNull MessageEmbed newContent)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessageFormat(@Nonnull String format, @Nonnull Object... args)
+    public MessageAction editMessageFormat(@NotNull String format, @NotNull Object... args)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull Message newContent)
+    public MessageAction editMessage(@NotNull Message newContent)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {
@@ -408,7 +408,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
@@ -423,7 +423,7 @@ public abstract class AbstractMessage implements Message
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> pin()
     {
@@ -431,7 +431,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> unpin()
     {
@@ -439,23 +439,23 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> addReaction(@Nonnull Emote emote)
+    public RestAction<Void> addReaction(@NotNull Emote emote)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> addReaction(@Nonnull String unicode)
+    public RestAction<Void> addReaction(@NotNull String unicode)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> clearReactions()
     {
@@ -463,79 +463,79 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactions(@Nonnull String unicode)
+    public RestAction<Void> clearReactions(@NotNull String unicode)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactions(@Nonnull Emote emote)
+    public RestAction<Void> clearReactions(@NotNull Emote emote)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull Emote emote)
+    public RestAction<Void> removeReaction(@NotNull Emote emote)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
+    public RestAction<Void> removeReaction(@NotNull Emote emote, @NotNull User user)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull String unicode)
+    public RestAction<Void> removeReaction(@NotNull String unicode)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user)
+    public RestAction<Void> removeReaction(@NotNull String unicode, @NotNull User user)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ReactionPaginationAction retrieveReactionUsers(@Nonnull Emote emote)
+    public ReactionPaginationAction retrieveReactionUsers(@NotNull Emote emote)
     {
         unsupported();
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ReactionPaginationAction retrieveReactionUsers(@Nonnull String unicode)
-    {
-        unsupported();
-        return null;
-    }
-
-    @Override
-    public MessageReaction.ReactionEmote getReactionByUnicode(@Nonnull String unicode)
+    public ReactionPaginationAction retrieveReactionUsers(@NotNull String unicode)
     {
         unsupported();
         return null;
     }
 
     @Override
-    public MessageReaction.ReactionEmote getReactionById(@Nonnull String id)
+    public MessageReaction.ReactionEmote getReactionByUnicode(@NotNull String unicode)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Override
+    public MessageReaction.ReactionEmote getReactionById(@NotNull String id)
     {
         unsupported();
         return null;
@@ -548,7 +548,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> suppressEmbeds(boolean suppressed)
     {
@@ -556,7 +556,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Message> crosspost()
     {
@@ -571,7 +571,7 @@ public abstract class AbstractMessage implements Message
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<MessageFlag> getFlags()
     {
@@ -579,7 +579,7 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageType getType()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ActivityImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ActivityImpl.java
@@ -17,9 +17,9 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.RichPresence;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Objects;
 
 public class ActivityImpl implements Activity
@@ -66,7 +66,7 @@ public class ActivityImpl implements Activity
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
@@ -79,7 +79,7 @@ public class ActivityImpl implements Activity
         return url;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ActivityType getType()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -21,8 +21,8 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.ApplicationInfo;
 import net.dv8tion.jda.api.entities.ApplicationTeam;
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 
 public class ApplicationInfoImpl implements ApplicationInfo
@@ -65,7 +65,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return obj instanceof ApplicationInfoImpl && this.id == ((ApplicationInfoImpl) obj).id;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getDescription()
     {
@@ -85,7 +85,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
                 : "https://cdn.discordapp.com/app-icons/" + this.id + '/' + this.iconId + ".png";
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ApplicationTeam getTeam()
     {
@@ -98,7 +98,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return this.id;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getInviteUrl(final String guildId, final Collection<Permission> permissions)
     {
@@ -118,21 +118,21 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return builder.toString();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return this.api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
         return this.name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getOwner()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationTeamImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationTeamImpl.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.entities.ApplicationTeam;
 import net.dv8tion.jda.api.entities.TeamMember;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,7 +49,7 @@ public class ApplicationTeamImpl implements ApplicationTeam
         return iconId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<TeamMember> getMembers()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
@@ -24,8 +24,8 @@ import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,14 +51,14 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getType()
     {
         return ChannelType.CATEGORY;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getMembers()
     {
@@ -83,9 +83,9 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
         throw new IllegalStateException("Somehow when determining position we never found the Category in the Guild's channels? wtf?");
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<Category> createCopy(@Nonnull Guild guild)
+    public ChannelAction<Category> createCopy(@NotNull Guild guild)
     {
         Checks.notNull(guild, "Guild");
         ChannelAction<Category> action = guild.createCategory(name);
@@ -102,21 +102,21 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
         return action;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public InviteAction createInvite()
     {
         throw new UnsupportedOperationException("Cannot create invites for category!");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<Invite>> retrieveInvites()
     {
         return new CompletedRestAction<>(getJDA(), Collections.emptyList());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<GuildChannel> getChannels()
     {
@@ -128,7 +128,7 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
         return Collections.unmodifiableList(channels);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<StoreChannel> getStoreChannels()
     {
@@ -137,7 +137,7 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
                     .sorted().collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<TextChannel> getTextChannels()
     {
@@ -146,7 +146,7 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
                     .sorted().collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<VoiceChannel> getVoiceChannels()
     {
@@ -155,17 +155,17 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
                     .sorted().collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<TextChannel> createTextChannel(@Nonnull String name)
+    public ChannelAction<TextChannel> createTextChannel(@NotNull String name)
     {
         ChannelAction<TextChannel> action = getGuild().createTextChannel(name, this);
         return trySync(action);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<VoiceChannel> createVoiceChannel(@Nonnull String name)
+    public ChannelAction<VoiceChannel> createVoiceChannel(@NotNull String name)
     {
         ChannelAction<VoiceChannel> action = getGuild().createVoiceChannel(name, this);
         return trySync(action);
@@ -187,14 +187,14 @@ public class CategoryImpl extends AbstractChannelImpl<Category, CategoryImpl> im
         return action.syncPermissionOverrides();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CategoryOrderAction modifyTextChannelPositions()
     {
         return getGuild().modifyTextChannelPositions(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CategoryOrderAction modifyVoiceChannelPositions()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/DataMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/DataMessage.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.internal.entities;
 import net.dv8tion.jda.api.entities.MessageActivity;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.MessageType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -64,7 +64,7 @@ public class DataMessage extends AbstractMessage
         return mentionedUsers;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageType getType()
     {
@@ -103,7 +103,7 @@ public class DataMessage extends AbstractMessage
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageEmbed> getEmbeds()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -27,8 +27,8 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.EmoteManagerImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -82,7 +82,7 @@ public class EmoteImpl implements ListedEmote
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Role> getRoles()
     {
@@ -97,7 +97,7 @@ public class EmoteImpl implements ListedEmote
         return roles != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
@@ -129,14 +129,14 @@ public class EmoteImpl implements ListedEmote
         return id;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDAImpl getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getUser()
     {
@@ -151,7 +151,7 @@ public class EmoteImpl implements ListedEmote
         return user != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EmoteManager getManager()
     {
@@ -166,7 +166,7 @@ public class EmoteImpl implements ListedEmote
         return animated;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -49,9 +49,9 @@ import net.dv8tion.jda.internal.utils.cache.MemberCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -57,10 +57,10 @@ import net.dv8tion.jda.internal.utils.cache.MemberCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -122,7 +122,7 @@ public class GuildImpl implements Guild
             memberPresences = null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<EnumSet<Region>> retrieveRegions(boolean includeDeprecated)
     {
@@ -145,9 +145,9 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MemberAction addMember(@Nonnull String accessToken, @Nonnull String userId)
+    public MemberAction addMember(@NotNull String accessToken, @NotNull String userId)
     {
         Checks.notBlank(accessToken, "Access-Token");
         Checks.isSnowflake(userId, "User ID");
@@ -194,7 +194,7 @@ public class GuildImpl implements Guild
         return memberCount;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
@@ -207,7 +207,7 @@ public class GuildImpl implements Guild
         return iconId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<String> getFeatures()
     {
@@ -220,7 +220,7 @@ public class GuildImpl implements Guild
         return splashId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @Deprecated
     public RestAction<String> retrieveVanityUrl()
@@ -244,7 +244,7 @@ public class GuildImpl implements Guild
     }
 
     @Override
-    @Nonnull
+    @NotNull
     public RestAction<VanityInvite> retrieveVanityInvite()
     {
         checkPermission(Permission.MANAGE_SERVER);
@@ -261,7 +261,7 @@ public class GuildImpl implements Guild
         return description;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Locale getLocale()
     {
@@ -275,7 +275,7 @@ public class GuildImpl implements Guild
         return banner;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public BoostTier getBoostTier()
     {
@@ -288,7 +288,7 @@ public class GuildImpl implements Guild
         return boostCount;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("ConstantConditions") // can't be null here
     public List<Member> getBoosters()
@@ -311,7 +311,7 @@ public class GuildImpl implements Guild
         return maxPresences;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<MetaData> retrieveMetaData()
     {
@@ -353,7 +353,7 @@ public class GuildImpl implements Guild
         return communityUpdatesChannel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<Webhook>> retrieveWebhooks()
     {
@@ -396,14 +396,14 @@ public class GuildImpl implements Guild
         return ownerId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Timeout getAfkTimeout()
     {
         return afkTimeout;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getRegionRaw()
     {
@@ -411,12 +411,12 @@ public class GuildImpl implements Guild
     }
 
     @Override
-    public boolean isMember(@Nonnull User user)
+    public boolean isMember(@NotNull User user)
     {
         return memberCache.get(user.getIdLong()) != null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getSelfMember()
     {
@@ -427,62 +427,62 @@ public class GuildImpl implements Guild
     }
 
     @Override
-    public Member getMember(@Nonnull User user)
+    public Member getMember(@NotNull User user)
     {
         Checks.notNull(user, "User");
         return getMemberById(user.getIdLong());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MemberCacheView getMemberCache()
     {
         return memberCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SortedSnowflakeCacheView<Category> getCategoryCache()
     {
         return categoryCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SortedSnowflakeCacheView<StoreChannel> getStoreChannelCache()
     {
         return storeChannelCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SortedSnowflakeCacheView<TextChannel> getTextChannelCache()
     {
         return textChannelCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SortedSnowflakeCacheView<VoiceChannel> getVoiceChannelCache()
     {
         return voiceChannelCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SortedSnowflakeCacheView<Role> getRoleCache()
     {
         return roleCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SnowflakeCacheView<Emote> getEmoteCache()
     {
         return emoteCache;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<GuildChannel> getChannels(boolean includeHidden)
     {
@@ -545,7 +545,7 @@ public class GuildImpl implements Guild
         return Collections.unmodifiableList(channels);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<ListedEmote>> retrieveEmotes()
     {
@@ -566,9 +566,9 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<ListedEmote> retrieveEmoteById(@Nonnull String id)
+    public RestAction<ListedEmote> retrieveEmoteById(@NotNull String id)
     {
         Checks.isSnowflake(id, "Emote ID");
 
@@ -593,7 +593,7 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestActionImpl<List<Ban>> retrieveBanList()
     {
@@ -617,9 +617,9 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Ban> retrieveBanById(@Nonnull String userId)
+    public RestAction<Ban> retrieveBanById(@NotNull String userId)
     {
         if (!getSelfMember().hasPermission(Permission.BAN_MEMBERS))
             throw new InsufficientPermissionException(this, Permission.BAN_MEMBERS);
@@ -637,7 +637,7 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Integer> retrievePrunableMemberCount(int days)
     {
@@ -650,7 +650,7 @@ public class GuildImpl implements Guild
         return new RestActionImpl<>(getJDA(), route, (response, request) -> response.getObject().getInt("pruned"));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Role getPublicRole()
     {
@@ -667,7 +667,7 @@ public class GuildImpl implements Guild
                                     .min(Comparator.naturalOrder()).orElse(null);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildManager getManager()
     {
@@ -676,14 +676,14 @@ public class GuildImpl implements Guild
         return manager;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditLogPaginationAction retrieveAuditLogs()
     {
         return new AuditLogPaginationActionImpl(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> leave()
     {
@@ -694,7 +694,7 @@ public class GuildImpl implements Guild
         return new RestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> delete()
     {
@@ -704,7 +704,7 @@ public class GuildImpl implements Guild
         return delete(null);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> delete(String mfaCode)
     {
@@ -722,7 +722,7 @@ public class GuildImpl implements Guild
         return new RestActionImpl<>(getJDA(), route, mfaBody);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AudioManager getAudioManager()
     {
@@ -749,14 +749,14 @@ public class GuildImpl implements Guild
         return mng;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDAImpl getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<GuildVoiceState> getVoiceStates()
     {
@@ -767,28 +767,28 @@ public class GuildImpl implements Guild
                     .collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public VerificationLevel getVerificationLevel()
     {
         return verificationLevel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public NotificationLevel getDefaultNotificationLevel()
     {
         return defaultNotificationLevel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MFALevel getRequiredMFALevel()
     {
         return mfaLevel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ExplicitContentLevel getExplicitContentLevel()
     {
@@ -833,7 +833,7 @@ public class GuildImpl implements Guild
         return available;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @Deprecated
     public CompletableFuture<Void> retrieveMembers()
@@ -861,9 +861,9 @@ public class GuildImpl implements Guild
         return future;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Task<Void> loadMembers(@Nonnull Consumer<Member> callback)
+    public Task<Void> loadMembers(@NotNull Consumer<Member> callback)
     {
         Checks.notNull(callback, "Callback");
         if (!getJDA().isIntent(GatewayIntent.GUILD_MEMBERS))
@@ -898,7 +898,7 @@ public class GuildImpl implements Guild
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Member> retrieveMemberById(long id, boolean update)
     {
@@ -918,9 +918,9 @@ public class GuildImpl implements Guild
                 });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Task<List<Member>> retrieveMembersByIds(boolean includePresence, @Nonnull long... ids)
+    public Task<List<Member>> retrieveMembersByIds(boolean includePresence, @NotNull long... ids)
     {
         Checks.notNull(ids, "ID Array");
         Checks.check(!includePresence || api.isIntent(GatewayIntent.GUILD_PRESENCES),
@@ -946,10 +946,10 @@ public class GuildImpl implements Guild
         return new GatewayTask<>(result, () -> handle.cancel(false));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public Task<List<Member>> retrieveMembersByPrefix(@Nonnull String prefix, int limit)
+    public Task<List<Member>> retrieveMembersByPrefix(@NotNull String prefix, int limit)
     {
         Checks.notEmpty(prefix, "Prefix");
         Checks.positive(limit, "Limit");
@@ -978,7 +978,7 @@ public class GuildImpl implements Guild
         return id;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<Invite>> retrieveInvites()
     {
@@ -998,9 +998,9 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> moveVoiceMember(@Nonnull Member member, @Nullable VoiceChannel voiceChannel)
+    public RestAction<Void> moveVoiceMember(@NotNull Member member, @Nullable VoiceChannel voiceChannel)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -1029,9 +1029,9 @@ public class GuildImpl implements Guild
         return new RestActionImpl<>(getJDA(), route, body);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> modifyNickname(@Nonnull Member member, String nickname)
+    public AuditableRestAction<Void> modifyNickname(@NotNull Member member, String nickname)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -1061,9 +1061,9 @@ public class GuildImpl implements Guild
         }).setCacheCheck(() -> !Objects.equals(nickname, member.getNickname()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Integer> prune(int days, boolean wait, @Nonnull Role... roles)
+    public AuditableRestAction<Integer> prune(int days, boolean wait, @NotNull Role... roles)
     {
         checkPermission(Permission.KICK_MEMBERS);
 
@@ -1087,9 +1087,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route, body, (response, request) -> response.getObject().getInt("pruned", 0));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> kick(@Nonnull Member member, String reason)
+    public AuditableRestAction<Void> kick(@NotNull Member member, String reason)
     {
         Checks.notNull(member, "member");
         checkGuild(member.getGuild(), "member");
@@ -1098,9 +1098,9 @@ public class GuildImpl implements Guild
         return kick0(member.getUser().getId(), reason);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> kick(@Nonnull String userId, @Nullable String reason)
+    public AuditableRestAction<Void> kick(@NotNull String userId, @Nullable String reason)
     {
         Member member = getMemberById(userId);
         if (member != null)
@@ -1111,8 +1111,8 @@ public class GuildImpl implements Guild
         return kick0(userId, reason);
     }
 
-    @Nonnull
-    private AuditableRestAction<Void> kick0(@Nonnull String userId, @Nullable String reason)
+    @NotNull
+    private AuditableRestAction<Void> kick0(@NotNull String userId, @Nullable String reason)
     {
         Route.CompiledRoute route = Route.Guilds.KICK_MEMBER.compile(getId(), userId);
         if (!Helpers.isBlank(reason))
@@ -1123,9 +1123,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> ban(@Nonnull User user, int delDays, String reason)
+    public AuditableRestAction<Void> ban(@NotNull User user, int delDays, String reason)
     {
         Checks.notNull(user, "User");
         checkPermission(Permission.BAN_MEMBERS);
@@ -1136,9 +1136,9 @@ public class GuildImpl implements Guild
         return ban0(user.getId(), delDays, reason);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> ban(@Nonnull String userId, int delDays, String reason)
+    public AuditableRestAction<Void> ban(@NotNull String userId, int delDays, String reason)
     {
         Checks.notNull(userId, "User");
         checkPermission(Permission.BAN_MEMBERS);
@@ -1150,8 +1150,8 @@ public class GuildImpl implements Guild
         return ban0(userId, delDays, reason);
     }
 
-    @Nonnull
-    private AuditableRestAction<Void> ban0(@Nonnull String userId, int delDays, String reason)
+    @NotNull
+    private AuditableRestAction<Void> ban0(@NotNull String userId, int delDays, String reason)
     {
         Checks.notNegative(delDays, "Deletion Days");
         Checks.check(delDays <= 7, "Deletion Days must not be bigger than 7.");
@@ -1169,9 +1169,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route, params);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> unban(@Nonnull String userId)
+    public AuditableRestAction<Void> unban(@NotNull String userId)
     {
         Checks.isSnowflake(userId, "User ID");
         checkPermission(Permission.BAN_MEMBERS);
@@ -1180,9 +1180,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> deafen(@Nonnull Member member, boolean deafen)
+    public AuditableRestAction<Void> deafen(@NotNull Member member, boolean deafen)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -1202,9 +1202,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route, body);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> mute(@Nonnull Member member, boolean mute)
+    public AuditableRestAction<Void> mute(@NotNull Member member, boolean mute)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -1224,9 +1224,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route, body);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> addRoleToMember(@Nonnull Member member, @Nonnull Role role)
+    public AuditableRestAction<Void> addRoleToMember(@NotNull Member member, @NotNull Role role)
     {
         Checks.notNull(member, "Member");
         Checks.notNull(role, "Role");
@@ -1239,9 +1239,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> removeRoleFromMember(@Nonnull Member member, @Nonnull Role role)
+    public AuditableRestAction<Void> removeRoleFromMember(@NotNull Member member, @NotNull Role role)
     {
         Checks.notNull(member, "Member");
         Checks.notNull(role, "Role");
@@ -1254,9 +1254,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, Collection<Role> rolesToAdd, Collection<Role> rolesToRemove)
+    public AuditableRestAction<Void> modifyMemberRoles(@NotNull Member member, Collection<Role> rolesToAdd, Collection<Role> rolesToRemove)
     {
         Checks.notNull(member, "Member");
         checkGuild(member.getGuild(), "Member");
@@ -1277,9 +1277,9 @@ public class GuildImpl implements Guild
         return modifyMemberRoles(member, currentRoles);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> modifyMemberRoles(@Nonnull Member member, @Nonnull Collection<Role> roles)
+    public AuditableRestAction<Void> modifyMemberRoles(@NotNull Member member, @NotNull Collection<Role> roles)
     {
         Checks.notNull(member, "Member");
         Checks.notNull(roles, "Roles");
@@ -1325,9 +1325,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route, body);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> transferOwnership(@Nonnull Member newOwner)
+    public AuditableRestAction<Void> transferOwnership(@NotNull Member newOwner)
     {
         Checks.notNull(newOwner, "Member");
         checkGuild(newOwner.getGuild(), "Member");
@@ -1344,9 +1344,9 @@ public class GuildImpl implements Guild
         return new AuditableRestActionImpl<>(getJDA(), route, body);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<TextChannel> createTextChannel(@Nonnull String name, Category parent)
+    public ChannelAction<TextChannel> createTextChannel(@NotNull String name, Category parent)
     {
         if (parent != null)
         {
@@ -1366,9 +1366,9 @@ public class GuildImpl implements Guild
         return new ChannelActionImpl<>(TextChannel.class, name, this, ChannelType.TEXT).setParent(parent);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<VoiceChannel> createVoiceChannel(@Nonnull String name, Category parent)
+    public ChannelAction<VoiceChannel> createVoiceChannel(@NotNull String name, Category parent)
     {
         if (parent != null)
         {
@@ -1388,9 +1388,9 @@ public class GuildImpl implements Guild
         return new ChannelActionImpl<>(VoiceChannel.class, name, this, ChannelType.VOICE).setParent(parent);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<Category> createCategory(@Nonnull String name)
+    public ChannelAction<Category> createCategory(@NotNull String name)
     {
         checkPermission(Permission.MANAGE_CHANNEL);
         Checks.notBlank(name, "Name");
@@ -1400,7 +1400,7 @@ public class GuildImpl implements Guild
         return new ChannelActionImpl<>(Category.class, name, this, ChannelType.CATEGORY);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RoleAction createRole()
     {
@@ -1408,9 +1408,9 @@ public class GuildImpl implements Guild
         return new RoleActionImpl(this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Emote> createEmote(@Nonnull String name, @Nonnull Icon icon, @Nonnull Role... roles)
+    public AuditableRestAction<Emote> createEmote(@NotNull String name, @NotNull Icon icon, @NotNull Role... roles)
     {
         checkPermission(Permission.MANAGE_EMOTES);
         Checks.notBlank(name, "Emote name");
@@ -1432,46 +1432,46 @@ public class GuildImpl implements Guild
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelOrderAction modifyCategoryPositions()
     {
         return new ChannelOrderActionImpl(this, ChannelType.CATEGORY.getSortBucket());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelOrderAction modifyTextChannelPositions()
     {
         return new ChannelOrderActionImpl(this, ChannelType.TEXT.getSortBucket());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelOrderAction modifyVoiceChannelPositions()
     {
         return new ChannelOrderActionImpl(this, ChannelType.VOICE.getSortBucket());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public CategoryOrderAction modifyTextChannelPositions(@Nonnull Category category)
+    public CategoryOrderAction modifyTextChannelPositions(@NotNull Category category)
     {
         Checks.notNull(category, "Category");
         checkGuild(category.getGuild(), "Category");
         return new CategoryOrderActionImpl(category, ChannelType.TEXT.getSortBucket());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public CategoryOrderAction modifyVoiceChannelPositions(@Nonnull Category category)
+    public CategoryOrderAction modifyVoiceChannelPositions(@NotNull Category category)
     {
         Checks.notNull(category, "Category");
         checkGuild(category.getGuild(), "Category");
         return new CategoryOrderActionImpl(category, ChannelType.VOICE.getSortBucket());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RoleOrderAction modifyRolePositions(boolean useAscendingOrder)
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -21,8 +21,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.GuildVoiceState;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.VoiceChannel;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class GuildVoiceStateImpl implements GuildVoiceState
 {
@@ -58,7 +57,7 @@ public class GuildVoiceStateImpl implements GuildVoiceState
         return selfDeafened;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
@@ -113,7 +112,7 @@ public class GuildVoiceStateImpl implements GuildVoiceState
         return connectedChannel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
@@ -123,7 +122,7 @@ public class GuildVoiceStateImpl implements GuildVoiceState
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Member getMember()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/InviteImpl.java
@@ -33,8 +33,8 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
@@ -89,7 +89,7 @@ public class InviteImpl implements Invite
                 jda.getEntityBuilder().createInvite(response.getObject()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {
@@ -98,7 +98,7 @@ public class InviteImpl implements Invite
         return new AuditableRestActionImpl<>(this.api, route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Invite> expand()
     {
@@ -150,7 +150,7 @@ public class InviteImpl implements Invite
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Invite.InviteType getType()
     {
@@ -163,14 +163,14 @@ public class InviteImpl implements Invite
         return this.channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getCode()
     {
         return this.code;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @Deprecated
     @DeprecatedSince("4.BETA.0")
@@ -198,7 +198,7 @@ public class InviteImpl implements Invite
         return this.inviter;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDAImpl getJDA()
     {
@@ -221,7 +221,7 @@ public class InviteImpl implements Invite
         return this.maxUses;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public OffsetDateTime getTimeCreated()
     {
@@ -299,14 +299,14 @@ public class InviteImpl implements Invite
             return id;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName()
         {
             return this.name;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ChannelType getType()
         {
@@ -361,7 +361,7 @@ public class InviteImpl implements Invite
             return id;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public String getName()
         {
@@ -381,7 +381,7 @@ public class InviteImpl implements Invite
                     : "https://cdn.discordapp.com/splashes/" + this.id + "/" + this.splashId + ".png";
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public VerificationLevel getVerificationLevel()
         {
@@ -400,7 +400,7 @@ public class InviteImpl implements Invite
             return memberCount;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Set<String> getFeatures()
         {

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -27,9 +27,9 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -67,7 +67,7 @@ public class MemberImpl implements Member
         return presences == null ? null : presences.get(getIdLong());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getUser()
     {
@@ -78,7 +78,7 @@ public class MemberImpl implements Member
         return user;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildImpl getGuild()
     {
@@ -88,14 +88,14 @@ public class MemberImpl implements Member
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public OffsetDateTime getTimeJoined()
     {
@@ -123,7 +123,7 @@ public class MemberImpl implements Member
         return voiceState;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Activity> getActivities()
     {
@@ -131,7 +131,7 @@ public class MemberImpl implements Member
         return presence == null ? Collections.emptyList() : presence.getActivities();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public OnlineStatus getOnlineStatus()
     {
@@ -139,9 +139,9 @@ public class MemberImpl implements Member
         return presence == null ? OnlineStatus.OFFLINE : presence.getOnlineStatus();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public OnlineStatus getOnlineStatus(@Nonnull ClientType type)
+    public OnlineStatus getOnlineStatus(@NotNull ClientType type)
     {
         Checks.notNull(type, "Type");
         MemberPresenceImpl presence = getPresence();
@@ -151,7 +151,7 @@ public class MemberImpl implements Member
         return status == null ? OnlineStatus.OFFLINE : status;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<ClientType> getActiveClients()
     {
@@ -165,14 +165,14 @@ public class MemberImpl implements Member
         return nickname;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getEffectiveName()
     {
         return nickname != null ? nickname : getUser().getName();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Role> getRoles()
     {
@@ -201,16 +201,16 @@ public class MemberImpl implements Member
         return Role.DEFAULT_COLOR_RAW;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getPermissions()
     {
         return Permission.getPermissions(PermissionUtil.getEffectivePermission(this));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumSet<Permission> getPermissions(@Nonnull GuildChannel channel)
+    public EnumSet<Permission> getPermissions(@NotNull GuildChannel channel)
     {
         Checks.notNull(channel, "Channel");
         if (!getGuild().equals(channel.getGuild()))
@@ -219,28 +219,28 @@ public class MemberImpl implements Member
         return Permission.getPermissions(PermissionUtil.getEffectivePermission(channel, this));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getPermissionsExplicit()
     {
         return Permission.getPermissions(PermissionUtil.getExplicitPermission(this));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumSet<Permission> getPermissionsExplicit(@Nonnull GuildChannel channel)
+    public EnumSet<Permission> getPermissionsExplicit(@NotNull GuildChannel channel)
     {
         return Permission.getPermissions(PermissionUtil.getExplicitPermission(channel, this));
     }
 
     @Override
-    public boolean hasPermission(@Nonnull Permission... permissions)
+    public boolean hasPermission(@NotNull Permission... permissions)
     {
         return PermissionUtil.checkPermission(this, permissions);
     }
 
     @Override
-    public boolean hasPermission(@Nonnull Collection<Permission> permissions)
+    public boolean hasPermission(@NotNull Collection<Permission> permissions)
     {
         Checks.notNull(permissions, "Permission Collection");
 
@@ -248,13 +248,13 @@ public class MemberImpl implements Member
     }
 
     @Override
-    public boolean hasPermission(@Nonnull GuildChannel channel, @Nonnull Permission... permissions)
+    public boolean hasPermission(@NotNull GuildChannel channel, @NotNull Permission... permissions)
     {
         return PermissionUtil.checkPermission(channel, this, permissions);
     }
 
     @Override
-    public boolean hasPermission(@Nonnull GuildChannel channel, @Nonnull Collection<Permission> permissions)
+    public boolean hasPermission(@NotNull GuildChannel channel, @NotNull Collection<Permission> permissions)
     {
         Checks.notNull(permissions, "Permission Collection");
 
@@ -262,7 +262,7 @@ public class MemberImpl implements Member
     }
 
     @Override
-    public boolean canSync(@Nonnull GuildChannel targetChannel, @Nonnull GuildChannel syncSource)
+    public boolean canSync(@NotNull GuildChannel targetChannel, @NotNull GuildChannel syncSource)
     {
         Checks.notNull(targetChannel, "Channel");
         Checks.notNull(syncSource, "Channel");
@@ -297,7 +297,7 @@ public class MemberImpl implements Member
     }
 
     @Override
-    public boolean canSync(@Nonnull GuildChannel channel)
+    public boolean canSync(@NotNull GuildChannel channel)
     {
         Checks.notNull(channel, "Channel");
         Checks.check(channel.getGuild().equals(getGuild()), "Channels must be from the same guild!");
@@ -311,19 +311,19 @@ public class MemberImpl implements Member
     }
 
     @Override
-    public boolean canInteract(@Nonnull Member member)
+    public boolean canInteract(@NotNull Member member)
     {
         return PermissionUtil.canInteract(this, member);
     }
 
     @Override
-    public boolean canInteract(@Nonnull Role role)
+    public boolean canInteract(@NotNull Role role)
     {
         return PermissionUtil.canInteract(this, role);
     }
 
     @Override
-    public boolean canInteract(@Nonnull Emote emote)
+    public boolean canInteract(@NotNull Emote emote)
     {
         return PermissionUtil.canInteract(this, emote);
     }
@@ -412,7 +412,7 @@ public class MemberImpl implements Member
         return "MB:" + getEffectiveName() + '(' + getUser().toString() + " / " + getGuild().toString() +')';
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAsMention()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -27,8 +27,8 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.PermissionOverrideActionImpl;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 import java.util.Objects;
 
@@ -70,28 +70,28 @@ public class PermissionOverrideImpl implements PermissionOverride
         return deny;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getAllowed()
     {
         return Permission.getPermissions(allow);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getInherit()
     {
         return Permission.getPermissions(getInheritRaw());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getDenied()
     {
         return Permission.getPermissions(deny);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
@@ -116,7 +116,7 @@ public class PermissionOverrideImpl implements PermissionOverride
         return getGuild().getRoleById(id);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildChannel getChannel()
     {
@@ -126,7 +126,7 @@ public class PermissionOverrideImpl implements PermissionOverride
         return channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
@@ -145,7 +145,7 @@ public class PermissionOverrideImpl implements PermissionOverride
         return isRole;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideAction getManager()
     {
@@ -162,7 +162,7 @@ public class PermissionOverrideImpl implements PermissionOverride
         return manager;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -25,8 +25,8 @@ import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.InputStream;
 import java.util.Collections;
@@ -53,7 +53,7 @@ public class PrivateChannelImpl implements PrivateChannel
             this.user = realUser;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getUser()
     {
@@ -76,28 +76,28 @@ public class PrivateChannelImpl implements PrivateChannel
         return lastMessageId > 0;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
         return getUser().getName();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getType()
     {
         return ChannelType.PRIVATE;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return user.getJDA();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> close()
     {
@@ -105,9 +105,9 @@ public class PrivateChannelImpl implements PrivateChannel
         return new RestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<CompletableFuture<Void>> purgeMessages(@Nonnull List<? extends Message> messages)
+    public List<CompletableFuture<Void>> purgeMessages(@NotNull List<? extends Message> messages)
     {
         if (messages == null || messages.isEmpty())
             return Collections.emptyList();
@@ -133,41 +133,41 @@ public class PrivateChannelImpl implements PrivateChannel
         return user.isFake();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendMessage(@Nonnull CharSequence text)
+    public MessageAction sendMessage(@NotNull CharSequence text)
     {
         checkBot();
         return PrivateChannel.super.sendMessage(text);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendMessage(@Nonnull MessageEmbed embed)
+    public MessageAction sendMessage(@NotNull MessageEmbed embed)
     {
         checkBot();
         return PrivateChannel.super.sendMessage(embed);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendMessage(@Nonnull Message msg)
+    public MessageAction sendMessage(@NotNull Message msg)
     {
         checkBot();
         return PrivateChannel.super.sendMessage(msg);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    public MessageAction sendFile(@NotNull InputStream data, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         checkBot();
         return PrivateChannel.super.sendFile(data, fileName, options);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendFile(@Nonnull File file, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    public MessageAction sendFile(@NotNull File file, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         checkBot();
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();
@@ -176,9 +176,9 @@ public class PrivateChannelImpl implements PrivateChannel
         return PrivateChannel.super.sendFile(file, fileName, options);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    public MessageAction sendFile(@NotNull byte[] data, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         checkBot();
         final long maxSize = getJDA().getSelfUser().getAllowedFileSize();

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -38,9 +38,9 @@ import net.dv8tion.jda.internal.utils.Checks;
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.bag.HashBag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.function.Function;
@@ -110,7 +110,7 @@ public class ReceivedMessage extends AbstractMessage
         this.flags = flags;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
@@ -129,23 +129,23 @@ public class ReceivedMessage extends AbstractMessage
         return pinned;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> pin()
     {
         return channel.pinMessageById(getId());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> unpin()
     {
         return channel.unpinMessageById(getId());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> addReaction(@Nonnull Emote emote)
+    public RestAction<Void> addReaction(@NotNull Emote emote)
     {
         Checks.notNull(emote, "Emote");
 
@@ -162,14 +162,14 @@ public class ReceivedMessage extends AbstractMessage
         return channel.addReactionById(getId(), emote);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> addReaction(@Nonnull String unicode)
+    public RestAction<Void> addReaction(@NotNull String unicode)
     {
         return channel.addReactionById(getId(), unicode);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> clearReactions()
     {
@@ -178,34 +178,34 @@ public class ReceivedMessage extends AbstractMessage
         return getTextChannel().clearReactionsById(getId());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactions(@Nonnull String unicode)
+    public RestAction<Void> clearReactions(@NotNull String unicode)
     {
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactions(@Nonnull Emote emote)
+    public RestAction<Void> clearReactions(@NotNull Emote emote)
     {
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull Emote emote)
+    public RestAction<Void> removeReaction(@NotNull Emote emote)
     {
         return channel.removeReactionById(getId(), emote);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
+    public RestAction<Void> removeReaction(@NotNull Emote emote, @NotNull User user)
     {
         Checks.notNull(user, "User");  // to prevent NPEs
         // check if the passed user is the SelfUser, then the ChannelType doesn't matter and
@@ -218,16 +218,16 @@ public class ReceivedMessage extends AbstractMessage
         return getTextChannel().removeReactionById(getIdLong(), emote, user);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull String unicode)
+    public RestAction<Void> removeReaction(@NotNull String unicode)
     {
         return channel.removeReactionById(getId(), unicode);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user)
+    public RestAction<Void> removeReaction(@NotNull String unicode, @NotNull User user)
     {
         Checks.notNull(user, "User");
         if (user.equals(getJDA().getSelfUser()))
@@ -238,22 +238,22 @@ public class ReceivedMessage extends AbstractMessage
         return getTextChannel().removeReactionById(getId(), unicode, user);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ReactionPaginationAction retrieveReactionUsers(@Nonnull Emote emote)
+    public ReactionPaginationAction retrieveReactionUsers(@NotNull Emote emote)
     {
         return channel.retrieveReactionUsersById(id, emote);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ReactionPaginationAction retrieveReactionUsers(@Nonnull String unicode)
+    public ReactionPaginationAction retrieveReactionUsers(@NotNull String unicode)
     {
         return channel.retrieveReactionUsersById(id, unicode);
     }
 
     @Override
-    public MessageReaction.ReactionEmote getReactionByUnicode(@Nonnull String unicode)
+    public MessageReaction.ReactionEmote getReactionByUnicode(@NotNull String unicode)
     {
         Checks.notEmpty(unicode, "Emoji");
         Checks.noWhitespace(unicode, "Emoji");
@@ -265,7 +265,7 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
-    public MessageReaction.ReactionEmote getReactionById(@Nonnull String id)
+    public MessageReaction.ReactionEmote getReactionById(@NotNull String id)
     {
         return getReactionById(MiscUtil.parseSnowflake(id));
     }
@@ -279,7 +279,7 @@ public class ReceivedMessage extends AbstractMessage
             .findFirst().orElse(null);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageType getType()
     {
@@ -292,7 +292,7 @@ public class ReceivedMessage extends AbstractMessage
         return id;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getJumpUrl()
     {
@@ -310,7 +310,7 @@ public class ReceivedMessage extends AbstractMessage
         return user;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public synchronized List<User> getMentionedUsers()
     {
@@ -319,7 +319,7 @@ public class ReceivedMessage extends AbstractMessage
         return userMentions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<User> getMentionedUsersBag()
     {
@@ -332,7 +332,7 @@ public class ReceivedMessage extends AbstractMessage
         return getJDA().getTextChannelById(channelId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public synchronized List<TextChannel> getMentionedChannels()
     {
@@ -341,7 +341,7 @@ public class ReceivedMessage extends AbstractMessage
         return channelMentions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<TextChannel> getMentionedChannelsBag()
     {
@@ -359,7 +359,7 @@ public class ReceivedMessage extends AbstractMessage
             return getJDA().getRoleById(roleId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public synchronized List<Role> getMentionedRoles()
     {
@@ -368,16 +368,16 @@ public class ReceivedMessage extends AbstractMessage
         return roleMentions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<Role> getMentionedRolesBag()
     {
         return processMentions(MentionType.ROLE, new HashBag<>(), false, this::matchRole);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Member> getMentionedMembers(@Nonnull Guild guild)
+    public List<Member> getMentionedMembers(@NotNull Guild guild)
     {
         Checks.notNull(guild, "Guild");
         if (isFromGuild() && guild.equals(getGuild()) && memberMentions != null)
@@ -394,7 +394,7 @@ public class ReceivedMessage extends AbstractMessage
         return Collections.unmodifiableList(members);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getMentionedMembers()
     {
@@ -404,9 +404,9 @@ public class ReceivedMessage extends AbstractMessage
             throw new IllegalStateException("You must specify a Guild for Messages which are not sent from a TextChannel!");
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<IMentionable> getMentions(@Nonnull MentionType... types)
+    public List<IMentionable> getMentions(@NotNull MentionType... types)
     {
         if (types == null || types.length == 0)
             return getMentions(MentionType.values());
@@ -449,7 +449,7 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
-    public boolean isMentioned(@Nonnull IMentionable mentionable, @Nonnull MentionType... types)
+    public boolean isMentioned(@NotNull IMentionable mentionable, @NotNull MentionType... types)
     {
         Checks.notNull(types, "Mention Types");
         if (types.length == 0)
@@ -563,7 +563,7 @@ public class ReceivedMessage extends AbstractMessage
         return editedTime;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getAuthor()
     {
@@ -576,7 +576,7 @@ public class ReceivedMessage extends AbstractMessage
         return member;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getContentStripped()
     {
@@ -590,7 +590,7 @@ public class ReceivedMessage extends AbstractMessage
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getContentDisplay()
     {
@@ -626,14 +626,14 @@ public class ReceivedMessage extends AbstractMessage
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getContentRaw()
     {
         return content;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<String> getInvites()
     {
@@ -658,26 +658,26 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
-    public boolean isFromType(@Nonnull ChannelType type)
+    public boolean isFromType(@NotNull ChannelType type)
     {
         return getChannelType() == type;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getChannelType()
     {
         return channel.getType();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageChannel getChannel()
     {
         return channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PrivateChannel getPrivateChannel()
     {
@@ -686,7 +686,7 @@ public class ReceivedMessage extends AbstractMessage
         return (PrivateChannel) channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public TextChannel getTextChannel()
     {
@@ -703,21 +703,21 @@ public class ReceivedMessage extends AbstractMessage
         return isFromGuild() ? getTextChannel().getParent() : null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return getTextChannel().getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Attachment> getAttachments()
     {
         return attachments;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageEmbed> getEmbeds()
     {
@@ -735,7 +735,7 @@ public class ReceivedMessage extends AbstractMessage
         return emote;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public synchronized List<Emote> getEmotes()
     {
@@ -744,21 +744,21 @@ public class ReceivedMessage extends AbstractMessage
         return emoteMentions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Bag<Emote> getEmotesBag()
     {
         return processMentions(MentionType.EMOTE, new HashBag<>(), false, this::matchEmote);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageReaction> getReactions()
     {
         return reactions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<MessageSticker> getStickers()
     {
@@ -784,31 +784,31 @@ public class ReceivedMessage extends AbstractMessage
         return activity;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull CharSequence newContent)
+    public MessageAction editMessage(@NotNull CharSequence newContent)
     {
         return editMessage(new MessageBuilder().append(newContent).build());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull MessageEmbed newContent)
+    public MessageAction editMessage(@NotNull MessageEmbed newContent)
     {
         return editMessage(new MessageBuilder().setEmbed(newContent).build());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessageFormat(@Nonnull String format, @Nonnull Object... args)
+    public MessageAction editMessageFormat(@NotNull String format, @NotNull Object... args)
     {
         Checks.notBlank(format, "Format String");
         return editMessage(new MessageBuilder().appendFormat(format, args).build());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull Message newContent)
+    public MessageAction editMessage(@NotNull Message newContent)
     {
         if (!getJDA().getSelfUser().equals(getAuthor()))
             throw new IllegalStateException("Attempted to update message that was not sent by this account. You cannot modify other User's messages!");
@@ -816,7 +816,7 @@ public class ReceivedMessage extends AbstractMessage
         return getChannel().editMessageById(getIdLong(), newContent);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {
@@ -833,7 +833,7 @@ public class ReceivedMessage extends AbstractMessage
         return channel.deleteMessageById(getIdLong());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> suppressEmbeds(boolean suppressed)
     {
@@ -848,7 +848,7 @@ public class ReceivedMessage extends AbstractMessage
         return new AuditableRestActionImpl<>(jda, route, DataObject.empty().put("flags", newFlags));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Message> crosspost()
     {
@@ -868,7 +868,7 @@ public class ReceivedMessage extends AbstractMessage
         return (this.flags & MessageFlag.EMBEDS_SUPPRESSED.getValue()) > 0;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<MessageFlag> getFlags()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/RichPresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RichPresenceImpl.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.entities.ActivityFlag;
 import net.dv8tion.jda.api.entities.RichPresence;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Objects;
 
@@ -72,7 +72,7 @@ public class RichPresenceImpl extends ActivityImpl implements RichPresence
         return applicationId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getApplicationId()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -37,8 +37,8 @@ import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.awt.*;
 import java.time.OffsetDateTime;
 import java.util.Collection;
@@ -94,7 +94,7 @@ public class RoleImpl implements Role
         return rawPosition;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
@@ -125,30 +125,30 @@ public class RoleImpl implements Role
         return rawPermissions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getPermissions()
     {
         return Permission.getPermissions(rawPermissions);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumSet<Permission> getPermissions(@Nonnull GuildChannel channel)
+    public EnumSet<Permission> getPermissions(@NotNull GuildChannel channel)
     {
         return Permission.getPermissions(PermissionUtil.getEffectivePermission(channel, this));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<Permission> getPermissionsExplicit()
     {
         return getPermissions();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public EnumSet<Permission> getPermissionsExplicit(@Nonnull GuildChannel channel)
+    public EnumSet<Permission> getPermissionsExplicit(@NotNull GuildChannel channel)
     {
         return Permission.getPermissions(PermissionUtil.getExplicitPermission(channel, this));
     }
@@ -172,7 +172,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean hasPermission(@Nonnull Permission... permissions)
+    public boolean hasPermission(@NotNull Permission... permissions)
     {
         long effectivePerms = rawPermissions | getGuild().getPublicRole().getPermissionsRaw();
         for (Permission perm : permissions)
@@ -185,7 +185,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean hasPermission(@Nonnull Collection<Permission> permissions)
+    public boolean hasPermission(@NotNull Collection<Permission> permissions)
     {
         Checks.notNull(permissions, "Permission Collection");
 
@@ -193,7 +193,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean hasPermission(@Nonnull GuildChannel channel, @Nonnull Permission... permissions)
+    public boolean hasPermission(@NotNull GuildChannel channel, @NotNull Permission... permissions)
     {
         long effectivePerms = PermissionUtil.getEffectivePermission(channel, this);
         for (Permission perm : permissions)
@@ -206,7 +206,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean hasPermission(@Nonnull GuildChannel channel, @Nonnull Collection<Permission> permissions)
+    public boolean hasPermission(@NotNull GuildChannel channel, @NotNull Collection<Permission> permissions)
     {
         Checks.notNull(permissions, "Permission Collection");
 
@@ -214,7 +214,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean canSync(@Nonnull GuildChannel targetChannel, @Nonnull GuildChannel syncSource)
+    public boolean canSync(@NotNull GuildChannel targetChannel, @NotNull GuildChannel syncSource)
     {
         Checks.notNull(targetChannel, "Channel");
         Checks.notNull(syncSource, "Channel");
@@ -249,7 +249,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean canSync(@Nonnull GuildChannel channel)
+    public boolean canSync(@NotNull GuildChannel channel)
     {
         Checks.notNull(channel, "Channel");
         Checks.check(channel.getGuild().equals(getGuild()), "Channels must be from the same guild!");
@@ -263,12 +263,12 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public boolean canInteract(@Nonnull Role role)
+    public boolean canInteract(@NotNull Role role)
     {
         return PermissionUtil.canInteract(this, role);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
@@ -278,9 +278,9 @@ public class RoleImpl implements Role
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RoleAction createCopy(@Nonnull Guild guild)
+    public RoleAction createCopy(@NotNull Guild guild)
     {
         Checks.notNull(guild, "Guild");
         return guild.createRole()
@@ -291,7 +291,7 @@ public class RoleImpl implements Role
                     .setPermissions(rawPermissions);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RoleManager getManager()
     {
@@ -300,7 +300,7 @@ public class RoleImpl implements Role
         return manager;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {
@@ -316,21 +316,21 @@ public class RoleImpl implements Role
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RoleTags getTags()
     {
         return tags == null ? RoleTagsImpl.EMPTY : tags;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAsMention()
     {
@@ -367,7 +367,7 @@ public class RoleImpl implements Role
     }
 
     @Override
-    public int compareTo(@Nonnull Role r)
+    public int compareTo(@NotNull Role r)
     {
         if (this == r)
             return 0;

--- a/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SelfUserImpl.java
@@ -22,8 +22,7 @@ import net.dv8tion.jda.api.managers.AccountManager;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.AccountManagerImpl;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class SelfUserImpl extends UserImpl implements SelfUser
 {
@@ -55,7 +54,7 @@ public class SelfUserImpl extends UserImpl implements SelfUser
         throw new UnsupportedOperationException("You cannot get a PrivateChannel with yourself (SelfUser)");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<PrivateChannel> openPrivateChannel()
     {
@@ -83,7 +82,7 @@ public class SelfUserImpl extends UserImpl implements SelfUser
             return Message.MAX_FILE_SIZE;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AccountManager getManager()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/StoreChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StoreChannelImpl.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -38,14 +38,14 @@ public class StoreChannelImpl extends AbstractChannelImpl<StoreChannel, StoreCha
         return super.setPosition(rawPosition);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getType()
     {
         return ChannelType.STORE;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getMembers()
     {
@@ -66,9 +66,9 @@ public class StoreChannelImpl extends AbstractChannelImpl<StoreChannel, StoreCha
         throw new IllegalStateException("Somehow when determining position we never found the StoreChannel in the Guild's channels? wtf?");
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<StoreChannel> createCopy(@Nonnull Guild guild)
+    public ChannelAction<StoreChannel> createCopy(@NotNull Guild guild)
     {
         throw new UnsupportedOperationException("Bots cannot create store channels");
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
@@ -20,8 +20,8 @@ import gnu.trove.set.TLongSet;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -38,44 +38,44 @@ public class SystemMessage extends ReceivedMessage
             tts, pinned, content, nonce, author, member, activity, editTime, reactions, attachments, embeds, stickers, flags);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> pin()
     {
         throw new UnsupportedOperationException("Cannot pin message of this Message Type. MessageType: " + getType());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<Void> unpin()
     {
         throw new UnsupportedOperationException("Cannot unpin message of this Message Type. MessageType: " + getType());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull CharSequence newContent)
+    public MessageAction editMessage(@NotNull CharSequence newContent)
     {
         throw new UnsupportedOperationException("Cannot edit message of this Message Type. MessageType: " + getType());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull MessageEmbed newContent)
+    public MessageAction editMessage(@NotNull MessageEmbed newContent)
     {
         throw new UnsupportedOperationException("Cannot edit message of this Message Type. MessageType: " + getType());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessageFormat(@Nonnull String format, @Nonnull Object... args)
+    public MessageAction editMessageFormat(@NotNull String format, @NotNull Object... args)
     {
         throw new UnsupportedOperationException("Cannot edit message of this Message Type. MessageType: " + getType());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessage(@Nonnull Message newContent)
+    public MessageAction editMessage(@NotNull Message newContent)
     {
         throw new UnsupportedOperationException("Cannot edit message of this Message Type. MessageType: " + getType());
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/TeamMemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TeamMemberImpl.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.entities;
 
 import net.dv8tion.jda.api.entities.TeamMember;
 import net.dv8tion.jda.api.entities.User;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Objects;
 
 public class TeamMemberImpl implements TeamMember
@@ -35,14 +35,14 @@ public class TeamMemberImpl implements TeamMember
         this.teamId = teamId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getUser()
     {
         return user;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MembershipState getMembershipState()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -39,8 +39,8 @@ import net.dv8tion.jda.internal.requests.restaction.WebhookActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.pagination.ReactionPaginationActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -68,7 +68,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return super.setPosition(rawPosition);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<Webhook>> retrieveWebhooks()
     {
@@ -98,9 +98,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public WebhookAction createWebhook(@Nonnull String name)
+    public WebhookAction createWebhook(@NotNull String name)
     {
         Checks.notBlank(name, "Webhook name");
         name = name.trim();
@@ -110,9 +110,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new WebhookActionImpl(getJDA(), this, name);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Webhook.WebhookReference> follow(@Nonnull String targetChannelId)
+    public RestAction<Webhook.WebhookReference> follow(@NotNull String targetChannelId)
     {
         Checks.notNull(targetChannelId, "Target Channel ID");
         if (!isNews())
@@ -125,9 +125,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         });
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> deleteMessages(@Nonnull Collection<Message> messages)
+    public RestAction<Void> deleteMessages(@NotNull Collection<Message> messages)
     {
         Checks.notEmpty(messages, "Messages collection");
 
@@ -136,9 +136,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
                 .collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> deleteMessagesByIds(@Nonnull Collection<String> messageIds)
+    public RestAction<Void> deleteMessagesByIds(@NotNull Collection<String> messageIds)
     {
         checkPermission(Permission.MESSAGE_MANAGE, "Must have MESSAGE_MANAGE in order to bulk delete messages in this channel regardless of author.");
         if (messageIds.size() < 2 || messageIds.size() > 100)
@@ -151,9 +151,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return deleteMessages0(messageIds);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> deleteWebhookById(@Nonnull String id)
+    public AuditableRestAction<Void> deleteWebhookById(@NotNull String id)
     {
         Checks.isSnowflake(id, "Webhook ID");
 
@@ -170,7 +170,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
     }
 
     @Override
-    public boolean canTalk(@Nonnull Member member)
+    public boolean canTalk(@NotNull Member member)
     {
         if (!getGuild().equals(member.getGuild()))
             throw new IllegalArgumentException("Provided Member is not from the Guild that this TextChannel is part of.");
@@ -178,9 +178,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return member.hasPermission(this, Permission.MESSAGE_READ, Permission.MESSAGE_WRITE);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<CompletableFuture<Void>> purgeMessages(@Nonnull List<? extends Message> messages)
+    public List<CompletableFuture<Void>> purgeMessages(@NotNull List<? extends Message> messages)
     {
         if (messages == null || messages.isEmpty())
             return Collections.emptyList();
@@ -197,10 +197,10 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.purgeMessages(messages);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("ConstantConditions")
-    public List<CompletableFuture<Void>> purgeMessagesById(@Nonnull long... messageIds)
+    public List<CompletableFuture<Void>> purgeMessagesById(@NotNull long... messageIds)
     {
         if (messageIds == null || messageIds.length == 0)
             return Collections.emptyList();
@@ -261,7 +261,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return lastMessageId != 0;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getType()
     {
@@ -292,7 +292,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return slowmode;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getMembers()
     {
@@ -317,9 +317,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         throw new IllegalStateException("Somehow when determining position we never found the TextChannel in the Guild's channels? wtf?");
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<TextChannel> createCopy(@Nonnull Guild guild)
+    public ChannelAction<TextChannel> createCopy(@NotNull Guild guild)
     {
         Checks.notNull(guild, "Guild");
         ChannelAction<TextChannel> action = guild.createTextChannel(name).setNSFW(nsfw).setTopic(topic).setSlowmode(slowmode);
@@ -339,18 +339,18 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return action;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendMessage(@Nonnull CharSequence text)
+    public MessageAction sendMessage(@NotNull CharSequence text)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
         return TextChannel.super.sendMessage(text);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendMessage(@Nonnull MessageEmbed embed)
+    public MessageAction sendMessage(@NotNull MessageEmbed embed)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
@@ -359,9 +359,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.sendMessage(embed);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendMessage(@Nonnull Message msg)
+    public MessageAction sendMessage(@NotNull Message msg)
     {
         Checks.notNull(msg, "Message");
 
@@ -374,9 +374,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.sendMessage(msg);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendFile(@Nonnull File file, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    public MessageAction sendFile(@NotNull File file, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
@@ -390,9 +390,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.sendFile(file, fileName, options);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendFile(@Nonnull InputStream data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    public MessageAction sendFile(@NotNull InputStream data, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
@@ -402,9 +402,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.sendFile(data, fileName, options);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction sendFile(@Nonnull byte[] data, @Nonnull String fileName, @Nonnull AttachmentOption... options)
+    public MessageAction sendFile(@NotNull byte[] data, @NotNull String fileName, @NotNull AttachmentOption... options)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
@@ -417,9 +417,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.sendFile(data, fileName, options);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Message> retrieveMessageById(@Nonnull String messageId)
+    public RestAction<Message> retrieveMessageById(@NotNull String messageId)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_HISTORY);
@@ -428,9 +428,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.retrieveMessageById(messageId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> deleteMessageById(@Nonnull String messageId)
+    public AuditableRestAction<Void> deleteMessageById(@NotNull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
         checkPermission(Permission.MESSAGE_READ);
@@ -439,9 +439,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.deleteMessageById(messageId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> pinMessageById(@Nonnull String messageId)
+    public RestAction<Void> pinMessageById(@NotNull String messageId)
     {
         checkPermission(Permission.MESSAGE_READ, "You cannot pin a message in a channel you can't access. (MESSAGE_READ)");
         checkPermission(Permission.MESSAGE_MANAGE, "You need MESSAGE_MANAGE to pin or unpin messages.");
@@ -450,9 +450,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.pinMessageById(messageId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> unpinMessageById(@Nonnull String messageId)
+    public RestAction<Void> unpinMessageById(@NotNull String messageId)
     {
         checkPermission(Permission.MESSAGE_READ, "You cannot unpin a message in a channel you can't access. (MESSAGE_READ)");
         checkPermission(Permission.MESSAGE_MANAGE, "You need MESSAGE_MANAGE to pin or unpin messages.");
@@ -461,7 +461,7 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.unpinMessageById(messageId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<List<Message>> retrievePinnedMessages()
     {
@@ -471,9 +471,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.retrievePinnedMessages();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> addReactionById(@Nonnull String messageId, @Nonnull String unicode)
+    public RestAction<Void> addReactionById(@NotNull String messageId, @NotNull String unicode)
     {
         checkPermission(Permission.MESSAGE_HISTORY);
 
@@ -481,9 +481,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.addReactionById(messageId, unicode);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> addReactionById(@Nonnull String messageId, @Nonnull Emote emote)
+    public RestAction<Void> addReactionById(@NotNull String messageId, @NotNull Emote emote)
     {
         checkPermission(Permission.MESSAGE_HISTORY);
 
@@ -491,9 +491,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.addReactionById(messageId, emote);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactionsById(@Nonnull String messageId)
+    public RestAction<Void> clearReactionsById(@NotNull String messageId)
     {
         Checks.isSnowflake(messageId, "Message ID");
 
@@ -502,9 +502,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new RestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull String unicode)
+    public RestAction<Void> clearReactionsById(@NotNull String messageId, @NotNull String unicode)
     {
         Checks.notNull(messageId, "Message ID");
         Checks.notNull(unicode, "Emote Name");
@@ -515,17 +515,17 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new RestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emote emote)
+    public RestAction<Void> clearReactionsById(@NotNull String messageId, @NotNull Emote emote)
     {
         Checks.notNull(emote, "Emote");
         return clearReactionsById(messageId, emote.getName() + ":" + emote.getId());
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestActionImpl<Void> removeReactionById(@Nonnull String messageId, @Nonnull String unicode, @Nonnull User user)
+    public RestActionImpl<Void> removeReactionById(@NotNull String messageId, @NotNull String unicode, @NotNull User user)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(unicode, "Provided Unicode");
@@ -548,9 +548,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new RestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ReactionPaginationAction retrieveReactionUsersById(@Nonnull String messageId, @Nonnull String unicode)
+    public ReactionPaginationAction retrieveReactionUsersById(@NotNull String messageId, @NotNull String unicode)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notEmpty(unicode, "Emoji");
@@ -561,9 +561,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new ReactionPaginationActionImpl(this, messageId, EncodingUtil.encodeUTF8(unicode));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ReactionPaginationAction retrieveReactionUsersById(@Nonnull String messageId, @Nonnull Emote emote)
+    public ReactionPaginationAction retrieveReactionUsersById(@NotNull String messageId, @NotNull Emote emote)
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notNull(emote, "Emote");
@@ -573,18 +573,18 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return new ReactionPaginationActionImpl(this, messageId, String.format("%s:%s", emote, emote.getId()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessageById(@Nonnull String messageId, @Nonnull CharSequence newContent)
+    public MessageAction editMessageById(@NotNull String messageId, @NotNull CharSequence newContent)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
         return TextChannel.super.editMessageById(messageId, newContent);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessageById(@Nonnull String messageId, @Nonnull MessageEmbed newEmbed)
+    public MessageAction editMessageById(@NotNull String messageId, @NotNull MessageEmbed newEmbed)
     {
         checkPermission(Permission.MESSAGE_READ);
         checkPermission(Permission.MESSAGE_WRITE);
@@ -592,9 +592,9 @@ public class TextChannelImpl extends AbstractChannelImpl<TextChannel, TextChanne
         return TextChannel.super.editMessageById(messageId, newEmbed);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction editMessageById(@Nonnull String id, @Nonnull Message newContent)
+    public MessageAction editMessageById(@NotNull String id, @NotNull Message newContent)
     {
         Checks.notNull(newContent, "Message");
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserById.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserById.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.api.entities.PrivateChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -43,7 +43,7 @@ public class UserById implements User
         return this.id;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAsMention()
     {
@@ -78,7 +78,7 @@ public class UserById implements User
         throw new UnsupportedOperationException("This User instance only wraps an ID. Other operations are unsupported");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
@@ -86,7 +86,7 @@ public class UserById implements User
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getDiscriminator()
     {
@@ -102,7 +102,7 @@ public class UserById implements User
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getDefaultAvatarId()
     {
@@ -110,7 +110,7 @@ public class UserById implements User
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAsTag()
     {
@@ -125,7 +125,7 @@ public class UserById implements User
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<PrivateChannel> openPrivateChannel()
     {
@@ -133,7 +133,7 @@ public class UserById implements User
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Guild> getMutualGuilds()
     {
@@ -155,7 +155,7 @@ public class UserById implements User
         return false;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
@@ -163,7 +163,7 @@ public class UserById implements User
         return null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<UserFlag> getFlags()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -27,8 +27,8 @@ import net.dv8tion.jda.internal.requests.DeferredRestAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 import java.util.FormattableFlags;
 import java.util.Formatter;
@@ -53,14 +53,14 @@ public class UserImpl extends UserById implements User
         this.api = api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
         return name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getDiscriminator()
     {
@@ -73,14 +73,14 @@ public class UserImpl extends UserById implements User
         return avatarId;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getDefaultAvatarId()
     {
         return String.valueOf(discriminator % 5);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAsTag()
     {
@@ -93,7 +93,7 @@ public class UserImpl extends UserById implements User
         return privateChannel != 0;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<PrivateChannel> openPrivateChannel()
     {
@@ -117,7 +117,7 @@ public class UserImpl extends UserById implements User
         return channel != null ? channel : new PrivateChannelImpl(privateChannel, this);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Guild> getMutualGuilds()
     {
@@ -136,7 +136,7 @@ public class UserImpl extends UserById implements User
         return system;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDAImpl getJDA()
     {
@@ -150,7 +150,7 @@ public class UserImpl extends UserById implements User
         return fake;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<UserFlag> getFlags()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -21,8 +21,8 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,14 +57,14 @@ public class VoiceChannelImpl extends AbstractChannelImpl<VoiceChannel, VoiceCha
         return bitrate;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getType()
     {
         return ChannelType.VOICE;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getMembers()
     {
@@ -83,9 +83,9 @@ public class VoiceChannelImpl extends AbstractChannelImpl<VoiceChannel, VoiceCha
         throw new IllegalStateException("Somehow when determining position we never found the VoiceChannel in the Guild's channels? wtf?");
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelAction<VoiceChannel> createCopy(@Nonnull Guild guild)
+    public ChannelAction<VoiceChannel> createCopy(@NotNull Guild guild)
     {
         Checks.notNull(guild, "Guild");
         ChannelAction<VoiceChannel> action = guild.createVoiceChannel(name).setBitrate(bitrate).setUserlimit(userLimit);

--- a/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
@@ -27,8 +27,7 @@ import net.dv8tion.jda.internal.requests.Requester;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The implementation for {@link net.dv8tion.jda.api.entities.Webhook Webhook}
@@ -62,7 +61,7 @@ public class WebhookImpl implements Webhook
         this.type = type;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public WebhookType getType()
     {
@@ -75,14 +74,14 @@ public class WebhookImpl implements Webhook
         return channel == null;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
@@ -91,7 +90,7 @@ public class WebhookImpl implements Webhook
         return getChannel().getGuild();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public TextChannel getChannel()
     {
@@ -114,14 +113,14 @@ public class WebhookImpl implements Webhook
         return ownerUser;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public User getDefaultUser()
     {
         return user;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getName()
     {
@@ -134,7 +133,7 @@ public class WebhookImpl implements Webhook
         return token;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getUrl()
     {
@@ -153,7 +152,7 @@ public class WebhookImpl implements Webhook
         return sourceGuild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<Void> delete()
     {
@@ -167,16 +166,16 @@ public class WebhookImpl implements Webhook
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<Void> delete(@Nonnull String token)
+    public AuditableRestAction<Void> delete(@NotNull String token)
     {
         Checks.notNull(token, "Token");
         Route.CompiledRoute route = Route.Webhooks.DELETE_TOKEN_WEBHOOK.compile(getId(), token);
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public WebhookManager getManager()
     {

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupController.java
@@ -30,9 +30,9 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.MemberChunkManager;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildSetupNode.java
@@ -37,8 +37,8 @@ import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.managers.AudioManagerImpl;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/net/dv8tion/jda/internal/handle/PresenceUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/PresenceUpdateHandler.java
@@ -35,9 +35,9 @@ import net.dv8tion.jda.internal.entities.MemberPresenceImpl;
 import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import net.dv8tion.jda.internal.utils.UnlockHook;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;

--- a/src/main/java/net/dv8tion/jda/internal/hooks/EventManagerProxy.java
+++ b/src/main/java/net/dv8tion/jda/internal/hooks/EventManagerProxy.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.events.GenericEvent;
 import net.dv8tion.jda.api.hooks.IEventManager;
 import net.dv8tion.jda.api.hooks.InterfacedEventManager;
 import net.dv8tion.jda.internal.JDAImpl;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -48,19 +48,19 @@ public class EventManagerProxy implements IEventManager
     }
 
     @Override
-    public void register(@Nonnull Object listener)
+    public void register(@NotNull Object listener)
     {
         this.subject.register(listener);
     }
 
     @Override
-    public void unregister(@Nonnull Object listener)
+    public void unregister(@NotNull Object listener)
     {
         this.subject.unregister(listener);
     }
 
     @Override
-    public void handle(@Nonnull GenericEvent event)
+    public void handle(@NotNull GenericEvent event)
     {
         try
         {
@@ -80,7 +80,7 @@ public class EventManagerProxy implements IEventManager
         }
     }
 
-    private void handleInternally(@Nonnull GenericEvent event)
+    private void handleInternally(@NotNull GenericEvent event)
     {
         // don't allow mere exceptions to obstruct the socket handler
         try
@@ -93,7 +93,7 @@ public class EventManagerProxy implements IEventManager
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Object> getRegisteredListeners()
     {

--- a/src/main/java/net/dv8tion/jda/internal/managers/AccountManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/AccountManagerImpl.java
@@ -25,9 +25,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 public class AccountManagerImpl extends ManagerBase<AccountManager> implements AccountManager
 {
@@ -50,14 +50,14 @@ public class AccountManagerImpl extends ManagerBase<AccountManager> implements A
         this.selfUser = selfUser;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public SelfUser getSelfUser()
     {
         return selfUser;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public AccountManagerImpl reset(long fields)
@@ -68,7 +68,7 @@ public class AccountManagerImpl extends ManagerBase<AccountManager> implements A
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public AccountManagerImpl reset(long... fields)
@@ -77,7 +77,7 @@ public class AccountManagerImpl extends ManagerBase<AccountManager> implements A
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public AccountManagerImpl reset()
@@ -87,10 +87,10 @@ public class AccountManagerImpl extends ManagerBase<AccountManager> implements A
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public AccountManagerImpl setName(@Nonnull String name)
+    public AccountManagerImpl setName(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         Checks.check(name.length() >= 2 && name.length() <= 32, "Name must be between 2-32 characters long");
@@ -99,7 +99,7 @@ public class AccountManagerImpl extends ManagerBase<AccountManager> implements A
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public AccountManagerImpl setAvatar(Icon avatar)

--- a/src/main/java/net/dv8tion/jda/internal/managers/AudioManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/AudioManagerImpl.java
@@ -32,8 +32,8 @@ import net.dv8tion.jda.internal.audio.AudioConnection;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.concurrent.locks.ReentrantLock;
@@ -138,7 +138,7 @@ public class AudioManagerImpl implements AudioManager
     }
 
     @Override
-    public void setSpeakingMode(@Nonnull Collection<SpeakingMode> mode)
+    public void setSpeakingMode(@NotNull Collection<SpeakingMode> mode)
     {
         Checks.notEmpty(mode, "Speaking Mode");
         this.speakingModes = EnumSet.copyOf(mode);
@@ -146,7 +146,7 @@ public class AudioManagerImpl implements AudioManager
             audioConnection.setSpeakingMode(this.speakingModes);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public EnumSet<SpeakingMode> getSpeakingMode()
     {
@@ -161,14 +161,14 @@ public class AudioManagerImpl implements AudioManager
             audioConnection.setSpeakingDelay(millis);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDAImpl getJDA()
     {
         return getGuild().getJDA();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildImpl getGuild()
     {
@@ -253,7 +253,7 @@ public class AudioManagerImpl implements AudioManager
         return connectionListener.getListener();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ConnectionStatus getConnectionStatus()
     {

--- a/src/main/java/net/dv8tion/jda/internal/managers/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ChannelManagerImpl.java
@@ -32,9 +32,9 @@ import net.dv8tion.jda.internal.requests.restaction.PermOverrideData;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.EnumSet;
 
@@ -76,7 +76,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         this.overridesRem = new TLongHashSet();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildChannel getChannel()
     {
@@ -86,7 +86,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl reset(long fields)
@@ -111,7 +111,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl reset(long... fields)
@@ -120,7 +120,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl reset()
@@ -138,7 +138,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl clearOverridesAdded()
@@ -152,7 +152,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl clearOverridesRemoved()
@@ -166,10 +166,10 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public ChannelManagerImpl putPermissionOverride(@Nonnull IPermissionHolder permHolder, long allow, long deny)
+    public ChannelManagerImpl putPermissionOverride(@NotNull IPermissionHolder permHolder, long allow, long deny)
     {
         Checks.notNull(permHolder, "PermissionHolder");
         Checks.check(permHolder.getGuild().equals(getGuild()), "PermissionHolder is not from the same Guild!");
@@ -203,10 +203,10 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public ChannelManagerImpl removePermissionOverride(@Nonnull IPermissionHolder permHolder)
+    public ChannelManagerImpl removePermissionOverride(@NotNull IPermissionHolder permHolder)
     {
         Checks.notNull(permHolder, "PermissionHolder");
         Checks.check(permHolder.getGuild().equals(getGuild()), "PermissionHolder is not from the same Guild!");
@@ -222,10 +222,10 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public ChannelManagerImpl sync(@Nonnull GuildChannel syncSource)
+    public ChannelManagerImpl sync(@NotNull GuildChannel syncSource)
     {
         Checks.notNull(syncSource, "SyncSource");
         Checks.check(getGuild().equals(syncSource.getGuild()), "Sync only works for channels of same guild");
@@ -272,10 +272,10 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public ChannelManagerImpl setName(@Nonnull String name)
+    public ChannelManagerImpl setName(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         Checks.check(name.length() > 0 && name.length() <= 100, "Name must be between 1-100 characters long");
@@ -286,7 +286,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setParent(Category category)
@@ -302,7 +302,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setPosition(int position)
@@ -312,7 +312,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setTopic(String topic)
@@ -325,7 +325,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setNSFW(boolean nsfw)
@@ -337,7 +337,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setSlowmode(int slowmode)
@@ -350,7 +350,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setUserLimit(int userLimit)
@@ -364,7 +364,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setBitrate(int bitrate)
@@ -379,7 +379,7 @@ public class ChannelManagerImpl extends ManagerBase<ChannelManager> implements C
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelManagerImpl setNews(boolean news)

--- a/src/main/java/net/dv8tion/jda/internal/managers/DirectAudioControllerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/DirectAudioControllerImpl.java
@@ -22,8 +22,7 @@ import net.dv8tion.jda.api.managers.DirectAudioController;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.Checks;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class DirectAudioControllerImpl implements DirectAudioController
 {
@@ -34,7 +33,7 @@ public class DirectAudioControllerImpl implements DirectAudioController
         this.api = api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDAImpl getJDA()
     {
@@ -42,7 +41,7 @@ public class DirectAudioControllerImpl implements DirectAudioController
     }
 
     @Override
-    public void connect(@Nonnull VoiceChannel channel)
+    public void connect(@NotNull VoiceChannel channel)
     {
         Checks.notNull(channel, "Voice Channel");
         JDAImpl jda = getJDA();
@@ -51,7 +50,7 @@ public class DirectAudioControllerImpl implements DirectAudioController
     }
 
     @Override
-    public void disconnect(@Nonnull Guild guild)
+    public void disconnect(@NotNull Guild guild)
     {
         Checks.notNull(guild, "Guild");
         JDAImpl jda = getJDA();
@@ -60,7 +59,7 @@ public class DirectAudioControllerImpl implements DirectAudioController
     }
 
     @Override
-    public void reconnect(@Nonnull VoiceChannel channel)
+    public void reconnect(@NotNull VoiceChannel channel)
     {
         Checks.notNull(channel, "Voice Channel");
         JDAImpl jda = getJDA();

--- a/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
@@ -28,9 +28,9 @@ import net.dv8tion.jda.internal.entities.EmoteImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -64,14 +64,14 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         return g;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Emote getEmote()
     {
         return emote;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public EmoteManagerImpl reset(long fields)
@@ -84,7 +84,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public EmoteManagerImpl reset(long... fields)
@@ -93,7 +93,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public EmoteManagerImpl reset()
@@ -104,10 +104,10 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public EmoteManagerImpl setName(@Nonnull String name)
+    public EmoteManagerImpl setName(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         Checks.check(name.length() >= 2 && name.length() <= 32, "Name must be between 2-32 characters long");
@@ -116,7 +116,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public EmoteManagerImpl setRoles(Set<Role> roles)

--- a/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
@@ -29,10 +29,10 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public class GuildManagerImpl extends ManagerBase<GuildManager> implements GuildManager
 {
@@ -58,7 +58,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
             checkPermissions();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
@@ -68,7 +68,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl reset(long fields)
@@ -97,7 +97,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl reset(long... fields)
@@ -106,7 +106,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl reset()
@@ -124,10 +124,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setName(@Nonnull String name)
+    public GuildManagerImpl setName(@NotNull String name)
     {
         Checks.notNull(name, "Name");
         Checks.check(name.length() >= 2 && name.length() <= 100, "Name must be between 2-100 characters long");
@@ -136,10 +136,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setRegion(@Nonnull Region region)
+    public GuildManagerImpl setRegion(@NotNull Region region)
     {
         Checks.notNull(region, "Region");
         Checks.check(region != Region.UNKNOWN, "Region must not be UNKNOWN");
@@ -149,7 +149,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl setIcon(Icon icon)
@@ -159,7 +159,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl setSplash(Icon splash)
@@ -170,7 +170,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl setAfkChannel(VoiceChannel afkChannel)
@@ -181,7 +181,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl setSystemChannel(TextChannel systemChannel)
@@ -192,7 +192,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl setRulesChannel(TextChannel rulesChannel)
@@ -203,7 +203,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildManagerImpl setCommunityUpdatesChannel(TextChannel communityUpdatesChannel)
@@ -214,10 +214,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setAfkTimeout(@Nonnull Guild.Timeout timeout)
+    public GuildManagerImpl setAfkTimeout(@NotNull Guild.Timeout timeout)
     {
         Checks.notNull(timeout, "Timeout");
         this.afkTimeout = timeout.getSeconds();
@@ -225,10 +225,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setVerificationLevel(@Nonnull Guild.VerificationLevel level)
+    public GuildManagerImpl setVerificationLevel(@NotNull Guild.VerificationLevel level)
     {
         Checks.notNull(level, "Level");
         Checks.check(level != Guild.VerificationLevel.UNKNOWN, "Level must not be UNKNOWN");
@@ -237,10 +237,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setDefaultNotificationLevel(@Nonnull Guild.NotificationLevel level)
+    public GuildManagerImpl setDefaultNotificationLevel(@NotNull Guild.NotificationLevel level)
     {
         Checks.notNull(level, "Level");
         Checks.check(level != Guild.NotificationLevel.UNKNOWN, "Level must not be UNKNOWN");
@@ -249,10 +249,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setRequiredMFALevel(@Nonnull Guild.MFALevel level)
+    public GuildManagerImpl setRequiredMFALevel(@NotNull Guild.MFALevel level)
     {
         Checks.notNull(level, "Level");
         Checks.check(level != Guild.MFALevel.UNKNOWN, "Level must not be UNKNOWN");
@@ -261,10 +261,10 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildManagerImpl setExplicitContentLevel(@Nonnull Guild.ExplicitContentLevel level)
+    public GuildManagerImpl setExplicitContentLevel(@NotNull Guild.ExplicitContentLevel level)
     {
         Checks.notNull(level, "Level");
         Checks.check(level != Guild.ExplicitContentLevel.UNKNOWN, "Level must not be UNKNOWN");
@@ -273,7 +273,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildManager setBanner(@Nullable Icon banner)
     {
@@ -283,7 +283,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildManager setVanityCode(@Nullable String code)
     {
@@ -293,7 +293,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildManager setDescription(@Nullable String description)
     {

--- a/src/main/java/net/dv8tion/jda/internal/managers/ManagerBase.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ManagerBase.java
@@ -22,8 +22,8 @@ import net.dv8tion.jda.api.managers.Manager;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -48,7 +48,7 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
         super(api, route);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M setCheck(BooleanSupplier checks)
@@ -56,15 +56,15 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
         return (M) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
-    public M timeout(long timeout, @Nonnull TimeUnit unit)
+    public M timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (M) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M deadline(long timestamp)
@@ -72,7 +72,7 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
         return (M) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M reset(long fields)
@@ -86,7 +86,7 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M reset(long... fields)
@@ -105,7 +105,7 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
         return reset(sum);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M reset()

--- a/src/main/java/net/dv8tion/jda/internal/managers/PermOverrideManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PermOverrideManagerImpl.java
@@ -27,9 +27,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.AbstractChannelImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> implements PermOverrideManager
 {
@@ -66,7 +66,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
             this.denied = getPermissionOverride().getDeniedRaw();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverride getPermissionOverride()
     {
@@ -77,7 +77,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         return override;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermOverrideManagerImpl reset(long fields)
@@ -86,7 +86,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermOverrideManagerImpl reset(long... fields)
@@ -95,7 +95,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermOverrideManagerImpl reset()
@@ -104,7 +104,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermOverrideManagerImpl grant(long permissions)
@@ -118,7 +118,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermOverrideManagerImpl deny(long permissions)
@@ -132,7 +132,7 @@ public class PermOverrideManagerImpl extends ManagerBase<PermOverrideManager> im
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermOverrideManagerImpl clear(long permissions)

--- a/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/PresenceImpl.java
@@ -25,8 +25,8 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.WebSocketCode;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 
 /**
@@ -57,14 +57,14 @@ public class PresenceImpl implements Presence
     /* -- Public Getters -- */
 
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public OnlineStatus getStatus()
     {

--- a/src/main/java/net/dv8tion/jda/internal/managers/RoleManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/RoleManagerImpl.java
@@ -28,9 +28,9 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.EnumSet;
 
@@ -59,7 +59,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
             checkPermissions();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Role getRole()
     {
@@ -69,7 +69,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return role;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl reset(long fields)
@@ -82,7 +82,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl reset(long... fields)
@@ -91,7 +91,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl reset()
@@ -102,10 +102,10 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public RoleManagerImpl setName(@Nonnull String name)
+    public RoleManagerImpl setName(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         Checks.check(name.length() <= 100, "Name must be less or equal to 100 characters in length");
@@ -114,7 +114,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl setPermissions(long perms)
@@ -136,7 +136,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl setColor(int rgb)
@@ -146,7 +146,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl setHoisted(boolean hoisted)
@@ -156,7 +156,7 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleManagerImpl setMentionable(boolean mentionable)
@@ -166,20 +166,20 @@ public class RoleManagerImpl extends ManagerBase<RoleManager> implements RoleMan
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public RoleManagerImpl givePermissions(@Nonnull Collection<Permission> perms)
+    public RoleManagerImpl givePermissions(@NotNull Collection<Permission> perms)
     {
         Checks.noneNull(perms, "Permissions");
         setupPermissions();
         return setPermissions(this.permissions | Permission.getRaw(perms));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public RoleManagerImpl revokePermissions(@Nonnull Collection<Permission> perms)
+    public RoleManagerImpl revokePermissions(@NotNull Collection<Permission> perms)
     {
         Checks.noneNull(perms, "Permissions");
         setupPermissions();

--- a/src/main/java/net/dv8tion/jda/internal/managers/WebhookManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/WebhookManagerImpl.java
@@ -28,9 +28,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements WebhookManager
 {
@@ -53,14 +53,14 @@ public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements W
             checkPermissions();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Webhook getWebhook()
     {
         return webhook;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public WebhookManagerImpl reset(long fields)
@@ -75,7 +75,7 @@ public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements W
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public WebhookManagerImpl reset(long... fields)
@@ -84,7 +84,7 @@ public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements W
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public WebhookManagerImpl reset()
@@ -96,10 +96,10 @@ public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements W
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public WebhookManagerImpl setName(@Nonnull String name)
+    public WebhookManagerImpl setName(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         this.name = name;
@@ -107,7 +107,7 @@ public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements W
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public WebhookManagerImpl setAvatar(Icon icon)
@@ -117,10 +117,10 @@ public class WebhookManagerImpl extends ManagerBase<WebhookManager> implements W
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public WebhookManagerImpl setChannel(@Nonnull TextChannel channel)
+    public WebhookManagerImpl setChannel(@NotNull TextChannel channel)
     {
         Checks.notNull(channel, "Channel");
         Checks.check(channel.getGuild().equals(getGuild()), "Channel is not from the same guild");

--- a/src/main/java/net/dv8tion/jda/internal/requests/CompletedRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/CompletedRestAction.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -52,35 +52,35 @@ public class CompletedRestAction<T> implements AuditableRestAction<T>
     }
 
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> reason(@Nullable String reason)
     {
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> setCheck(@Nullable BooleanSupplier checks)
     {
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<T> timeout(long timeout, @Nonnull TimeUnit unit)
+    public AuditableRestAction<T> timeout(long timeout, @NotNull TimeUnit unit)
     {
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> deadline(long timestamp)
     {
@@ -122,7 +122,7 @@ public class CompletedRestAction<T> implements AuditableRestAction<T>
         return value;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<T> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/DeferredRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/DeferredRestAction.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -57,14 +57,14 @@ public class DeferredRestAction<T, R extends RestAction<T>> implements Auditable
         this.actionSupplier = actionSupplier;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> reason(String reason)
     {
@@ -72,7 +72,7 @@ public class DeferredRestAction<T, R extends RestAction<T>> implements Auditable
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> setCheck(BooleanSupplier checks)
     {
@@ -87,15 +87,15 @@ public class DeferredRestAction<T, R extends RestAction<T>> implements Auditable
         return transitiveChecks;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<T> timeout(long timeout, @Nonnull TimeUnit unit)
+    public AuditableRestAction<T> timeout(long timeout, @NotNull TimeUnit unit)
     {
         Checks.notNull(unit, "TimeUnit");
         return deadline(timeout <= 0 ? 0 : System.currentTimeMillis() + unit.toMillis(timeout));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> deadline(long timestamp)
     {
@@ -139,7 +139,7 @@ public class DeferredRestAction<T, R extends RestAction<T>> implements Auditable
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<T> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/FunctionalCallback.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/FunctionalCallback.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.utils.IOBiConsumer;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.function.BiConsumer;
 
@@ -47,14 +47,14 @@ public class FunctionalCallback implements Callback
     }
 
     @Override
-    public void onFailure(@Nonnull Call call, @Nonnull IOException e)
+    public void onFailure(@NotNull Call call, @NotNull IOException e)
     {
         if (failure != null)
             failure.accept(call, e);
     }
 
     @Override
-    public void onResponse(@Nonnull Call call, @Nonnull Response response) throws IOException
+    public void onResponse(@NotNull Call call, @NotNull Response response) throws IOException
     {
         if (success != null)
             success.accept(call, response);

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -40,7 +40,6 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;

--- a/src/main/java/net/dv8tion/jda/internal/requests/RestActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/RestActionImpl.java
@@ -30,10 +30,10 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.JDALogger;
 import okhttp3.RequestBody;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.*;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -90,7 +90,7 @@ public class RestActionImpl<T> implements RestAction<T>
         DEFAULT_SUCCESS = callback == null ? t -> {} : callback;
     }
 
-    public static void setDefaultTimeout(long timeout, @Nonnull TimeUnit unit)
+    public static void setDefaultTimeout(long timeout, @NotNull TimeUnit unit)
     {
         Checks.notNull(unit, "TimeUnit");
         defaultTimeout = unit.toMillis(timeout);
@@ -152,14 +152,14 @@ public class RestActionImpl<T> implements RestAction<T>
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return api;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<T> setCheck(BooleanSupplier checks)
     {
@@ -174,7 +174,7 @@ public class RestActionImpl<T> implements RestAction<T>
         return this.checks;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<T> deadline(long timestamp)
     {
@@ -197,7 +197,7 @@ public class RestActionImpl<T> implements RestAction<T>
         api.getRequester().request(new Request<>(this, success, failure, finisher, true, data, rawData, getDeadline(), priority, route, headers));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<T> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.requests;
 
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 
 import static net.dv8tion.jda.internal.requests.Method.*;
 
@@ -228,8 +228,8 @@ public class Route
         public static final Route DELETE_INVITE =       new Route(DELETE, "invites/{code}");
     }
 
-    @Nonnull
-    public static Route custom(@Nonnull Method method, @Nonnull String route)
+    @NotNull
+    public static Route custom(@NotNull Method method, @NotNull String route)
     {
         Checks.notNull(method, "Method");
         Checks.notEmpty(route, "Route");
@@ -237,32 +237,32 @@ public class Route
         return new Route(method, route);
     }
 
-    @Nonnull
-    public static Route delete(@Nonnull String route)
+    @NotNull
+    public static Route delete(@NotNull String route)
     {
         return custom(DELETE, route);
     }
 
-    @Nonnull
-    public static Route post(@Nonnull String route)
+    @NotNull
+    public static Route post(@NotNull String route)
     {
         return custom(POST, route);
     }
 
-    @Nonnull
-    public static Route put(@Nonnull String route)
+    @NotNull
+    public static Route put(@NotNull String route)
     {
         return custom(PUT, route);
     }
 
-    @Nonnull
-    public static Route patch(@Nonnull String route)
+    @NotNull
+    public static Route patch(@NotNull String route)
     {
         return custom(PATCH, route);
     }
 
-    @Nonnull
-    public static Route get(@Nonnull String route)
+    @NotNull
+    public static Route get(@NotNull String route)
     {
         return custom(GET, route);
     }
@@ -366,7 +366,7 @@ public class Route
             this(baseRoute, compiledRoute, major, false);
         }
 
-        @Nonnull
+        @NotNull
         @CheckReturnValue
         public CompiledRoute withQueryParams(String... params)
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -47,10 +47,10 @@ import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.compress.Decompressor;
 import net.dv8tion.jda.internal.utils.compress.ZlibDecompressor;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
-import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
@@ -1360,14 +1360,14 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected abstract class ConnectNode implements SessionController.SessionConnectNode
     {
-        @Nonnull
+        @NotNull
         @Override
         public JDA getJDA()
         {
             return api;
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public JDA.ShardInfo getShardInfo()
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/AuditableRestActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/AuditableRestActionImpl.java
@@ -27,10 +27,10 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
 import okhttp3.RequestBody;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
@@ -69,28 +69,28 @@ public class AuditableRestActionImpl<T> extends RestActionImpl<T> implements Aud
         super(api, route, data, handler);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> setCheck(BooleanSupplier checks)
     {
         return (AuditableRestAction<T>) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public AuditableRestAction<T> timeout(long timeout, @Nonnull TimeUnit unit)
+    public AuditableRestAction<T> timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (AuditableRestAction<T>) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditableRestAction<T> deadline(long timestamp)
     {
         return (AuditableRestAction<T>) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @CheckReturnValue
     public AuditableRestActionImpl<T> reason(@Nullable String reason)
     {
@@ -115,7 +115,7 @@ public class AuditableRestActionImpl<T> extends RestActionImpl<T> implements Aud
         return generateHeaders(headers, reason);
     }
 
-    @Nonnull
+    @NotNull
     private CaseInsensitiveMap<String, String> generateHeaders(CaseInsensitiveMap<String, String> headers, String reason)
     {
         if (headers == null)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
@@ -31,9 +31,9 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -67,45 +67,45 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         this.name = name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelActionImpl<T> setCheck(BooleanSupplier checks)
     {
         return (ChannelActionImpl<T>) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public ChannelActionImpl<T> timeout(long timeout, @Nonnull TimeUnit unit)
+    public ChannelActionImpl<T> timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (ChannelActionImpl<T>) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelActionImpl<T> deadline(long timestamp)
     {
         return (ChannelActionImpl<T>) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelType getType()
     {
         return type;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public ChannelActionImpl<T> setName(@Nonnull String name)
+    public ChannelActionImpl<T> setName(@NotNull String name)
     {
         Checks.notNull(name, "Channel name");
         if (name.length() < 1 || name.length() > 100)
@@ -115,7 +115,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setParent(Category category)
@@ -125,7 +125,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setPosition(Integer position)
@@ -135,7 +135,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setTopic(String topic)
@@ -148,7 +148,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setNSFW(boolean nsfw)
@@ -159,7 +159,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setSlowmode(int slowmode)
@@ -171,7 +171,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setNews(boolean news)
@@ -184,7 +184,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> addMemberPermissionOverride(long userId, long allow, long deny)
@@ -192,7 +192,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return addOverride(userId, PermOverrideData.MEMBER_TYPE, allow, deny);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> addRolePermissionOverride(long roleId, long allow, long deny)
@@ -200,7 +200,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return addOverride(roleId, PermOverrideData.ROLE_TYPE, allow, deny);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelAction<T> removePermissionOverride(long id)
     {
@@ -208,7 +208,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChannelAction<T> clearPermissionOverrides()
     {
@@ -216,7 +216,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public ChannelAction<T> syncPermissionOverrides()
@@ -279,7 +279,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
     }
 
     // --voice only--
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setBitrate(Integer bitrate)
@@ -299,7 +299,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelActionImpl<T> setUserlimit(Integer userlimit)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/GuildActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/GuildActionImpl.java
@@ -28,9 +28,9 @@ import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -59,28 +59,28 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         this.roles.add(new RoleData(0));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildActionImpl setCheck(BooleanSupplier checks)
     {
         return (GuildActionImpl) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public GuildActionImpl timeout(long timeout, @Nonnull TimeUnit unit)
+    public GuildActionImpl timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (GuildActionImpl) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildActionImpl deadline(long timestamp)
     {
         return (GuildActionImpl) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildActionImpl setRegion(Region region)
@@ -90,7 +90,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildActionImpl setIcon(Icon icon)
@@ -99,10 +99,10 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildActionImpl setName(@Nonnull String name)
+    public GuildActionImpl setName(@NotNull String name)
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
@@ -111,7 +111,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildActionImpl setVerificationLevel(Guild.VerificationLevel level)
@@ -120,7 +120,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildActionImpl setNotificationLevel(Guild.NotificationLevel level)
@@ -129,7 +129,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public GuildActionImpl setExplicitContentLevel(Guild.ExplicitContentLevel level)
@@ -140,17 +140,17 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
 
     // Channels
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildActionImpl addChannel(@Nonnull ChannelData channel)
+    public GuildActionImpl addChannel(@NotNull ChannelData channel)
     {
         Checks.notNull(channel, "Channel");
         this.channels.add(channel);
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelData getChannel(int index)
@@ -158,7 +158,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this.channels.get(index);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public ChannelData removeChannel(int index)
@@ -166,19 +166,19 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this.channels.remove(index);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public GuildActionImpl removeChannel(@Nonnull ChannelData data)
+    public GuildActionImpl removeChannel(@NotNull ChannelData data)
     {
         this.channels.remove(data);
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public ChannelData newChannel(@Nonnull ChannelType type, @Nonnull String name)
+    public ChannelData newChannel(@NotNull ChannelType type, @NotNull String name)
     {
         ChannelData data = new ChannelData(type, name);
         addChannel(data);
@@ -187,7 +187,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
 
     // Roles
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleData getPublicRole()
@@ -195,7 +195,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this.roles.get(0);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleData getRole(int index)
@@ -203,7 +203,7 @@ public class GuildActionImpl extends RestActionImpl<Void> implements GuildAction
         return this.roles.get(index);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleData newRole()

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/InviteActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/InviteActionImpl.java
@@ -25,9 +25,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -43,28 +43,28 @@ public class InviteActionImpl extends AuditableRestActionImpl<Invite> implements
         super(api, Route.Invites.CREATE_INVITE.compile(channelId));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public InviteActionImpl setCheck(BooleanSupplier checks)
     {
         return (InviteActionImpl) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public InviteActionImpl timeout(long timeout, @Nonnull TimeUnit unit)
+    public InviteActionImpl timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (InviteActionImpl) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public InviteActionImpl deadline(long timestamp)
     {
         return (InviteActionImpl) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public InviteActionImpl setMaxAge(final Integer maxAge)
@@ -76,10 +76,10 @@ public class InviteActionImpl extends AuditableRestActionImpl<Invite> implements
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public InviteActionImpl setMaxAge(final Long maxAge, @Nonnull final TimeUnit timeUnit)
+    public InviteActionImpl setMaxAge(final Long maxAge, @NotNull final TimeUnit timeUnit)
     {
         if (maxAge == null)
             return this.setMaxAge(null);
@@ -90,7 +90,7 @@ public class InviteActionImpl extends AuditableRestActionImpl<Invite> implements
         return this.setMaxAge(Math.toIntExact(timeUnit.toSeconds(maxAge)));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public InviteActionImpl setMaxUses(final Integer maxUses)
@@ -102,7 +102,7 @@ public class InviteActionImpl extends AuditableRestActionImpl<Invite> implements
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public InviteActionImpl setTemporary(final Boolean temporary)
@@ -111,7 +111,7 @@ public class InviteActionImpl extends AuditableRestActionImpl<Invite> implements
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public InviteActionImpl setUnique(final Boolean unique)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MemberActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MemberActionImpl.java
@@ -27,10 +27,10 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -57,35 +57,35 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
         this.guild = guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MemberAction setCheck(BooleanSupplier checks)
     {
         return (MemberAction) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MemberAction timeout(long timeout, @Nonnull TimeUnit unit)
+    public MemberAction timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (MemberAction) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MemberAction deadline(long timestamp)
     {
         return (MemberAction) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getAccessToken()
     {
         return accessToken;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public String getUserId()
     {
@@ -99,14 +99,14 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
         return getJDA().getUserById(userId);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MemberActionImpl setNickname(String nick)
@@ -124,7 +124,7 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MemberActionImpl setRoles(Collection<Role> roles)
@@ -141,7 +141,7 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MemberActionImpl setRoles(Role... roles)
@@ -158,7 +158,7 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MemberActionImpl setMute(boolean mute)
@@ -167,7 +167,7 @@ public class MemberActionImpl extends RestActionImpl<Void> implements MemberActi
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MemberActionImpl setDeafen(boolean deaf)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -37,10 +37,10 @@ import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +75,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
                 : Helpers.copyEnumSet(Message.MentionType.class, allowedMentions);
     }
 
-    @Nonnull
+    @NotNull
     public static EnumSet<Message.MentionType> getDefaultMentions()
     {
         return defaultMentions.clone();
@@ -119,28 +119,28 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         this.allowedMentions = defaultMentions;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageAction setCheck(BooleanSupplier checks)
     {
         return (MessageAction) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction timeout(long timeout, @Nonnull TimeUnit unit)
+    public MessageAction timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (MessageAction) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageAction deadline(long timestamp)
     {
         return (MessageAction) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageChannel getChannel()
     {
@@ -160,7 +160,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return finalizeRoute().getMethod() == Method.PATCH;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     @SuppressWarnings({"ResultOfMethodCallIgnored", "ConstantConditions"})
@@ -210,7 +210,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return content(content).tts(message.isTTS());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageActionImpl referenceById(long messageId)
     {
@@ -218,7 +218,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageAction mentionRepliedUser(boolean mention)
     {
@@ -226,7 +226,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageAction failOnInvalidReply(boolean fail)
     {
@@ -234,7 +234,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl tts(final boolean isTTS)
@@ -243,7 +243,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl reset()
@@ -251,7 +251,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return content(null).nonce(null).embed(null).tts(false).override(false).clearFiles();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl nonce(final String nonce)
@@ -260,7 +260,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl content(final String content)
@@ -274,7 +274,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl embed(final MessageEmbed embed)
@@ -289,7 +289,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl append(final CharSequence csq, final int start, final int end)
@@ -300,7 +300,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl append(final char c)
@@ -311,10 +311,10 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public MessageActionImpl addFile(@Nonnull final InputStream data, @Nonnull String name, @Nonnull AttachmentOption... options)
+    public MessageActionImpl addFile(@NotNull final InputStream data, @NotNull String name, @NotNull AttachmentOption... options)
     {
         checkEdit();
         Checks.notNull(data, "Data");
@@ -327,10 +327,10 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public MessageActionImpl addFile(@Nonnull final File file, @Nonnull String name, @Nonnull AttachmentOption... options)
+    public MessageActionImpl addFile(@NotNull final File file, @NotNull String name, @NotNull AttachmentOption... options)
     {
         Checks.notNull(file, "File");
         Checks.noneNull(options, "Options");
@@ -350,7 +350,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl clearFiles()
@@ -360,10 +360,10 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public MessageActionImpl clearFiles(@Nonnull BiConsumer<String, InputStream> finalizer)
+    public MessageActionImpl clearFiles(@NotNull BiConsumer<String, InputStream> finalizer)
     {
         Checks.notNull(finalizer, "Finalizer");
         for (Iterator<Map.Entry<String, InputStream>> it = files.entrySet().iterator(); it.hasNext();)
@@ -376,10 +376,10 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public MessageActionImpl clearFiles(@Nonnull Consumer<InputStream> finalizer)
+    public MessageActionImpl clearFiles(@NotNull Consumer<InputStream> finalizer)
     {
         Checks.notNull(finalizer, "Finalizer");
         for (Iterator<InputStream> it = files.values().iterator(); it.hasNext(); )
@@ -391,7 +391,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public MessageActionImpl override(final boolean bool)
@@ -400,7 +400,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageAction allowedMentions(@Nullable Collection<Message.MentionType> allowedMentions)
     {
@@ -410,9 +410,9 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction mention(@Nonnull IMentionable... mentions)
+    public MessageAction mention(@NotNull IMentionable... mentions)
     {
         Checks.noneNull(mentions, "Mentionables");
         for (IMentionable mentionable : mentions)
@@ -425,18 +425,18 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction mentionUsers(@Nonnull String... userIds)
+    public MessageAction mentionUsers(@NotNull String... userIds)
     {
         Checks.noneNull(userIds, "User Id");
         Collections.addAll(mentionableUsers, userIds);
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public MessageAction mentionRoles(@Nonnull String... roleIds)
+    public MessageAction mentionRoles(@NotNull String... roleIds)
     {
         Checks.noneNull(roleIds, "Role Id");
         Collections.addAll(mentionableRoles, roleIds);

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermOverrideData.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermOverrideData.java
@@ -19,8 +19,7 @@ package net.dv8tion.jda.internal.requests.restaction;
 import net.dv8tion.jda.api.entities.PermissionOverride;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class PermOverrideData implements SerializableData
 {
@@ -47,7 +46,7 @@ public class PermOverrideData implements SerializableData
         this.deny = override.getDeniedRaw();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public DataObject toData()
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/PermissionOverrideActionImpl.java
@@ -30,9 +30,9 @@ import net.dv8tion.jda.internal.entities.PermissionOverrideImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.PermissionUtil;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -93,28 +93,28 @@ public class PermissionOverrideActionImpl
         };
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideActionImpl setCheck(BooleanSupplier checks)
     {
         return (PermissionOverrideActionImpl) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public PermissionOverrideActionImpl timeout(long timeout, @Nonnull TimeUnit unit)
+    public PermissionOverrideActionImpl timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (PermissionOverrideActionImpl) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideActionImpl deadline(long timestamp)
     {
         return (PermissionOverrideActionImpl) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideAction resetAllow()
     {
@@ -123,7 +123,7 @@ public class PermissionOverrideActionImpl
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideAction resetDeny()
     {
@@ -132,7 +132,7 @@ public class PermissionOverrideActionImpl
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public GuildChannel getChannel()
     {
@@ -181,7 +181,7 @@ public class PermissionOverrideActionImpl
         return isRole;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermissionOverrideActionImpl setAllow(long allowBits)
@@ -193,14 +193,14 @@ public class PermissionOverrideActionImpl
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideAction grant(long allowBits)
     {
         return setAllow(getCurrentAllow() | allowBits);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermissionOverrideActionImpl setDeny(long denyBits)
@@ -212,14 +212,14 @@ public class PermissionOverrideActionImpl
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideAction deny(long denyBits)
     {
         return setDeny(getCurrentDeny() | denyBits);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PermissionOverrideAction clear(long inheritedBits)
     {
@@ -243,7 +243,7 @@ public class PermissionOverrideActionImpl
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public PermissionOverrideActionImpl setPermissions(long allowBits, long denyBits)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/RoleActionImpl.java
@@ -28,9 +28,9 @@ import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -55,35 +55,35 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
         this.guild = guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RoleActionImpl setCheck(BooleanSupplier checks)
     {
         return (RoleActionImpl) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RoleActionImpl timeout(long timeout, @Nonnull TimeUnit unit)
+    public RoleActionImpl timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (RoleActionImpl) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RoleActionImpl deadline(long timestamp)
     {
         return (RoleActionImpl) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {
         return guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleActionImpl setName(String name)
@@ -93,7 +93,7 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleActionImpl setHoisted(Boolean hoisted)
@@ -102,7 +102,7 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleActionImpl setMentionable(Boolean mentionable)
@@ -111,7 +111,7 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleActionImpl setColor(Integer rgb)
@@ -120,7 +120,7 @@ public class RoleActionImpl extends AuditableRestActionImpl<Role> implements Rol
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public RoleActionImpl setPermissions(Long permissions)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookActionImpl.java
@@ -27,9 +27,9 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
@@ -50,38 +50,38 @@ public class WebhookActionImpl extends AuditableRestActionImpl<Webhook> implemen
         this.name = name;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public WebhookActionImpl setCheck(BooleanSupplier checks)
     {
         return (WebhookActionImpl) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public WebhookActionImpl timeout(long timeout, @Nonnull TimeUnit unit)
+    public WebhookActionImpl timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (WebhookActionImpl) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public WebhookActionImpl deadline(long timestamp)
     {
         return (WebhookActionImpl) super.deadline(timestamp);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public TextChannel getChannel()
     {
         return channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
-    public WebhookActionImpl setName(@Nonnull String name)
+    public WebhookActionImpl setName(@NotNull String name)
     {
         Checks.notNull(name, "Webhook name");
         Checks.check(name.length() >= 2 && name.length() <= 100, "The webhook name must be in the range of 2-100!");
@@ -90,7 +90,7 @@ public class WebhookActionImpl extends AuditableRestActionImpl<Webhook> implemen
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @CheckReturnValue
     public WebhookActionImpl setAvatar(Icon icon)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/CombineRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/CombineRestAction.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,14 +51,14 @@ public class CombineRestAction<I1, I2, O> implements RestAction<O>
         action2.addCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return action1.getJDA();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<O> setCheck(@Nullable BooleanSupplier checks)
     {
@@ -68,9 +68,9 @@ public class CombineRestAction<I1, I2, O> implements RestAction<O>
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public RestAction<O> addCheck(@Nonnull BooleanSupplier checks)
+    public RestAction<O> addCheck(@NotNull BooleanSupplier checks)
     {
         action1.addCheck(checks);
         action2.addCheck(checks);
@@ -89,7 +89,7 @@ public class CombineRestAction<I1, I2, O> implements RestAction<O>
              && !failed;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<O> deadline(long timestamp)
     {
@@ -161,7 +161,7 @@ public class CombineRestAction<I1, I2, O> implements RestAction<O>
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<O> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/DelayRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/DelayRestAction.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.requests.restaction.operator;
 
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +65,7 @@ public class DelayRestAction<T> extends RestActionOperator<T, T>
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<T> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/FlatMapErrorRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/FlatMapErrorRestAction.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.utils.Helpers;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -98,7 +98,7 @@ public class FlatMapErrorRestAction<T> extends RestActionOperator<T, T>
         throw new AssertionError("Unreachable");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<T> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/FlatMapRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/FlatMapRestAction.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.requests.restaction.operator;
 
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -65,7 +65,7 @@ public class FlatMapRestAction<I, O> extends RestActionOperator<I, O>
         return supply(action.complete(shouldQueue)).complete(shouldQueue);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<O> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/MapErrorRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/MapErrorRestAction.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.internal.utils.Helpers;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
@@ -86,7 +86,7 @@ public class MapErrorRestAction<T> extends RestActionOperator<T, T>
         throw new AssertionError("Unreachable");
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<T> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/MapRestAction.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/MapRestAction.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.requests.restaction.operator;
 
 import net.dv8tion.jda.api.exceptions.RateLimitedException;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -47,7 +47,7 @@ public class MapRestAction<I, O> extends RestActionOperator<I, O>
         return function.apply(action.complete(shouldQueue));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<O> submit(boolean shouldQueue)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/RestActionOperator.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/operator/RestActionOperator.java
@@ -19,9 +19,9 @@ package net.dv8tion.jda.internal.requests.restaction.operator;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.exceptions.ContextException;
 import net.dv8tion.jda.api.requests.RestAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
@@ -54,14 +54,14 @@ public abstract class RestActionOperator<I, O> implements RestAction<O>
             throw (Error) throwable;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public JDA getJDA()
     {
         return action.getJDA();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<O> setCheck(@Nullable BooleanSupplier checks)
     {
@@ -77,7 +77,7 @@ public abstract class RestActionOperator<I, O> implements RestAction<O>
         return action.getCheck();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public RestAction<O> deadline(long timestamp)
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/CategoryOrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/CategoryOrderActionImpl.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.requests.restaction.order.CategoryOrderAction;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -46,7 +46,7 @@ public class CategoryOrderActionImpl
         this.category = category;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Category getCategory()
     {
@@ -61,7 +61,7 @@ public class CategoryOrderActionImpl
         Checks.check(orderList.contains(entity), "Provided channel is not in the list of orderable channels!");
     }
 
-    @Nonnull
+    @NotNull
     private static Collection<GuildChannel> getChannelsOfType(Category category, int bucket)
     {
         Checks.notNull(category, "Category");

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/ChannelOrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/ChannelOrderActionImpl.java
@@ -27,8 +27,8 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -89,7 +89,7 @@ public class ChannelOrderActionImpl
         this.orderList.addAll(channels);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/OrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/OrderActionImpl.java
@@ -21,8 +21,8 @@ import net.dv8tion.jda.api.requests.restaction.order.OrderAction;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -72,7 +72,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         this.ascendingOrder = ascendingOrder;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M setCheck(BooleanSupplier checks)
@@ -80,15 +80,15 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return (M) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
-    public M timeout(long timeout, @Nonnull TimeUnit unit)
+    public M timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (M) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M deadline(long timestamp)
@@ -102,14 +102,14 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return ascendingOrder;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<T> getCurrentOrder()
     {
         return Collections.unmodifiableList(orderList);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M selectPosition(int selectedPosition)
@@ -122,9 +122,9 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public M selectPosition(@Nonnull T selectedEntity)
+    public M selectPosition(@NotNull T selectedEntity)
     {
         Checks.notNull(selectedEntity, "Channel");
         validateInput(selectedEntity);
@@ -138,7 +138,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return selectedPosition;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public T getSelectedEntity()
     {
@@ -148,7 +148,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return orderList.get(selectedPosition);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public M moveUp(int amount)
     {
@@ -174,7 +174,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
             return moveTo(selectedPosition + amount);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public M moveDown(int amount)
     {
@@ -201,7 +201,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
             return moveTo(selectedPosition - amount);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M moveTo(int position)
@@ -215,7 +215,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M swapPosition(int swapPosition)
@@ -232,10 +232,10 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
-    public M swapPosition(@Nonnull T swapEntity)
+    public M swapPosition(@NotNull T swapEntity)
     {
         Checks.notNull(swapEntity, "Provided swapEntity");
         validateInput(swapEntity);
@@ -243,7 +243,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return swapPosition(orderList.indexOf(swapEntity));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M reverseOrder()
@@ -252,7 +252,7 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M shuffleOrder()
@@ -261,10 +261,10 @@ public abstract class OrderActionImpl<T, M extends OrderAction<T, M>>
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
-    public M sortOrder(@Nonnull final Comparator<T> comparator)
+    public M sortOrder(@NotNull final Comparator<T> comparator)
     {
         Checks.notNull(comparator, "Provided comparator");
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/RoleOrderActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/order/RoleOrderActionImpl.java
@@ -27,8 +27,8 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -78,7 +78,7 @@ public class RoleOrderActionImpl
 
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
@@ -34,8 +34,8 @@ import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,7 +56,7 @@ public class AuditLogPaginationActionImpl
         this.guild = guild;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditLogPaginationActionImpl type(ActionType type)
     {
@@ -64,14 +64,14 @@ public class AuditLogPaginationActionImpl
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditLogPaginationActionImpl user(User user)
     {
         return user(user == null ? null : user.getId());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditLogPaginationActionImpl user(String userId)
     {
@@ -81,14 +81,14 @@ public class AuditLogPaginationActionImpl
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public AuditLogPaginationActionImpl user(long userId)
     {
         return user(Long.toUnsignedString(userId));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Guild getGuild()
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/MessagePaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/MessagePaginationActionImpl.java
@@ -27,8 +27,8 @@ import net.dv8tion.jda.api.requests.restaction.pagination.MessagePaginationActio
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Route;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,7 +55,7 @@ public class MessagePaginationActionImpl
         this.channel = channel;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageChannel getChannel()
     {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
@@ -22,8 +22,8 @@ import net.dv8tion.jda.api.utils.Procedure;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -85,7 +85,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         this.limit = new AtomicInteger(0);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M skipTo(long id)
@@ -109,7 +109,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return lastKey;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M setCheck(BooleanSupplier checks)
@@ -117,15 +117,15 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return (M) super.setCheck(checks);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
-    public M timeout(long timeout, @Nonnull TimeUnit unit)
+    public M timeout(long timeout, @NotNull TimeUnit unit)
     {
         return (M) super.timeout(timeout, unit);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M deadline(long timestamp)
@@ -145,14 +145,14 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return cached.isEmpty();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<T> getCached()
     {
         return Collections.unmodifiableList(cached);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public T getLast()
     {
@@ -162,7 +162,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return last;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public T getFirst()
     {
@@ -171,7 +171,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return cached.get(0);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M limit(final int limit)
@@ -182,7 +182,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return (M) this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     @SuppressWarnings("unchecked")
     public M cache(final boolean enableCache)
@@ -215,7 +215,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return limit.get();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<List<T>> takeAsync(int amount)
     {
@@ -225,7 +225,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         }, task::completeExceptionally));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public CompletableFuture<List<T>> takeRemainingAsync(int amount)
     {
@@ -244,16 +244,16 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return task;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public PaginationIterator<T> iterator()
     {
         return new PaginationIterator<>(cached, this::getNextChunk);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public CompletableFuture<?> forEachAsync(@Nonnull final Procedure<? super T> action, @Nonnull final Consumer<? super Throwable> failure)
+    public CompletableFuture<?> forEachAsync(@NotNull final Procedure<? super T> action, @NotNull final Consumer<? super Throwable> failure)
     {
         Checks.notNull(action, "Procedure");
         Checks.notNull(failure, "Failure Consumer");
@@ -276,9 +276,9 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         return task;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public CompletableFuture<?> forEachRemainingAsync(@Nonnull final Procedure<? super T> action, @Nonnull final Consumer<? super Throwable> failure)
+    public CompletableFuture<?> forEachRemainingAsync(@NotNull final Procedure<? super T> action, @NotNull final Consumer<? super Throwable> failure)
     {
         Checks.notNull(action, "Procedure");
         Checks.notNull(failure, "Failure Consumer");
@@ -302,7 +302,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     }
 
     @Override
-    public void forEachRemaining(@Nonnull final Procedure<? super T> action)
+    public void forEachRemaining(@NotNull final Procedure<? super T> action)
     {
         Checks.notNull(action, "Procedure");
         Queue<T> queue = new LinkedList<>();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ReactionPaginationActionImpl.java
@@ -28,8 +28,8 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.EncodingUtil;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -72,7 +72,7 @@ public class ReactionPaginationActionImpl
             : EncodingUtil.encodeUTF8(emote.getName());
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public MessageReaction getReaction()
     {

--- a/src/main/java/net/dv8tion/jda/internal/utils/BufferedRequestBody.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/BufferedRequestBody.java
@@ -22,9 +22,9 @@ import okio.BufferedSink;
 import okio.BufferedSource;
 import okio.Okio;
 import okio.Source;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 public class BufferedRequestBody extends RequestBody
@@ -47,7 +47,7 @@ public class BufferedRequestBody extends RequestBody
     }
 
     @Override
-    public void writeTo(@Nonnull BufferedSink sink) throws IOException
+    public void writeTo(@NotNull BufferedSink sink) throws IOException
     {
         if (data != null)
         {

--- a/src/main/java/net/dv8tion/jda/internal/utils/ClassWalker.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/ClassWalker.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.internal.utils;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.*;
 
 public class ClassWalker implements Iterable<Class<?>>
@@ -45,7 +46,7 @@ public class ClassWalker implements Iterable<Class<?>>
         return new ClassWalker(start);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<Class<?>> iterator()
     {

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -26,8 +26,8 @@ import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import org.apache.commons.collections4.iterators.ObjectArrayIterator;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -103,7 +103,7 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> impleme
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public LockIterator<T> lockedIterator()
     {
@@ -121,7 +121,7 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> impleme
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<T> asList()
     {
@@ -138,7 +138,7 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> impleme
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<T> asSet()
     {
@@ -167,9 +167,9 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> impleme
         return elements.isEmpty();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<T> getElementsByName(@Nonnull String name, boolean ignoreCase)
+    public List<T> getElementsByName(@NotNull String name, boolean ignoreCase)
     {
         Checks.notEmpty(name, "Name");
         if (elements.isEmpty())
@@ -197,21 +197,21 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> impleme
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> stream()
     {
         return StreamSupport.stream(spliterator(), false);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> parallelStream()
     {
         return StreamSupport.stream(spliterator(), true);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<T> iterator()
     {

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
@@ -20,9 +20,9 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.utils.cache.MemberCacheView;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 
 public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implements MemberCacheView
@@ -38,9 +38,9 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
         return get(id);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase)
+    public List<Member> getElementsByUsername(@NotNull String name, boolean ignoreCase)
     {
         Checks.notEmpty(name, "Name");
         if (isEmpty())
@@ -55,7 +55,7 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
         return Collections.unmodifiableList(members);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase)
     {
@@ -78,17 +78,17 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
         return Collections.unmodifiableList(members);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Member> getElementsWithRoles(@Nonnull Role... roles)
+    public List<Member> getElementsWithRoles(@NotNull Role... roles)
     {
         Checks.notNull(roles, "Roles");
         return getElementsWithRoles(Arrays.asList(roles));
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles)
+    public List<Member> getElementsWithRoles(@NotNull Collection<Role> roles)
     {
         Checks.noneNull(roles, "Roles");
         if (isEmpty())

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ShardCacheViewImpl.java
@@ -29,8 +29,8 @@ import net.dv8tion.jda.internal.utils.ChainedClosableIterator;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import org.apache.commons.collections4.iterators.ObjectArrayIterator;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
@@ -98,7 +98,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<JDA> asList()
     {
@@ -113,7 +113,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<JDA> asSet()
     {
@@ -128,7 +128,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public LockIterator<JDA> lockedIterator()
     {
@@ -158,9 +158,9 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         return elements.isEmpty();
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<JDA> getElementsByName(@Nonnull String name, boolean ignoreCase)
+    public List<JDA> getElementsByName(@NotNull String name, boolean ignoreCase)
     {
         Checks.notEmpty(name, "Name");
         if (elements.isEmpty())
@@ -200,21 +200,21 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<JDA> stream()
     {
         return StreamSupport.stream(spliterator(), false);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<JDA> parallelStream()
     {
         return StreamSupport.stream(spliterator(), true);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<JDA> iterator()
     {
@@ -284,7 +284,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
             return generator.get().allMatch(CacheView::isEmpty);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public List<JDA> asList()
         {
@@ -293,7 +293,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
             return Collections.unmodifiableList(list);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Set<JDA> asSet()
         {
@@ -302,7 +302,7 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
             return Collections.unmodifiableSet(set);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public ClosableIterator<JDA> lockedIterator()
         {
@@ -310,9 +310,9 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
             return new ChainedClosableIterator<>(gen);
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public List<JDA> getElementsByName(@Nonnull String name, boolean ignoreCase)
+        public List<JDA> getElementsByName(@NotNull String name, boolean ignoreCase)
         {
             return Collections.unmodifiableList(distinctStream()
                 .flatMap(view -> view.getElementsByName(name, ignoreCase).stream())
@@ -328,21 +328,21 @@ public class ShardCacheViewImpl extends ReadWriteLockCache<JDA> implements Shard
                 .findFirst().orElse(null);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Stream<JDA> stream()
         {
             return generator.get().flatMap(CacheView::stream).distinct();
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Stream<JDA> parallelStream()
         {
             return generator.get().flatMap(CacheView::parallelStream).distinct();
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public Iterator<JDA> iterator()
         {

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeReference.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeReference.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.utils.cache;
 
 import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.entities.ISnowflake;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.lang.ref.WeakReference;
 import java.util.function.LongFunction;
 
@@ -42,7 +42,7 @@ public class SnowflakeReference<T extends ISnowflake> implements ISnowflake
         this.id = referent.getIdLong();
     }
 
-    @Nonnull
+    @NotNull
     public T resolve()
     {
         T referent = reference.get();

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.utils.cache.SortedSnowflakeCacheView;
 import net.dv8tion.jda.internal.utils.UnlockHook;
 import org.apache.commons.collections4.iterators.ObjectArrayIterator;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -46,7 +46,7 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<? su
     }
 
     @Override
-    public void forEach(@Nonnull Consumer<? super T> action)
+    public void forEach(@NotNull Consumer<? super T> action)
     {
         try (UnlockHook hook = readLock())
         {
@@ -55,12 +55,12 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<? su
     }
 
     @Override
-    public void forEachUnordered(@Nonnull Consumer<? super T> action)
+    public void forEachUnordered(@NotNull Consumer<? super T> action)
     {
         super.forEach(action);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<T> asList()
     {
@@ -78,7 +78,7 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<? su
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public NavigableSet<T> asSet()
     {
@@ -95,9 +95,9 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<? su
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<T> getElementsByName(@Nonnull String name, boolean ignoreCase)
+    public List<T> getElementsByName(@NotNull String name, boolean ignoreCase)
     {
         List<T> filtered = super.getElementsByName(name, ignoreCase);
         filtered.sort(comparator);
@@ -113,35 +113,35 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<? su
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> streamUnordered()
     {
         return super.stream();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> parallelStreamUnordered()
     {
         return super.parallelStream();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> stream()
     {
         return super.stream().sorted(comparator);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> parallelStream()
     {
         return super.parallelStream().sorted(comparator);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<T> iterator()
     {

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/UnifiedCacheViewImpl.java
@@ -25,9 +25,9 @@ import net.dv8tion.jda.api.utils.cache.MemberCacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.api.utils.cache.UnifiedMemberCacheView;
 import net.dv8tion.jda.internal.utils.ChainedClosableIterator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -66,7 +66,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public List<T> asList()
     {
@@ -75,7 +75,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         return Collections.unmodifiableList(list);
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Set<T> asSet()
     {
@@ -88,7 +88,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         }
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public ChainedClosableIterator<T> lockedIterator()
     {
@@ -96,9 +96,9 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
         return new ChainedClosableIterator<>(gen);
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public List<T> getElementsByName(@Nonnull String name, boolean ignoreCase)
+    public List<T> getElementsByName(@NotNull String name, boolean ignoreCase)
     {
         return Collections.unmodifiableList(distinctStream()
                 .flatMap(view -> view.getElementsByName(name, ignoreCase).stream())
@@ -106,21 +106,21 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
                 .collect(Collectors.toList()));
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> stream()
     {
         return distinctStream().flatMap(CacheView::stream).distinct();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Stream<T> parallelStream()
     {
         return distinctStream().flatMap(CacheView::parallelStream).distinct();
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public Iterator<T> iterator()
     {
@@ -159,7 +159,7 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
             super(generator);
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public List<Member> getElementsById(long id)
         {
@@ -169,16 +169,16 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
                 .collect(Collectors.toList()));
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public List<Member> getElementsByUsername(@Nonnull String name, boolean ignoreCase)
+        public List<Member> getElementsByUsername(@NotNull String name, boolean ignoreCase)
         {
             return Collections.unmodifiableList(distinctStream()
                 .flatMap(view -> view.getElementsByUsername(name, ignoreCase).stream())
                 .collect(Collectors.toList()));
         }
 
-        @Nonnull
+        @NotNull
         @Override
         public List<Member> getElementsByNickname(@Nullable String name, boolean ignoreCase)
         {
@@ -187,18 +187,18 @@ public class UnifiedCacheViewImpl<T, E extends CacheView<T>> implements CacheVie
                 .collect(Collectors.toList()));
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public List<Member> getElementsWithRoles(@Nonnull Role... roles)
+        public List<Member> getElementsWithRoles(@NotNull Role... roles)
         {
             return Collections.unmodifiableList(distinctStream()
                 .flatMap(view -> view.getElementsWithRoles(roles).stream())
                 .collect(Collectors.toList()));
         }
 
-        @Nonnull
+        @NotNull
         @Override
-        public List<Member> getElementsWithRoles(@Nonnull Collection<Role> roles)
+        public List<Member> getElementsWithRoles(@NotNull Collection<Role> roles)
         {
             return Collections.unmodifiableList(distinctStream()
                 .flatMap(view -> view.getElementsWithRoles(roles).stream())

--- a/src/main/java/net/dv8tion/jda/internal/utils/compress/Decompressor.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/compress/Decompressor.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.utils.compress;
 
 import net.dv8tion.jda.api.utils.Compression;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
-import javax.annotation.Nullable;
 import java.util.zip.DataFormatException;
 
 public interface Decompressor

--- a/src/main/java/net/dv8tion/jda/internal/utils/concurrent/CountingThreadFactory.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/concurrent/CountingThreadFactory.java
@@ -16,7 +16,8 @@
 
 package net.dv8tion.jda.internal.utils.concurrent;
 
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -27,20 +28,20 @@ public class CountingThreadFactory implements ThreadFactory
     private final AtomicLong count = new AtomicLong(1);
     private final boolean daemon;
 
-    public CountingThreadFactory(@Nonnull Supplier<String> identifier, @Nonnull String specifier)
+    public CountingThreadFactory(@NotNull Supplier<String> identifier, @NotNull String specifier)
     {
         this(identifier, specifier, true);
     }
 
-    public CountingThreadFactory(@Nonnull Supplier<String> identifier, @Nonnull String specifier, boolean daemon)
+    public CountingThreadFactory(@NotNull Supplier<String> identifier, @NotNull String specifier, boolean daemon)
     {
         this.identifier = () -> identifier.get() + " " + specifier;
         this.daemon = daemon;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Thread newThread(@Nonnull Runnable r)
+    public Thread newThread(@NotNull Runnable r)
     {
         final Thread thread = new Thread(r, identifier.get() + "-Worker " + count.getAndIncrement());
         thread.setDaemon(daemon);

--- a/src/main/java/net/dv8tion/jda/internal/utils/concurrent/task/GatewayTask.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/concurrent/task/GatewayTask.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.utils.concurrent.Task;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.JDALogger;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -45,9 +45,9 @@ public class GatewayTask<T> implements Task<T>
         return true;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Task<T> onError(@Nonnull Consumer<? super Throwable> callback)
+    public Task<T> onError(@NotNull Consumer<? super Throwable> callback)
     {
         Checks.notNull(callback, "Callback");
         Consumer<Throwable> failureHandler = ContextException.here((error) -> log.error("Task Failure callback threw error", error));
@@ -67,9 +67,9 @@ public class GatewayTask<T> implements Task<T>
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
-    public Task<T> onSuccess(@Nonnull Consumer<? super T> callback)
+    public Task<T> onSuccess(@NotNull Consumer<? super T> callback)
     {
         Checks.notNull(callback, "Callback");
         Consumer<Throwable> failureHandler = ContextException.here((error) -> log.error("Task Success callback threw error", error));
@@ -88,7 +88,7 @@ public class GatewayTask<T> implements Task<T>
         return this;
     }
 
-    @Nonnull
+    @NotNull
     @Override
     public T get()
     {

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/AuthorizationConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/AuthorizationConfig.java
@@ -18,32 +18,31 @@ package net.dv8tion.jda.internal.utils.config;
 
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.internal.utils.Checks;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public final class AuthorizationConfig
 {
     private String token;
 
-    public AuthorizationConfig(@Nonnull String token)
+    public AuthorizationConfig(@NotNull String token)
     {
         Checks.notNull(token, "Token");
         setToken(token);
     }
 
-    @Nonnull
+    @NotNull
     public AccountType getAccountType()
     {
         return AccountType.BOT;
     }
 
-    @Nonnull
+    @NotNull
     public String getToken()
     {
         return token;
     }
 
-    public void setToken(@Nonnull String token)
+    public void setToken(@NotNull String token)
     {
         this.token = "Bot " + token;
     }

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/MetaConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/MetaConfig.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.utils.config;
 
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -55,7 +55,7 @@ public class MetaConfig
         return mdcContextMap;
     }
 
-    @Nonnull
+    @NotNull
     public EnumSet<CacheFlag> getCacheFlags()
     {
         return cacheFlags;
@@ -76,7 +76,7 @@ public class MetaConfig
         return maxBufferSize;
     }
 
-    @Nonnull
+    @NotNull
     public static MetaConfig getDefault()
     {
         return defaultConfig;

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
@@ -22,9 +22,9 @@ import net.dv8tion.jda.api.utils.ConcurrentSessionController;
 import net.dv8tion.jda.api.utils.SessionController;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 public class SessionConfig
@@ -64,7 +64,7 @@ public class SessionConfig
             flags.remove(ConfigFlag.AUTO_RECONNECT);
     }
 
-    @Nonnull
+    @NotNull
     public SessionController getSessionController()
     {
         return sessionController;
@@ -76,7 +76,7 @@ public class SessionConfig
         return httpClient;
     }
 
-    @Nonnull
+    @NotNull
     public WebSocketFactory getWebSocketFactory()
     {
         return webSocketFactory;
@@ -128,7 +128,7 @@ public class SessionConfig
         return flags;
     }
 
-    @Nonnull
+    @NotNull
     public static SessionConfig getDefault()
     {
         return new SessionConfig(null, new OkHttpClient(), null, null, ConfigFlag.getDefault(), 900, 250);

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
@@ -17,9 +17,9 @@
 package net.dv8tion.jda.internal.utils.config;
 
 import net.dv8tion.jda.internal.utils.concurrent.CountingThreadFactory;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
@@ -79,7 +79,7 @@ public class ThreadingConfig
         this.shutdownAudioPool = shutdown;
     }
 
-    public void init(@Nonnull Supplier<String> identifier)
+    public void init(@NotNull Supplier<String> identifier)
     {
         if (this.rateLimitPool == null)
             this.rateLimitPool = newScheduler(5, identifier, "RateLimit", false);
@@ -132,19 +132,19 @@ public class ThreadingConfig
             audioPool.shutdownNow();
     }
 
-    @Nonnull
+    @NotNull
     public ScheduledExecutorService getRateLimitPool()
     {
         return rateLimitPool;
     }
 
-    @Nonnull
+    @NotNull
     public ScheduledExecutorService getGatewayPool()
     {
         return gatewayPool;
     }
 
-    @Nonnull
+    @NotNull
     public ExecutorService getCallbackPool()
     {
         return callbackPool;
@@ -157,7 +157,7 @@ public class ThreadingConfig
     }
 
     @Nullable
-    public ScheduledExecutorService getAudioPool(@Nonnull Supplier<String> identifier)
+    public ScheduledExecutorService getAudioPool(@NotNull Supplier<String> identifier)
     {
         ScheduledExecutorService pool = audioPool;
         if (pool == null)
@@ -197,19 +197,19 @@ public class ThreadingConfig
         return shutdownAudioPool;
     }
 
-    @Nonnull
+    @NotNull
     public static ScheduledThreadPoolExecutor newScheduler(int coreSize, Supplier<String> identifier, String baseName)
     {
         return newScheduler(coreSize, identifier, baseName, true);
     }
 
-    @Nonnull
+    @NotNull
     public static ScheduledThreadPoolExecutor newScheduler(int coreSize, Supplier<String> identifier, String baseName, boolean daemon)
     {
         return new ScheduledThreadPoolExecutor(coreSize, new CountingThreadFactory(identifier, baseName, daemon));
     }
 
-    @Nonnull
+    @NotNull
     public static ThreadingConfig getDefault()
     {
         return new ThreadingConfig();

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/EventConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/EventConfig.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.utils.config.sharding;
 
 import net.dv8tion.jda.api.hooks.IEventManager;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntFunction;
@@ -36,37 +36,37 @@ public class EventConfig
         this.eventManagerProvider = eventManagerProvider;
     }
 
-    public void addEventListener(@Nonnull Object listener)
+    public void addEventListener(@NotNull Object listener)
     {
         Checks.notNull(listener, "Listener");
         listeners.add(listener);
     }
 
-    public void removeEventListener(@Nonnull Object listener)
+    public void removeEventListener(@NotNull Object listener)
     {
         Checks.notNull(listener, "Listener");
         listeners.remove(listener);
     }
 
-    public void addEventListenerProvider(@Nonnull IntFunction<Object> provider)
+    public void addEventListenerProvider(@NotNull IntFunction<Object> provider)
     {
         Checks.notNull(provider, "Provider");
         listenerProviders.add(provider);
     }
 
-    public void removeEventListenerProvider(@Nonnull IntFunction<Object> provider)
+    public void removeEventListenerProvider(@NotNull IntFunction<Object> provider)
     {
         Checks.notNull(provider, "Provider");
         listenerProviders.remove(provider);
     }
 
-    @Nonnull
+    @NotNull
     public List<Object> getListeners()
     {
         return listeners;
     }
 
-    @Nonnull
+    @NotNull
     public List<IntFunction<Object>> getListenerProviders()
     {
         return listenerProviders;
@@ -78,7 +78,7 @@ public class EventConfig
         return eventManagerProvider;
     }
 
-    @Nonnull
+    @NotNull
     public static EventConfig getDefault()
     {
         return new EventConfig(null);

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/PresenceProviderConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/PresenceProviderConfig.java
@@ -18,9 +18,9 @@ package net.dv8tion.jda.internal.utils.config.sharding;
 
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.function.IntFunction;
 
 public class PresenceProviderConfig
@@ -62,7 +62,7 @@ public class PresenceProviderConfig
         this.idleProvider = idleProvider;
     }
 
-    @Nonnull
+    @NotNull
     public static PresenceProviderConfig getDefault()
     {
         return new PresenceProviderConfig();

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingConfig.java
@@ -18,8 +18,7 @@ package net.dv8tion.jda.internal.utils.config.sharding;
 
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
-
-import javax.annotation.Nonnull;
+import org.jetbrains.annotations.NotNull;
 
 public class ShardingConfig
 {
@@ -61,7 +60,7 @@ public class ShardingConfig
         return useShutdownNow;
     }
 
-    @Nonnull
+    @NotNull
     public static ShardingConfig getDefault()
     {
         return new ShardingConfig(1, false, GatewayIntent.ALL_INTENTS, MemberCachePolicy.ALL);

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingMetaConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingMetaConfig.java
@@ -21,9 +21,9 @@ import net.dv8tion.jda.api.utils.Compression;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.internal.utils.config.MetaConfig;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.IntFunction;
@@ -70,7 +70,7 @@ public class ShardingMetaConfig extends MetaConfig
         return contextProvider;
     }
 
-    @Nonnull
+    @NotNull
     public static ShardingMetaConfig getDefault()
     {
         return defaultConfig;

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingSessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingSessionConfig.java
@@ -25,9 +25,9 @@ import net.dv8tion.jda.internal.utils.config.SessionConfig;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import net.dv8tion.jda.internal.utils.config.flags.ShardingConfigFlag;
 import okhttp3.OkHttpClient;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 public class ShardingSessionConfig extends SessionConfig
@@ -74,7 +74,7 @@ public class ShardingSessionConfig extends SessionConfig
         return audioSendFactory;
     }
 
-    @Nonnull
+    @NotNull
     public static ShardingSessionConfig getDefault()
     {
         return new ShardingSessionConfig(null, null, new OkHttpClient(), null, null, null, ConfigFlag.getDefault(), ShardingConfigFlag.getDefault(), 900, 250);

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ThreadingProviderConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ThreadingProviderConfig.java
@@ -17,9 +17,9 @@
 package net.dv8tion.jda.internal.utils.config.sharding;
 
 import net.dv8tion.jda.api.sharding.ThreadPoolProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -85,7 +85,7 @@ public class ThreadingProviderConfig
         return audioPoolProvider;
     }
 
-    @Nonnull
+    @NotNull
     public static ThreadingProviderConfig getDefault()
     {
         return new ThreadingProviderConfig(null, null, null, null, null, null);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Runtime dependencies & code annotations

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

First of all, this PR removes the `org.jetbrains:annotations` & `com.google.code.findbugs:jsr` dependencies from the runtime classpath. That being said, they are never used at runtime, and it's absolutely nonsense to have them in the ABI. These are just a few annotations used by various IDEs.

Second of all, `org.slf4j:slf4j-api` is now an implementation dependency, not an API one. That dependency isn't a part of API (not method return type, not public field type, etc) and is used by the JDA's internal parts, which is the implementation dependency configuration for.

Third of all, all the `@Nonnull` & `@Nullable` annotations were replaced with the JetBrains' `@NotNull` & `@Nullable` ones. Or isn't it why the `org.jetbrains:annotations` dependency was added for?

-----

A brief summary of the size changes with these changes. Based on the [development](https://github.com/DV8FromTheWorld/JDA/tree/1dad81d1e5c8bc5f1524ba12efbc555d2e684fba) branch.

File | Size Before | Size After | Decrease |
-- | :---: | :---: | :---: |
JDA-4.2.1_DEV.jar | 1235Kb | 1256Kb | +21Kb
JDA-4.2.1_DEV-withDependencies.jar | 10,164Kb | 10,148Kb | -16Kb
JDA-4.2.1_DEV-withDependencies-min.jar | 4,419Kb | 4,395Kb | -24Kb
JDA-4.2.1_DEV-withDependencies-no-opus.jar | 6,861Kb | 6,845Kb | -16Kb