### PR TITLE
Add JDA Version to Websocket errors

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -959,12 +959,13 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         catch (ParsingException ex)
         {
-            LOG.warn("Got an unexpected Json-parse error. Please redirect following message to the devs:\n\t{}\n\t{} -> {}",
-                ex.getMessage(), type, content, ex);
+            LOG.warn("Got an unexpected Json-parse error. Please redirect following message to the devs:\n\tJDA {}\n\t{}\n\t{} -> {}",
+                JDAInfo.VERSION, ex.getMessage(), type, content, ex);
         }
         catch (Exception ex)
         {
-            LOG.error("Got an unexpected error. Please redirect following message to the devs:\n\t{} -> {}", type, content, ex);
+            LOG.error("Got an unexpected error. Please redirect following message to the devs:\n\tJDA {}\n\t{} -> {}",
+                JDAInfo.VERSION, type, content, ex);
         }
 
         if (responseTotal % EventCache.TIMEOUT_AMOUNT == 0)

--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -959,12 +959,12 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
         }
         catch (ParsingException ex)
         {
-            LOG.warn("Got an unexpected Json-parse error. Please redirect following message to the devs:\n\tJDA {}\n\t{}\n\t{} -> {}",
+            LOG.warn("Got an unexpected Json-parse error. Please redirect the following message to the devs:\n\tJDA {}\n\t{}\n\t{} -> {}",
                 JDAInfo.VERSION, ex.getMessage(), type, content, ex);
         }
         catch (Exception ex)
         {
-            LOG.error("Got an unexpected error. Please redirect following message to the devs:\n\tJDA {}\n\t{} -> {}",
+            LOG.error("Got an unexpected error. Please redirect the following message to the devs:\n\tJDA {}\n\t{} -> {}",
                 JDAInfo.VERSION, type, content, ex);
         }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds the JDA version to the "Got an unexpected error. Please redirect following message to the devs:" message, which may now look like this:
```
[00:00:01 ERROR]: [net.dv8tion.jda.internal.requests.WebSocketClient] Got an unexpected error. Please redirect following message to the devs:
JDA 4.3.0_307
MESSAGE_CREATE -> // JSON stuff
// Exception
```
This is mainly to help people, most importantly maintainers, to easily find out what version is used and if the error is caused by an outdated version of JDA or if the issue persists in newer builds and is therefore something to fix or look into.
