### PR TITLE
Update Lavalink links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,9 +562,9 @@ to understand a proper implementation.
 <br>Sedmelluq provided a demo in his repository which presents an example implementation for JDA:
 https://github.com/sedmelluq/lavaplayer/tree/master/demo-jda
 
-### [Lavalink](https://github.com/frederikam/Lavalink)
+### [Lavalink](https://github.com/freyacodes/)
 
-Created and maintained by [Frederik Mikkelsen](https://github.com/Frederikam), the creator of FredBoat.
+Maintained by [Freya Arbjerg](https://github.com/freyacodes).
 
 Lavalink is a popular standalone audio sending node based on Lavaplayer. Lavalink was built with scalability in mind,
 and allows streaming music via many servers. It supports most of Lavaplayer's features.

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ to understand a proper implementation.
 <br>Sedmelluq provided a demo in his repository which presents an example implementation for JDA:
 https://github.com/sedmelluq/lavaplayer/tree/master/demo-jda
 
-### [Lavalink](https://github.com/freyacodes/)
+### [Lavalink](https://github.com/freyacodes/Lavalink)
 
 Maintained by [Freya Arbjerg](https://github.com/freyacodes).
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: README

## Description

The name apparently changed and some Troll took the user and repo name.
For more info see: https://github.com/Frederikam/Lavalink/pull/3#issuecomment-862751709

Im not sure about the maintainer part so I just changed it to the owner of the new repo.