### PR TITLE
Enable unmuting suppressed users

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1436,8 +1436,9 @@ public class GuildImpl implements Guild
         {
             if (voiceState.getChannel() == null)
                 throw new IllegalStateException("Can only mute members who are currently in a voice channel");
-            if (voiceState.isGuildMuted() == mute && !voiceState.isSuppressed())
-                return new CompletedRestAction<>(getJDA(), null);
+            if (voiceState.isGuildMuted() == mute)
+                if (mute || !voiceState.isSuppressed())
+                    return new CompletedRestAction<>(getJDA(), null);
         }
 
         DataObject body = DataObject.empty().put("mute", mute);

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1436,9 +1436,8 @@ public class GuildImpl implements Guild
         {
             if (voiceState.getChannel() == null)
                 throw new IllegalStateException("Can only mute members who are currently in a voice channel");
-            if (voiceState.isGuildMuted() == mute)
-                if (mute || !voiceState.isSuppressed())
-                    return new CompletedRestAction<>(getJDA(), null);
+            if (voiceState.isGuildMuted() == mute && (mute || !voiceState.isSuppressed()))
+                return new CompletedRestAction<>(getJDA(), null);
         }
 
         DataObject body = DataObject.empty().put("mute", mute);

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1436,7 +1436,7 @@ public class GuildImpl implements Guild
         {
             if (voiceState.getChannel() == null)
                 throw new IllegalStateException("Can only mute members who are currently in a voice channel");
-            if (voiceState.isGuildMuted() == mute)
+            if (voiceState.isGuildMuted() == mute && !voiceState.isSuppressed())
                 return new CompletedRestAction<>(getJDA(), null);
         }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1781

## Description

Discord handles unmuting suppressed users with no talk permissions by sending an API call that would otherwise unmute the member guild-wide. This check inside of the mute action prevents this:
```Java
if (voiceState.isGuildMuted() == mute)
    return new CompletedRestAction<>(getJDA(), null);
```
For my thought process debugging this, see: #1781