### PR TITLE
Fix checks in CommandData#addSubcommand and CommandData#addSubcommandGroup

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/CommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/CommandData.java
@@ -259,7 +259,7 @@ public class CommandData extends BaseCommand<CommandData> implements Serializabl
         Checks.noneNull(subcommands, "Subcommands");
         if (!allowSubcommands)
             throw new IllegalArgumentException("You cannot mix options with subcommands/groups.");
-        allowOption = allowGroups = false;
+        allowOption = false;
         Checks.check(subcommands.length + options.length() <= 25, "Cannot have more than 25 subcommands for a command!");
         for (SubcommandData data : subcommands)
             options.add(data);
@@ -303,7 +303,7 @@ public class CommandData extends BaseCommand<CommandData> implements Serializabl
         Checks.noneNull(groups, "SubcommandGroups");
         if (!allowGroups)
             throw new IllegalArgumentException("You cannot mix options with subcommands/groups.");
-        allowSubcommands = allowOption = false;
+        allowOption = false;
         Checks.check(groups.length + options.length() <= 25, "Cannot have more than 25 subcommand groups for a command!");
         for (SubcommandGroupData data : groups)
             options.add(data);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Even though Discord does not allow combining command options with subcommands or subcommand groups, it is allowed to have subcommands in combination with subcommand groups on a single command. JDA currently does not allow this, as it always throws an error when trying to create such a command.
This commit simply removes setting the `allowGroups` and `allowSubcommands` flags when adding subcommands or subcommand groups.
