### PR TITLE
Clarifies the use-case of GuildMessageEmbedEvent within the docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageEmbedEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/guild/GuildMessageEmbedEvent.java
@@ -23,9 +23,10 @@ import javax.annotation.Nonnull;
 import java.util.List;
 
 /**
- * Indicates that a Guild Message contains one or more {@link net.dv8tion.jda.api.entities.MessageEmbed Embeds}.
- * 
- * <p>Can be used to retrieve the affected TextChannel, the id of the affected Message and a list of MessageEmbeds.
+ * Indicates that a Message contains an {@link net.dv8tion.jda.api.entities.MessageEmbed Embed} in a {@link net.dv8tion.jda.api.entities.GuildChannel GuildChannel}.
+ * <br>Discord may need to do additional calculations and resizing tasks on messages that embed websites, thus they send the message only with content and link and use this update to add the missing embed later when the server finishes those calculations.
+ *
+ * <p>Can be used to retrieve MessageEmbeds from any guild message.
  *
  * <h2>Requirements</h2>
  *
@@ -35,7 +36,7 @@ public class GuildMessageEmbedEvent extends GenericGuildMessageEvent
 {
     private final List<MessageEmbed> embeds;
 
-    public GuildMessageEmbedEvent(@Nonnull JDA api, long responseNumber, long messageId, @Nonnull TextChannel channel, @Nonnull List<MessageEmbed> embeds)
+    public GuildMessageEmbedEvent(@Nonnull final JDA api, final long responseNumber, final long messageId, @Nonnull final TextChannel channel, @Nonnull final List<MessageEmbed> embeds)
     {
         super(api, responseNumber, messageId, channel);
         this.embeds = embeds;


### PR DESCRIPTION
## Pull Request Etiquette


- [X ] I have checked the PRs for upcoming features/bug fixes.
- [ X] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ X] Documentation
- [ ] Other: \_____

Closes Issue: 1712

## Description

Makes the docs of the GuildMessageEmbedEvent more clear of when the event actually triggers
