### PR TITLE
rename the manage emotes permission to contain stickers 

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -74,7 +74,7 @@ public enum Permission
     MANAGE_ROLES(      28, true,  false, "Manage Roles"),
     MANAGE_PERMISSIONS(28, false, true,  "Manage Permissions"),
     MANAGE_WEBHOOKS(   29, true,  true,  "Manage Webhooks"),
-    MANAGE_EMOTES(     30, true,  false, "Manage Emojis"),
+    MANAGE_EMOTES(     30, true,  false, "Manage Emojis and Stickers"),
 
     REQUEST_TO_SPEAK(  32, true, true, "Request to Speak"),
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR renames the MANAGE_EMOTES permission to contain stickers as it's a single permission. it'd make sense to rename the constant itself too, but it'd obviously be breaking