### PR TITLE
Implement per-guild avatars

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -50,6 +50,9 @@ import java.util.List;
  */
 public interface Member extends IMentionable, IPermissionHolder, IFakeable
 {
+
+    String AVATAR_URL = "https://cdn.discordapp.com/guilds/%s/users/%s/avatars/%s.%s";
+
     /**
      * The user wrapped by this Entity.
      *
@@ -206,6 +209,42 @@ public interface Member extends IMentionable, IPermissionHolder, IFakeable
      */
     @Nonnull
     String getEffectiveName();
+
+    /**
+     * The Discord Id for this member's per guild avatar image.
+     * If the member has not set a per guild avatar, this will return null.
+     *
+     * @return Possibly-null String containing the {@link net.dv8tion.jda.api.entities.Member} per guild avatar id.
+     */
+    @Nullable
+    String getAvatarId();
+
+    /**
+     * The URL for the member's per guild avatar image.
+     * If the member has not set a per guild avatar, this will return null.
+     *
+     * @return Possibly-null String containing the {@link net.dv8tion.jda.api.entities.Member} per guild avatar url.
+     */
+    @Nullable
+    default String getAvatarUrl()
+    {
+        String avatarId = getAvatarId();
+        return avatarId == null ? null : String.format(AVATAR_URL, getGuild().getId(), getId(), avatarId, avatarId.startsWith("a_") ? "gif" : "png");
+    }
+
+    /**
+     * The URL for the member's effective avatar image.
+     * If they do not have a per guild avatar set, this will return the URL of
+     * their effective {@link User} avatar.
+     *
+     * @return Never-null String containing the {@link net.dv8tion.jda.api.entities.Member} avatar url.
+     */
+    @Nonnull
+    default String getEffectiveAvatarUrl()
+    {
+        String avatarUrl = getAvatarUrl();
+        return avatarUrl == null ? getUser().getEffectiveAvatarUrl() : avatarUrl;
+    }
 
     /**
      * The roles applied to this Member.

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateAvatarEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateAvatarEvent.java
@@ -1,0 +1,54 @@
+package net.dv8tion.jda.api.events.guild.member.update;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Member;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} avatar.
+ *
+ * <p>Can be used to retrieve members who change their per guild avatar, triggering guild, the old avatar id and the new avatar id.
+ *
+ * <p>Identifier: {@code avatar}
+ *
+ * <h2>Requirements</h2>
+ *
+ * <p>This event requires the {@link net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS GUILD_MEMBERS} intent to be enabled.
+ * <br>{@link net.dv8tion.jda.api.JDABuilder#createDefault(String) createDefault(String)} and
+ * {@link net.dv8tion.jda.api.JDABuilder#createLight(String) createLight(String)} disable this by default!
+ *
+ * <p>Additionally, this event requires the {@link net.dv8tion.jda.api.utils.MemberCachePolicy MemberCachePolicy}
+ * to cache the updated members. Discord does not specifically tell us about the updates, but merely tells us the
+ * member was updated and gives us the updated member object. In order to fire a specific event like this we
+ * need to have the old member cached to compare against.
+ */
+public class GuildMemberUpdateAvatarEvent extends GenericGuildMemberUpdateEvent<String>
+{
+    public static final String IDENTIFIER = "avatar";
+
+    public GuildMemberUpdateAvatarEvent(@NotNull JDA api, long responseNumber, @NotNull Member member, @Nullable String oldAvatarId)
+    {
+        super(api, responseNumber, member, oldAvatarId, member.getAvatarId(), IDENTIFIER);
+    }
+
+    /**
+     * The old avatar id
+     *
+     * @return The old avatar id
+     */
+    public String getOldAvatarId()
+    {
+        return getOldValue();
+    }
+
+    /**
+     * The new avatar id
+     *
+     * @return The new avatar id
+     */
+    public String getNewAvatarId()
+    {
+        return getNewValue();
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/ListenerAdapter.java
@@ -58,10 +58,7 @@ import net.dv8tion.jda.api.events.guild.invite.GenericGuildInviteEvent;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteCreateEvent;
 import net.dv8tion.jda.api.events.guild.invite.GuildInviteDeleteEvent;
 import net.dv8tion.jda.api.events.guild.member.*;
-import net.dv8tion.jda.api.events.guild.member.update.GenericGuildMemberUpdateEvent;
-import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateBoostTimeEvent;
-import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
-import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdatePendingEvent;
+import net.dv8tion.jda.api.events.guild.member.update.*;
 import net.dv8tion.jda.api.events.guild.override.GenericPermissionOverrideEvent;
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideCreateEvent;
 import net.dv8tion.jda.api.events.guild.override.PermissionOverrideDeleteEvent;
@@ -348,6 +345,7 @@ public abstract class ListenerAdapter implements EventListener
     //Guild Member Update Events
     public void onGuildMemberUpdate(@Nonnull GuildMemberUpdateEvent event) {}
     public void onGuildMemberUpdateNickname(@Nonnull GuildMemberUpdateNicknameEvent event) {}
+    public void onGuildMemberUpdateAvatar(@Nonnull GuildMemberUpdateAvatarEvent event) {}
     public void onGuildMemberUpdateBoostTime(@Nonnull GuildMemberUpdateBoostTimeEvent event) {}
     public void onGuildMemberUpdatePending(@Nonnull GuildMemberUpdatePendingEvent event) {}
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.api.entities.Guild.VerificationLevel;
 import net.dv8tion.jda.api.entities.MessageEmbed.*;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
+import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateAvatarEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateBoostTimeEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdatePendingEvent;
@@ -468,6 +469,8 @@ public class EntityBuilder
             // Create a brand new member
             member = new MemberImpl(guild, user);
             member.setNickname(memberJson.getString("nick", null));
+            member.setAvatarId(memberJson.getString("avatar", null));
+
             long epoch = 0;
             if (!memberJson.isNull("premium_since"))
             {
@@ -560,6 +563,19 @@ public class EntityBuilder
                     new GuildMemberUpdateNicknameEvent(
                         getJDA(), responseNumber,
                         member, oldNick));
+            }
+        }
+        if (content.hasKey("avatar"))
+        {
+            String oldAvatarId = member.getAvatarId();
+            String newAvatarId = content.getString("avatar", null);
+            if (!Objects.equals(oldAvatarId, newAvatarId))
+            {
+                member.setAvatarId(newAvatarId);
+                getJDA().handleEvent(
+                        new GuildMemberUpdateAvatarEvent(
+                                getJDA(), responseNumber,
+                                member, oldAvatarId));
             }
         }
         if (content.hasKey("premium_since"))

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -48,6 +48,7 @@ public class MemberImpl implements Member
     private GuildImpl guild;
     private User user;
     private String nickname;
+    private String avatarId;
     private long joinDate, boostDate;
     private boolean pending = false;
 
@@ -163,6 +164,12 @@ public class MemberImpl implements Member
     public String getNickname()
     {
         return nickname;
+    }
+
+    @Override
+    public String getAvatarId()
+    {
+        return avatarId;
     }
 
     @Nonnull
@@ -356,6 +363,12 @@ public class MemberImpl implements Member
     public MemberImpl setNickname(String nickname)
     {
         this.nickname = nickname;
+        return this;
+    }
+
+    public MemberImpl setAvatarId(String avatarId)
+    {
+        this.avatarId = avatarId;
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette
- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This pull request implements per-guild avatars ([#3081](https://github.com/discord/discord-api-docs/pull/3081)). These additions have been tested and do work. It is still unclear whether bots will be able to access these.