### PR TITLE
Fix documentation in Message interface

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -229,7 +229,7 @@ public interface Message extends ISnowflake, Formattable
      * counts direct mentions of the user and not mentions through roles or the everyone tag.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return immutable list of mentioned users
      */
@@ -260,7 +260,7 @@ public interface Message extends ISnowflake, Formattable
      * }</pre>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return {@link org.apache.commons.collections4.Bag Bag} of mentioned users
      *
@@ -276,7 +276,7 @@ public interface Message extends ISnowflake, Formattable
      * <p><b>This may include TextChannels from other {@link net.dv8tion.jda.api.entities.Guild Guilds}</b>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return immutable list of mentioned TextChannels
      */
@@ -307,7 +307,7 @@ public interface Message extends ISnowflake, Formattable
      * }</pre>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return {@link org.apache.commons.collections4.Bag Bag} of mentioned channels
      *
@@ -324,7 +324,7 @@ public interface Message extends ISnowflake, Formattable
      * <p><b>This may include Roles from other {@link net.dv8tion.jda.api.entities.Guild Guilds}</b>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return immutable list of mentioned Roles
      */
@@ -356,7 +356,7 @@ public interface Message extends ISnowflake, Formattable
      * }</pre>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return {@link org.apache.commons.collections4.Bag Bag} of mentioned roles
      *
@@ -377,7 +377,7 @@ public interface Message extends ISnowflake, Formattable
      *         that will be used to retrieve Members.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalArgumentException
      *         If the specified Guild is {@code null}
      *
@@ -396,7 +396,7 @@ public interface Message extends ISnowflake, Formattable
      * <br>It will provide the {@link #getGuild()} output Guild to {@link #getMentionedMembers(Guild)}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         If this message was not sent in a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *
@@ -419,7 +419,7 @@ public interface Message extends ISnowflake, Formattable
      *         to include in the list of mentions
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalArgumentException
      *         If provided with {@code null}
      *
@@ -448,7 +448,7 @@ public interface Message extends ISnowflake, Formattable
      *         This will be used with {@link #getMentions(Message.MentionType...) getMentions(MentionType...)}
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return True, if the given mentionable was mentioned in this message
      */
@@ -458,7 +458,7 @@ public interface Message extends ISnowflake, Formattable
      * Indicates if this Message mentions everyone using @everyone or @here.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return True, if message is mentioning everyone
      */
@@ -468,7 +468,7 @@ public interface Message extends ISnowflake, Formattable
      * Returns whether or not this Message has been edited before.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return True if this message has been edited.
      */
@@ -480,7 +480,7 @@ public interface Message extends ISnowflake, Formattable
      * will return {@code null}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Time of the most recent edit, or {@code null} if the Message has never been edited.
      */
@@ -491,7 +491,7 @@ public interface Message extends ISnowflake, Formattable
      * The author of this Message
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Message author
      */
@@ -509,7 +509,7 @@ public interface Message extends ISnowflake, Formattable
      * unless the member is already cached.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Message author, or {@code null} if the message was not sent in a TextChannel, or if the message was sent by a Webhook.
      *
@@ -523,7 +523,7 @@ public interface Message extends ISnowflake, Formattable
      * jump to the specified message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return A String representing the jump-to URL for the message
      */
@@ -545,7 +545,7 @@ public interface Message extends ISnowflake, Formattable
      * <p>If you want the actual Content (mentions as {@literal <@id>}), use {@link #getContentRaw()} instead
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return The textual content of the message with mentions resolved to be visually like the Discord client.
      */
@@ -569,7 +569,7 @@ public interface Message extends ISnowflake, Formattable
      * for formatting are escaped to prevent possible formatting.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return The textual content from {@link #getContentDisplay()} with all text formatting characters removed or escaped.
      */
@@ -587,7 +587,7 @@ public interface Message extends ISnowflake, Formattable
      * {@link net.dv8tion.jda.api.entities.Invite#resolve(JDA, String) Invite.resolve(JDA, String)}
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Immutable list of invite codes
      */
@@ -621,7 +621,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link net.dv8tion.jda.api.entities.ChannelType ChannelType} to check against.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return True if the {@link net.dv8tion.jda.api.entities.ChannelType ChannelType} which this message was received
      *         from is the same as the one specified by {@code type}.
@@ -645,7 +645,7 @@ public interface Message extends ISnowflake, Formattable
      * {@link net.dv8tion.jda.api.entities.VoiceChannel VoiceChannels}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return The ChannelType which this message was received from.
      */
@@ -658,7 +658,7 @@ public interface Message extends ISnowflake, Formattable
      * <br>Useful if you want to ignore non-users.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return True if this message was sent by a {@link net.dv8tion.jda.api.entities.Webhook Webhook}.
      */
@@ -668,7 +668,7 @@ public interface Message extends ISnowflake, Formattable
      * Returns the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} that this message was sent in.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return The MessageChannel of this Message
      */
@@ -684,7 +684,7 @@ public interface Message extends ISnowflake, Formattable
      * if you do not need functionality specific to {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         If this was not sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel}.
      *
@@ -706,7 +706,7 @@ public interface Message extends ISnowflake, Formattable
      * if you do not need functionality specific to {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         If this was not sent in a {@link net.dv8tion.jda.api.entities.TextChannel}.
      *
@@ -725,7 +725,7 @@ public interface Message extends ISnowflake, Formattable
      * <br>Equivalent to {@code getTextChannel().getParent()} if this was sent in a {@link net.dv8tion.jda.api.entities.TextChannel}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return {@link net.dv8tion.jda.api.entities.Category Category} for this message
      */
@@ -739,7 +739,7 @@ public interface Message extends ISnowflake, Formattable
      * <br>You can check the type of channel this message was sent from using {@link #isFromType(ChannelType)} or {@link #getChannelType()}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         If this was not sent in a {@link net.dv8tion.jda.api.entities.TextChannel}.
      *
@@ -757,7 +757,7 @@ public interface Message extends ISnowflake, Formattable
      * <br>Most likely this will only ever be 1 {@link net.dv8tion.jda.api.entities.Message.Attachment Attachment} at most.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Immutable list of {@link net.dv8tion.jda.api.entities.Message.Attachment Attachments}.
      */
@@ -769,7 +769,7 @@ public interface Message extends ISnowflake, Formattable
      * Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Immutable list of all given MessageEmbeds.
      */
@@ -858,7 +858,7 @@ public interface Message extends ISnowflake, Formattable
      * <p><b><u>Unicode emojis are not included as {@link net.dv8tion.jda.api.entities.Emote Emote}!</u></b>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return An immutable list of the Emotes used in this message (example match {@literal <:jda:230988580904763393>})
      */
@@ -888,7 +888,7 @@ public interface Message extends ISnowflake, Formattable
      * }</pre>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return {@link org.apache.commons.collections4.Bag Bag} of used emotes
      *
@@ -901,7 +901,7 @@ public interface Message extends ISnowflake, Formattable
      * All {@link net.dv8tion.jda.api.entities.MessageReaction MessageReactions} that are on this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Immutable list of all MessageReactions on this message.
      */
@@ -912,7 +912,7 @@ public interface Message extends ISnowflake, Formattable
      * All {@link net.dv8tion.jda.api.entities.MessageSticker MessageStickers} that are in this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return Immutable list of all MessageStickers in this message.
      */
@@ -958,7 +958,7 @@ public interface Message extends ISnowflake, Formattable
      *         the new content of the Message
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         If the message attempting to be edited was not created by the currently logged in account, or if
      *         {@code newContent}'s length is 0 or greater than 2000.
@@ -994,7 +994,7 @@ public interface Message extends ISnowflake, Formattable
      *         the new content of the Message
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         If the message attempting to be edited was not created by the currently logged in account, or
      *         if the passed-in embed is {@code null}
@@ -1035,7 +1035,7 @@ public interface Message extends ISnowflake, Formattable
      *         The arguments to use in order to be converted in the format string
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws IllegalArgumentException
      *         If the provided format String is {@code null} or blank, or if
      *         the created message exceeds the 2000 character limit
@@ -1080,7 +1080,7 @@ public interface Message extends ISnowflake, Formattable
      *         the new content of the Message
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalStateException
      *         <ul>
      *             <li>If the message attempting to be edited was not created by the currently logged in account</li>
@@ -1345,7 +1345,7 @@ public interface Message extends ISnowflake, Formattable
      * Returns the {@link net.dv8tion.jda.api.JDA JDA} instance related to this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return  the corresponding JDA instance
      */
@@ -1356,7 +1356,7 @@ public interface Message extends ISnowflake, Formattable
      * Whether or not this Message has been pinned in its parent channel.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return True - if this message has been pinned.
      */
@@ -1385,7 +1385,7 @@ public interface Message extends ISnowflake, Formattable
      * </ul>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If this Message is from a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and:
      *         <br><ul>
@@ -1424,7 +1424,7 @@ public interface Message extends ISnowflake, Formattable
      * </ul>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If this Message is from a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and:
      *         <br><ul>
@@ -1481,7 +1481,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link net.dv8tion.jda.api.entities.Emote Emote} to add as a reaction to this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the logged in account does not have
@@ -1554,7 +1554,7 @@ public interface Message extends ISnowflake, Formattable
      *         The unicode emoji to add as a reaction to this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the logged in account does not have
@@ -1596,7 +1596,7 @@ public interface Message extends ISnowflake, Formattable
      * </ul>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
@@ -1645,7 +1645,7 @@ public interface Message extends ISnowflake, Formattable
      *         The unicode emoji to remove reactions for
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws InsufficientPermissionException
      *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
      * @throws IllegalArgumentException
@@ -1684,7 +1684,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link Emote} to remove reactions for
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws InsufficientPermissionException
      *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
      * @throws IllegalArgumentException
@@ -1731,7 +1731,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link net.dv8tion.jda.api.entities.Emote Emote} to remove as a reaction from this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
@@ -1788,7 +1788,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link net.dv8tion.jda.api.entities.User User} to remove the reaction for.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}.
@@ -1854,7 +1854,7 @@ public interface Message extends ISnowflake, Formattable
      *         The unicode emoji to add as a reaction to this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
@@ -1909,7 +1909,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link net.dv8tion.jda.api.entities.User User} to remove the reaction for.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the logged in account does not have
@@ -1958,7 +1958,7 @@ public interface Message extends ISnowflake, Formattable
      *         The {@link net.dv8tion.jda.api.entities.Emote emote} to retrieve users for.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and the
      *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel.
@@ -2001,7 +2001,7 @@ public interface Message extends ISnowflake, Formattable
      *         The unicode emote to retrieve users for.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and the
      *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel.
@@ -2028,7 +2028,7 @@ public interface Message extends ISnowflake, Formattable
      *         The unicode value of the reaction emoji.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalArgumentException
      *         If the provided unicode value is null or empty.
      *
@@ -2052,7 +2052,7 @@ public interface Message extends ISnowflake, Formattable
      *         The string id of the reaction emote.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws java.lang.IllegalArgumentException
      *         If the provided id is not a valid snowflake.
      *
@@ -2076,7 +2076,7 @@ public interface Message extends ISnowflake, Formattable
      *         The long id of the reaction emote.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return The {@link net.dv8tion.jda.api.entities.MessageReaction.ReactionEmote ReactionEmote} of this message or null if not present.
      *
@@ -2109,7 +2109,7 @@ public interface Message extends ISnowflake, Formattable
      * @param  suppressed
      *         Whether or not the embed should be suppressed
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
      *         and the currently logged in account does not have
@@ -2151,7 +2151,7 @@ public interface Message extends ISnowflake, Formattable
      * </ul>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @throws IllegalStateException
      *         If the channel is not a text or news channel. See {@link TextChannel#isNews()}.
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
@@ -2174,7 +2174,7 @@ public interface Message extends ISnowflake, Formattable
      * {@link net.dv8tion.jda.api.entities.Message.MessageFlag#EMBEDS_SUPPRESSED MessageFlag#EMBEDS_SUPPRESSED}
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @return Whether or not Embeds are suppressed for this Message.
      * @see    #suppressEmbeds(boolean)
      */
@@ -2184,7 +2184,7 @@ public interface Message extends ISnowflake, Formattable
      * Returns an EnumSet of all {@link Message.MessageFlag MessageFlags} present for this Message.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      * @return Never-Null EnumSet of present {@link Message.MessageFlag MessageFlags}
      * @see    Message.MessageFlag
      */
@@ -2199,7 +2199,7 @@ public interface Message extends ISnowflake, Formattable
      * or special messages like {@link net.dv8tion.jda.api.entities.MessageType#GUILD_MEMBER_JOIN welcome messages}.
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message
      *
      * @return The {@link net.dv8tion.jda.api.entities.MessageType MessageType} of this message.
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR fixes some documentation in the `Message` interface. 
Previously, some of these methods would throw an Exception if the Message was not of Type `DEFAULT`, this has now changed with `INLINE_REPLIES` and `APPLICATION_COMMAND`, since all of these methods can be accessed in them.