### PR TITLE
Clarified VoiceChannelUpdateUserLimitEvent docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateUserLimitEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/channel/voice/update/VoiceChannelUpdateUserLimitEvent.java
@@ -39,7 +39,7 @@ public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateE
     /**
      * The old userlimit
      *
-     * @return The old userlimit
+     * @return The old userlimit, or 0 if there is no limit set.
      */
     public int getOldUserLimit()
     {
@@ -49,7 +49,7 @@ public class VoiceChannelUpdateUserLimitEvent extends GenericVoiceChannelUpdateE
     /**
      * The new userlimit
      *
-     * @return The new userlimit
+     * @return The new userlimit, or 0 if there is no limit set.
      */
     public int getNewUserLimit()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR clarifies some docs for voice update events (VoiceChannelUpdateUserLimitEvent). The docs were previously ambiguous as to what happens when no user limit is set. This has been corrected.
