### PR TITLE
Message interface declutter & mention / component abstraction

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -116,7 +116,7 @@ import java.util.stream.Collectors;
  * @see MessageChannel#deleteMessageById(String)
  * @see MessageChannel#editMessageById(String, CharSequence)
  */
-public interface Message extends ISnowflake, Formattable
+public interface Message extends ISnowflake, Formattable, PartialMessage
 {
     /**
      * The maximum sendable file size (8 MiB)

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageComponents.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageComponents.java
@@ -3,39 +3,83 @@ package net.dv8tion.jda.api.entities;
 import java.util.Collections;
 import java.util.List;
 
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.selections.SelectionMenu;
+import net.dv8tion.jda.internal.utils.Checks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class MessageComponents
 {
+    private final List<ActionRow> actionRows;
+
+    public MessageComponents(@NotNull List<ActionRow> actionRows) {
+        this.actionRows = actionRows;
+    }
+
     @NotNull
     public List<Button> getButtons()
     {
-        return Collections.emptyList();
+        return getActionRows().stream()
+                .map(ActionRow::getButtons)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
     }
 
     @NotNull
     public List<SelectionMenu> getMenus()
     {
-        return Collections.emptyList();
+        return getActionRows()
+                .stream()
+                .flatMap(x -> x.getComponents().stream())
+                .filter(SelectionMenu.class::isInstance)
+                .map(SelectionMenu.class::cast)
+                .collect(Collectors.toList());
     }
 
     @NotNull
     public List<ActionRow> getActionRows()
     {
-        return Collections.emptyList();
+        return actionRows;
     }
 
     @Nullable
-    public Button getButtonById(String id, boolean ignoreCase) {
-        return null;
+    public Button getButtonById(@NotNull String id)
+    {
+        Checks.notNull(id, "Button ID");
+        return getButtons().stream()
+                .filter(it -> id.equals(it.getId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Nonnull
+    List<Button> getButtonsByLabel(@Nonnull String label, boolean ignoreCase)
+    {
+        Checks.notNull(label, "Label");
+        Predicate<Button> filter;
+        if (ignoreCase)
+            filter = b -> label.equalsIgnoreCase(b.getLabel());
+        else
+            filter = b -> label.equals(b.getLabel());
+
+        return getButtons().stream()
+                .filter(filter)
+                .collect(Collectors.toList());
     }
 
     @Nullable
-    public SelectionMenu getMenuById(String id, boolean ignoreCase) {
-        return null;
+    public SelectionMenu getMenuById(@NotNull String id)
+    {
+        Checks.notNull(id, "Menu ID");
+        return getMenus().stream()
+                .filter(it -> id.equals(it.getId()))
+                .findFirst().orElse(null);
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageComponents.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageComponents.java
@@ -1,5 +1,41 @@
 package net.dv8tion.jda.api.entities;
 
+import java.util.Collections;
+import java.util.List;
+
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.selections.SelectionMenu;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public class MessageComponents
 {
+    @NotNull
+    public List<Button> getButtons()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<SelectionMenu> getMenus()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<ActionRow> getActionRows()
+    {
+        return Collections.emptyList();
+    }
+
+    @Nullable
+    public Button getButtonById(String id, boolean ignoreCase) {
+        return null;
+    }
+
+    @Nullable
+    public SelectionMenu getMenuById(String id, boolean ignoreCase) {
+        return null;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageComponents.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageComponents.java
@@ -1,0 +1,5 @@
+package net.dv8tion.jda.api.entities;
+
+public class MessageComponents
+{
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageMentions.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageMentions.java
@@ -1,56 +1,220 @@
 package net.dv8tion.jda.api.entities;
 
-import java.util.Collections;
-import java.util.List;
+import gnu.trove.set.TLongSet;
 
+import java.util.*;
+
+import java.util.stream.Collectors;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.MiscUtil;
+import net.dv8tion.jda.internal.JDAImpl;
+import net.dv8tion.jda.internal.entities.EmoteImpl;
+import net.dv8tion.jda.internal.utils.Checks;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+import java.util.regex.Matcher;
 
 public class MessageMentions
 {
+    private final String content;
+    private final boolean mentionsEveryone;
+    private final TLongSet userIds;
+    private final TLongSet roleIds;
+    private final JDAImpl jda;
+    private final Guild guild;
+
+    private final List<User> users;
+    private final List<Member> members;
+    private final List<Role> roles;
+    private final List<TextChannel> textChannels;
+    private final List<VoiceChannel> voiceChannels;
+
+    private final List<Emote> emotes;
+    private final List<String> invites;
+    private final List<MessageSticker> stickers;
+
+    public MessageMentions(
+            String content, boolean mentionsEveryone, TLongSet userIds, TLongSet roleIds, List<MessageSticker> stickers,
+            Guild guild, JDAImpl jda
+    ) {
+        this.content = content;
+        this.mentionsEveryone = mentionsEveryone;
+        this.userIds = userIds;
+        this.roleIds = roleIds;
+        this.jda = jda;
+        this.guild = guild;
+
+        this.users = Collections.unmodifiableList(processMentions(Message.MentionType.USER, new ArrayList<>(), true, this::matchUser));
+
+        if (guild == null)
+        {
+            this.members = new ArrayList<>();
+        }
+        else
+        {
+            this.members = Collections.unmodifiableList(
+                    getUsers()
+                        .stream()
+                        .map(guild::getMember)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList())
+            );
+        }
+
+        this.roles = Collections.unmodifiableList(processMentions(Message.MentionType.ROLE, new ArrayList<>(), true, this::matchRole));
+        this.textChannels = Collections.unmodifiableList(processMentions(Message.MentionType.CHANNEL, new ArrayList<>(), true, it -> matchChannel(it, ChannelType.TEXT, TextChannel.class)));
+        this.voiceChannels = Collections.unmodifiableList(processMentions(Message.MentionType.CHANNEL, new ArrayList<>(), true, it -> matchChannel(it, ChannelType.VOICE, VoiceChannel.class)));
+        this.emotes = Collections.unmodifiableList(processMentions(Message.MentionType.EMOTE, new ArrayList<>(), true, this::matchEmote));
+        this.invites = matchInvites();
+        this.stickers = stickers;
+    }
+
     @NotNull
     public List<Member> getMembers()
     {
-        return Collections.emptyList();
+        return members;
+    }
+
+    @NotNull
+    public List<User> getUsers()
+    {
+        return users;
     }
 
     @NotNull
     public List<TextChannel> getTextChannels()
     {
-        return Collections.emptyList();
+        return textChannels;
     }
 
     @NotNull
     public List<VoiceChannel> getVoiceChannels()
     {
-        return Collections.emptyList();
+        return voiceChannels;
     }
 
     @NotNull
     public List<Role> getRoles()
     {
-        return Collections.emptyList();
+        return roles;
     }
 
     @NotNull
     public List<Emote> getEmotes()
     {
-        return Collections.emptyList();
+        return emotes;
     }
 
     @NotNull
-    public List<Invite> getInvites()
+    public List<String> getInvites()
     {
-        return Collections.emptyList();
+        return invites;
+    }
+
+    @NotNull
+    public RestAction<List<Invite>> resolveInvites()
+    {
+        return RestAction.allOf(
+            getInvites()
+                    .stream()
+                    .map(it -> Invite.resolve(jda, it))
+                    .collect(Collectors.toList())
+        );
     }
 
     @NotNull
     public List<MessageSticker> getStickers()
     {
-        return Collections.emptyList();
+        return stickers;
     }
 
     public boolean mentionsEveryone()
     {
-        return false;
+        return mentionsEveryone;
+    }
+
+    @NotNull
+    public JDA getJDA()
+    {
+        return jda;
+    }
+
+    private <T, C extends Collection<T>> C processMentions(Message.MentionType type, C collection, boolean distinct, Function<Matcher, T> map)
+    {
+        Matcher matcher = type.getPattern().matcher(content);
+        while (matcher.find())
+        {
+            try
+            {
+                T elem = map.apply(matcher);
+                if (elem == null || (distinct && collection.contains(elem)))
+                    continue;
+                collection.add(elem);
+            }
+            catch (NumberFormatException ignored) {}
+        }
+        return collection;
+    }
+
+    private User matchUser(Matcher matcher)
+    {
+        long userId = MiscUtil.parseSnowflake(matcher.group(1));
+        if (!userIds.contains(userId))
+            return null;
+        User user = getJDA().getUserById(userId);
+        if (user == null)
+            user = users.stream().filter(it -> it.getIdLong() == userId).findFirst().orElse(null);
+        return user;
+    }
+
+    private Role matchRole(Matcher matcher)
+    {
+        long roleId = MiscUtil.parseSnowflake(matcher.group(1));
+        if (!roleIds.contains(roleId))
+            return null;
+        if (guild != null)
+            return guild.getRoleById(roleId);
+        else
+            return getJDA().getRoleById(roleId);
+    }
+
+    private Emote matchEmote(Matcher matcher)
+    {
+        long emoteId = MiscUtil.parseSnowflake(matcher.group(2));
+        String name = matcher.group(1);
+        boolean animated = matcher.group(0).startsWith("<a:");
+        Emote emote = getJDA().getEmoteById(emoteId);
+        if (emote == null)
+            emote = new EmoteImpl(emoteId, jda).setName(name).setAnimated(animated);
+        return emote;
+    }
+
+    private List<String> matchInvites()
+    {
+        List<String> invites = new ArrayList<>();
+        Matcher m = Message.INVITE_PATTERN.matcher(content);
+        while (m.find())
+            invites.add(m.group(1));
+        return invites;
+    }
+
+    private <T extends GuildChannel> T matchChannel(Matcher matcher, ChannelType type, Class<T> clazz)
+    {
+        long channelId = MiscUtil.parseSnowflake(matcher.group(1));
+
+        switch (type)
+        {
+        case TEXT:
+            return clazz.cast(getJDA().getTextChannelById(channelId));
+
+        case VOICE:
+            return clazz.cast(getJDA().getVoiceChannelById(channelId));
+
+        default:
+            return null;
+        }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageMentions.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageMentions.java
@@ -1,5 +1,56 @@
 package net.dv8tion.jda.api.entities;
 
+import java.util.Collections;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+
 public class MessageMentions
 {
+    @NotNull
+    public List<Member> getMembers()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<TextChannel> getTextChannels()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<VoiceChannel> getVoiceChannels()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<Role> getRoles()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<Emote> getEmotes()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<Invite> getInvites()
+    {
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    public List<MessageSticker> getStickers()
+    {
+        return Collections.emptyList();
+    }
+
+    public boolean mentionsEveryone()
+    {
+        return false;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageMentions.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageMentions.java
@@ -1,0 +1,5 @@
+package net.dv8tion.jda.api.entities;
+
+public class MessageMentions
+{
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/PartialMessage.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PartialMessage.java
@@ -1,0 +1,113 @@
+package net.dv8tion.jda.api.entities;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.interactions.components.ComponentLayout;
+import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface PartialMessage
+{
+    @NotNull
+    String getNonce();
+
+    @NotNull
+    String getGuildId();
+
+    long getGuildIdLong();
+
+    @NotNull
+    String getChannelId();
+
+    long getChannelIdLong();
+
+    @NotNull
+    MessageMentions getMentions();
+
+    @NotNull
+    MessageComponents getComponents();
+
+    @Nullable
+    MessageReference getMessageReference();
+
+    @Nullable
+    String getContentRaw();
+
+    @Nullable
+    String getContentStripped();
+
+    @Nullable
+    String getContentDisplay();
+
+    @NotNull
+    List<MessageEmbed> getEmbeds();
+
+    @NotNull
+    List<Message.Attachment> getAttachments();
+
+    @NotNull
+    RestAction<Void> pin();
+
+    @NotNull
+    RestAction<Void> unpin();
+
+    @NotNull
+    RestAction<Void> delete();
+
+    @NotNull
+    MessageAction edit(CharSequence content);
+
+    @NotNull
+    MessageAction edit(PartialMessage content);
+
+    @NotNull
+    MessageAction editFormat(String content, Object... format);
+
+    @NotNull
+    MessageAction editEmbeds(MessageEmbed... embeds);
+
+    @NotNull
+    MessageAction editEmbeds(Collection<MessageEmbed> embeds);
+
+    @NotNull
+    MessageAction editComponents(ComponentLayout... components);
+
+    @NotNull
+    MessageAction editComponents(Collection<ComponentLayout> components);
+
+    @NotNull
+    User getAuthor();
+
+    @NotNull
+    String getJumpUrl();
+
+    @NotNull
+    JDA getJDA();
+
+    boolean isFromType(ChannelType type);
+
+    boolean isFromGuild();
+
+    boolean isEdited();
+
+    boolean isPinned();
+
+    boolean isTTS();
+
+    boolean isWebhook();
+
+    @NotNull
+    ChannelType getType();
+
+    @NotNull
+    OffsetDateTime getTimeEdited();
+
+    @NotNull
+    EnumSet<Message.MessageFlag> getFlags();
+}

--- a/src/main/java/net/dv8tion/jda/api/entities/PartialMessage.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/PartialMessage.java
@@ -103,9 +103,9 @@ public interface PartialMessage
     boolean isWebhook();
 
     @NotNull
-    ChannelType getType();
+    MessageType getType();
 
-    @NotNull
+    @Nullable
     OffsetDateTime getTimeEdited();
 
     @NotNull

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -149,16 +149,8 @@ public class PermissionOverrideImpl implements PermissionOverride
     @Override
     public PermissionOverrideAction getManager()
     {
-        Member selfMember = getGuild().getSelfMember();
-        IPermissionContainer channel = getChannel();
+        checkPermissions();
 
-        //TODO-v5: These perms appear to be duplicated with #delete()
-        if (!selfMember.hasPermission(channel, Permission.VIEW_CHANNEL))
-            throw new MissingAccessException(channel, Permission.VIEW_CHANNEL);
-        if (!selfMember.hasAccess(channel))
-            throw new MissingAccessException(channel, Permission.VOICE_CONNECT);
-        if (!selfMember.hasPermission(channel, Permission.MANAGE_PERMISSIONS))
-            throw new InsufficientPermissionException(channel, Permission.MANAGE_PERMISSIONS);
         if (manager == null)
             return manager = new PermissionOverrideActionImpl(this).setOverride(false);
         return manager;
@@ -168,14 +160,7 @@ public class PermissionOverrideImpl implements PermissionOverride
     @Override
     public AuditableRestAction<Void> delete()
     {
-        Member selfMember = getGuild().getSelfMember();
-        IPermissionContainer channel = getChannel();
-        if (!selfMember.hasPermission(channel, Permission.VIEW_CHANNEL))
-            throw new MissingAccessException(channel, Permission.VIEW_CHANNEL);
-        if (!selfMember.hasAccess(channel))
-            throw new MissingAccessException(channel, Permission.VOICE_CONNECT);
-        if (!selfMember.hasPermission(channel, Permission.MANAGE_PERMISSIONS))
-            throw new InsufficientPermissionException(channel, Permission.MANAGE_PERMISSIONS);
+        checkPermissions();
 
         Route.CompiledRoute route = Route.Channels.DELETE_PERM_OVERRIDE.compile(this.channel.getId(), getId());
         return new AuditableRestActionImpl<>(getJDA(), route);
@@ -220,5 +205,17 @@ public class PermissionOverrideImpl implements PermissionOverride
     public String toString()
     {
         return "PermOver:(" + (isMemberOverride() ? "M" : "R") + ")(" + channel.getId() + " | " + getId() + ")";
+    }
+
+    private void checkPermissions()
+    {
+        Member selfMember = getGuild().getSelfMember();
+        IPermissionContainer channel = getChannel();
+        if (!selfMember.hasPermission(channel, Permission.VIEW_CHANNEL))
+            throw new MissingAccessException(channel, Permission.VIEW_CHANNEL);
+        if (!selfMember.hasAccess(channel))
+            throw new MissingAccessException(channel, Permission.VOICE_CONNECT);
+        if (!selfMember.hasPermission(channel, Permission.MANAGE_PERMISSIONS))
+            throw new InsufficientPermissionException(channel, Permission.MANAGE_PERMISSIONS);
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR implements the new message mentions / components abstractions that are planned for v5. It will be draft until the checklist is complete. This is open for contribution.

- [x] Decide on nullability for getContentX
- [x] Decide on behavior on empty components / content 
- [ ] Decide on how this should impact internal Message abstractions (AbstractMessage / ReceivedMessage)
- [ ] Decide on the abstraction layout of Message(Mentions/Components), potential interface?

# TODO

- [ ] Make getContentX nonnull
- [ ] Throw on empty content access
- [ ] Expose application flags through JDA