### PR TITLE
Unify reply methods

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/Interaction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/Interaction.java
@@ -272,7 +272,7 @@ public interface Interaction extends ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    default ReplyAction replyEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds)
+    default ReplyAction reply(@Nonnull Collection<? extends MessageEmbed> embeds)
     {
         return deferReply().addEmbeds(embeds);
     }
@@ -299,7 +299,7 @@ public interface Interaction extends ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    default ReplyAction replyEmbeds(@Nonnull MessageEmbed embed, @Nonnull MessageEmbed... embeds)
+    default ReplyAction reply(@Nonnull MessageEmbed embed, @Nonnull MessageEmbed... embeds)
     {
         Checks.notNull(embed, "MessageEmbed");
         Checks.noneNull(embeds, "MessageEmbed");


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation

## Description

Currently, there are several methods to reply to interactions. For TextChannels, there are only two methods (TextChannel#sendMessage and TextChannel#sendMessageFormat) and not an extra one for embeds. For interactons, there is an extra one. It would be better and more consistent to other methods (like the TextChannel methods) to unify them so that there isn't more an extra method for embeds.