### PR TITLE
Fix Message.editMessage(Message) only accepting Message of type DEFAULT

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -140,7 +140,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     @SuppressWarnings({"ResultOfMethodCallIgnored", "ConstantConditions"})
     public MessageActionImpl apply(final Message message)
     {
-        if (message == null || message.getType() != MessageType.DEFAULT)
+        if (message == null || (message.getType() != MessageType.DEFAULT && message.getType() != MessageType.INLINE_REPLY))
             return this;
         final List<MessageEmbed> embeds = message.getEmbeds();
         if (embeds != null && !embeds.isEmpty() && embeds.get(0).getType() == EmbedType.RICH)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -140,7 +140,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     @SuppressWarnings({"ResultOfMethodCallIgnored", "ConstantConditions"})
     public MessageActionImpl apply(final Message message)
     {
-        if (message == null || (message.getType() != MessageType.DEFAULT && message.getType() != MessageType.INLINE_REPLY))
+        if (message == null || message.getType().isSystem())
             return this;
         final List<MessageEmbed> embeds = message.getEmbeds();
         if (embeds != null && !embeds.isEmpty() && embeds.get(0).getType() == EmbedType.RICH)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1654 

## Description

This PR fixes not being able to use `Message#editMessage(Message)` if the passed `Message` is of type `INLINE_REPLY` or `APPLICATION_COMMAND`
