### PR TITLE
Add missing getJDA() on Interaction

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/Interaction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/Interaction.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.api.interactions;
 
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
@@ -483,4 +484,13 @@ public interface Interaction extends ISnowflake
             return (PrivateChannel) channel;
         throw new IllegalStateException("Cannot convert channel of type " + getChannelType() + " to PrivateChannel");
     }
+
+    /**
+     * Returns the {@link net.dv8tion.jda.api.JDA JDA} instance of this interaction
+     *
+     * @return the corresponding JDA instance
+     */
+    @Nonnull
+    JDA getJDA();
+
 }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.internal.interactions;
 
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.InteractionHook;
@@ -24,6 +25,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyActionImpl;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -151,5 +153,12 @@ public class InteractionImpl implements Interaction
     public ReplyActionImpl deferReply()
     {
         return new ReplyActionImpl(this.hook);
+    }
+
+    @NotNull
+    @Override
+    public JDA getJDA()
+    {
+        return api;
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -25,7 +25,6 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyActionImpl;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -155,7 +154,7 @@ public class InteractionImpl implements Interaction
         return new ReplyActionImpl(this.hook);
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public JDA getJDA()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

Adds a missing `getJDA()` on Interaction.