### PR TITLE
Introduce public max length fields for SelectOption

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
@@ -69,6 +69,21 @@ import javax.annotation.Nullable;
 public interface Button extends Component
 {
     /**
+     * The maximum length a button label can have
+     */
+    int LABEL_MAX_LENGTH = 80;
+
+    /**
+     * The maximum length a button id can have
+     */
+    int ID_MAX_LENGTH = 100;
+
+    /**
+     * The maximum length a button url can have
+     */
+    int URL_MAX_LENGTH = 512;
+
+    /**
      * The visible text on the button.
      *
      * @return The button label
@@ -182,7 +197,7 @@ public interface Button extends Component
     default Button withLabel(@Nonnull String label)
     {
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(getId(), label, getStyle(), getUrl(), isDisabled(), getEmoji());
     }
 
@@ -202,7 +217,7 @@ public interface Button extends Component
     default Button withId(@Nonnull String id)
     {
         Checks.notEmpty(id, "ID");
-        Checks.notLonger(id, 100, "ID");
+        Checks.notLonger(id, ID_MAX_LENGTH, "ID");
         return new ButtonImpl(id, getLabel(), getStyle(), null, isDisabled(), getEmoji());
     }
 
@@ -222,7 +237,7 @@ public interface Button extends Component
     default Button withUrl(@Nonnull String url)
     {
         Checks.notEmpty(url, "URL");
-        Checks.notLonger(url, 512, "URL");
+        Checks.notLonger(url, URL_MAX_LENGTH, "URL");
         return new ButtonImpl(null, getLabel(), ButtonStyle.LINK, url, isDisabled(), getEmoji());
     }
 
@@ -272,8 +287,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.PRIMARY, false, null);
     }
 
@@ -299,7 +314,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.PRIMARY, false, emoji);
     }
 
@@ -323,8 +338,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.SECONDARY, false, null);
     }
 
@@ -350,7 +365,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.SECONDARY, false, emoji);
     }
 
@@ -374,8 +389,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.SUCCESS, false, null);
     }
 
@@ -401,7 +416,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.SUCCESS, false, emoji);
     }
 
@@ -425,8 +440,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.DANGER, false, null);
     }
 
@@ -452,7 +467,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.DANGER, false, emoji);
     }
 
@@ -479,8 +494,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(url, "URL");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(url, 512, "URL");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(url, URL_MAX_LENGTH, "URL");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(null, label, ButtonStyle.LINK, url, false, null);
     }
 
@@ -509,7 +524,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(url, "URL");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(url, 512, "URL");
+        Checks.notLonger(url, URL_MAX_LENGTH, "URL");
         return new ButtonImpl(null, "", ButtonStyle.LINK, url, false, emoji);
     }
 
@@ -538,11 +553,11 @@ public interface Button extends Component
         Checks.check(style != ButtonStyle.UNKNOWN, "Cannot make button with unknown style!");
         Checks.notNull(style, "Style");
         Checks.notNull(label, "Label");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         if (style == ButtonStyle.LINK)
             return link(idOrUrl, label);
         Checks.notEmpty(idOrUrl, "Id");
-        Checks.notLonger(idOrUrl, 100, "Id");
+        Checks.notLonger(idOrUrl, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(idOrUrl, label, style, false, null);
     }
 
@@ -574,7 +589,7 @@ public interface Button extends Component
         if (style == ButtonStyle.LINK)
             return link(idOrUrl, emoji);
         Checks.notEmpty(idOrUrl, "Id");
-        Checks.notLonger(idOrUrl, 100, "Id");
+        Checks.notLonger(idOrUrl, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(idOrUrl, "", style, false, emoji);
     }
 

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
@@ -30,6 +30,21 @@ import javax.annotation.Nullable;
  */
 public class SelectOption implements SerializableData
 {
+    /**
+     * The maximum length a select option label can have
+     */
+    public static final int LABEL_MAX_LENGTH = 25;
+
+    /**
+     * The maximum length a select option value can have
+     */
+    public static final int VALUE_MAX_LENGTH = 100;
+
+    /**
+     * The maximum length a select option description can have
+     */
+    public static final int DESCRIPTION_MAX_LENGTH = 50;
+
     private final String label, value;
     private final String description;
     private final boolean isDefault;
@@ -72,10 +87,10 @@ public class SelectOption implements SerializableData
     {
         Checks.notEmpty(label, "Label");
         Checks.notEmpty(value, "Value");
-        Checks.notLonger(label, 25, "Label");
-        Checks.notLonger(value, 100, "Value");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
+        Checks.notLonger(value, VALUE_MAX_LENGTH, "Value");
         if (description != null)
-            Checks.notLonger(description, 50, "Description");
+            Checks.notLonger(description, DESCRIPTION_MAX_LENGTH, "Description");
         this.label = label;
         this.value = value;
         this.description = description;


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].


### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->


## Description

Introduces public fields in SelectOption that contain the maximum length of Label, Value and Description. Identical to MessageEmbed, these fields can then be used by developers without having to update themselves when changes occur.