### PR TITLE
Bump selection option limits and extract max length values of SelectOption and Button

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -150,7 +150,7 @@ public class EmbedBuilder
     }
 
     /**
-     * Checks if the given embed is empty. Empty embeds will throw an exception if built
+     * Checks if the given embed is empty. Empty embeds will throw an exception if built.
      *
      * @return true if the embed is empty and cannot be built
      */
@@ -193,7 +193,7 @@ public class EmbedBuilder
      * Checks whether the constructed {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbed}
      * is within the limits for a bot account.
      *
-     * @return True, if the {@link #length() length} is less or equal to the specific limit
+     * @return True, if the {@link #length() length} is less or equal to {@value net.dv8tion.jda.api.entities.MessageEmbed#EMBED_MAX_LENGTH_BOT}
      *
      * @see    MessageEmbed#EMBED_MAX_LENGTH_BOT
      */
@@ -215,7 +215,8 @@ public class EmbedBuilder
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided {@code title} is an empty String.</li>
-     *             <li>If the length of {@code title} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code title}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH},
+     *             is exceeded.</li>
      *         </ul>
      *
      * @return the builder after the title has been set
@@ -240,8 +241,10 @@ public class EmbedBuilder
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If the provided {@code title} is an empty String.</li>
-     *             <li>If the length of {@code title} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH}.</li>
-     *             <li>If the length of {@code url} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code title}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
      *         </ul>
      *
@@ -291,7 +294,8 @@ public class EmbedBuilder
      *         the description of the embed, {@code null} to reset
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the length of {@code description} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH}
+     *         If {@code description} is longer than {@value net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH} characters,
+     *         as defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH}
      *
      * @return the builder after the description has been set
      */
@@ -314,8 +318,9 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the provided {@code description} String is null</li>
-     *             <li>If the length of {@code description} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH}.</li>
+     *             <li>If the provided {@code description} String is null.</li>
+     *             <li>If the character limit for {@code description}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#DESCRIPTION_MAX_LENGTH},
+     *             is exceeded.</li>
      *         </ul>
      *
      * @return the builder after the description has been set
@@ -390,7 +395,7 @@ public class EmbedBuilder
     /**
      * Sets the Color of the embed.
      *
-     * <a href="https://raw.githubusercontent.com/DV8FromTheWorld/JDA/assets/assets/docs/embeds/02-setColor.png" target="_blank">Example</a>
+     * <p><b><a href="https://raw.githubusercontent.com/DV8FromTheWorld/JDA/assets/assets/docs/embeds/02-setColor.png" target="_blank">Example</a></b>
      *
      * @param  color
      *         The {@link java.awt.Color Color} of the embed
@@ -410,7 +415,7 @@ public class EmbedBuilder
     /**
      * Sets the raw RGB color value for the embed.
      *
-     * <a href="https://raw.githubusercontent.com/DV8FromTheWorld/JDA/assets/assets/docs/embeds/02-setColor.png" target="_blank">Example</a>
+     * <p><b><a href="https://raw.githubusercontent.com/DV8FromTheWorld/JDA/assets/assets/docs/embeds/02-setColor.png" target="_blank">Example</a></b>
      *
      * @param  color
      *         The raw rgb value, or {@link Role#DEFAULT_COLOR_RAW} to use no color
@@ -451,7 +456,8 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code url} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
      *         </ul>
      *
@@ -497,7 +503,8 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code url} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
      *         </ul>
      *
@@ -531,7 +538,8 @@ public class EmbedBuilder
      *         the name of the author of the embed. If this is not set, the author will not appear in the embed
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the length of {@code name} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH}.
+     *         If {@code name} is longer than {@value net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH} characters,
+     *         as defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH}
      *
      * @return the builder after the author has been set
      */
@@ -555,8 +563,10 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code name} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH}.</li>
-     *             <li>If the length of {@code url} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code name}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
      *         </ul>
      *
@@ -598,10 +608,13 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code name} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH}.</li>
-     *             <li>If the length of {@code url} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code name}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#AUTHOR_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
-     *             <li>If the length of {@code iconUrl} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code iconUrl}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code iconUrl} is not a properly formatted http or https url.</li>
      *         </ul>
      *
@@ -635,7 +648,8 @@ public class EmbedBuilder
      *         the text of the footer of the embed. If this is not set or set to null, the footer will not appear in the embed.
      *
      * @throws java.lang.IllegalArgumentException
-     *         If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.
+     *         If {@code text} is longer than {@value net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH} characters,
+     *         as defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}
      *
      * @return the builder after the footer has been set
      */
@@ -672,8 +686,10 @@ public class EmbedBuilder
      *
      * @throws java.lang.IllegalArgumentException
      *         <ul>
-     *             <li>If the length of {@code text} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH}.</li>
-     *             <li>If the length of {@code iconUrl} is longer than {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code text}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#TEXT_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code iconUrl}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
      *             <li>If the provided {@code iconUrl} is not a properly formatted http or https url.</li>
      *         </ul>
      *
@@ -731,8 +747,10 @@ public class EmbedBuilder
      * @throws java.lang.IllegalArgumentException
      *         <ul>
      *             <li>If only {@code name} or {@code value} is set. Both must be set.</li>
-     *             <li>If the length of {@code name} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH}.</li>
-     *             <li>If the length of {@code value} is greater than {@link net.dv8tion.jda.api.entities.MessageEmbed#VALUE_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code name}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#TITLE_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code value}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#VALUE_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#VALUE_MAX_LENGTH},
+     *             is exceeded.</li>
      *         </ul>
      *
      * @return the builder after the field has been added

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -343,7 +343,7 @@ public class MessageEmbed implements SerializableData
     /**
      * The total amount of characters that is displayed when this embed is displayed by the Discord client.
      *
-     * <p>An Embed can only have, at max, {@value #EMBED_MAX_LENGTH_BOT} displayable text characters.
+     * <p>The total character limit is defined by {@link #EMBED_MAX_LENGTH_BOT} as {@value #EMBED_MAX_LENGTH_BOT}.
      *
      * @return A never-negative sum of all displayed text characters.
      */

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
@@ -188,7 +188,7 @@ public interface Button extends Component
      *         The label to use
      *
      * @throws IllegalArgumentException
-     *         If the label is not between 1-80 characters
+     *         If the label is null, empty, or longer than {@value #LABEL_MAX_LENGTH} characters
      *
      * @return New button with the changed label
      */
@@ -208,7 +208,7 @@ public interface Button extends Component
      *         The id to use
      *
      * @throws IllegalArgumentException
-     *         If the id is not between 1-100 characters
+     *         If the id is null, empty, or longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return New button with the changed id
      */
@@ -228,7 +228,7 @@ public interface Button extends Component
      *         The url to use
      *
      * @throws IllegalArgumentException
-     *         If the url is null, empty, or longer than 512 characters
+     *         If the url is null, empty, or longer than {@value #URL_MAX_LENGTH} characters
      *
      * @return New button with the changed url
      */
@@ -278,7 +278,7 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than 80 characters, or the id is longer than 100 characters
+     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -305,7 +305,7 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than 100 characters
+     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -329,7 +329,7 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than 80 characters, or the id is longer than 100 characters
+     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -356,7 +356,7 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than 100 characters
+     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -380,7 +380,7 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than 80 characters, or the id is longer than 100 characters
+     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -407,7 +407,7 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than 100 characters
+     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -431,7 +431,7 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than 80 characters, or the id is longer than 100 characters
+     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -458,7 +458,7 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than 100 characters
+     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -485,7 +485,7 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than 80 characters, or the url is longer than 512 characters
+     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the url is longer than {@value #URL_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -515,7 +515,7 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the url is longer than 512 characters
+     *         If any argument is empty or null or the url is longer than {@value #URL_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -543,7 +543,7 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than 80 characters, the id is longer than 100 characters, or the url is longer than 512 characters
+     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, the id is longer than {@value #ID_MAX_LENGTH} characters, or the url is longer than {@value #URL_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -576,7 +576,7 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the id is longer than 100 characters, or the url is longer than 512 characters
+     *         If any argument is empty or null, the id is longer than {@value #ID_MAX_LENGTH} characters, or the url is longer than {@value #URL_MAX_LENGTH} characters
      *
      * @return The button instance
      */
@@ -613,8 +613,8 @@ public interface Button extends Component
      *         If any of the following scenarios occurs:
      *         <ul>
      *             <li>The style is null</li>
-     *             <li>You provide a URL that is null, empty or longer than 512 characters, or you provide an ID that is null, empty or longer than 100 characters</li>
-     *             <li>The label is non-null and longer than 80 characters</li>
+     *             <li>You provide a URL that is null, empty or longer than {@value #URL_MAX_LENGTH} characters, or you provide an ID that is null, empty or longer than {@value #ID_MAX_LENGTH} characters</li>
+     *             <li>The label is non-null and longer than {@value #LABEL_MAX_LENGTH} characters</li>
      *             <li>The label is null/empty, and the emoji is also null</li>
      *         </ul>
      *

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
@@ -188,7 +188,11 @@ public interface Button extends Component
      *         The label to use
      *
      * @throws IllegalArgumentException
-     *         If the label is null, empty, or longer than {@value #LABEL_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If the provided {@code label} is null or empty.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return New button with the changed label
      */
@@ -208,7 +212,11 @@ public interface Button extends Component
      *         The id to use
      *
      * @throws IllegalArgumentException
-     *         If the id is null, empty, or longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If the provided {@code id} is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return New button with the changed id
      */
@@ -228,7 +236,11 @@ public interface Button extends Component
      *         The url to use
      *
      * @throws IllegalArgumentException
-     *         If the url is null, empty, or longer than {@value #URL_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If the provided {@code url} is null or empty.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link #URL_MAX_LENGTH} as {@value #URL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return New button with the changed url
      */
@@ -250,7 +262,10 @@ public interface Button extends Component
      *         The style to use
      *
      * @throws IllegalArgumentException
-     *         If the style is null or tries to change whether this button is a LINK button
+     *         <ul>
+     *             <li>If the provided {@code style} is null.</li>
+     *             <li>If the provided {@code style} tries to change whether this button is a {@link ButtonStyle#LINK LINK} button.</li>
+     *         </ul>
      *
      * @return New button with the changed style
      */
@@ -278,7 +293,13 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -305,7 +326,11 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -329,7 +354,13 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -356,7 +387,11 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -380,7 +415,13 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -407,7 +448,11 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -431,7 +476,13 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -458,7 +509,11 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the id is longer than {@value #ID_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code id}, defined by {@link #ID_MAX_LENGTH} as {@value #ID_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -485,7 +540,13 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, or the url is longer than {@value #URL_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link #URL_MAX_LENGTH} as {@value #URL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -515,7 +576,11 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null or the url is longer than {@value #URL_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the character limit for {@code url}, defined by {@link #URL_MAX_LENGTH} as {@value #URL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -543,7 +608,13 @@ public interface Button extends Component
      *         The text to display on the button
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the label is longer than {@value #LABEL_MAX_LENGTH} characters, the id is longer than {@value #ID_MAX_LENGTH} characters, or the url is longer than {@value #URL_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the id is longer than {@value #ID_MAX_LENGTH}, as defined by {@link #ID_MAX_LENGTH}.</li>
+     *             <li>If the url is longer than {@value #URL_MAX_LENGTH}, as defined by {@link #URL_MAX_LENGTH}.</li>
+     *             <li>If the character limit for {@code label}, defined by {@link #LABEL_MAX_LENGTH} as {@value #LABEL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -576,7 +647,11 @@ public interface Button extends Component
      *         The emoji to use as the button label
      *
      * @throws IllegalArgumentException
-     *         If any argument is empty or null, the id is longer than {@value #ID_MAX_LENGTH} characters, or the url is longer than {@value #URL_MAX_LENGTH} characters
+     *         <ul>
+     *             <li>If any provided argument is null or empty.</li>
+     *             <li>If the id is longer than {@value #ID_MAX_LENGTH}, as defined by {@link #ID_MAX_LENGTH}.</li>
+     *             <li>If the url is longer than {@value #URL_MAX_LENGTH}, as defined by {@link #URL_MAX_LENGTH}.</li>
+     *         </ul>
      *
      * @return The button instance
      */
@@ -613,9 +688,10 @@ public interface Button extends Component
      *         If any of the following scenarios occurs:
      *         <ul>
      *             <li>The style is null</li>
-     *             <li>You provide a URL that is null, empty or longer than {@value #URL_MAX_LENGTH} characters, or you provide an ID that is null, empty or longer than {@value #ID_MAX_LENGTH} characters</li>
-     *             <li>The label is non-null and longer than {@value #LABEL_MAX_LENGTH} characters</li>
-     *             <li>The label is null/empty, and the emoji is also null</li>
+     *             <li>You provide a URL that is null, empty or longer than {@value #URL_MAX_LENGTH} characters, as defined by {@link #URL_MAX_LENGTH}
+     *             or you provide an ID that is null, empty or longer than {@value #ID_MAX_LENGTH} characters, as defined by {@link #ID_MAX_LENGTH}.</li>
+     *             <li>The {@code label} is non-null and longer than {@value #LABEL_MAX_LENGTH} characters, as defined by {@link #LABEL_MAX_LENGTH}.</li>
+     *             <li>The {@code label} is null/empty, and the {@code emoji} is also null.</li>
      *         </ul>
      *
      * @return The button instance

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/Button.java
@@ -69,6 +69,21 @@ import javax.annotation.Nullable;
 public interface Button extends Component
 {
     /**
+     * The maximum length a button label can have
+     */
+    int LABEL_MAX_LENGTH = 80;
+
+    /**
+     * The maximum length a button id can have
+     */
+    int ID_MAX_LENGTH = 100;
+
+    /**
+     * The maximum length a button url can have
+     */
+    int URL_MAX_LENGTH = 512;
+
+    /**
      * The visible text on the button.
      *
      * @return The button label
@@ -182,7 +197,7 @@ public interface Button extends Component
     default Button withLabel(@Nonnull String label)
     {
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(getId(), label, getStyle(), getUrl(), isDisabled(), getEmoji());
     }
 
@@ -202,7 +217,7 @@ public interface Button extends Component
     default Button withId(@Nonnull String id)
     {
         Checks.notEmpty(id, "ID");
-        Checks.notLonger(id, 100, "ID");
+        Checks.notLonger(id, ID_MAX_LENGTH, "ID");
         return new ButtonImpl(id, getLabel(), getStyle(), null, isDisabled(), getEmoji());
     }
 
@@ -222,7 +237,7 @@ public interface Button extends Component
     default Button withUrl(@Nonnull String url)
     {
         Checks.notEmpty(url, "URL");
-        Checks.notLonger(url, 512, "URL");
+        Checks.notLonger(url, URL_MAX_LENGTH, "URL");
         return new ButtonImpl(null, getLabel(), ButtonStyle.LINK, url, isDisabled(), getEmoji());
     }
 
@@ -272,8 +287,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.PRIMARY, false, null);
     }
 
@@ -299,7 +314,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.PRIMARY, false, emoji);
     }
 
@@ -323,8 +338,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.SECONDARY, false, null);
     }
 
@@ -350,7 +365,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.SECONDARY, false, emoji);
     }
 
@@ -374,8 +389,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.SUCCESS, false, null);
     }
 
@@ -401,7 +416,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.SUCCESS, false, emoji);
     }
 
@@ -425,8 +440,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(id, 100, "Id");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(id, label, ButtonStyle.DANGER, false, null);
     }
 
@@ -452,7 +467,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(id, "Id");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(id, 100, "Id");
+        Checks.notLonger(id, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(id, "", ButtonStyle.DANGER, false, emoji);
     }
 
@@ -479,8 +494,8 @@ public interface Button extends Component
     {
         Checks.notEmpty(url, "URL");
         Checks.notEmpty(label, "Label");
-        Checks.notLonger(url, 512, "URL");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(url, URL_MAX_LENGTH, "URL");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         return new ButtonImpl(null, label, ButtonStyle.LINK, url, false, null);
     }
 
@@ -509,7 +524,7 @@ public interface Button extends Component
     {
         Checks.notEmpty(url, "URL");
         Checks.notNull(emoji, "Emoji");
-        Checks.notLonger(url, 512, "URL");
+        Checks.notLonger(url, URL_MAX_LENGTH, "URL");
         return new ButtonImpl(null, "", ButtonStyle.LINK, url, false, emoji);
     }
 
@@ -538,11 +553,11 @@ public interface Button extends Component
         Checks.check(style != ButtonStyle.UNKNOWN, "Cannot make button with unknown style!");
         Checks.notNull(style, "Style");
         Checks.notNull(label, "Label");
-        Checks.notLonger(label, 80, "Label");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
         if (style == ButtonStyle.LINK)
             return link(idOrUrl, label);
         Checks.notEmpty(idOrUrl, "Id");
-        Checks.notLonger(idOrUrl, 100, "Id");
+        Checks.notLonger(idOrUrl, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(idOrUrl, label, style, false, null);
     }
 
@@ -574,7 +589,7 @@ public interface Button extends Component
         if (style == ButtonStyle.LINK)
             return link(idOrUrl, emoji);
         Checks.notEmpty(idOrUrl, "Id");
-        Checks.notLonger(idOrUrl, 100, "Id");
+        Checks.notLonger(idOrUrl, ID_MAX_LENGTH, "Id");
         return new ButtonImpl(idOrUrl, "", style, false, emoji);
     }
 

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
@@ -30,6 +30,21 @@ import javax.annotation.Nullable;
  */
 public class SelectOption implements SerializableData
 {
+    /**
+     * The maximum length a select option label can have
+     */
+    public static final int LABEL_MAX_LENGTH = 25;
+
+    /**
+     * The maximum length a select option value can have
+     */
+    public static final int VALUE_MAX_LENGTH = 100;
+
+    /**
+     * The maximum length a select option description can have
+     */
+    public static final int DESCRIPTION_MAX_LENGTH = 50;
+
     private final String label, value;
     private final String description;
     private final boolean isDefault;
@@ -72,10 +87,10 @@ public class SelectOption implements SerializableData
     {
         Checks.notEmpty(label, "Label");
         Checks.notEmpty(value, "Value");
-        Checks.notLonger(label, 25, "Label");
-        Checks.notLonger(value, 100, "Value");
+        Checks.notLonger(label, LABEL_MAX_LENGTH, "Label");
+        Checks.notLonger(value, VALUE_MAX_LENGTH, "Value");
         if (description != null)
-            Checks.notLonger(description, 50, "Description");
+            Checks.notLonger(description, DESCRIPTION_MAX_LENGTH, "Description");
         this.label = label;
         this.value = value;
         this.description = description;

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
@@ -54,9 +54,10 @@ public class SelectOption implements SerializableData
      * Creates a new SelectOption instance
      *
      * @param  label
-     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters, as defined by {@link #LABEL_MAX_LENGTH}
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()},
+     *         up to {@value #VALUE_MAX_LENGTH} characters, as defined by {@link #VALUE_MAX_LENGTH}
      *
      * @throws IllegalArgumentException
      *         If the null is provided, or any of the individual parameter requirements are violated.
@@ -70,11 +71,12 @@ public class SelectOption implements SerializableData
      * Creates a new SelectOption instance
      *
      * @param  label
-     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters, as defined by {@link #LABEL_MAX_LENGTH}
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()},
+     *         up to {@value #VALUE_MAX_LENGTH} characters, as defined by {@link #VALUE_MAX_LENGTH}
      * @param  description
-     *         The description explaining the meaning of this option in more detail, up to {@value #DESCRIPTION_MAX_LENGTH} characters
+     *         The description explaining the meaning of this option in more detail, up to {@value #DESCRIPTION_MAX_LENGTH} characters, as defined by {@link #DESCRIPTION_MAX_LENGTH}
      * @param  isDefault
      *         Whether this option is selected by default
      * @param  emoji
@@ -103,9 +105,10 @@ public class SelectOption implements SerializableData
      * <br>You can further configure this with the various setters that return new instances.
      *
      * @param  label
-     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters, as defined by {@link #LABEL_MAX_LENGTH}
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()},
+     *         up to {@value #VALUE_MAX_LENGTH} characters, as defined by {@link #VALUE_MAX_LENGTH}
      *
      * @throws IllegalArgumentException
      *         If the null is provided, or any of the individual parameter requirements are violated.
@@ -123,7 +126,7 @@ public class SelectOption implements SerializableData
      * Returns a copy of this select option with the changed label.
      *
      * @param  label
-     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters, as defined by {@link #LABEL_MAX_LENGTH}
      *
      * @throws IllegalArgumentException
      *         If the label is null, empty, or longer than {@value #LABEL_MAX_LENGTH} characters
@@ -141,7 +144,8 @@ public class SelectOption implements SerializableData
      * Returns a copy of this select option with the changed value.
      *
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()},
+     *         up to {@value #VALUE_MAX_LENGTH} characters, as defined by {@link #VALUE_MAX_LENGTH}
      *
      * @throws IllegalArgumentException
      *         If the label is null, empty, or longer than {@value #VALUE_MAX_LENGTH} characters
@@ -160,7 +164,8 @@ public class SelectOption implements SerializableData
      * <br>Default: {@code null}
      *
      * @param  description
-     *         The new description or null to have no description, up to {@value #DESCRIPTION_MAX_LENGTH} characters
+     *         The new description or null to have no description,
+     *         up to {@value #DESCRIPTION_MAX_LENGTH} characters, as defined by {@link #DESCRIPTION_MAX_LENGTH}
      *
      * @throws IllegalArgumentException
      *         If the provided description is longer than {@value #DESCRIPTION_MAX_LENGTH} characters

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
@@ -54,9 +54,9 @@ public class SelectOption implements SerializableData
      * Creates a new SelectOption instance
      *
      * @param  label
-     *         The label for the option, up to 25 characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to 100 characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
      *
      * @throws IllegalArgumentException
      *         If the null is provided, or any of the individual parameter requirements are violated.
@@ -70,11 +70,11 @@ public class SelectOption implements SerializableData
      * Creates a new SelectOption instance
      *
      * @param  label
-     *         The label for the option, up to 25 characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to 100 characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
      * @param  description
-     *         The description explaining the meaning of this option in more detail, up to 50 characters
+     *         The description explaining the meaning of this option in more detail, up to {@value #DESCRIPTION_MAX_LENGTH} characters
      * @param  isDefault
      *         Whether this option is selected by default
      * @param  emoji
@@ -103,9 +103,9 @@ public class SelectOption implements SerializableData
      * <br>You can further configure this with the various setters that return new instances.
      *
      * @param  label
-     *         The label for the option, up to 25 characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to 100 characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
      *
      * @throws IllegalArgumentException
      *         If the null is provided, or any of the individual parameter requirements are violated.
@@ -123,10 +123,10 @@ public class SelectOption implements SerializableData
      * Returns a copy of this select option with the changed label.
      *
      * @param  label
-     *         The label for the option, up to 25 characters
+     *         The label for the option, up to {@value #LABEL_MAX_LENGTH} characters
      *
      * @throws IllegalArgumentException
-     *         If the label is null, empty, or longer than 25 characters
+     *         If the label is null, empty, or longer than {@value #LABEL_MAX_LENGTH} characters
      *
      * @return The new select option instance
      */
@@ -141,10 +141,10 @@ public class SelectOption implements SerializableData
      * Returns a copy of this select option with the changed value.
      *
      * @param  value
-     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to 100 characters
+     *         The value for the option used to indicate which option was selected with {@link SelectionMenuInteraction#getValues()}, up to {@value #VALUE_MAX_LENGTH} characters
      *
      * @throws IllegalArgumentException
-     *         If the label is null, empty, or longer than 100 characters
+     *         If the label is null, empty, or longer than {@value #VALUE_MAX_LENGTH} characters
      *
      * @return The new select option instance
      */
@@ -160,10 +160,10 @@ public class SelectOption implements SerializableData
      * <br>Default: {@code null}
      *
      * @param  description
-     *         The new description or null to have no description, up to 50 characters
+     *         The new description or null to have no description, up to {@value #DESCRIPTION_MAX_LENGTH} characters
      *
      * @throws IllegalArgumentException
-     *         If the provided description is longer than 50 characters
+     *         If the provided description is longer than {@value #DESCRIPTION_MAX_LENGTH} characters
      *
      * @return The new select option instance
      */

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectOption.java
@@ -33,7 +33,7 @@ public class SelectOption implements SerializableData
     /**
      * The maximum length a select option label can have
      */
-    public static final int LABEL_MAX_LENGTH = 25;
+    public static final int LABEL_MAX_LENGTH = 100;
 
     /**
      * The maximum length a select option value can have
@@ -43,7 +43,7 @@ public class SelectOption implements SerializableData
     /**
      * The maximum length a select option description can have
      */
-    public static final int DESCRIPTION_MAX_LENGTH = 50;
+    public static final int DESCRIPTION_MAX_LENGTH = 100;
 
     private final String label, value;
     private final String description;


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].


### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->


## Description

Introduces public fields in SelectOption that contain the maximum length of Label, Value and Description.
Introduces public fields in Button that contain the maximum length of Label, ID and URL.
Identical to MessageEmbed, these fields can then be used by developers without having to update themselves when changes occur.