### PR TITLE
Fix exception schema parsing if _errors array is top-level

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
@@ -190,6 +190,11 @@ public class ErrorResponseException extends RuntimeException
         // check what kind of errors we are dealing with
         for (String name : errors.keys())
         {
+            if (name.equals("_errors"))
+            {
+                schemaErrors.add(parseSchemaError(currentLocation, errors));
+                continue;
+            }
             DataObject schemaError = errors.getObject(name);
             if (!schemaError.isNull("_errors"))
             {

--- a/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
+++ b/src/main/java/net/dv8tion/jda/api/exceptions/ErrorResponseException.java
@@ -443,7 +443,7 @@ public class ErrorResponseException extends RuntimeException
         @Override
         public String toString()
         {
-            return location + "\n\t- " + errors.stream().map(Object::toString).collect(Collectors.joining("\n\t- "));
+            return (location.isEmpty() ? "" : location+"\n") + "\t- " + errors.stream().map(Object::toString).collect(Collectors.joining("\n\t- "));
         }
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1799 

## Description

This pull request fixes exception schema parsing if the `_errors` array is top-level instead of it being on a property
