### PR TITLE
Fixed a parse error on empty selection menu events

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/SelectionMenuInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/SelectionMenuInteractionImpl.java
@@ -37,16 +37,9 @@ public class SelectionMenuInteractionImpl extends ComponentInteractionImpl imple
     public SelectionMenuInteractionImpl(JDAImpl jda, DataObject data)
     {
         super(jda, data);
-        if (!data.getObject("data").hasKey("values"))
-        {
-            values = Collections.emptyList();
-        }
-        else
-        {
-            values = Collections.unmodifiableList(data.getObject("data").getArray("values")
-                    .stream(DataArray::getString)
-                    .collect(Collectors.toList()));
-        }
+        values = Collections.unmodifiableList(data.getObject("data").optArray("values")
+                .map(it -> it.stream(DataArray::getString).collect(Collectors.toList()))
+                .orElse(Collections.emptyList()));
         if (message != null)
         {
             menu = (SelectionMenu) message.getActionRows()

--- a/src/main/java/net/dv8tion/jda/internal/interactions/SelectionMenuInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/SelectionMenuInteractionImpl.java
@@ -37,9 +37,16 @@ public class SelectionMenuInteractionImpl extends ComponentInteractionImpl imple
     public SelectionMenuInteractionImpl(JDAImpl jda, DataObject data)
     {
         super(jda, data);
-        values = Collections.unmodifiableList(data.getObject("data").getArray("values")
-            .stream(DataArray::getString)
-            .collect(Collectors.toList()));
+        if (!data.getObject("data").hasKey("values"))
+        {
+            values = Collections.emptyList();
+        }
+        else
+        {
+            values = Collections.unmodifiableList(data.getObject("data").getArray("values")
+                    .stream(DataArray::getString)
+                    .collect(Collectors.toList()));
+        }
         if (message != null)
         {
             menu = (SelectionMenu) message.getActionRows()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord doesn't send a `values` field in the `data` object when a user unchecks all options in the Selection Menu, causing an "unexpected Json-parse error"
```
[WARN] [JDA [0 / 1] MainWS-ReadThread] Got an unexpected Json-parse error. Please redirect following message to the devs:
        Unable to resolve value with key values to type DataArray: null
```
