### PR TITLE
Change choice name length check to 100 instead of 32

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -51,7 +51,7 @@ public class OptionData implements SerializableData
     /**
      * The maximum length of the name of some OptionData names
      */
-    public static final int MAX_NAME_OPTION_LENGTH = 100;
+    public static final int MAX_CHOICE_NAME_LENGTH = 100;
 
     /**
      * The maximum length the description of an option can be.
@@ -292,7 +292,7 @@ public class OptionData implements SerializableData
     public OptionData addChoice(@Nonnull String name, double value)
     {
         Checks.notEmpty(name, "Name");
-        Checks.notLonger(name, MAX_NAME_OPTION_LENGTH, "Name");
+        Checks.notLonger(name, MAX_CHOICE_NAME_LENGTH, "Name");
         Checks.check(value >= MIN_NEGATIVE_NUMBER, "Double value may not be lower than %f", MIN_NEGATIVE_NUMBER);
         Checks.check(value <= MAX_POSITIVE_NUMBER, "Double value may not be larger than %f", MAX_POSITIVE_NUMBER);
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
@@ -325,7 +325,7 @@ public class OptionData implements SerializableData
     public OptionData addChoice(@Nonnull String name, int value)
     {
         Checks.notEmpty(name, "Name");
-        Checks.notLonger(name, MAX_NAME_OPTION_LENGTH, "Name");
+        Checks.notLonger(name, MAX_CHOICE_NAME_LENGTH, "Name");
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
         if (type != OptionType.INTEGER)
             throw new IllegalArgumentException("Cannot add int choice for OptionType." + type);
@@ -358,7 +358,7 @@ public class OptionData implements SerializableData
     {
         Checks.notEmpty(name, "Name");
         Checks.notEmpty(value, "Value");
-        Checks.notLonger(name, MAX_NAME_OPTION_LENGTH, "Name");
+        Checks.notLonger(name, MAX_CHOICE_NAME_LENGTH, "Name");
         Checks.notLonger(value, MAX_CHOICE_VALUE_LENGTH, "Value");
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
         if (type != OptionType.STRING)

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -272,15 +272,15 @@ public class OptionData implements SerializableData
      * <br>The user can only provide one of the choices and cannot specify any other value.
      * 
      * @param  name
-     *         The name used in the client, up to {@value #MAX_NAME_LENGTH} characters long, as defined by
-     *         {@link #MAX_NAME_LENGTH}
+     *         The name used in the client, up to {@value #MAX_CHOICE_NAME_LENGTH} characters long, as defined by
+     *         {@link #MAX_CHOICE_NAME_LENGTH}
      * @param  value
      *         The value received in {@link net.dv8tion.jda.api.interactions.commands.OptionMapping OptionMapping}
      * 
      * @throws IllegalArgumentException
      *         If any of the following checks fail
      *         <ul>
-     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_NAME_LENGTH} characters long</li>
+     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_CHOICE_NAME_LENGTH} characters long</li>
      *             <li>{@code value} is not less than {@link #MIN_NEGATIVE_NUMBER} and not larger than {@link #MAX_POSITIVE_NUMBER}</li>
      *             <li>The amount of already set choices is less than {@link #MAX_CHOICES}</li>
      *             <li>The {@link OptionType} is {@link OptionType#NUMBER}</li>
@@ -314,7 +314,7 @@ public class OptionData implements SerializableData
      * @throws IllegalArgumentException
      *         If any of the following checks fail
      *         <ul>
-     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_NAME_LENGTH} characters long</li>
+     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_CHOICE_NAME_LENGTH} characters long</li>
      *             <li>The amount of already set choices is less than {@link #MAX_CHOICES}</li>
      *             <li>The {@link OptionType} is {@link OptionType#INTEGER}</li>
      *         </ul>
@@ -345,7 +345,7 @@ public class OptionData implements SerializableData
      * @throws IllegalArgumentException
      *         If any of the following checks fail
      *         <ul>
-     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_NAME_LENGTH} characters long</li>
+     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_CHOICE_NAME_LENGTH} characters long</li>
      *             <li>{@code value} is not null, empty and less or equal to {@value #MAX_CHOICE_VALUE_LENGTH} characters long</li>
      *             <li>The amount of already set choices is less than {@link #MAX_CHOICES}</li>
      *             <li>The {@link OptionType} is {@link OptionType#STRING}</li>

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -49,7 +49,7 @@ public class OptionData implements SerializableData
     public static final int MAX_NAME_LENGTH = 32;
     
     /**
-     * The maximum length of the name of some OptionData names
+     * The maximum length of the name of Command Option Choice names
      */
     public static final int MAX_CHOICE_NAME_LENGTH = 100;
 

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -47,6 +47,11 @@ public class OptionData implements SerializableData
      * The maximum length the name of an option can be.
      */
     public static final int MAX_NAME_LENGTH = 32;
+    
+    /**
+     * The maximum length of the name of some OptionData names
+     */
+    public static final int MAX_NAME_OPTION_LENGTH = 100;
 
     /**
      * The maximum length the description of an option can be.
@@ -287,7 +292,7 @@ public class OptionData implements SerializableData
     public OptionData addChoice(@Nonnull String name, double value)
     {
         Checks.notEmpty(name, "Name");
-        Checks.notLonger(name, MAX_NAME_LENGTH, "Name");
+        Checks.notLonger(name, MAX_NAME_OPTION_LENGTH, "Name");
         Checks.check(value >= MIN_NEGATIVE_NUMBER, "Double value may not be lower than %f", MIN_NEGATIVE_NUMBER);
         Checks.check(value <= MAX_POSITIVE_NUMBER, "Double value may not be larger than %f", MAX_POSITIVE_NUMBER);
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
@@ -320,7 +325,7 @@ public class OptionData implements SerializableData
     public OptionData addChoice(@Nonnull String name, int value)
     {
         Checks.notEmpty(name, "Name");
-        Checks.notLonger(name, MAX_NAME_LENGTH, "Name");
+        Checks.notLonger(name, MAX_NAME_OPTION_LENGTH, "Name");
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
         if (type != OptionType.INTEGER)
             throw new IllegalArgumentException("Cannot add int choice for OptionType." + type);
@@ -353,7 +358,7 @@ public class OptionData implements SerializableData
     {
         Checks.notEmpty(name, "Name");
         Checks.notEmpty(value, "Value");
-        Checks.notLonger(name, MAX_NAME_LENGTH, "Name");
+        Checks.notLonger(name, MAX_NAME_OPTION_LENGTH, "Name");
         Checks.notLonger(value, MAX_CHOICE_VALUE_LENGTH, "Value");
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
         if (type != OptionType.STRING)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

A commit that moved many constants to the MAX_NAME_LENGTH mistakenly also moved a few values that were 100 into a constant with value 32.

This commit will add a new constant, MAX_NAME_OPTION_LENGTH, to fix those values back to their intended values of 100.

The commit title is meant to say Option Choice, not OptionData.
