### PR TITLE
Change checks for emote name length to check minimum length

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1654,6 +1654,8 @@ public class GuildImpl implements Guild
     {
         checkPermission(Permission.MANAGE_EMOTES);
         Checks.notBlank(name, "Emote name");
+        Checks.notShorter(name, 2, "Emote name");
+        Checks.notLonger(name, 32, "Emote name");
         Checks.notNull(icon, "Emote icon");
         Checks.notNull(roles, "Roles");
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1653,9 +1653,7 @@ public class GuildImpl implements Guild
     public AuditableRestAction<Emote> createEmote(@Nonnull String name, @Nonnull Icon icon, @Nonnull Role... roles)
     {
         checkPermission(Permission.MANAGE_EMOTES);
-        Checks.notBlank(name, "Emote name");
-        Checks.notShorter(name, 2, "Emote name");
-        Checks.notLonger(name, 32, "Emote name");
+        Checks.inRange(name, 2, 32, "Emote name");
         Checks.notNull(icon, "Emote icon");
         Checks.notNull(roles, "Roles");
 

--- a/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
@@ -112,6 +112,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
         Checks.notBlank(name, "Name");
         name = name.trim();
         Checks.notEmpty(name, "Name");
+        Checks.notShorter(name, 2, "Name");
         Checks.notLonger(name, 32, "Name");
         this.name = name;
         set |= NAME;

--- a/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/EmoteManagerImpl.java
@@ -111,9 +111,7 @@ public class EmoteManagerImpl extends ManagerBase<EmoteManager> implements Emote
     {
         Checks.notBlank(name, "Name");
         name = name.trim();
-        Checks.notEmpty(name, "Name");
-        Checks.notShorter(name, 2, "Name");
-        Checks.notLonger(name, 32, "Name");
+        Checks.inRange(name, 2, 32, "Name");
         this.name = name;
         set |= NAME;
         return this;

--- a/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
@@ -146,6 +146,12 @@ public class Checks
         argument.forEach(it -> noWhitespace(it, name));
     }
 
+    public static void notShorter(final String input, final int length, final String name)
+    {
+        notNull(input, name);
+        check(Helpers.codePointLength(input) >= length, "%s may not be shorter than %d characters! Provided: \"%s\"", name, length, input);
+    }
+
     public static void notLonger(final String input, final int length, final String name)
     {
         notNull(input, name);

--- a/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
@@ -150,7 +150,7 @@ public class Checks
     {
         notNull(input, name);
         int length = Helpers.codePointLength(input);
-        check(length >= min && (max < 1 || length <= max),
+        check(min <= length && length <= max,
                 "%s must be between %d and %d characters long! Provided: \"%s\"",
                 name, min, max, input);
     }

--- a/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
@@ -146,10 +146,13 @@ public class Checks
         argument.forEach(it -> noWhitespace(it, name));
     }
 
-    public static void notShorter(final String input, final int length, final String name)
+    public static void inRange(final String input, final int min, final int max, final String name)
     {
         notNull(input, name);
-        check(Helpers.codePointLength(input) >= length, "%s may not be shorter than %d characters! Provided: \"%s\"", name, length, input);
+        int length = Helpers.codePointLength(input);
+        check(length >= min && (max < 1 || length <= max),
+                "%s is not in bounds! A minimum length of %d characters, and a maximum length of %d characters is required! Provided: \"%s\"",
+                name, min, max, input);
     }
 
     public static void notLonger(final String input, final int length, final String name)

--- a/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Checks.java
@@ -151,7 +151,7 @@ public class Checks
         notNull(input, name);
         int length = Helpers.codePointLength(input);
         check(length >= min && (max < 1 || length <= max),
-                "%s is not in bounds! A minimum length of %d characters, and a maximum length of %d characters is required! Provided: \"%s\"",
+                "%s must be between %d and %d characters long! Provided: \"%s\"",
                 name, min, max, input);
     }
 


### PR DESCRIPTION
Add Checks#notShorter(), and check for the name length when creating/updating emotes.

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds a `Checks#notShorter()` method, and adds checks for the name length when creating/updating emotes.
