### PR TITLE
Fix isEmpty checks for embeds

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -175,7 +175,7 @@ public class EmbedBuilder
      */
     public int length()
     {
-        int length = description.length();
+        int length = description.toString().trim().length();
         synchronized (fields)
         {
             length = fields.stream().map(f -> f.getName().length() + f.getValue().length()).reduce(length, Integer::sum);

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -156,14 +156,14 @@ public class EmbedBuilder
      */
     public boolean isEmpty()
     {
-        return title == null
+        return (title == null || title.isEmpty())
             && timestamp == null
             && thumbnail == null
             && author == null
             && footer == null
             && image == null
             && color == Role.DEFAULT_COLOR_RAW
-            && description.length() == 0
+            && description.toString().isEmpty()
             && fields.isEmpty();
     }
 

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -156,14 +156,14 @@ public class EmbedBuilder
      */
     public boolean isEmpty()
     {
-        return (title == null || title.isEmpty())
+        return Helpers.isBlank(title)
             && timestamp == null
             && thumbnail == null
             && author == null
             && footer == null
             && image == null
             && color == Role.DEFAULT_COLOR_RAW
-            && description.toString().isEmpty()
+            && Helpers.isBlank(description)
             && fields.isEmpty();
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -354,7 +354,7 @@ public class MessageEmbed implements SerializableData
             if (title != null)
                 length += Helpers.codePointLength(title);
             if (description != null)
-                length += Helpers.codePointLength(description);
+                length += Helpers.codePointLength(description.toString().trim());
             if (author != null)
                 length += Helpers.codePointLength(author.getName());
             if (footer != null)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Builder code

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description
This PR fixes some oversights for embed validation. Discord disallows embeds with no content (a space character or similar) and JDA didn't check this before sending the embed.
