### PR TITLE
Fix exception handling for parsing errors

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/Response.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/Response.java
@@ -47,9 +47,9 @@ public class Response implements Closeable
     private boolean attemptedParsing = false;
     private Exception exception;
 
-    public Response(@Nullable final okhttp3.Response response, @Nonnull final Exception exception, @Nonnull final Set<String> cfRays)
+    public Response(@Nonnull final Exception exception, @Nonnull final Set<String> cfRays)
     {
-        this(response, response != null ? response.code() : ERROR_CODE, ERROR_MESSAGE, -1, cfRays);
+        this(null, ERROR_CODE, ERROR_MESSAGE, -1, cfRays);
         this.exception = exception;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -40,7 +40,6 @@ import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -244,7 +243,7 @@ public class Requester
         catch (UnknownHostException e)
         {
             LOG.error("DNS resolution failed: {}", e.getMessage());
-            apiRequest.handleResponse(new Response(lastResponse, e, rays));
+            apiRequest.handleResponse(new Response(e, rays));
             return null;
         }
         catch (IOException e)
@@ -252,13 +251,13 @@ public class Requester
             if (retryOnTimeout && !retried && isRetry(e))
                 return execute(apiRequest, true, handleOnRatelimit);
             LOG.error("There was an I/O error while executing a REST request: {}", e.getMessage());
-            apiRequest.handleResponse(new Response(lastResponse, e, rays));
+            apiRequest.handleResponse(new Response(e, rays));
             return null;
         }
         catch (Exception e)
         {
             LOG.error("There was an unexpected error while executing a REST request", e);
-            apiRequest.handleResponse(new Response(lastResponse, e, rays));
+            apiRequest.handleResponse(new Response(e, rays));
             return null;
         }
         finally


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This prevents bots from crashing when using `complete()` if the internal response parsing fails. The `Response` constructor was trying to re-read the body of the response because we pass in the same (already closed) response when handling exceptions thrown by `RestActionImpl#handleResponse`.

The stacktrace looks like this:

```
[15:46:09] [ERROR] Requester: There was an unexpected error while executing a REST request
java.lang.IllegalArgumentException: UNKNOWN_MESSAGE_TYPE
    at net.dv8tion.jda.internal.entities.EntityBuilder.createMessage(EntityBuilder.java:1234)
    at net.dv8tion.jda.api.entities.MessageChannel.lambda$retrieveMessageById$0(MessageChannel.java:896)
    at net.dv8tion.jda.internal.requests.RestActionImpl.handleSuccess(RestActionImpl.java:278)
    at net.dv8tion.jda.internal.requests.RestActionImpl.handleResponse(RestActionImpl.java:268)
    at net.dv8tion.jda.api.requests.Request.handleResponse(Request.java:259)
    at net.dv8tion.jda.internal.requests.Requester.execute(Requester.java:238)
    at net.dv8tion.jda.internal.requests.Requester.execute(Requester.java:142)
    at net.dv8tion.jda.internal.requests.Requester.execute(Requester.java:125)
    at net.dv8tion.jda.internal.requests.ratelimit.BotRateLimiter$Bucket.run(BotRateLimiter.java:478)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:834)
[15:46:09] [ERROR] RateLimiter: Encountered exception trying to execute request
java.lang.IllegalStateException: An error occurred while parsing the response for a RestAction
    at net.dv8tion.jda.api.requests.Response.<init>(Response.java:76)
    at net.dv8tion.jda.api.requests.Response.<init>(Response.java:52)
    at net.dv8tion.jda.internal.requests.Requester.execute(Requester.java:261)
    at net.dv8tion.jda.internal.requests.Requester.execute(Requester.java:142)
    at net.dv8tion.jda.internal.requests.Requester.execute(Requester.java:125)
    at net.dv8tion.jda.internal.requests.ratelimit.BotRateLimiter$Bucket.run(BotRateLimiter.java:478)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.io.IOException: closed
    at okio.RealBufferedSource$1.read(RealBufferedSource.java:443)
    at java.base/java.io.BufferedInputStream.fill(BufferedInputStream.java:252)
    at java.base/java.io.BufferedInputStream.read(BufferedInputStream.java:271)
    at java.base/java.util.zip.CheckedInputStream.read(CheckedInputStream.java:60)
    at java.base/java.util.zip.GZIPInputStream.readUByte(GZIPInputStream.java:267)
    at java.base/java.util.zip.GZIPInputStream.readUShort(GZIPInputStream.java:259)
    at java.base/java.util.zip.GZIPInputStream.readHeader(GZIPInputStream.java:165)
    at java.base/java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:80)
    at java.base/java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:92)
    at net.dv8tion.jda.internal.utils.IOUtil.getBody(IOUtil.java:243)
    at net.dv8tion.jda.api.requests.Response...
```

