### PR TITLE
Increase audio request retry from 2 seconds to 10 seconds

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
@@ -226,7 +226,7 @@ class WebSocketSendingThread implements Runnable
             //If we didn't get RateLimited, Next request attempt will be 2 seconds from now
             // we remove it in VoiceStateUpdateHandler once we hear that it has updated our status
             // in 2 seconds we will attempt again in case we did not receive an update
-            audioRequest.setNextAttemptEpoch(System.currentTimeMillis() + 2000);
+            audioRequest.setNextAttemptEpoch(System.currentTimeMillis() + 10000);
             //If we are already in the correct state according to voice state
             // we will not receive a VOICE_STATE_UPDATE that would remove it
             // thus we update it here

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketSendingThread.java
@@ -223,9 +223,9 @@ class WebSocketSendingThread implements Runnable
         LOG.debug("Sending voice request {}", packet);
         if (send(packet))
         {
-            //If we didn't get RateLimited, Next request attempt will be 2 seconds from now
+            //If we didn't get RateLimited, Next request attempt will be 10 seconds from now
             // we remove it in VoiceStateUpdateHandler once we hear that it has updated our status
-            // in 2 seconds we will attempt again in case we did not receive an update
+            // in 10 seconds we will attempt again in case we did not receive an update
             audioRequest.setNextAttemptEpoch(System.currentTimeMillis() + 10000);
             //If we are already in the correct state according to voice state
             // we will not receive a VOICE_STATE_UPDATE that would remove it


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord is very slow when the corresponding voice state update event, so a retry that small can lead to JDA spamming Discord with way too may voice state updates. This bumps the retry to 10 seconds.
