### PR TITLE
Hotfix referened_message

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -175,7 +175,7 @@ public class EmbedBuilder
      */
     public int length()
     {
-        int length = description.length();
+        int length = description.toString().trim().length();
         synchronized (fields)
         {
             length = fields.stream().map(f -> f.getName().length() + f.getValue().length()).reduce(length, Integer::sum);

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -360,7 +360,7 @@ public class MessageEmbed implements SerializableData
             if (title != null)
                 length += Helpers.codePointLength(title);
             if (description != null)
-                length += Helpers.codePointLength(description);
+                length += Helpers.codePointLength(description.toString().trim());
             if (author != null)
                 length += Helpers.codePointLength(author.getName());
             if (footer != null)

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReference.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReference.java
@@ -289,7 +289,7 @@ public class MessageReference
 
         if (!selfMember.hasAccess(guildChannel))
             throw new MissingAccessException(guildChannel, Permission.VIEW_CHANNEL);
-        if (!selfMember.hasPermission(permission))
+        if (!selfMember.hasPermission(guildChannel, permission))
             throw new InsufficientPermissionException(guildChannel, permission);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -114,12 +114,6 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Override
-    public Message getReferencedMessage()
-    {
-        return null;
-    }
-
     @Nonnull
     @Override
     public Bag<User> getMentionedUsersBag()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR fixes some bugs with Message#getReferencedMessage and MessageReference#resolve

getReferencedMessage was previously returning null due to an incorrect override in AbstractMessage

resolve was previously not considering channel overrides when checking permissions.


