### PR TITLE
Add SlashCommandEvent.getText()

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/interaction/SlashCommandEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/interaction/SlashCommandEvent.java
@@ -97,4 +97,5 @@ public class SlashCommandEvent extends GenericInteractionCreateEvent implements 
     {
         return commandInteraction.getText();
     }
+    //c
 }

--- a/src/main/java/net/dv8tion/jda/api/events/interaction/SlashCommandEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/interaction/SlashCommandEvent.java
@@ -83,4 +83,7 @@ public class SlashCommandEvent extends GenericInteractionCreateEvent implements 
     {
         return commandInteraction.getOptions();
     }
+
+    @Nonnull
+    public String getText() { return commandInteraction.getText(); }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/interaction/SlashCommandEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/interaction/SlashCommandEvent.java
@@ -84,6 +84,17 @@ public class SlashCommandEvent extends GenericInteractionCreateEvent implements 
         return commandInteraction.getOptions();
     }
 
+    /**
+     * Gets the slash command String for this slash command.
+     * <br>This is similar to the String you see when clicking the interaction name in the client.
+     *
+     * <p>Example return for an echo command: {@code /say echo phrase: Say this}
+     *
+     * @return The command String for this slash command
+     */
     @Nonnull
-    public String getText() { return commandInteraction.getText(); }
+    public String getText()
+    {
+        return commandInteraction.getText();
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/CommandInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/CommandInteractionImpl.java
@@ -35,6 +35,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class CommandInteractionImpl extends InteractionImpl implements CommandInteraction
 {
@@ -44,6 +46,7 @@ public class CommandInteractionImpl extends InteractionImpl implements CommandIn
     private final String name;
     private String subcommand;
     private String group;
+    private String text;
 
     public CommandInteractionImpl(JDAImpl jda, DataObject data)
     {
@@ -73,6 +76,7 @@ public class CommandInteractionImpl extends InteractionImpl implements CommandIn
 
         parseResolved(jda, resolveJson);
         parseOptions(options);
+        buildText();
     }
 
     private void parseOptions(DataArray options)
@@ -123,6 +127,22 @@ public class CommandInteractionImpl extends InteractionImpl implements CommandIn
         }
     }
 
+    private void buildText() {
+        //Get text like the text that appears when you hover over the interaction in discord
+        StringBuilder builder = new StringBuilder();
+        builder.append("/").append(getCommandPath().replace("/", " ")).append(" "); //get command name and format it
+        for (OptionMapping o : this.options) { //build options (formatted appropriately)
+            Matcher match = Pattern.compile("(\\(.+\\))", Pattern.CASE_INSENSITIVE).matcher(o.toString());
+            if (match.find()) {
+                String str = match.group(0);
+                str = str.substring(1); //remove leading (
+                str = str.substring(0, str.length()-1); //remove trailing )
+                builder.append(str).append(" ");
+            }
+        }
+        this.text = builder.toString().trim();
+    }
+
     @Nonnull
     @Override
     @SuppressWarnings("ConstantConditions")
@@ -162,4 +182,7 @@ public class CommandInteractionImpl extends InteractionImpl implements CommandIn
     {
         return options;
     }
+
+    @Nonnull
+    public String getText() { return text; }
 }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/CommandInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/CommandInteractionImpl.java
@@ -35,8 +35,6 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class CommandInteractionImpl extends InteractionImpl implements CommandInteraction
 {
@@ -127,18 +125,15 @@ public class CommandInteractionImpl extends InteractionImpl implements CommandIn
         }
     }
 
-    private void buildText() {
+    private void buildText()
+    {
         //Get text like the text that appears when you hover over the interaction in discord
         StringBuilder builder = new StringBuilder();
-        builder.append("/").append(getCommandPath().replace("/", " ")).append(" "); //get command name and format it
-        for (OptionMapping o : this.options) { //build options (formatted appropriately)
-            Matcher match = Pattern.compile("(\\(.+\\))", Pattern.CASE_INSENSITIVE).matcher(o.toString());
-            if (match.find()) {
-                String str = match.group(0);
-                str = str.substring(1); //remove leading (
-                str = str.substring(0, str.length()-1); //remove trailing )
-                builder.append(str).append(" ");
-            }
+        builder.append("/").append(getCommandPath().replace("/", " ")).append(" ");
+        //build options (formatted appropriately)
+        for (OptionMapping o : this.options)
+        {
+            builder.append(o.getName()).append(":").append(o.getAsString()).append(" ");
         }
         this.text = builder.toString().trim();
     }
@@ -184,5 +179,8 @@ public class CommandInteractionImpl extends InteractionImpl implements CommandIn
     }
 
     @Nonnull
-    public String getText() { return text; }
+    public String getText()
+    {
+        return text;
+    }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds SlashCommandEvent.getText() which provides the command path and options in a single string similar to the text in the tooltip when clicking the interaction name on the client
