### PR TITLE
Feature: Markdown escape all

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -266,7 +266,14 @@ public class MarkdownSanitizer
                         builder.append("\\`");
                         break;
                     case '|':
-                        builder.append("\\|");
+                        if(i+1 < sequence.length()){
+                            if(sequence.charAt(i+1) == '|'){
+                                builder.append("\\|\\|");
+                                i++;
+                                continue;
+                            }
+                        }
+                        builder.append("|");
                         break;
                     case '~':
                         builder.append("\\~");

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -189,6 +189,76 @@ public class MarkdownSanitizer
     }
 
     /**
+     * Escapes every single markdown formatting token found in the provided string.
+     * <br>Example: {@code escape("**Hello _World_", true)}
+     *
+     * @param sequence
+     *        The string to sanitize
+     * @param single
+     *        Whether it should scape single tokens or not.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If provided with null sequence
+     *
+     * @return The string with escaped markdown
+     */
+    @Nonnull
+    public static String escape(@Nonnull String sequence, boolean single)
+    {
+        Checks.notNull(sequence, "Input");
+        if(single)
+        {
+            StringBuilder builder = new StringBuilder();
+            boolean escaped = false;
+            for (int i = 0; i < sequence.length(); i++)
+            {
+                char current = sequence.charAt(i);
+                if(!escaped)
+                {
+                    switch (current)
+                    {
+                    case '*':
+                        builder.append("\\*");
+                        break;
+                    case '_':
+                        builder.append("\\_");
+                        break;
+                    case '`':
+                        builder.append("\\`");
+                        break;
+                    case '|':
+                        builder.append("\\|");
+                        break;
+                    case '~':
+                        builder.append("\\~");
+                        break;
+                    case '>':
+                        builder.append("\\>");
+                        break;
+                    case '\\':
+                        builder.append(current);
+                        escaped = true;
+                        break;
+                    default:
+                        builder.append(current);
+                    }
+                }
+                else
+                {
+                    builder.append(current);
+                    escaped = false;
+                }
+
+            }
+            return builder.toString();
+        }
+        else
+        {
+            return escape(sequence);
+        }
+    }
+
+    /**
      * Switches the used {@link net.dv8tion.jda.api.utils.MarkdownSanitizer.SanitizationStrategy}.
      *
      * @param  strategy

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -210,9 +210,48 @@ public class MarkdownSanitizer
         {
             StringBuilder builder = new StringBuilder();
             boolean escaped = false;
+            boolean newline = true;
             for (int i = 0; i < sequence.length(); i++)
             {
                 char current = sequence.charAt(i);
+                if(newline)
+                {
+                    if(current == '>')
+                    {
+                        if(i+1 < sequence.length())
+                        {
+                            if(sequence.charAt(i+1) == ' ')
+                            {
+                                builder.append("\\>");
+                            }
+                            else
+                            {
+                                if(i + 3 < sequence.length())
+                                {
+                                    if(sequence.startsWith(">>> ", i))
+                                    {
+                                        builder.append("\\>\\>\\> ");
+                                        i += 3;
+                                        newline = false;
+                                        continue;
+                                    }
+                                }
+                                builder.append(current);
+                            }
+                            newline = false;
+                            continue;
+                        }
+                        else
+                            escaped = true;
+                    }
+                    else if(current == ' ')
+                    {
+                        builder.append(current);
+                        continue;
+                    }
+                    newline=false;
+                }
+
                 if(!escaped)
                 {
                     switch (current)
@@ -232,12 +271,13 @@ public class MarkdownSanitizer
                     case '~':
                         builder.append("\\~");
                         break;
-                    case '>':
-                        builder.append("\\>");
-                        break;
                     case '\\':
                         builder.append(current);
                         escaped = true;
+                        break;
+                    case '\n':
+                        builder.append(current);
+                        newline = true;
                         break;
                     default:
                         builder.append(current);

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -434,8 +434,8 @@ class EscapeMarkdownAllTest
     @Test
     public void testPipe()
     {
-        Assertions.assertEquals("Hello\\|\\|World",MarkdownSanitizer.escape("Hello||World",true));
-        Assertions.assertEquals("Hello\\|World",MarkdownSanitizer.escape("Hello|World",true));
+        Assertions.assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello||World", true));
+        Assertions.assertEquals("Hello|World", MarkdownSanitizer.escape("Hello|World", true));
 
         Assertions.assertEquals("Hello\\|\\|World",MarkdownSanitizer.escape("Hello\\|\\|World",true));
         Assertions.assertEquals("Hello\\|World",MarkdownSanitizer.escape("Hello\\|World",true));

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -397,68 +397,67 @@ class EscapeMarkdownAllTest
     @Test
     public void testAsterisk()
     {
+        Assertions.assertEquals("Hello\\*World", MarkdownSanitizer.escape("Hello*World", true));
+        Assertions.assertEquals("Hello\\*\\*World", MarkdownSanitizer.escape("Hello**World", true));
+        Assertions.assertEquals("Hello\\*\\*\\*World", MarkdownSanitizer.escape("Hello***World", true));
 
-        Assertions.assertEquals("Hello\\*World",MarkdownSanitizer.escape("Hello*World",true));
-        Assertions.assertEquals("Hello\\*\\*World",MarkdownSanitizer.escape("Hello**World",true));
-        Assertions.assertEquals("Hello\\*\\*\\*World",MarkdownSanitizer.escape("Hello***World",true));
-
-        Assertions.assertEquals("Hello\\*World",MarkdownSanitizer.escape("Hello\\*World",true));
-        Assertions.assertEquals("Hello\\*\\*World",MarkdownSanitizer.escape("Hello\\*\\*World",true));
-        Assertions.assertEquals("Hello\\*\\*\\*World",MarkdownSanitizer.escape("Hello\\*\\*\\*World",true));
+        Assertions.assertEquals("Hello\\*World", MarkdownSanitizer.escape("Hello\\*World", true));
+        Assertions.assertEquals("Hello\\*\\*World", MarkdownSanitizer.escape("Hello\\*\\*World", true));
+        Assertions.assertEquals("Hello\\*\\*\\*World", MarkdownSanitizer.escape("Hello\\*\\*\\*World", true));
     }
 
     @Test
     public void testUnderscore()
     {
-        Assertions.assertEquals("Hello\\_World",MarkdownSanitizer.escape("Hello_World",true));
-        Assertions.assertEquals("Hello\\_\\_World",MarkdownSanitizer.escape("Hello__World",true));
-        Assertions.assertEquals("Hello\\_\\_\\_World",MarkdownSanitizer.escape("Hello___World",true));
+        Assertions.assertEquals("Hello\\_World", MarkdownSanitizer.escape("Hello_World", true));
+        Assertions.assertEquals("Hello\\_\\_World", MarkdownSanitizer.escape("Hello__World", true));
+        Assertions.assertEquals("Hello\\_\\_\\_World", MarkdownSanitizer.escape("Hello___World", true));
 
-        Assertions.assertEquals("Hello\\_World",MarkdownSanitizer.escape("Hello\\_World",true));
-        Assertions.assertEquals("Hello\\_\\_World",MarkdownSanitizer.escape("Hello\\_\\_World",true));
-        Assertions.assertEquals("Hello\\_\\_\\_World",MarkdownSanitizer.escape("Hello\\_\\_\\_World",true));
+        Assertions.assertEquals("Hello\\_World", MarkdownSanitizer.escape("Hello\\_World", true));
+        Assertions.assertEquals("Hello\\_\\_World", MarkdownSanitizer.escape("Hello\\_\\_World", true));
+        Assertions.assertEquals("Hello\\_\\_\\_World", MarkdownSanitizer.escape("Hello\\_\\_\\_World", true));
     }
 
     @Test
-    public void testBackQuote()
+    public void testCodeBlock()
     {
-        Assertions.assertEquals("Hello\\`World",MarkdownSanitizer.escape("Hello`World",true));
-        Assertions.assertEquals("Hello\\`\\`World",MarkdownSanitizer.escape("Hello``World",true));
-        Assertions.assertEquals("Hello\\`\\`\\`World",MarkdownSanitizer.escape("Hello```World",true));
+        Assertions.assertEquals("Hello\\`World", MarkdownSanitizer.escape("Hello`World", true));
+        Assertions.assertEquals("Hello\\`\\`World", MarkdownSanitizer.escape("Hello``World", true));
+        Assertions.assertEquals("Hello\\`\\`\\`World", MarkdownSanitizer.escape("Hello```World", true));
 
-        Assertions.assertEquals("Hello\\`World",MarkdownSanitizer.escape("Hello\\`World",true));
-        Assertions.assertEquals("Hello\\`\\`World",MarkdownSanitizer.escape("Hello\\`\\`World",true));
-        Assertions.assertEquals("Hello\\`\\`\\`World",MarkdownSanitizer.escape("Hello\\`\\`\\`World",true));
+        Assertions.assertEquals("Hello\\`World", MarkdownSanitizer.escape("Hello\\`World", true));
+        Assertions.assertEquals("Hello\\`\\`World", MarkdownSanitizer.escape("Hello\\`\\`World", true));
+        Assertions.assertEquals("Hello\\`\\`\\`World", MarkdownSanitizer.escape("Hello\\`\\`\\`World", true));
     }
 
     @Test
-    public void testPipe()
+    public void testSpoiler()
     {
         Assertions.assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello||World", true));
         Assertions.assertEquals("Hello|World", MarkdownSanitizer.escape("Hello|World", true));
 
-        Assertions.assertEquals("Hello\\|\\|World",MarkdownSanitizer.escape("Hello\\|\\|World",true));
-        Assertions.assertEquals("Hello\\|World",MarkdownSanitizer.escape("Hello\\|World",true));
+        Assertions.assertEquals("Hello\\|\\|World", MarkdownSanitizer.escape("Hello\\|\\|World", true));
+        Assertions.assertEquals("Hello\\|World", MarkdownSanitizer.escape("Hello\\|World", true));
     }
 
     @Test
-    public void testTilde()
+    public void testStrike()
     {
-        Assertions.assertEquals("Hello\\~\\~World",MarkdownSanitizer.escape("Hello~~World",true));
-
-        Assertions.assertEquals("Hello\\~\\~World",MarkdownSanitizer.escape("Hello\\~\\~World",true));
+        Assertions.assertEquals("Hello\\~\\~World", MarkdownSanitizer.escape("Hello~~World", true));
+        Assertions.assertEquals("Hello\\~\\~World", MarkdownSanitizer.escape("Hello\\~\\~World", true));
     }
 
     @Test
-    public void testAngle()
+    public void testQuote()
     {
-        Assertions.assertEquals("\\> Hello World",MarkdownSanitizer.escape("> Hello World",true));
-        Assertions.assertEquals(">Hello World",MarkdownSanitizer.escape(">Hello World",true));
-        Assertions.assertEquals("\\>\\>\\> Hello World",MarkdownSanitizer.escape(">>> Hello World",true));
-        Assertions.assertEquals(">>>Hello World",MarkdownSanitizer.escape(">>>Hello World",true));
-        Assertions.assertEquals("\\>\\>\\> Hello > World\n\\> Hello >>> World\n<@12345> > Hello\n \\> Hello world",MarkdownSanitizer.escape(">>> Hello > World\n> Hello >>> World\n<@12345> > Hello\n > Hello world",true));
+        Assertions.assertEquals("\\> Hello World", MarkdownSanitizer.escape("> Hello World", true));
+        Assertions.assertEquals(">Hello World", MarkdownSanitizer.escape(">Hello World", true));
+        Assertions.assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape(">>> Hello World", true));
+        Assertions.assertEquals(">>>Hello World", MarkdownSanitizer.escape(">>>Hello World", true));
+        Assertions.assertEquals("\\>\\>\\> Hello > World\n\\> Hello >>> World\n<@12345> > Hello\n \\> Hello world", MarkdownSanitizer.escape(">>> Hello > World\n> Hello >>> World\n<@12345> > Hello\n > Hello world", true));
 
-        Assertions.assertEquals("\\> Hello World",MarkdownSanitizer.escape("\\> Hello World",true));
-        Assertions.assertEquals("\\>\\>\\> Hello World",MarkdownSanitizer.escape("\\>\\>\\> Hello World",true));
+        Assertions.assertEquals("\\> Hello World", MarkdownSanitizer.escape("\\> Hello World", true));
+        Assertions.assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape("\\>\\>\\> Hello World", true));
+        Assertions.assertEquals("Hello > World", MarkdownSanitizer.escape("Hello > World"));
     }
 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -453,7 +453,10 @@ class EscapeMarkdownAllTest
     public void testAngle()
     {
         Assertions.assertEquals("\\> Hello World",MarkdownSanitizer.escape("> Hello World",true));
+        Assertions.assertEquals(">Hello World",MarkdownSanitizer.escape(">Hello World",true));
         Assertions.assertEquals("\\>\\>\\> Hello World",MarkdownSanitizer.escape(">>> Hello World",true));
+        Assertions.assertEquals(">>>Hello World",MarkdownSanitizer.escape(">>>Hello World",true));
+        Assertions.assertEquals("\\>\\>\\> Hello > World\n\\> Hello >>> World\n<@12345> > Hello\n \\> Hello world",MarkdownSanitizer.escape(">>> Hello > World\n> Hello >>> World\n<@12345> > Hello\n > Hello world",true));
 
         Assertions.assertEquals("\\> Hello World",MarkdownSanitizer.escape("\\> Hello World",true));
         Assertions.assertEquals("\\>\\>\\> Hello World",MarkdownSanitizer.escape("\\>\\>\\> Hello World",true));

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -391,3 +391,71 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\> \\_Hello \n\\> World\\_", markdown.compute("> _Hello \n> World_"));
     }
 }
+
+class EscapeMarkdownAllTest
+{
+    @Test
+    public void testAsterisk()
+    {
+
+        Assertions.assertEquals("Hello\\*World",MarkdownSanitizer.escape("Hello*World",true));
+        Assertions.assertEquals("Hello\\*\\*World",MarkdownSanitizer.escape("Hello**World",true));
+        Assertions.assertEquals("Hello\\*\\*\\*World",MarkdownSanitizer.escape("Hello***World",true));
+
+        Assertions.assertEquals("Hello\\*World",MarkdownSanitizer.escape("Hello\\*World",true));
+        Assertions.assertEquals("Hello\\*\\*World",MarkdownSanitizer.escape("Hello\\*\\*World",true));
+        Assertions.assertEquals("Hello\\*\\*\\*World",MarkdownSanitizer.escape("Hello\\*\\*\\*World",true));
+    }
+
+    @Test
+    public void testUnderscore()
+    {
+        Assertions.assertEquals("Hello\\_World",MarkdownSanitizer.escape("Hello_World",true));
+        Assertions.assertEquals("Hello\\_\\_World",MarkdownSanitizer.escape("Hello__World",true));
+        Assertions.assertEquals("Hello\\_\\_\\_World",MarkdownSanitizer.escape("Hello___World",true));
+
+        Assertions.assertEquals("Hello\\_World",MarkdownSanitizer.escape("Hello\\_World",true));
+        Assertions.assertEquals("Hello\\_\\_World",MarkdownSanitizer.escape("Hello\\_\\_World",true));
+        Assertions.assertEquals("Hello\\_\\_\\_World",MarkdownSanitizer.escape("Hello\\_\\_\\_World",true));
+    }
+
+    @Test
+    public void testBackQuote()
+    {
+        Assertions.assertEquals("Hello\\`World",MarkdownSanitizer.escape("Hello`World",true));
+        Assertions.assertEquals("Hello\\`\\`World",MarkdownSanitizer.escape("Hello``World",true));
+        Assertions.assertEquals("Hello\\`\\`\\`World",MarkdownSanitizer.escape("Hello```World",true));
+
+        Assertions.assertEquals("Hello\\`World",MarkdownSanitizer.escape("Hello\\`World",true));
+        Assertions.assertEquals("Hello\\`\\`World",MarkdownSanitizer.escape("Hello\\`\\`World",true));
+        Assertions.assertEquals("Hello\\`\\`\\`World",MarkdownSanitizer.escape("Hello\\`\\`\\`World",true));
+    }
+
+    @Test
+    public void testPipe()
+    {
+        Assertions.assertEquals("Hello\\|\\|World",MarkdownSanitizer.escape("Hello||World",true));
+        Assertions.assertEquals("Hello\\|World",MarkdownSanitizer.escape("Hello|World",true));
+
+        Assertions.assertEquals("Hello\\|\\|World",MarkdownSanitizer.escape("Hello\\|\\|World",true));
+        Assertions.assertEquals("Hello\\|World",MarkdownSanitizer.escape("Hello\\|World",true));
+    }
+
+    @Test
+    public void testTilde()
+    {
+        Assertions.assertEquals("Hello\\~\\~World",MarkdownSanitizer.escape("Hello~~World",true));
+
+        Assertions.assertEquals("Hello\\~\\~World",MarkdownSanitizer.escape("Hello\\~\\~World",true));
+    }
+
+    @Test
+    public void testAngle()
+    {
+        Assertions.assertEquals("\\> Hello World",MarkdownSanitizer.escape("> Hello World",true));
+        Assertions.assertEquals("\\>\\>\\> Hello World",MarkdownSanitizer.escape(">>> Hello World",true));
+
+        Assertions.assertEquals("\\> Hello World",MarkdownSanitizer.escape("\\> Hello World",true));
+        Assertions.assertEquals("\\>\\>\\> Hello World",MarkdownSanitizer.escape("\\>\\>\\> Hello World",true));
+    }
+}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1298

## Description

Added method to escape all markdown tokens in a given String, without checking for region ends, ignoring already escaped characters.

This pull request also contains tests for the described method.