### PR TITLE
Make Message#getMentionedChannels return a List of GuildChannels instead of TextChannels

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -279,7 +279,7 @@ public interface Message extends ISnowflake, Formattable
      * <p><b>This may include GuildChannel from other {@link net.dv8tion.jda.api.entities.Guild Guilds}</b>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is ia system message.
+     *         If this is a system message.
      *
      * @return immutable list of mentioned GuildChannels
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -273,18 +273,18 @@ public interface Message extends ISnowflake, Formattable
     Bag<User> getMentionedUsersBag();
 
     /**
-     * A immutable list of all mentioned {@link net.dv8tion.jda.api.entities.TextChannel TextChannels}.
+     * A immutable list of all mentioned {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannels}.
      * <br>If none were mentioned, this list is empty. Elements are sorted in order of appearance.
      *
-     * <p><b>This may include TextChannels from other {@link net.dv8tion.jda.api.entities.Guild Guilds}</b>
+     * <p><b>This may include GuildChannel from other {@link net.dv8tion.jda.api.entities.Guild Guilds}</b>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is ia system message.
      *
-     * @return immutable list of mentioned TextChannels
+     * @return immutable list of mentioned GuildChannels
      */
     @Nonnull
-    List<TextChannel> getMentionedChannels();
+    List<GuildChannel> getMentionedChannels();
 
     /**
      * A {@link org.apache.commons.collections4.Bag Bag} of mentioned channels.
@@ -294,10 +294,10 @@ public interface Message extends ISnowflake, Formattable
      * <pre>{@code
      * public void sendCount(Message msg)
      * {
-     *     List<TextChannel> mentions = msg.getMentionedTextChannels(); // distinct list, in order of appearance
-     *     Bag<TextChannel> count = msg.getMentionedTextChannelsBag();
+     *     List<GuildChannel> mentions = msg.getMentionedChannels(); // distinct list, in order of appearance
+     *     Bag<GuildChannel> count = msg.getMentionedChannelsBag();
      *     StringBuilder content = new StringBuilder();
-     *     for (TextChannel channel : mentions)
+     *     for (GuildChannel channel : mentions)
      *     {
      *         content.append("#")
      *                .append(channel.getName())
@@ -310,14 +310,14 @@ public interface Message extends ISnowflake, Formattable
      * }</pre>
      *
      * @throws java.lang.UnsupportedOperationException
-     *         If this is not a Received Message from {@link net.dv8tion.jda.api.entities.MessageType#DEFAULT MessageType.DEFAULT}
+     *         If this is a system message.
      *
      * @return {@link org.apache.commons.collections4.Bag Bag} of mentioned channels
      *
      * @see    #getMentionedChannels()
      */
     @Nonnull
-    Bag<TextChannel> getMentionedChannelsBag();
+    Bag<GuildChannel> getMentionedChannelsBag();
 
     /**
      * A immutable list of all mentioned {@link net.dv8tion.jda.api.entities.Role Roles}.

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -120,7 +120,7 @@ public abstract class AbstractMessage implements Message
 
     @Nonnull
     @Override
-    public Bag<TextChannel> getMentionedChannelsBag()
+    public Bag<GuildChannel> getMentionedChannelsBag()
     {
         unsupported();
         return null;
@@ -144,7 +144,7 @@ public abstract class AbstractMessage implements Message
 
     @Nonnull
     @Override
-    public List<TextChannel> getMentionedChannels()
+    public List<GuildChannel> getMentionedChannels()
     {
         unsupported();
         return null;

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -85,7 +85,7 @@ public class ReceivedMessage extends AbstractMessage
     protected List<Member> memberMentions = null;
     protected List<Emote> emoteMentions = null;
     protected List<Role> roleMentions = null;
-    protected List<TextChannel> channelMentions = null;
+    protected List<GuildChannel> channelMentions = null;
     protected List<String> invites = null;
 
     public ReceivedMessage(
@@ -345,20 +345,26 @@ public class ReceivedMessage extends AbstractMessage
         return getJDA().getTextChannelById(channelId);
     }
 
+    private GuildChannel matchGuildChannel(Matcher matcher)
+    {
+        long channelId = MiscUtil.parseSnowflake(matcher.group(1));
+        return getJDA().getGuildChannelById(channelId);
+    }
+
     @Nonnull
     @Override
-    public synchronized List<TextChannel> getMentionedChannels()
+    public synchronized List<GuildChannel> getMentionedChannels()
     {
         if (channelMentions == null)
-            channelMentions = Collections.unmodifiableList(processMentions(MentionType.CHANNEL, new ArrayList<>(), true, this::matchTextChannel));
+            channelMentions = Collections.unmodifiableList(processMentions(MentionType.CHANNEL, new ArrayList<>(), true, this::matchGuildChannel));
         return channelMentions;
     }
 
     @Nonnull
     @Override
-    public Bag<TextChannel> getMentionedChannelsBag()
+    public Bag<GuildChannel> getMentionedChannelsBag()
     {
-        return processMentions(MentionType.CHANNEL, new HashBag<>(), false, this::matchTextChannel);
+        return processMentions(MentionType.CHANNEL, new HashBag<>(), false, this::matchGuildChannel);
     }
 
     private Role matchRole(Matcher matcher)
@@ -627,9 +633,10 @@ public class ReceivedMessage extends AbstractMessage
             {
                 tmp = tmp.replace(emote.getAsMention(), ":" + emote.getName() + ":");
             }
-            for (TextChannel mentionedChannel : getMentionedChannels())
+            for (GuildChannel mentionedChannel : getMentionedChannels())
             {
-                tmp = tmp.replace(mentionedChannel.getAsMention(), '#' + mentionedChannel.getName());
+                if (mentionedChannel instanceof TextChannel)
+                    tmp = tmp.replace(mentionedChannel.getAsMention(), '#' + mentionedChannel.getName());
             }
             for (Role mentionedRole : getMentionedRoles())
             {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This pull request fixes Message#getMentionedChannels only returning TextChannels, since you can also mention other channels now.
