### PR TITLE
Bump embed max description length

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -690,7 +690,7 @@ public class EmbedBuilder
         }
         else
         {
-            Checks.check(text.length() <= MessageEmbed.TEXT_MAX_LENGTH, "Text cannot be longer than %d characters.", MessageEmbed.TEXT_MAX_LENGTH);
+            Checks.check(text.length() <= MessageEmbed.FOOTER_MAX_LENGTH, "Text cannot be longer than %d characters.", MessageEmbed.FOOTER_MAX_LENGTH);
             urlCheck(iconUrl);
             this.footer = new MessageEmbed.Footer(text, iconUrl, null);
         }

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -117,8 +117,8 @@ public class EmbedBuilder
     {
         if (isEmpty())
             throw new IllegalStateException("Cannot build an empty embed!");
-        if (description.length() > MessageEmbed.TEXT_MAX_LENGTH)
-            throw new IllegalStateException(Helpers.format("Description is longer than %d! Please limit your input!", MessageEmbed.TEXT_MAX_LENGTH));
+        if (description.length() > MessageEmbed.DESCRIPTION_MAX_LENGTH)
+            throw new IllegalStateException(Helpers.format("Description is longer than %d! Please limit your input!", MessageEmbed.DESCRIPTION_MAX_LENGTH));
         if (length() > MessageEmbed.EMBED_MAX_LENGTH_BOT)
             throw new IllegalStateException("Cannot build an embed with more than " + MessageEmbed.EMBED_MAX_LENGTH_BOT + " characters!");
         final String description = this.description.length() < 1 ? null : this.description.toString();
@@ -291,7 +291,7 @@ public class EmbedBuilder
      *         the description of the embed, {@code null} to reset
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the length of {@code description} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}
+     *         If the length of {@code description} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH}
      *
      * @return the builder after the description has been set
      */
@@ -315,7 +315,7 @@ public class EmbedBuilder
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided {@code description} String is null</li>
-     *             <li>If the length of {@code description} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.</li>
+     *             <li>If the length of {@code description} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH}.</li>
      *         </ul>
      *
      * @return the builder after the description has been set
@@ -324,8 +324,8 @@ public class EmbedBuilder
     public EmbedBuilder appendDescription(@Nonnull CharSequence description)
     {
         Checks.notNull(description, "description");
-        Checks.check(this.description.length() + description.length() <= MessageEmbed.TEXT_MAX_LENGTH,
-                "Description cannot be longer than %d characters.", MessageEmbed.TEXT_MAX_LENGTH);
+        Checks.check(this.description.length() + description.length() <= MessageEmbed.DESCRIPTION_MAX_LENGTH,
+                "Description cannot be longer than %d characters.", MessageEmbed.DESCRIPTION_MAX_LENGTH);
         this.description.append(description);
         return this;
     }
@@ -635,7 +635,7 @@ public class EmbedBuilder
      *         the text of the footer of the embed. If this is not set or set to null, the footer will not appear in the embed.
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#FOOTER_MAX_LENGTH}.
+     *         If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.
      *
      * @return the builder after the footer has been set
      */
@@ -672,7 +672,7 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#FOOTER_MAX_LENGTH}.</li>
+     *             <li>If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.</li>
      *             <li>If the length of {@code iconUrl} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
      *             <li>If the provided {@code iconUrl} is not a properly formatted http or https url.</li>
      *         </ul>
@@ -690,7 +690,7 @@ public class EmbedBuilder
         }
         else
         {
-            Checks.check(text.length() <= MessageEmbed.FOOTER_MAX_LENGTH, "Text cannot be longer than %d characters.", MessageEmbed.FOOTER_MAX_LENGTH);
+            Checks.check(text.length() <= MessageEmbed.TEXT_MAX_LENGTH, "Text cannot be longer than %d characters.", MessageEmbed.TEXT_MAX_LENGTH);
             urlCheck(iconUrl);
             this.footer = new MessageEmbed.Footer(text, iconUrl, null);
         }

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -635,7 +635,7 @@ public class EmbedBuilder
      *         the text of the footer of the embed. If this is not set or set to null, the footer will not appear in the embed.
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.
+     *         If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#FOOTER_MAX_LENGTH}.
      *
      * @return the builder after the footer has been set
      */
@@ -672,7 +672,7 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.</li>
+     *             <li>If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#FOOTER_MAX_LENGTH}.</li>
      *             <li>If the length of {@code iconUrl} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
      *             <li>If the provided {@code iconUrl} is not a properly formatted http or https url.</li>
      *         </ul>

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -71,7 +71,7 @@ public class MessageEmbed implements SerializableData
      * @see net.dv8tion.jda.api.EmbedBuilder#setFooter(String, String) EmbedBuilder.setFooter(text, iconUrl)
      * @see net.dv8tion.jda.api.EmbedBuilder#setDescription(CharSequence) EmbedBuilder.setDescription(text)
      */
-    public static final int TEXT_MAX_LENGTH = 2048;
+    public static final int TEXT_MAX_LENGTH = 4096;
 
     /**
      * The maximum length any URL can have inside an embed

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -66,12 +66,18 @@ public class MessageEmbed implements SerializableData
     public static final int VALUE_MAX_LENGTH = 1024;
 
     /**
-     * The maximum length the description and footer of an embed can have
+     * The maximum length the description of an embed can have
      *
-     * @see net.dv8tion.jda.api.EmbedBuilder#setFooter(String, String) EmbedBuilder.setFooter(text, iconUrl)
      * @see net.dv8tion.jda.api.EmbedBuilder#setDescription(CharSequence) EmbedBuilder.setDescription(text)
      */
     public static final int TEXT_MAX_LENGTH = 4096;
+    
+    /**
+     * The maximum length the footer of an embed can have
+     *
+     * @see net.dv8tion.jda.api.EmbedBuilder#setFooter(String, String) EmbedBuilder.setFooter(text, iconUrl)
+     */
+    public static final int FOOTER_MAX_LENGTH = 2048;
 
     /**
      * The maximum length any URL can have inside an embed

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -70,14 +70,14 @@ public class MessageEmbed implements SerializableData
      *
      * @see net.dv8tion.jda.api.EmbedBuilder#setDescription(CharSequence) EmbedBuilder.setDescription(text)
      */
-    public static final int TEXT_MAX_LENGTH = 4096;
+    public static final int DESCRIPTION_MAX_LENGTH = 4096;
     
     /**
      * The maximum length the footer of an embed can have
      *
      * @see net.dv8tion.jda.api.EmbedBuilder#setFooter(String, String) EmbedBuilder.setFooter(text, iconUrl)
      */
-    public static final int FOOTER_MAX_LENGTH = 2048;
+    public static final int TEXT_MAX_LENGTH = 2048;
 
     /**
      * The maximum length any URL can have inside an embed


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1702

## Description

Increases the `MessageEmbed.TEXT_MAX_LENGTH` to `4096` and also adds new value called `FOOTER_MAX_LENGTH` since the old Javadoc mentions the text value being for description AND footer.

Not sure if a new value shouldn't be added for the description while deprecating the text one for those who are using this int value for both footer and description...
