### PR TITLE
Fix for UNKNOWN_MESSAGE_TYPE

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
@@ -120,6 +120,12 @@ public enum MessageType
     APPLICATION_COMMAND(20, false),
 
     /**
+     * This message is the first message you see in a Thread
+     * <br> It only contains a {@link MessageReference MessageReference} that points to the message the thread is started from.
+     */
+    THREAD_STARTER_MESSAGE(21, false),
+
+    /**
      * Unknown MessageType.
      */
     UNKNOWN(-1);


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: 

Closes Issue: NaN

## Description


This commit adds the THREAD_STARTER_MESSAGE to the MessageType enum

See
```
java.lang.IllegalArgumentException: UNKNOWN_MESSAGE_TYPE
        at net.dv8tion.jda.internal.entities.EntityBuilder.createMessage(EntityBuilder.java:1289)
```

This error happens when retrieving the first message of a thread, because it doesn't recognize the MessageType it errors.