### PR TITLE
Fix SelectionMenu example having label and value switched in addOption

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
@@ -44,9 +44,9 @@ import java.util.stream.Collectors;
  *   SelectionMenu menu = SelectionMenu.create("menu:class")
  *     .setPlaceholder("Choose your class") // shows the placeholder indicating what this menu is for
  *     .setRequireRange(1, 1) // only one can be selected
- *     .addOption("mage-arcane", "Arcane Mage")
- *     .addOption("mage-fire", "Fire Mage")
- *     .addOption("mage-frost", "Frost Mage")
+ *     .addOption("Arcane Mage", "mage-arcane")
+ *     .addOption("Fire Mage", "mage-fire")
+ *     .addOption("Frost Mage", "mage-frost")
  *     .build();
  *
  *   event.reply("Please pick your class below")


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The example for the `SelectionMenu` had wrong `addOption` setups where the label and value were flipped.
