### PR TITLE
Remove last CLIENT AccountType occurrences

### DIFF
--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -86,7 +86,7 @@ public class MessageListenerExample extends ListenerAdapter
         User author = event.getAuthor();                //The user that sent the message
         Message message = event.getMessage();           //The message that was received.
         MessageChannel channel = event.getChannel();    //This is the MessageChannel that the message was sent to.
-                                                        //  This could be a TextChannel, PrivateChannel, or Group!
+                                                        //  This could be a channel from a guild (TextChannel or a StoreChannel) or a PrivateChannel!
 
         String msg = message.getContentDisplay();       //This returns a human readable version of the Message. Similar to
                                                         //  what you would see in the client.

--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -86,7 +86,7 @@ public class MessageListenerExample extends ListenerAdapter
         User author = event.getAuthor();                //The user that sent the message
         Message message = event.getMessage();           //The message that was received.
         MessageChannel channel = event.getChannel();    //This is the MessageChannel that the message was sent to.
-                                                        //  This could be a channel from a guild (TextChannel or a StoreChannel) or a PrivateChannel!
+                                                        //  This could be a TextChannel or a PrivateChannel!
 
         String msg = message.getContentDisplay();       //This returns a human readable version of the Message. Similar to
                                                         //  what you would see in the client.

--- a/src/examples/java/MessageListenerExample.java
+++ b/src/examples/java/MessageListenerExample.java
@@ -35,8 +35,7 @@ public class MessageListenerExample extends ListenerAdapter
      */
     public static void main(String[] args)
     {
-        //We construct a builder for a BOT account. If we wanted to use a CLIENT account
-        // we would use AccountType.CLIENT
+        //We construct a builder for the bot.
         try
         {
             JDA jda = JDABuilder.createDefault("Your-Token-Goes-Here") // The token of the account that is logging in.
@@ -89,11 +88,11 @@ public class MessageListenerExample extends ListenerAdapter
         MessageChannel channel = event.getChannel();    //This is the MessageChannel that the message was sent to.
                                                         //  This could be a TextChannel, PrivateChannel, or Group!
 
-        String msg = message.getContentDisplay();              //This returns a human readable version of the Message. Similar to
-                                                        // what you would see in the client.
+        String msg = message.getContentDisplay();       //This returns a human readable version of the Message. Similar to
+                                                        //  what you would see in the client.
 
-        boolean bot = author.isBot();                    //This boolean is useful to determine if the User that
-                                                        // sent the Message is a BOT or not!
+        boolean bot = author.isBot();                   //This boolean is useful to determine if the User that
+                                                        //  sent the Message is a BOT or not!
 
         if (event.isFromType(ChannelType.TEXT))         //If this message was sent to a Guild TextChannel
         {
@@ -109,11 +108,11 @@ public class MessageListenerExample extends ListenerAdapter
             if (message.isWebhookMessage())
             {
                 name = author.getName();                //If this is a Webhook message, then there is no Member associated
-            }                                           // with the User, thus we default to the author for name.
+            }                                           //  with the User, thus we default to the author for name.
             else
             {
                 name = member.getEffectiveName();       //This will either use the Member's nickname if they have one,
-            }                                           // otherwise it will default to their username. (User#getName())
+            }                                           //  otherwise it will default to their username. (User#getName())
 
             System.out.printf("(%s)[%s]<%s>: %s\n", guild.getName(), textChannel.getName(), name, msg);
         }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -15,6 +15,8 @@
  */
 package net.dv8tion.jda.api.entities;
 
+import net.dv8tion.jda.annotations.DeprecatedSince;
+import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
@@ -92,6 +94,20 @@ public class MessageEmbed implements SerializableData
      * @see net.dv8tion.jda.api.EmbedBuilder#addField(String, String, boolean)
      */
     public static final int EMBED_MAX_LENGTH_BOT = 6000;
+
+    /**
+     * The maximum amount of total visible characters an embed can have
+     * <br>This limit depends on the current {@link net.dv8tion.jda.api.AccountType AccountType} and applies to CLIENT
+     *
+     * @see net.dv8tion.jda.api.EmbedBuilder#setDescription(CharSequence)
+     * @see net.dv8tion.jda.api.EmbedBuilder#setTitle(String)
+     * @see net.dv8tion.jda.api.EmbedBuilder#setFooter(String, String)
+     * @see net.dv8tion.jda.api.EmbedBuilder#addField(String, String, boolean)
+     */
+    @Deprecated
+    @ForRemoval(deadline="4.4.0")
+    @DeprecatedSince("4.3.0")
+    public static final int EMBED_MAX_LENGTH_CLIENT = 2000;
 
     protected final Object mutex = new Object();
 

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -93,17 +93,6 @@ public class MessageEmbed implements SerializableData
      */
     public static final int EMBED_MAX_LENGTH_BOT = 6000;
 
-    /**
-     * The maximum amount of total visible characters an embed can have
-     * <br>This limit depends on the current {@link net.dv8tion.jda.api.AccountType AccountType} and applies to CLIENT
-     *
-     * @see net.dv8tion.jda.api.EmbedBuilder#setDescription(CharSequence)
-     * @see net.dv8tion.jda.api.EmbedBuilder#setTitle(String)
-     * @see net.dv8tion.jda.api.EmbedBuilder#setFooter(String, String)
-     * @see net.dv8tion.jda.api.EmbedBuilder#addField(String, String, boolean)
-     */
-    public static final int EMBED_MAX_LENGTH_CLIENT = 2000;
-
     protected final Object mutex = new Object();
 
     protected final String url;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Examples

## Description

Removes the last occurrences of the `CLIENT` `AccountType` by removing a constant and its mention from the [`MessageListenerExample`](https://github.com/DV8FromTheWorld/JDA/blob/development/src/examples/java/MessageListenerExample.java).

Also removed the `Group` mention from the Example and added the `StoreChannel` instead.