### PR TITLE
Add new message types for Threads

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageHistory.java
@@ -32,7 +32,9 @@ import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.JDALogger;
 import org.apache.commons.collections4.map.ListOrderedMap;
+import org.slf4j.Logger;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
@@ -55,6 +57,7 @@ import java.util.*;
 public class MessageHistory
 {
     protected final MessageChannel channel;
+    protected static final Logger LOG = JDALogger.getLog(MessageHistory.class);
 
     protected final ListOrderedMap<Long, Message> history = new ListOrderedMap<>();
 
@@ -196,7 +199,16 @@ public class MessageHistory
             DataArray historyJson = response.getArray();
 
             for (int i = 0; i < historyJson.length(); i++)
-                messages.add(builder.createMessage(historyJson.getObject(i), channel, false));
+            {
+                try
+                {
+                    messages.add(builder.createMessage(historyJson.getObject(i), channel, false));
+                }
+                catch (Exception e)
+                {
+                    LOG.warn("Encountered exception when retrieving messages ", e);
+                }
+            }
 
             messages.forEach(msg -> history.put(msg.getIdLong(), msg));
             return messages;
@@ -265,7 +277,16 @@ public class MessageHistory
             DataArray historyJson = response.getArray();
 
             for (int i = 0; i < historyJson.length(); i++)
-                messages.add(builder.createMessage(historyJson.getObject(i), channel, false));
+            {
+                try
+                {
+                    messages.add(builder.createMessage(historyJson.getObject(i), channel, false));
+                }
+                catch (Exception e)
+                {
+                    LOG.warn("Encountered exception when retrieving messages ", e);
+                }
+            }
 
             for (Iterator<Message> it = messages.descendingIterator(); it.hasNext();)
             {
@@ -581,7 +602,7 @@ public class MessageHistory
                     DataObject obj = array.getObject(i);
                     result.history.put(obj.getLong("id"), builder.createMessage(obj, channel, false));
                 }
-                catch (UncheckedIOException | NullPointerException e)
+                catch (Exception e)
                 {
                     LOG.warn("Encountered exception in MessagePagination", e);
                 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
@@ -135,6 +135,11 @@ public enum MessageType
     THREAD_STARTER_MESSAGE(21),
 
     /**
+     * The "Invite your friends" messages that are sent to guild owners in new servers.
+     */
+    GUILD_INVITE_REMINDER(22),
+
+    /**
      * Unknown MessageType.
      */
     UNKNOWN(-1);

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageType.java
@@ -30,11 +30,13 @@ public enum MessageType
 
     /**
      * Specialized messages used for Groups as a System-Message showing that a new User has been added to the Group.
+     * Also used in message threads to indicate a member has joined that thread.
      */
     RECIPIENT_ADD(1),
 
     /**
      * Specialized messages used for Groups as a System-Message showing that a new User has been removed from the Group.
+     * Also used in message threads to indicate a member has left that thread.
      */
     RECIPIENT_REMOVE(2),
 
@@ -45,6 +47,7 @@ public enum MessageType
 
     /**
      * Specialized message used for Groups as a System-Message showing that the name of the Group was changed.
+     * Also used in message threads to indicate the name of that thread has changed.
      */
     CHANNEL_NAME_CHANGE(4),
 
@@ -109,6 +112,12 @@ public enum MessageType
     GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING(17),
 
     /**
+     * This is sent to a TextChannel when a message thread is created if the message from which the thread was started is "old".
+     * The definition of "old" is loose, but is currently a very liberal definition.
+     */
+    THREAD_CREATED(18),
+
+    /**
      * Reply to another message. This usually comes with a {@link Message#getReferencedMessage() referenced message}.
      */
     INLINE_REPLY(19, false),
@@ -118,6 +127,12 @@ public enum MessageType
      * <br>Most commonly this type will appear as a {@link Message#getReferencedMessage() referenced message}.
      */
     APPLICATION_COMMAND(20, false),
+
+    /**
+     * A new message sent as the first message in threads that are started from an existing message in the parent channel.
+     * It only contains a message reference field that points to the message from which the thread was started.
+     */
+    THREAD_STARTER_MESSAGE(21),
 
     /**
      * Unknown MessageType.


### PR DESCRIPTION
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ 

Closes Issue: NaN

## Description

Adds the new message types for threads of THREAD_CREATED and THREAD_STARTER_MESSAGE, as well as documenting the old types that have been repurposed with the release of Threads.
