### PR TITLE
Change SelectionMenu.Builder#Builder visibility to protected

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
@@ -212,7 +212,7 @@ public interface SelectionMenu extends Component
         private boolean disabled = false;
         private final List<SelectOption> options = new ArrayList<>();
 
-        private Builder(@Nonnull String customId)
+        protected Builder(@Nonnull String customId)
         {
             setId(customId);
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have read the [contributing guidelines][contributing].
- [x] I have checked the PRs for upcoming features/bug fixes.

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR changes the visibility of the SelectionMenu.Builder's constructor to be protected, in order to make inheriting this builder possible
