### PR TITLE
Add Emoji overloads for reaction methods

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -1870,6 +1870,72 @@ public interface Message extends ISnowflake, Formattable
     RestAction<Void> addReaction(@Nonnull String unicode);
 
     /**
+     * Adds a reaction to this Message using an {@link net.dv8tion.jda.api.entities.Emoji Emoji}.
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
+     * showing how many users have reacted with the same emoji/emote.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The reaction request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         due to {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ} being revoked
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#REACTION_BLOCKED REACTION_BLOCKED}
+     *     <br>The user has blocked the currently logged in account and the reaction failed</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#TOO_MANY_REACTIONS TOO_MANY_REACTIONS}
+     *     <br>The message already has too many reactions to proceed</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The reaction request was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION}
+     *         or {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
+     *         in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} when adding the reaction.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>If the message has already been deleted. This might also be triggered for ephemeral messages.</li>
+     * </ul>
+     *
+     * @param  emoji
+     *         The {@link net.dv8tion.jda.api.entities.Emoji Emoji} to add as a reaction to this Message.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         and the logged in account does not have
+     *         <ul>
+     *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION}</li>
+     *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *         </ul>
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emoji emoji} is null or cannot be found.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emoji emoji} cannot be used in the current channel.
+     *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *         </ul>
+     * @throws IllegalStateException
+     *         If this message is ephemeral
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     *
+     * @since 4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Void> addReaction(@Nonnull Emoji emoji);
+
+    /**
      * Removes all reactions from this Message.
      * <br>This is useful for moderator commands that wish to remove all reactions at once from a specific message.
      *
@@ -2006,6 +2072,49 @@ public interface Message extends ISnowflake, Formattable
     @Nonnull
     @CheckReturnValue
     RestAction<Void> clearReactions(@Nonnull Emote emote);
+
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <p>Please note that you <b>can't</b> clear reactions if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was invalid. It either did not correspond to a valid unicode emoji,
+     *     or, if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>If the message has already been deleted. This might also be triggered for ephemeral messages.</li>
+     * </ul>
+     *
+     * @param  emoji
+     *         The {@link Emoji} to remove reactions for
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     * @throws java.lang.IllegalStateException
+     *         <ul>
+     *             <li>If this message was <b>not</b> sent in a {@link net.dv8tion.jda.api.entities.Guild Guild}.</li>
+     *             <li>If this message is ephemeral</li>
+     *         </ul>
+     *
+     * @return {@link RestAction}
+     *
+     * @since  4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Void> clearReactions(@Nonnull Emoji emoji);
 
     /**
      * Removes a reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emote Emote}.
@@ -2250,6 +2359,123 @@ public interface Message extends ISnowflake, Formattable
     @Nonnull
     @CheckReturnValue
     RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user);
+
+    /**
+     * Removes a reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emoji Emoji}.
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
+     * showing how many users have reacted with the same emoji/emote.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The reaction request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         due to {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ} being revoked
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was invalid. It either did not correspond to a valid unicode emoji,
+     *     or, if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>If the message has already been deleted. This might also be triggered for ephemeral messages.</li>
+     * </ul>
+     *
+     * @param  emoji
+     *         The {@link net.dv8tion.jda.api.entities.Emoji Emoji} to remove as a reaction from this Message.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         and the logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emoji Emoji} is null or empty.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emoji Emoji} cannot be used in the current channel.
+     *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *         </ul>
+     * @throws IllegalStateException
+     *         If this is an ephemeral message
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     *
+     * @since  4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Void> removeReaction(@Nonnull Emoji emoji);
+
+    /**
+     * Removes a {@link net.dv8tion.jda.api.entities.User User's} reaction from this Message using an {@link net.dv8tion.jda.api.entities.Emoji Emoji}.
+     *
+     * <p>Please note that you <b>can't</b> remove reactions of other users if this message was sent in a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}!
+     *
+     * <p>This message instance will not be updated by this operation.
+     *
+     * <p>Reactions are the small emoji/emotes below a message that have a counter beside them
+     * showing how many users have reacted with the same emoji/emote.
+     *
+     * <p><b>Neither success nor failure of this request will affect this Message's {@link #getReactions()} return as Message is immutable.</b>
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The reaction request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         due to {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ} being revoked
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The reaction request was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE}
+     *         in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} when removing the reaction.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided emoji was invalid. It either did not correspond to a valid unicode emoji,
+     *     or, if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>If the message has already been deleted. This might also be triggered for ephemeral messages.</li>
+     * </ul>
+     *
+     * @param  emoji
+     *         The {@link net.dv8tion.jda.api.entities.Emoji Emoji} to remove as a reaction from this Message.
+     * @param  user
+     *         The {@link net.dv8tion.jda.api.entities.User User} to remove the reaction for.
+     *
+     * @throws java.lang.UnsupportedOperationException
+     *         If this is a system message
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the MessageChannel this message was sent in was a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *         and the logged in account does not have {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}.
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emoji Emoji} is null or empty.</li>
+     *             <li>If the provided {@link net.dv8tion.jda.api.entities.Emoji Emoji} cannot be used in the current channel.
+     *                 See {@link Emote#canInteract(User, MessageChannel)} or {@link Emote#canInteract(Member)} for more information.</li>
+     *             <li>If the provided user is null</li>
+     *         </ul>
+     * @throws java.lang.IllegalStateException
+     * <ul>
+     *     <li>If this message was <b>not</b> sent in a
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         <b>and</b> the given user is <b>not</b> the {@link net.dv8tion.jda.api.entities.SelfUser SelfUser}.</li>
+     *     <li>If this message is ephemeral</li>
+     * </ul>
+     *
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: {@link java.lang.Void}
+     *
+     * @since  4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    RestAction<Void> removeReaction(@Nonnull Emoji emoji, @Nonnull User user);
 
     /**
      * This obtains the {@link net.dv8tion.jda.api.entities.User users} who reacted using the given {@link net.dv8tion.jda.api.entities.Emote emote}.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -2019,6 +2019,24 @@ public interface MessageChannel extends AbstractChannel, Formattable
         return addReactionById(Long.toUnsignedString(messageId), emote);
     }
 
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> addReactionById(@Nonnull String messageId, @Nonnull Emoji emoji)
+    {
+        Checks.notNull(emoji, "Emoji");
+        String emojiName = emoji.getName();
+        if (emoji.isCustom())
+            emojiName += ":" + emoji.getId();
+        return addReactionById(messageId, emojiName);
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> addReactionById(long messageId, @Nonnull Emoji emoji)
+    {
+        return addReactionById(Long.toUnsignedString(messageId), emoji);
+    }
+
     /**
      * Attempts to remove the reaction from a message represented by the specified {@code messageId}
      * in this MessageChannel.
@@ -2250,6 +2268,112 @@ public interface MessageChannel extends AbstractChannel, Formattable
     default RestAction<Void> removeReactionById(long messageId, @Nonnull Emote emote)
     {
         return removeReactionById(Long.toUnsignedString(messageId), emote);
+    }
+
+    /**
+     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * in this MessageChannel.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION} in the
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emoji} was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The messageId to remove the reaction from
+     * @param  emoji
+     *         The emote to remove
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If provided {@code messageId} is {@code null} or not a valid snowflake.</li>
+     *             <li>If provided {@code emoji} is {@code null}.</li>
+     *         </ul>
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull Emoji emoji)
+    {
+        Checks.notNull(emoji, "Emoji");
+        String emojiName = emoji.getName();
+        if (emoji.isCustom())
+            emojiName += ":" + emoji.getId();
+        return removeReactionById(messageId, emojiName);
+    }
+
+    /**
+     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * in this MessageChannel.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION} in the
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emoji} was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The messageId to remove the reaction from
+     * @param  emoji
+     *         The emote to remove
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If provided {@code messageId} is {@code null} or not a valid snowflake.</li>
+     *             <li>If provided {@code emoji} is {@code null}.</li>
+     *         </ul>
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> removeReactionById(long messageId, @Nonnull Emoji emoji)
+    {
+        return removeReactionById(Long.toUnsignedString(messageId), emoji);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/TextChannel.java
@@ -556,6 +556,48 @@ public interface TextChannel extends GuildChannel, MessageChannel
     /**
      * Removes all reactions for the specified emoji.
      *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emoji} was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id for the target message
+     * @param  emoji
+     *         The {@link Emoji} to remove reactions for
+     *
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     *
+     * @since  4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> clearReactionsById(@Nonnull String messageId, @Nonnull Emoji emoji) {
+        Checks.notNull(emoji, "Emoji");
+        String emojiName = emoji.getName();
+        if (emoji.isCustom())
+            emojiName += ":" + emoji.getId();
+        return clearReactionsById(messageId, emojiName);
+    }
+
+    /**
+     * Removes all reactions for the specified emoji.
+     *
      * <h2>Example</h2>
      * <pre><code>
      * // custom
@@ -635,6 +677,44 @@ public interface TextChannel extends GuildChannel, MessageChannel
     default RestAction<Void> clearReactionsById(long messageId, @Nonnull Emote emote)
     {
         return clearReactionsById(Long.toUnsignedString(messageId), emote);
+    }
+
+    /**
+     * Removes all reactions for the specified emoji.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The currently logged in account lost access to the channel by either being removed from the guild
+     *         or losing the {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL VIEW_CHANNEL} permission</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emoji} was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The id for the target message
+     * @param  emoji
+     *         The {@link Emoji} to remove reactions for
+     *
+     * @throws InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MESSAGE_MANAGE} in the channel
+     * @throws IllegalArgumentException
+     *         If provided with null
+     *
+     * @return {@link RestAction}
+     *
+     * @since  4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> clearReactionsById(long messageId, @Nonnull Emoji emoji) {
+        return clearReactionsById(Long.toUnsignedString(messageId), emoji);
     }
 
     /**
@@ -789,9 +869,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI}
-     *     <br>The provided unicode character does not refer to a known emoji unicode character.
-     *     <br>Proper unicode characters for emojis can be found here:
-     *         <a href="https://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a></li>
+     *     <br>The provided {@link Emote} was deleted or doesn't exist.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
      *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
@@ -850,9 +928,7 @@ public interface TextChannel extends GuildChannel, MessageChannel
      *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI}
-     *     <br>The provided unicode character does not refer to a known emoji unicode character.
-     *     <br>Proper unicode characters for emojis can be found here:
-     *         <a href="https://unicode.org/emoji/charts/full-emoji-list.html" target="_blank">Emoji Table</a></li>
+     *     <br>The provided {@link Emote} was deleted or doesn't exist.</li>
      *
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
      *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
@@ -885,6 +961,128 @@ public interface TextChannel extends GuildChannel, MessageChannel
     default RestAction<Void> removeReactionById(long messageId, @Nonnull Emote emote, @Nonnull User user)
     {
         return removeReactionById(Long.toUnsignedString(messageId), emote, user);
+    }
+
+    /**
+     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * in this MessageChannel.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION} in the
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emoji} was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The messageId to remove the reaction from
+     * @param  emoji
+     *         The emote to remove
+     * @param  user
+     *         The target user of which to remove from
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If provided {@code messageId} is {@code null} or empty.</li>
+     *             <li>If provided {@code emoji} is {@code null}.</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction}
+     *
+     * @since 4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> removeReactionById(@Nonnull String messageId, @Nonnull Emoji emoji, @Nonnull User user)
+    {
+        Checks.notNull(emoji, "Emoji");
+        String emojiName = emoji.getName();
+        if (emoji.isCustom())
+            emojiName += ":" + emoji.getId();
+        return removeReactionById(messageId, emojiName, user);
+    }
+
+    /**
+     * Attempts to remove the reaction from a message represented by the specified {@code messageId}
+     * in this MessageChannel.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the
+     *         {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#MESSAGE_READ Permission.MESSAGE_READ}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}
+     *     <br>Also can happen if the account lost the {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_ADD_REACTION Permission.MESSAGE_ADD_REACTION} in the
+     *         {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_EMOJI}
+     *     <br>The provided {@link Emoji} was invalid. It either did not correspond to a unicode emoji or,
+     *     if it corresponded to a custom emote, it was deleted, doesn't exist,
+     *     or is not available to the currently logged-in account in this channel.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The provided {@code messageId} is unknown in this MessageChannel, either due to the id being invalid, or
+     *         the message it referred to has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the channel was deleted.</li>
+     * </ul>
+     *
+     * @param  messageId
+     *         The messageId to remove the reaction from
+     * @param  emoji
+     *         The emote to remove
+     * @param  user
+     *         The target user of which to remove from
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If provided {@code messageId} is {@code null} or empty.</li>
+     *             <li>If provided {@code emoji} is {@code null}.</li>
+     *         </ul>
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.api.Permission#MESSAGE_MANAGE Permission.MESSAGE_MANAGE} in this channel.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction}
+     *
+     * @since 4.4.0
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> removeReactionById(long messageId, @Nonnull Emoji emoji, @Nonnull User user)
+    {
+        return removeReactionById(Long.toUnsignedString(messageId), emoji, user);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -475,6 +475,14 @@ public abstract class AbstractMessage implements Message
 
     @Nonnull
     @Override
+    public RestAction<Void> addReaction(@Nonnull Emoji emoji)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Nonnull
+    @Override
     public RestAction<Void> clearReactions()
     {
         unsupported();
@@ -492,6 +500,14 @@ public abstract class AbstractMessage implements Message
     @Nonnull
     @Override
     public RestAction<Void> clearReactions(@Nonnull Emote emote)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> clearReactions(@Nonnull Emoji emoji)
     {
         unsupported();
         return null;
@@ -524,6 +540,22 @@ public abstract class AbstractMessage implements Message
     @Nonnull
     @Override
     public RestAction<Void> removeReaction(@Nonnull String unicode, @Nonnull User user)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> removeReaction(@Nonnull Emoji emoji)
+    {
+        unsupported();
+        return null;
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> removeReaction(@Nonnull Emoji emoji, @Nonnull User user)
     {
         unsupported();
         return null;

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -200,6 +200,27 @@ public class ReceivedMessage extends AbstractMessage
 
     @Nonnull
     @Override
+    public RestAction<Void> addReaction(@Nonnull Emoji emoji)
+    {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot add reactions to ephemeral messages.");
+
+        Checks.notNull(emoji, "Emoji");
+
+        // emote
+        if (emoji.isCustom()) {
+            Emote emote = api.getEmoteById(emoji.getIdLong());
+            if (emote == null)
+                throw new IllegalArgumentException("Emote is unavailable or was deleted");
+            return addReaction(emote);
+        }
+
+        // unicode
+        return addReaction(emoji.getName());
+    }
+
+    @Nonnull
+    @Override
     public RestAction<Void> clearReactions()
     {
         if (isEphemeral())
@@ -229,6 +250,17 @@ public class ReceivedMessage extends AbstractMessage
         if (!isFromGuild())
             throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
         return getTextChannel().clearReactionsById(getId(), emote);
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> clearReactions(@Nonnull Emoji emoji)
+    {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot clear reactions from ephemeral messages.");
+        if (!isFromGuild())
+            throw new IllegalStateException("Cannot clear reactions from a message in a Group or PrivateChannel.");
+        return getTextChannel().clearReactionsById(getId(), emoji);
     }
 
     @Nonnull
@@ -281,6 +313,31 @@ public class ReceivedMessage extends AbstractMessage
         if (!isFromGuild())
             throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
         return getTextChannel().removeReactionById(getId(), unicode, user);
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> removeReaction(@Nonnull Emoji emoji)
+    {
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot remove reactions from ephemeral messages.");
+
+        return channel.removeReactionById(getId(), emoji);
+    }
+
+    @Nonnull
+    @Override
+    public RestAction<Void> removeReaction(@Nonnull Emoji emoji, @Nonnull User user)
+    {
+        Checks.notNull(user, "User");
+        if (user.equals(getJDA().getSelfUser()))
+            return channel.removeReactionById(getIdLong(), emoji);
+
+        if (isEphemeral())
+            throw new IllegalStateException("Cannot remove reactions from ephemeral messages.");
+        if (!isFromGuild())
+            throw new IllegalStateException("Cannot remove reactions of others from a message in a Group or PrivateChannel.");
+        return getTextChannel().removeReactionById(getId(), emoji, user);
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code (I guess?)
- [x] Library interface (affecting end-user code) 
- [x] Documentation

## Description

Adds new overloaded parameters for adding/removing/clearing reactions given an Emoji.

Was unsure how versioning works for the `@since` tags so I put 4.4.0, lmk if that should be something else
