### PR TITLE
Add webhook id methods to Message

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -686,8 +686,40 @@ public interface Message extends ISnowflake, Formattable
      *         If this is a system message
      *
      * @return True if this message was sent by a {@link net.dv8tion.jda.api.entities.Webhook Webhook}.
+     *
+     * @see #getWebhookIdLong()
+     * @see #getWebhookId()
      */
     boolean isWebhookMessage();
+
+    /**
+     * Returns the id of the {@link net.dv8tion.jda.api.entities.Webhook Webhook} that sent this message
+     * or {@code null} if it wasn't sent by a Webhook.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     *
+     * @return The id of the webhook that sent this message or {@code null} if it wasn't sent by a webhook
+     *
+     * @see #isWebhookMessage()
+     */
+    default String getWebhookId()
+    {
+        return isWebhookMessage() ? Long.toUnsignedString(getIdLong()) : null;
+    }
+
+    /**
+     * Returns the id of the {@link net.dv8tion.jda.api.entities.Webhook Webhook} that sent this message
+     * or 0 if it wasn't sent by a Webhook.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     *
+     * @return The id of the webhook that sent this message or 0 if it wasn't sent by a webhook
+     *
+     * @see #isWebhookMessage()
+     */
+    long getWebhookIdLong();
 
     /**
      * Returns the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} that this message was sent in.

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -283,6 +283,13 @@ public abstract class AbstractMessage implements Message
         return false;
     }
 
+    @Override
+    public long getWebhookIdLong()
+    {
+        unsupported();
+        return 0;
+    }
+
     @Nonnull
     @Override
     public MessageChannel getChannel()

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1180,7 +1180,7 @@ public class EntityBuilder
         }
 
         final String content = jsonObject.getString("content", "");
-        final boolean fromWebhook = jsonObject.hasKey("webhook_id");
+        final long webhookId = jsonObject.getLong("webhook_id", 0);
         final boolean pinned = jsonObject.getBoolean("pinned");
         final boolean tts = jsonObject.getBoolean("tts");
         final boolean mentionsEveryone = jsonObject.getBoolean("mention_everyone");
@@ -1217,7 +1217,7 @@ public class EntityBuilder
                 user = member != null ? member.getUser() : null;
                 if (user == null)
                 {
-                    if (fromWebhook || !modifyCache)
+                    if (webhookId != 0 || !modifyCache)
                         user = createUser(author);
                     else
                         throw new IllegalArgumentException(MISSING_USER); // Specifically for MESSAGE_CREATE
@@ -1226,7 +1226,7 @@ public class EntityBuilder
             default: throw new IllegalArgumentException("Invalid Channel for creating a Message [" + channel.getType() + ']');
         }
 
-        if (modifyCache && !fromWebhook) // update the user information on message receive
+        if (modifyCache && webhookId == 0) // update the user information on message receive
             updateUser((UserImpl) user, author);
 
         TLongSet mentionedRoles = new TLongHashSet();
@@ -1302,13 +1302,13 @@ public class EntityBuilder
             throw new IllegalArgumentException(UNKNOWN_MESSAGE_TYPE);
         if (!type.isSystem())
         {
-            message = new ReceivedMessage(id, channel, type, messageReference, fromWebhook,
+            message = new ReceivedMessage(id, channel, type, messageReference, webhookId,
                     mentionsEveryone, mentionedUsers, mentionedRoles, tts, pinned,
                     content, nonce, user, member, activity, editTime, reactions, attachments, embeds, stickers, components, flags, messageInteraction);
         }
         else
         {
-            message = new SystemMessage(id, channel, type, messageReference, fromWebhook,
+            message = new SystemMessage(id, channel, type, messageReference, webhookId,
                     mentionsEveryone, mentionedUsers, mentionedRoles, tts, pinned,
                     content, nonce, user, member, activity, editTime, reactions, attachments, embeds, stickers, flags);
             return message; // We don't need to parse mentions for system messages, they are always empty anyway

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -60,7 +60,7 @@ public class ReceivedMessage extends AbstractMessage
     protected final MessageType type;
     protected final MessageChannel channel;
     protected final MessageReference messageReference;
-    protected final boolean fromWebhook;
+    protected final long webhookId;
     protected final boolean mentionsEveryone;
     protected final boolean pinned;
     protected final User author;
@@ -92,7 +92,7 @@ public class ReceivedMessage extends AbstractMessage
 
     public ReceivedMessage(
         long id, MessageChannel channel, MessageType type, MessageReference messageReference,
-        boolean fromWebhook, boolean mentionsEveryone, TLongSet mentionedUsers, TLongSet mentionedRoles, boolean tts, boolean pinned,
+        long webhookId, boolean mentionsEveryone, TLongSet mentionedUsers, TLongSet mentionedRoles, boolean tts, boolean pinned,
         String content, String nonce, User author, Member member, MessageActivity activity, OffsetDateTime editTime,
         List<MessageReaction> reactions, List<Attachment> attachments, List<MessageEmbed> embeds, List<MessageSticker> stickers, List<ActionRow> components, int flags, Message.Interaction interaction)
     {
@@ -102,7 +102,7 @@ public class ReceivedMessage extends AbstractMessage
         this.messageReference = messageReference;
         this.type = type;
         this.api = (channel != null) ? (JDAImpl) channel.getJDA() : null;
-        this.fromWebhook = fromWebhook;
+        this.webhookId = webhookId;
         this.mentionsEveryone = mentionsEveryone;
         this.pinned = pinned;
         this.author = author;
@@ -833,7 +833,13 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public boolean isWebhookMessage()
     {
-        return fromWebhook;
+        return webhookId != 0;
+    }
+
+    @Override
+    public long getWebhookIdLong()
+    {
+        return webhookId;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
@@ -32,12 +32,12 @@ public class SystemMessage extends ReceivedMessage
 {
     public SystemMessage(
         long id, MessageChannel channel, MessageType type, MessageReference messageReference,
-        boolean fromWebhook, boolean mentionsEveryone, TLongSet mentionedUsers, TLongSet mentionedRoles,
+        long webhookId, boolean mentionsEveryone, TLongSet mentionedUsers, TLongSet mentionedRoles,
         boolean tts, boolean pinned,
         String content, String nonce, User author, Member member, MessageActivity activity, OffsetDateTime editTime,
         List<MessageReaction> reactions, List<Attachment> attachments, List<MessageEmbed> embeds, List<MessageSticker> stickers, int flags)
     {
-        super(id, channel, type, messageReference, fromWebhook, mentionsEveryone, mentionedUsers, mentionedRoles,
+        super(id, channel, type, messageReference, webhookId, mentionsEveryone, mentionedUsers, mentionedRoles,
             tts, pinned, content, nonce, author, member, activity, editTime, reactions, attachments, embeds, stickers, Collections.emptyList(), flags, null);
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds `getWebhookId` and `getWebhookIdLong` methods to the Message class, which makes it possible to identify what webhook sent the message.
