### PR TITLE
Create ID alternatives to permission override methods in ChannelManager

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
@@ -236,8 +236,8 @@ public interface ChannelManager extends Manager<ChannelManager>
     }
 
     /**
-     * Adds an override for the specified role with the provided raw bitmasks as allowed and denied permissions. If the
-     * role already had an override on this channel it will be replaced instead.
+     * Adds an override for the specified role with the provided raw bitmasks as allowed and denied permissions.
+     * If the role already had an override on this channel it will be replaced instead.
      *
      * @param  roleId
      *         The ID of the role to set permissions for
@@ -260,8 +260,8 @@ public interface ChannelManager extends Manager<ChannelManager>
     ChannelManager putRolePermissionOverride(long roleId, long allow, long deny);
 
     /**
-     * Adds an override for the specified role with the provided permission sets as allowed and denied permissions. If
-     * the role already had an override on this channel it will be replaced instead.
+     * Adds an override for the specified role with the provided permission sets as allowed and denied permissions.
+     * If the role already had an override on this channel it will be replaced instead.
      *
      * @param  roleId
      *         The ID of the role to set permissions for
@@ -281,15 +281,16 @@ public interface ChannelManager extends Manager<ChannelManager>
      */
     @Nonnull
     @CheckReturnValue
-    default ChannelManager putRolePermissionOverride(long roleId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny) {
+    default ChannelManager putRolePermissionOverride(long roleId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
+    {
         long allowRaw = allow == null ? 0 : Permission.getRaw(allow);
         long denyRaw  = deny  == null ? 0 : Permission.getRaw(deny);
         return putRolePermissionOverride(roleId, allowRaw, denyRaw);
     }
 
     /**
-     * Adds an override for the specified member with the provided raw bitmasks as allowed and denied permissions. If the
-     * member already had an override on this channel it will be replaced instead.
+     * Adds an override for the specified member with the provided raw bitmasks as allowed and denied permissions.
+     * If the member already had an override on this channel it will be replaced instead.
      *
      * @param  memberId
      *         The ID of the member to set permissions for
@@ -312,8 +313,8 @@ public interface ChannelManager extends Manager<ChannelManager>
     ChannelManager putMemberPermissionOverride(long memberId, long allow, long deny);
 
     /**
-     * Adds an override for the specified member with the provided permission sets as allowed and denied permissions. If
-     * the member already had an override on this channel it will be replaced instead.
+     * Adds an override for the specified member with the provided permission sets as allowed and denied permissions.
+     * If the member already had an override on this channel it will be replaced instead.
      *
      * @param  memberId
      *         The ID of the member to set permissions for
@@ -333,7 +334,8 @@ public interface ChannelManager extends Manager<ChannelManager>
      */
     @Nonnull
     @CheckReturnValue
-    default ChannelManager putMemberPermissionOverride(long memberId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny) {
+    default ChannelManager putMemberPermissionOverride(long memberId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny)
+    {
         long allowRaw = allow == null ? 0 : Permission.getRaw(allow);
         long denyRaw  = deny  == null ? 0 : Permission.getRaw(deny);
         return putMemberPermissionOverride(memberId, allowRaw, denyRaw);

--- a/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
@@ -236,9 +236,113 @@ public interface ChannelManager extends Manager<ChannelManager>
     }
 
     /**
+     * Adds an override for the specified role with the provided raw bitmasks as allowed and denied permissions. If the
+     * role already had an override on this channel it will be replaced instead.
+     *
+     * @param  roleId
+     *         The ID of the role to set permissions for
+     * @param  allow
+     *         The bitmask to grant
+     * @param  deny
+     *         The bitmask to deny
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
+     *         in this channel, or tries to set permissions it does not have without having {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS} explicitly for this channel through an override.
+     *
+     * @return ChannelManager for chaining convenience
+     *
+     * @see    #putRolePermissionOverride(long, Collection, Collection)
+     * @see    net.dv8tion.jda.api.Permission#getRaw(Permission...) Permission.getRaw(Permission...)
+     */
+    @Nonnull
+    @CheckReturnValue
+    ChannelManager putRolePermissionOverride(long roleId, long allow, long deny);
+
+    /**
+     * Adds an override for the specified role with the provided permission sets as allowed and denied permissions. If
+     * the role already had an override on this channel it will be replaced instead.
+     *
+     * @param  roleId
+     *         The ID of the role to set permissions for
+     * @param  allow
+     *         The permissions to grant, or null
+     * @param  deny
+     *         The permissions to deny, or null
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
+     *         in this channel, or tries to set permissions it does not have without having {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS} explicitly for this channel through an override.
+     *
+     * @return ChannelManager for chaining convenience
+     *
+     * @see    #putRolePermissionOverride(long, long, long)
+     * @see    java.util.EnumSet EnumSet
+     */
+    @Nonnull
+    @CheckReturnValue
+    default ChannelManager putRolePermissionOverride(long roleId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny) {
+        long allowRaw = allow == null ? 0 : Permission.getRaw(allow);
+        long denyRaw  = deny  == null ? 0 : Permission.getRaw(deny);
+        return putRolePermissionOverride(roleId, allowRaw, denyRaw);
+    }
+
+    /**
+     * Adds an override for the specified member with the provided raw bitmasks as allowed and denied permissions. If the
+     * member already had an override on this channel it will be replaced instead.
+     *
+     * @param  memberId
+     *         The ID of the member to set permissions for
+     * @param  allow
+     *         The bitmask to grant
+     * @param  deny
+     *         The bitmask to deny
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
+     *         in this channel, or tries to set permissions it does not have without having {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS} explicitly for this channel through an override.
+     *
+     * @return ChannelManager for chaining convenience
+     *
+     * @see    #putMemberPermissionOverride(long, Collection, Collection)
+     * @see    net.dv8tion.jda.api.Permission#getRaw(Permission...) Permission.getRaw(Permission...)
+     */
+    @Nonnull
+    @CheckReturnValue
+    ChannelManager putMemberPermissionOverride(long memberId, long allow, long deny);
+
+    /**
+     * Adds an override for the specified member with the provided permission sets as allowed and denied permissions. If
+     * the member already had an override on this channel it will be replaced instead.
+     *
+     * @param  memberId
+     *         The ID of the member to set permissions for
+     * @param  allow
+     *         The permissions to grant, or null
+     * @param  deny
+     *         The permissions to deny, or null
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
+     *         in this channel, or tries to set permissions it does not have without having {@link Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS} explicitly for this channel through an override.
+     *
+     * @return ChannelManager for chaining convenience
+     *
+     * @see    #putMemberPermissionOverride(long, long, long)
+     * @see    java.util.EnumSet EnumSet
+     */
+    @Nonnull
+    @CheckReturnValue
+    default ChannelManager putMemberPermissionOverride(long memberId, @Nullable Collection<Permission> allow, @Nullable Collection<Permission> deny) {
+        long allowRaw = allow == null ? 0 : Permission.getRaw(allow);
+        long denyRaw  = deny  == null ? 0 : Permission.getRaw(deny);
+        return putMemberPermissionOverride(memberId, allowRaw, denyRaw);
+    }
+
+    /**
      * Removes the {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} for the specified
      * {@link net.dv8tion.jda.api.entities.IPermissionHolder IPermissionHolder}. If no override existed for this member
-     * this does nothing.
+     * or role, this does nothing.
      *
      * @param  permHolder
      *         The permission holder
@@ -254,6 +358,25 @@ public interface ChannelManager extends Manager<ChannelManager>
     @Nonnull
     @CheckReturnValue
     ChannelManager removePermissionOverride(@Nonnull IPermissionHolder permHolder);
+
+    /**
+     * Removes the {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverride} for the specified
+     * member or role ID. If no override existed for this member or role, this does nothing.
+     *
+     * @param  id
+     *         The ID of the permission holder
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided permission holder is {@code null}
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
+     *         in this channel
+     *
+     * @return ChannelManager for chaining convenience
+     */
+    @Nonnull
+    @CheckReturnValue
+    ChannelManager removePermissionOverride(long id);
 
     /**
      * Syncs all {@link net.dv8tion.jda.api.entities.PermissionOverride PermissionOverrides} of this GuildChannel with

--- a/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/ChannelManager.java
@@ -368,8 +368,6 @@ public interface ChannelManager extends Manager<ChannelManager>
      * @param  id
      *         The ID of the permission holder
      *
-     * @throws java.lang.IllegalArgumentException
-     *         If the provided permission holder is {@code null}
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_PERMISSIONS Permission.MANAGE_PERMISSIONS}
      *         in this channel


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

This provides ID-powered alternatives to `putPermissionOverride`/`removePermissionOverride` on `ChannelManager`. This allows for permissions to be safely modified on a channel without relying on an up-to-date cache.

Conspicuously missing is the ID-string equivalent to all of these methods, which I could add if needed but it doubles the number of new methods so I decided against it for now.

