### PR TITLE
Fix `ButtonInteraction#editButton` not checking id's before edit.

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/ButtonInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/ButtonInteraction.java
@@ -79,7 +79,7 @@ public interface ButtonInteraction extends ComponentInteraction
             for (ListIterator<Component> it = row.listIterator(); it.hasNext();)
             {
                 Component component = it.next();
-                if (id.equals(component.getId()))
+                if (component.getId().equals(newButton.getId()))
                 {
                     if (newButton == null)
                         it.remove();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1688

## Description

Changes the logic used to crossreference the old `Button` id before editing to new `Button`.