### PR TITLE
Fix compile error of AudioEchoExample

### DIFF
--- a/src/examples/java/AudioEchoExample.java
+++ b/src/examples/java/AudioEchoExample.java
@@ -95,7 +95,7 @@ public class AudioEchoExample extends ListenerAdapter
         // Note: None of these can be null due to our configuration with the JDABuilder!
         Member member = event.getMember();                              // Member is the context of the user for the specific guild, containing voice state and roles
         GuildVoiceState voiceState = member.getVoiceState();            // Check the current voice state of the user
-        VoiceChannel channel = voiceState.getChannel();                 // Use the channel the user is currently connected to
+        AudioChannel channel = voiceState.getChannel();                 // Use the channel the user is currently connected to
         if (channel != null)
         {
             connectTo(channel);                                         // Join the channel of the user
@@ -150,7 +150,7 @@ public class AudioEchoExample extends ListenerAdapter
      * @param textChannel
      *        The text channel to send the message in
      */
-    private void onConnecting(VoiceChannel channel, TextChannel textChannel)
+    private void onConnecting(AudioChannel channel, TextChannel textChannel)
     {
         textChannel.sendMessage("Connecting to " + channel.getName()).queue(); // never forget to queue()!
     }
@@ -174,7 +174,7 @@ public class AudioEchoExample extends ListenerAdapter
      * @param channel
      *        The channel to connect to
      */
-    private void connectTo(VoiceChannel channel)
+    private void connectTo(AudioChannel channel)
     {
         Guild guild = channel.getGuild();
         // Get an audio manager for this guild, this will be created upon first use for each guild

--- a/src/main/java/net/dv8tion/jda/api/entities/VoiceChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/VoiceChannel.java
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull;
  * @see   JDA#getVoiceChannelsByName(String, boolean)
  * @see   JDA#getVoiceChannelById(long)
  */
-public interface VoiceChannel extends GuildChannel, AudioChannel, ICategorizableChannel, ICopyableChannel, IPermissionContainer, IPositionableChannel, IMemberContainer, IInviteContainer
+public interface VoiceChannel extends AudioChannel, ICategorizableChannel, ICopyableChannel, IPermissionContainer, IPositionableChannel, IInviteContainer
 {
     /**
      * The maximum amount of {@link net.dv8tion.jda.api.entities.Member Members} that can be in this


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

This fixes the compile error introduced with the [change of GuildVoiceState#getChannel](https://github.com/DV8FromTheWorld/JDA/commit/47123047ad24965e6602ee0fa950222036d7a31f#diff-96be8e51fe5a0b0917f345357e6267ab47f0f6634bbecbcdcbe7d6809b7632e6L124-R124) returning a new class.
Furthermore I removed unnecessary extensions from the `VoiceChannel` interface.
