### PR TITLE
Add interaction related message flags

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2477,6 +2477,16 @@ public interface Message extends ISnowflake, Formattable
     EnumSet<MessageFlag> getFlags();
 
     /**
+     * Returns the raw message flags of this message
+     * 
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     * @return The raw message flags
+     * @see    #getFlags()
+     */
+    long getFlagsRaw();
+
+    /**
      * Whether this message is ephemeral.
      * <br>The message being ephemeral means it is only visible to the bot and the interacting user
      * <br>This is a shortcut method for checking if {@link #getFlags()} contains {@link MessageFlag#EPHEMERAL}

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1615,8 +1615,11 @@ public interface Message extends ISnowflake, Formattable
      *         does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in
      *         the channel.
      * @throws java.lang.IllegalStateException
-     *         If this Message was not sent by the currently logged in account and it was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
+     *         <ul>
+     *              <li>If this Message was not sent by the currently logged in account and it was <b>not</b> sent in a
+     *              {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
+     *              <li>If this Message is ephemeral</li>
+     *         </ul>
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *
@@ -1680,6 +1683,8 @@ public interface Message extends ISnowflake, Formattable
      *             <li>Missing {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}.
      *             <br>Required to actually pin the Message.</li>
      *         </ul>
+     * @throws IllegalStateException
+     *         If this Message is ephemeral
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -1719,6 +1724,8 @@ public interface Message extends ISnowflake, Formattable
      *             <li>Missing {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}.
      *             <br>Required to actually pin the Message.</li>
      *         </ul>
+     * @throws IllegalStateException
+     *         If this Message is ephemeral
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -1781,6 +1788,8 @@ public interface Message extends ISnowflake, Formattable
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} cannot be used in the current channel.
      *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
      *         </ul>
+     * @throws IllegalStateException
+     *         If this message is ephemeral
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -1850,6 +1859,8 @@ public interface Message extends ISnowflake, Formattable
      *         </ul>
      * @throws java.lang.IllegalArgumentException
      *         If the provided unicode emoji is null or empty.
+     * @throws IllegalStateException
+     *         If this Message is ephemeral
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -1888,8 +1899,11 @@ public interface Message extends ISnowflake, Formattable
      *         and the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
      *         in the channel.
      * @throws java.lang.IllegalStateException
-     *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *         <ul>
+     *             <li>If this message was <b>not</b> sent in a {@link net.dv8tion.jda.api.entities.Guild Guild}.</li>
+     *             <li>If this message is ephemeral</li>
+     *         </ul>
+     *         
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      */
@@ -1937,8 +1951,11 @@ public interface Message extends ISnowflake, Formattable
      * @throws IllegalArgumentException
      *         If provided with null
      * @throws java.lang.IllegalStateException
-     *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *         <ul>
+     *             <li>If this message was <b>not</b> sent in a {@link net.dv8tion.jda.api.entities.Guild Guild}.</li>
+     *             <li>If this message is ephemeral</li>
+     *         </ul>
+     *         
      *
      * @return {@link RestAction}
      *
@@ -1976,8 +1993,10 @@ public interface Message extends ISnowflake, Formattable
      * @throws IllegalArgumentException
      *         If provided with null
      * @throws java.lang.IllegalStateException
-     *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *         <ul>
+     *             <li>If this message was <b>not</b> sent in a {@link net.dv8tion.jda.api.entities.Guild Guild}.</li>
+     *             <li>If this message is ephemeral</li>
+     *         </ul>
      *
      * @return {@link RestAction}
      *
@@ -2027,6 +2046,8 @@ public interface Message extends ISnowflake, Formattable
      *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} cannot be used in the current channel.
      *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
      *         </ul>
+     * @throws IllegalStateException
+     *         If this is an ephemeral message
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      *
@@ -2086,9 +2107,13 @@ public interface Message extends ISnowflake, Formattable
      *             <li>If the provided user is null</li>
      *         </ul>
      * @throws java.lang.IllegalStateException
-     *         If this message was <b>not</b> sent in a
+     * <ul>
+     *     <li>If this message was <b>not</b> sent in a
      *         {@link net.dv8tion.jda.api.entities.Guild Guild}
-     *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
+     *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.</li>
+     *     <li>If this message is ephemeral</li>
+     * </ul>
+     *        
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      *
@@ -2146,6 +2171,8 @@ public interface Message extends ISnowflake, Formattable
      *         and the logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
      * @throws java.lang.IllegalArgumentException
      *         If the provided unicode emoji is null or empty.
+     * @throws IllegalStateException
+     *         If this is an ephemeral message
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      *
@@ -2206,9 +2233,14 @@ public interface Message extends ISnowflake, Formattable
      * @throws java.lang.IllegalArgumentException
      *         If the provided unicode emoji is null or empty or if the provided user is null.
      * @throws java.lang.IllegalStateException
-     *         If this message was <b>not</b> sent in a
-     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
-     *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.
+     *         If this message:
+     *         <ul>
+     *             <li>Was <b>not</b> sent in a
+     *                 {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *                 <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.</li>
+     *             <li>Is ephemeral</li>
+     *         </ul>
+     *         
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
      *
@@ -2250,7 +2282,8 @@ public interface Message extends ISnowflake, Formattable
      *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel.
      * @throws java.lang.IllegalArgumentException
      *         If the provided {@link net.dv8tion.jda.api.entities.Emote Emote} is null.
-     *
+     * @throws IllegalStateException
+     *         If this Message is ephemeral
      * @return The {@link net.dv8tion.jda.api.requests.restaction.pagination.ReactionPaginationAction ReactionPaginationAction} of the emote's users.
      *
      * @since  4.1.0
@@ -2293,7 +2326,8 @@ public interface Message extends ISnowflake, Formattable
      *         logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY} in the channel.
      * @throws java.lang.IllegalArgumentException
      *         If the provided unicode emoji is null or empty.
-     *
+     * @throws IllegalStateException
+     *         If this Message is ephemeral
      * @return The {@link net.dv8tion.jda.api.requests.restaction.pagination.ReactionPaginationAction ReactionPaginationAction} of the emoji's users.
      *
      * @since  4.1.0
@@ -2403,6 +2437,8 @@ public interface Message extends ISnowflake, Formattable
      * @throws net.dv8tion.jda.api.exceptions.PermissionException
      *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}
      *         and the message was not sent by the currently logged in account.
+     * @throws IllegalStateException 
+     *         If this Message is ephemeral
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: {@link java.lang.Void}
      * @see    #isSuppressedEmbeds()
      */
@@ -2438,7 +2474,10 @@ public interface Message extends ISnowflake, Formattable
      * @throws java.lang.UnsupportedOperationException
      *         If this is a system message
      * @throws IllegalStateException
-     *         If the channel is not a text or news channel. See {@link TextChannel#isNews()}.
+     *         <ul>
+     *             <li>If the channel is not a text or news channel. See {@link TextChannel#isNews()}.</li>
+     *             <li>If the message is ephemeral.</li>
+     *         </ul>
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
      *         If the currently logged in account does not have
      *         {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} in this channel

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2479,7 +2479,7 @@ public interface Message extends ISnowflake, Formattable
     /**
      * Whether this message is ephemeral
      * <br>The message being ephemeral means it is only visible to the bot and the interacting user
-     * <br>This is a shortcut method for checking is {@link #getFlags()} contains {@link MessageFlag#EPHEMERAL MessageFlag#EPHEMERAL}
+     * <br>This is a shortcut method for checking if {@link #getFlags()} contains {@link MessageFlag#EPHEMERAL}
      * 
      * @return Whether the message is ephemeral
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2477,6 +2477,15 @@ public interface Message extends ISnowflake, Formattable
     EnumSet<MessageFlag> getFlags();
 
     /**
+     * Whether this message is ephemeral
+     * <br>The message being ephemeral means it is only visible to the bot and the interacting user
+     * <br>This is a shortcut method for checking is {@link #getFlags()} contains {@link MessageFlag#EPHEMERAL MessageFlag#EPHEMERAL}
+     * 
+     * @return Whether the message is ephemeral
+     */
+    boolean isEphemeral();
+
+    /**
      * This specifies the {@link net.dv8tion.jda.api.entities.MessageType MessageType} of this Message.
      *
      * <p>Messages can represent more than just simple text sent by Users, they can also be special messages that
@@ -2583,7 +2592,16 @@ public interface Message extends ISnowflake, Formattable
         /**
          * Indicates, that this Message came from the urgent message system
          */
-        URGENT(4);
+        URGENT(4),
+        /**
+         * Indicates, that this Message is ephemeral, the Message is only visible to the bot and the interacting user
+         * @see Message#isEphemeral
+         */
+        EPHEMERAL(6),
+        /**
+         * Indicates, that this Message is an interaction response and the bot is "thinking"
+         */
+        LOADING(7);
 
         private final int value;
 

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2481,6 +2481,8 @@ public interface Message extends ISnowflake, Formattable
      * <br>The message being ephemeral means it is only visible to the bot and the interacting user
      * <br>This is a shortcut method for checking if {@link #getFlags()} contains {@link MessageFlag#EPHEMERAL}
      * 
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
      * @return Whether the message is ephemeral
      */
     boolean isEphemeral();

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2477,7 +2477,7 @@ public interface Message extends ISnowflake, Formattable
     EnumSet<MessageFlag> getFlags();
 
     /**
-     * Whether this message is ephemeral
+     * Whether this message is ephemeral.
      * <br>The message being ephemeral means it is only visible to the bot and the interacting user
      * <br>This is a shortcut method for checking if {@link #getFlags()} contains {@link MessageFlag#EPHEMERAL}
      * 

--- a/src/main/java/net/dv8tion/jda/api/events/interaction/GenericComponentInteractionCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/interaction/GenericComponentInteractionCreateEvent.java
@@ -72,7 +72,7 @@ public class GenericComponentInteractionCreateEvent extends GenericInteractionCr
         return interaction.getComponent();
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public Message getMessage()
     {

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/ButtonInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/ButtonInteraction.java
@@ -53,7 +53,6 @@ public interface ButtonInteraction extends ComponentInteraction
 
     /**
      * Update the button with a new button instance.
-     * <br>This only works for non-ephemeral messages where {@link #getMessage()} is available!
      *
      * <p>If this interaction is already acknowledged this will use {@link #getHook()}
      * and otherwise {@link #editComponents(Collection)} directly to acknowledge the interaction.
@@ -71,8 +70,6 @@ public interface ButtonInteraction extends ComponentInteraction
     default RestAction<Void> editButton(@Nullable Button newButton)
     {
         Message message = getMessage();
-        if (message == null)
-            throw new IllegalStateException("Cannot update button for ephemeral messages! Discord does not provide enough information to perform the update.");
         List<ActionRow> components = new ArrayList<>(message.getActionRows());
         ComponentLayout.updateComponent(components, getComponentId(), newButton);
 

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/ComponentInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/ComponentInteraction.java
@@ -62,11 +62,10 @@ public interface ComponentInteraction extends Interaction
 
     /**
      * The {@link Message} instance.
-     * <br>This is null on interactions for ephemeral messages.
      *
-     * @return The {@link Message}, or null if this message is ephemeral
+     * @return The {@link Message}
      */
-    @Nullable
+    @Nonnull
     Message getMessage();
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenuInteraction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenuInteraction.java
@@ -85,7 +85,6 @@ public interface SelectionMenuInteraction extends ComponentInteraction
 
     /**
      * Update the selection menu with a new selection menu instance.
-     * <br>This only works for non-ephemeral messages where {@link #getMessage()} is available!
      *
      * <p>If this interaction is already acknowledged this will use {@link #getHook()}
      * and otherwise {@link #editComponents(Collection)} directly to acknowledge the interaction.
@@ -106,8 +105,6 @@ public interface SelectionMenuInteraction extends ComponentInteraction
     default RestAction<Void> editSelectionMenu(@Nullable SelectionMenu newMenu)
     {
         Message message = getMessage();
-        if (message == null)
-            throw new IllegalStateException("Cannot update selection menu for ephemeral messages! Discord does not provide enough information to perform the update.");
         List<ActionRow> components = new ArrayList<>(message.getActionRows());
         ComponentLayout.updateComponent(components, getComponentId(), newMenu);
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -598,6 +598,13 @@ public abstract class AbstractMessage implements Message
     }
 
     @Override
+    public long getFlagsRaw()
+    {
+        unsupported();
+        return 0;
+    }
+
+    @Override
     public boolean isEphemeral()
     {
         unsupported();

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -597,6 +597,13 @@ public abstract class AbstractMessage implements Message
         return null;
     }
 
+    @Override
+    public boolean isEphemeral()
+    {
+        unsupported();
+        return false;
+    }
+
     @Nonnull
     @Override
     public MessageType getType()

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -191,7 +191,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> addReaction(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot react on ephemeral messages.");
+            throw new IllegalStateException("Cannot add reactions to ephemeral messages.");
         
         return channel.addReactionById(getId(), unicode);
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -345,9 +345,6 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public String getJumpUrl()
     {
-        if (isEphemeral())
-            throw new IllegalStateException("Cannot get the jump URL from ephemeral messages.");
-        
         return String.format("https://discord.com/channels/%s/%s/%s", isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getId());
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -169,7 +169,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> addReaction(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot add reactions for ephemeral messages.");
+            throw new IllegalStateException("Cannot add reactions to ephemeral messages.");
         
         Checks.notNull(emote, "Emote");
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -201,7 +201,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> clearReactions()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot clear reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot clear reactions from ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId());
@@ -212,7 +212,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> clearReactions(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot clear reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot clear reactions from ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
@@ -223,7 +223,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot clear reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot clear reactions from ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
@@ -234,7 +234,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot remove reactions from ephemeral messages.");
         
         return channel.removeReactionById(getId(), emote);
     }
@@ -245,7 +245,7 @@ public class ReceivedMessage extends AbstractMessage
     {
         Checks.notNull(user, "User");  // to prevent NPEs
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot remove reactions from ephemeral messages.");
         // check if the passed user is the SelfUser, then the ChannelType doesn't matter and
         // we can safely remove that
         if (user.equals(getJDA().getSelfUser()))
@@ -261,7 +261,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot remove reactions from ephemeral messages.");
         
         return channel.removeReactionById(getId(), unicode);
     }
@@ -275,7 +275,7 @@ public class ReceivedMessage extends AbstractMessage
             return channel.removeReactionById(getIdLong(), unicode);
 
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
+            throw new IllegalStateException("Cannot remove reactions from ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
@@ -939,7 +939,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Message> crosspost()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot suppress embeds on ephemeral messages.");
+            throw new IllegalStateException("Cannot crosspost ephemeral messages.");
         
         if (getFlags().contains(MessageFlag.CROSSPOSTED))
             return new CompletedRestAction<>(getJDA(), this);

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -967,6 +967,12 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
+    public long getFlagsRaw()
+    {
+        return flags;
+    }
+
+    @Override
     public boolean isEphemeral()
     {
         return (this.flags & MessageFlag.EPHEMERAL.getValue()) != 0;

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -919,6 +919,12 @@ public class ReceivedMessage extends AbstractMessage
     }
 
     @Override
+    public boolean isEphemeral()
+    {
+        return (this.flags & MessageFlag.EPHEMERAL.getValue()) > 0;
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (o == this)

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -148,6 +148,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> pin()
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot pin this message as it is ephemeral.");
+        
         return channel.pinMessageById(getId());
     }
 
@@ -155,6 +158,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> unpin()
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot unpin this message as it is ephemeral.");
+        
         return channel.unpinMessageById(getId());
     }
 
@@ -162,6 +168,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> addReaction(@Nonnull Emote emote)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot add reactions on this message as it is ephemeral.");
+        
         Checks.notNull(emote, "Emote");
 
         boolean missingReaction = reactions.stream()
@@ -181,6 +190,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> addReaction(@Nonnull String unicode)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot react on this message as it is ephemeral.");
+        
         return channel.addReactionById(getId(), unicode);
     }
 
@@ -188,6 +200,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions()
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot clear reactions on this message as it is ephemeral.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId());
@@ -197,6 +211,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull String unicode)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot clear reactions on this message as it is ephemeral.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
@@ -206,6 +222,8 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot clear reactions on this message as it is ephemeral.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
@@ -215,6 +233,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull Emote emote)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+        
         return channel.removeReactionById(getId(), emote);
     }
 
@@ -223,6 +244,10 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
     {
         Checks.notNull(user, "User");  // to prevent NPEs
+
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+        
         // check if the passed user is the SelfUser, then the ChannelType doesn't matter and
         // we can safely remove that
         if (user.equals(getJDA().getSelfUser()))
@@ -237,6 +262,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Void> removeReaction(@Nonnull String unicode)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+        
         return channel.removeReactionById(getId(), unicode);
     }
 
@@ -248,6 +276,8 @@ public class ReceivedMessage extends AbstractMessage
         if (user.equals(getJDA().getSelfUser()))
             return channel.removeReactionById(getIdLong(), unicode);
 
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
@@ -257,6 +287,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public ReactionPaginationAction retrieveReactionUsers(@Nonnull Emote emote)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot retrieve reactions on this message as it is ephemeral.");
+        
         return channel.retrieveReactionUsersById(id, emote);
     }
 
@@ -264,6 +297,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public ReactionPaginationAction retrieveReactionUsers(@Nonnull String unicode)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot retrieve reactions on this message as it is ephemeral.");
+        
         return channel.retrieveReactionUsersById(id, unicode);
     }
 
@@ -311,6 +347,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public String getJumpUrl()
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot get the jump URL on this message as it is ephemeral.");
+        
         return String.format("https://discord.com/channels/%s/%s/%s", isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getId());
     }
 
@@ -856,6 +895,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public AuditableRestAction<Void> delete()
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot delete this message as it is ephemeral.");
+        
         if (!getJDA().getSelfUser().equals(getAuthor()))
         {
             if (isFromType(ChannelType.PRIVATE))
@@ -873,6 +915,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public AuditableRestAction<Void> suppressEmbeds(boolean suppressed)
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot suppress embeds on this message as it is ephemeral.");
+        
         if (!getJDA().getSelfUser().equals(getAuthor()))
         {
             if (isFromType(ChannelType.PRIVATE))
@@ -895,6 +940,9 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public RestAction<Message> crosspost()
     {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot suppress embeds on this message as it is ephemeral.");
+        
         if (getFlags().contains(MessageFlag.CROSSPOSTED))
             return new CompletedRestAction<>(getJDA(), this);
         TextChannel textChannel = getTextChannel();

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -921,7 +921,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public boolean isEphemeral()
     {
-        return (this.flags & MessageFlag.EPHEMERAL.getValue()) > 0;
+        return (this.flags & MessageFlag.EPHEMERAL.getValue()) != 0;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -244,10 +244,8 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull Emote emote, @Nonnull User user)
     {
         Checks.notNull(user, "User");  // to prevent NPEs
-
         if (isEphemeral())
             throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
-        
         // check if the passed user is the SelfUser, then the ChannelType doesn't matter and
         // we can safely remove that
         if (user.equals(getJDA().getSelfUser()))

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -149,7 +149,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> pin()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot pin this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot pin ephemeral messages.");
         
         return channel.pinMessageById(getId());
     }
@@ -159,7 +159,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> unpin()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot unpin this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot unpin ephemeral messages.");
         
         return channel.unpinMessageById(getId());
     }
@@ -169,7 +169,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> addReaction(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot add reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot add reactions for ephemeral messages.");
         
         Checks.notNull(emote, "Emote");
 
@@ -191,7 +191,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> addReaction(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot react on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot react on ephemeral messages.");
         
         return channel.addReactionById(getId(), unicode);
     }
@@ -201,7 +201,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> clearReactions()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot clear reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot clear reactions on ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId());
@@ -212,7 +212,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> clearReactions(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot clear reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot clear reactions on ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), unicode);
@@ -223,7 +223,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot clear reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot clear reactions on ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
@@ -234,7 +234,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
         
         return channel.removeReactionById(getId(), emote);
     }
@@ -246,7 +246,7 @@ public class ReceivedMessage extends AbstractMessage
         Checks.notNull(user, "User");  // to prevent NPEs
 
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
         
         // check if the passed user is the SelfUser, then the ChannelType doesn't matter and
         // we can safely remove that
@@ -263,7 +263,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Void> removeReaction(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
         
         return channel.removeReactionById(getId(), unicode);
     }
@@ -277,7 +277,7 @@ public class ReceivedMessage extends AbstractMessage
             return channel.removeReactionById(getIdLong(), unicode);
 
         if (isEphemeral())
-            throw new IllegalStateException("Cannot remove reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot remove reactions on ephemeral messages.");
         if (!isFromGuild())
             throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
@@ -288,7 +288,7 @@ public class ReceivedMessage extends AbstractMessage
     public ReactionPaginationAction retrieveReactionUsers(@Nonnull Emote emote)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot retrieve reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot retrieve reactions on ephemeral messages.");
         
         return channel.retrieveReactionUsersById(id, emote);
     }
@@ -298,7 +298,7 @@ public class ReceivedMessage extends AbstractMessage
     public ReactionPaginationAction retrieveReactionUsers(@Nonnull String unicode)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot retrieve reactions on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot retrieve reactions on ephemeral messages.");
         
         return channel.retrieveReactionUsersById(id, unicode);
     }
@@ -348,7 +348,7 @@ public class ReceivedMessage extends AbstractMessage
     public String getJumpUrl()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot get the jump URL on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot get the jump URL from ephemeral messages.");
         
         return String.format("https://discord.com/channels/%s/%s/%s", isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getId());
     }
@@ -896,7 +896,7 @@ public class ReceivedMessage extends AbstractMessage
     public AuditableRestAction<Void> delete()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot delete this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot delete ephemeral messages.");
         
         if (!getJDA().getSelfUser().equals(getAuthor()))
         {
@@ -916,7 +916,7 @@ public class ReceivedMessage extends AbstractMessage
     public AuditableRestAction<Void> suppressEmbeds(boolean suppressed)
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot suppress embeds on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot suppress embeds on ephemeral messages.");
         
         if (!getJDA().getSelfUser().equals(getAuthor()))
         {
@@ -941,7 +941,7 @@ public class ReceivedMessage extends AbstractMessage
     public RestAction<Message> crosspost()
     {
         if (isEphemeral())
-            throw new IllegalStateException("Cannot suppress embeds on this message as it is ephemeral.");
+            throw new IllegalStateException("Cannot suppress embeds on ephemeral messages.");
         
         if (getFlags().contains(MessageFlag.CROSSPOSTED))
             return new CompletedRestAction<>(getJDA(), this);

--- a/src/main/java/net/dv8tion/jda/internal/interactions/ComponentInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/ComponentInteractionImpl.java
@@ -24,7 +24,6 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.requests.restaction.interactions.UpdateInteractionActionImpl;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public abstract class ComponentInteractionImpl extends InteractionImpl implements ComponentInteraction
 {
@@ -58,7 +57,7 @@ public abstract class ComponentInteractionImpl extends InteractionImpl implement
         return customId;
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public Message getMessage()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds the EPHEMERAL and LOADING message flags, the ephemeral flag is particularly useful as you can't determine if a message is ephemeral by checking if `GenericComponentInteractionEvent#getMessage` is `null`

Also fixes docs for ComponentInteraction#getMessage and enables `editButton` and `editSelectionMenu` methods
