### PR TITLE
Add long overload to OptionData#addChoice while still keeping the int overload

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -189,6 +189,7 @@ public class OptionData implements SerializableData
      * @return Immutable list of {@link net.dv8tion.jda.api.interactions.commands.Command.Choice Choices}
      *
      * @see #addChoice(String, int)
+     * @see #addChoice(String, long) 
      * @see #addChoice(String, String)
      */
     @Nonnull
@@ -346,6 +347,40 @@ public class OptionData implements SerializableData
      *         If any of the following checks fail
      *         <ul>
      *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_CHOICE_NAME_LENGTH} characters long</li>
+     *             <li>{@code value} is not less than {@link #MIN_NEGATIVE_NUMBER} and not larger than {@link #MAX_POSITIVE_NUMBER}</li>
+     *             <li>The amount of already set choices is less than {@link #MAX_CHOICES}</li>
+     *             <li>The {@link OptionType} is {@link OptionType#INTEGER}</li>
+     *         </ul>
+     *
+     * @return The OptionData instance, for chaining
+     */
+    @Nonnull
+    public OptionData addChoice(@Nonnull String name, long value)
+    {
+        Checks.notEmpty(name, "Name");
+        Checks.notLonger(name, MAX_NAME_LENGTH, "Name");
+        Checks.check(value >= MIN_NEGATIVE_NUMBER, "Long value may not be lower than %f", MIN_NEGATIVE_NUMBER);
+        Checks.check(value <= MAX_POSITIVE_NUMBER, "Long value may not be larger than %f", MAX_POSITIVE_NUMBER);
+        Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
+        if (type != OptionType.INTEGER)
+            throw new IllegalArgumentException("Cannot add Long choice for OptionType." + type);
+        choices.put(name, value);
+        return this;
+    }
+
+    /**
+     * Add a predefined choice for this option.
+     * <br>The user can only provide one of the choices and cannot specify any other value.
+     *
+     * @param  name
+     *         The name used in the client
+     * @param  value
+     *         The value received in {@link net.dv8tion.jda.api.interactions.commands.OptionMapping OptionMapping}
+     *
+     * @throws IllegalArgumentException
+     *         If any of the following checks fail
+     *         <ul>
+     *             <li>{@code name} is not null, empty and less or equal to {@value #MAX_CHOICE_NAME_LENGTH} characters long</li>
      *             <li>{@code value} is not null, empty and less or equal to {@value #MAX_CHOICE_VALUE_LENGTH} characters long</li>
      *             <li>The amount of already set choices is less than {@link #MAX_CHOICES}</li>
      *             <li>The {@link OptionType} is {@link OptionType#STRING}</li>
@@ -395,7 +430,7 @@ public class OptionData implements SerializableData
         for (Command.Choice choice : choices)
         {
             if (type == OptionType.INTEGER)
-                addChoice(choice.getName(), (int) choice.getAsLong());
+                addChoice(choice.getName(), choice.getAsLong());
             else if (type == OptionType.STRING)
                 addChoice(choice.getName(), choice.getAsString());
             else if (type == OptionType.NUMBER)

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -363,7 +363,7 @@ public class OptionData implements SerializableData
         Checks.check(value <= MAX_POSITIVE_NUMBER, "Long value may not be larger than %f", MAX_POSITIVE_NUMBER);
         Checks.check(choices.size() < MAX_CHOICES, "Cannot have more than 25 choices for an option!");
         if (type != OptionType.INTEGER)
-            throw new IllegalArgumentException("Cannot add Long choice for OptionType." + type);
+            throw new IllegalArgumentException("Cannot add long choice for OptionType." + type);
         choices.put(name, value);
         return this;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds the long overload to OptionData#addChoice while still keeping the int overload.
This is a fix for v4 that doesn't break the ABI Signature while still allowing longs to be added as choices.

PR for v5: #1816 
