### PR TITLE
Fixing getReferencedMessage and permissions for resolving a MessageReference

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReference.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReference.java
@@ -289,7 +289,7 @@ public class MessageReference
 
         if (!selfMember.hasAccess(guildChannel))
             throw new MissingAccessException(guildChannel, Permission.VIEW_CHANNEL);
-        if (!selfMember.hasPermission(permission))
+        if (!selfMember.hasPermission(guildChannel, permission))
             throw new InsufficientPermissionException(guildChannel, permission);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -114,12 +114,6 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
-    @Override
-    public Message getReferencedMessage()
-    {
-        return null;
-    }
-
     @Nonnull
     @Override
     public Bag<User> getMentionedUsersBag()


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

Discord User `rakosi2#0001` mentioned in the JDA server that `Message#getReferencedMessage` always returned `null` after #1686 was merged. This happend because `AbstractMessage#getReferencedMessage` overrode [the default implementation in the `Message` interface](https://github.com/DV8FromTheWorld/JDA/blob/969f3f399d050d5470ce27f2a78a8597914c39f9/src/main/java/net/dv8tion/jda/api/entities/Message.java#L243-L248). The fix was to remove that useless override.

While fixing this, I stumbled upon another bug in `MessageReference#resolve` where I got a "Missing MESSAGE_READ permission" error. This came due to only having that perm in the used channel as a Permission Override. This was fixed by adding the guild channel to the permission check.

Those two fixes where confirmed by @arynxd and me. Since #1686 resulted in kind of a breaking change, it would be good if this could be merged as the next build. @DV8FromTheWorld 

Here also an image showing that the fix works:
![showcasing the fix](https://user-images.githubusercontent.com/7572614/127750627-c98933e2-ab32-46ef-b87f-6169bc21d1ad.png)