### PR TITLE
Ensure permission in PermissionException is not null

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/exceptions/PermissionException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/PermissionException.java
@@ -16,6 +16,9 @@
 package net.dv8tion.jda.api.exceptions;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.internal.utils.Checks;
+
+import javax.annotation.Nonnull;
 
 /**
  * Indicates that the currently logged in account does not meet the specified {@link net.dv8tion.jda.api.Permission Permission}
@@ -42,7 +45,7 @@ public class PermissionException extends RuntimeException
      * @param permission
      *        The required {@link net.dv8tion.jda.api.Permission Permission}
      */
-    protected PermissionException(Permission permission)
+    protected PermissionException(@Nonnull Permission permission)
     {
         this(permission, "Cannot perform action due to a lack of Permission. Missing permission: " + permission.toString());
     }
@@ -55,9 +58,10 @@ public class PermissionException extends RuntimeException
      * @param reason
      *        The reason for this Exception
      */
-    protected PermissionException(Permission permission, String reason)
+    protected PermissionException(@Nonnull Permission permission, String reason)
     {
         super(reason);
+        Checks.notNull(permission, "permission");
         this.permission = permission;
     }
 
@@ -69,6 +73,7 @@ public class PermissionException extends RuntimeException
      *
      * @return The required {@link net.dv8tion.jda.api.Permission Permission}
      */
+    @Nonnull
     public Permission getPermission()
     {
         return permission;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

A null `Permission` is semantic nonsense: it is `Permission.UNKNOWN` but with extra steps (i.e. null checks). As such, it should not be allowed to propagate through a `PermissionException`. This PR enforces and encodes that.