### PR TITLE
Fixed the issue with last character handling for cases when the length of the message is 4001 characters

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -1274,7 +1274,7 @@ public class MessageBuilder implements Appendable
 
         LinkedList<Message> messages = new LinkedList<>();
 
-        if (builder.length() <= 2000) {
+        if (builder.length() <= Message.MAX_CONTENT_LENGTH) {
             messages.add(this.build());
             return messages;
         }
@@ -1287,7 +1287,7 @@ public class MessageBuilder implements Appendable
         int currentBeginIndex = 0;
 
         messageLoop:
-        while (currentBeginIndex < builder.length() - 2000)
+        while (currentBeginIndex < builder.length() - Message.MAX_CONTENT_LENGTH)
         {
             for (SplitPolicy splitPolicy : policy)
             {

--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -1302,9 +1302,9 @@ public class MessageBuilder implements Appendable
             throw new IllegalStateException("Failed to split the messages");
         }
 
-        if (currentBeginIndex < builder.length() - 1)
+        if (currentBeginIndex < builder.length())
         {
-            messages.add(build(currentBeginIndex, builder.length() - 1));
+            messages.add(build(currentBeginIndex, builder.length()));
         }
 
         if (this.embeds != null)

--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -1287,7 +1287,7 @@ public class MessageBuilder implements Appendable
         int currentBeginIndex = 0;
 
         messageLoop:
-        while (currentBeginIndex < builder.length() - 2001)
+        while (currentBeginIndex < builder.length() - 2000)
         {
             for (SplitPolicy splitPolicy : policy)
             {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This fixes the issue that happens when `MessageBuilder#buildAll` is called on a message with 2001+ characters. Once the message is split, the last character of the last message ends up being cut off. The reason this happens is because the endIndex of the substring is set as builder.length()-1, even though a substring's end index is exclusive. As a result, the last char in the StringBuilder of the message ends up being cut off. 

## Tested

With the following sample code
```java
        StringBuilder db = new StringBuilder();
        for (int i = 0; i < 4000; i++) {
            if (i != 1999 && i != 3999)
                db.append('a');
            else db.append('b');
        }
        db.append('c');

        new MessageBuilder(db.toString())
                .buildAll(MessageBuilder.SplitPolicy.ANYWHERE)
                .forEach(replyMessage -> getServer().getTextChannelById(CHANNEL_ID).sendMessage(replyMessage.getContentRaw()).queue());
```

Existing implementation loses last 'c' letter, by generating 2 messages 
![image](https://user-images.githubusercontent.com/86025730/122663274-0c5ce180-d14e-11eb-8817-21f3e7ab2972.png)

And proposed implementation correctly generates 3 messages
![image](https://user-images.githubusercontent.com/86025730/122663251-e46d7e00-d14d-11eb-8495-7e62f1ff5fed.png)

