### PR TITLE
Updated magic numbers to use the Message#MAX_CONTENT_LENGTH constant

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -1244,7 +1244,7 @@ public class MessageBuilder implements Appendable
         if (this.isEmpty())
             throw new IllegalStateException("Cannot build a Message with no content. (You never added any content to the message)");
         if (message.length() > Message.MAX_CONTENT_LENGTH)
-            throw new IllegalStateException("Cannot build a Message with more than 2000 characters. Please limit your input.");
+            throw new IllegalStateException("Cannot build a Message with more than " + Message.MAX_CONTENT_LENGTH + " characters. Please limit your input.");
 
         String[] ids = new String[0];
         return new DataMessage(isTTS, message, nonce, embeds,
@@ -1346,7 +1346,7 @@ public class MessageBuilder implements Appendable
         /**
          * Splits exactly after 2000 chars.
          */
-        SplitPolicy ANYWHERE = (i, b) -> Math.min(i + 2000, b.length());
+        SplitPolicy ANYWHERE = (i, b) -> Math.min(i + Message.MAX_CONTENT_LENGTH, b.length());
 
         /**
          * Creates a new {@link SplitPolicy} splitting on the specified chars.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -316,7 +316,7 @@ public interface MessageChannel extends AbstractChannel, Formattable
     default MessageAction sendMessage(@Nonnull CharSequence text)
     {
         Checks.notEmpty(text, "Provided text for message");
-        Checks.check(text.length() <= 2000, "Provided text for message must be less than 2000 characters in length");
+        Checks.check(text.length() <= Message.MAX_CONTENT_LENGTH, "Provided text for message must be less than " + Message.MAX_CONTENT_LENGTH + " characters in length");
 
         if (text instanceof StringBuilder)
             return new MessageActionImpl(getJDA(), null, this, (StringBuilder) text);
@@ -2731,7 +2731,7 @@ public interface MessageChannel extends AbstractChannel, Formattable
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notEmpty(newContent, "Provided message content");
-        Checks.check(newContent.length() <= 2000, "Provided newContent length must be 2000 or less characters.");
+        Checks.check(newContent.length() <= Message.MAX_CONTENT_LENGTH, "Provided newContent length must be " + Message.MAX_CONTENT_LENGTH + " or less characters.");
         if (newContent instanceof StringBuilder)
             return new MessageActionImpl(getJDA(), messageId, this, (StringBuilder) newContent);
         else

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -316,7 +316,7 @@ public interface MessageChannel extends AbstractChannel, Formattable
     default MessageAction sendMessage(@Nonnull CharSequence text)
     {
         Checks.notEmpty(text, "Provided text for message");
-        Checks.check(text.length() <= Message.MAX_CONTENT_LENGTH, "Provided text for message must be less than " + Message.MAX_CONTENT_LENGTH + " characters in length");
+        Checks.check(text.length() <= Message.MAX_CONTENT_LENGTH, "Provided text for message must be less than %d characters in length", Message.MAX_CONTENT_LENGTH);
 
         if (text instanceof StringBuilder)
             return new MessageActionImpl(getJDA(), null, this, (StringBuilder) text);
@@ -2731,7 +2731,7 @@ public interface MessageChannel extends AbstractChannel, Formattable
     {
         Checks.isSnowflake(messageId, "Message ID");
         Checks.notEmpty(newContent, "Provided message content");
-        Checks.check(newContent.length() <= Message.MAX_CONTENT_LENGTH, "Provided newContent length must be " + Message.MAX_CONTENT_LENGTH + " or less characters.");
+        Checks.check(newContent.length() <= Message.MAX_CONTENT_LENGTH, "Provided newContent length must be %d or less characters.", Message.MAX_CONTENT_LENGTH);
         if (newContent instanceof StringBuilder)
             return new MessageActionImpl(getJDA(), messageId, this, (StringBuilder) newContent);
         else

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -284,7 +284,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     public MessageActionImpl append(final CharSequence csq, final int start, final int end)
     {
         if (content.length() + end - start > Message.MAX_CONTENT_LENGTH)
-            throw new IllegalArgumentException("A message may not exceed 2000 characters. Please limit your input!");
+            throw new IllegalArgumentException("A message may not exceed " + Message.MAX_CONTENT_LENGTH + " characters. Please limit your input!");
         content.append(csq, start, end);
         return this;
     }
@@ -295,7 +295,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     public MessageActionImpl append(final char c)
     {
         if (content.length() == Message.MAX_CONTENT_LENGTH)
-            throw new IllegalArgumentException("A message may not exceed 2000 characters. Please limit your input!");
+            throw new IllegalArgumentException("A message may not exceed " + Message.MAX_CONTENT_LENGTH + " characters. Please limit your input!");
         content.append(c);
         return this;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This PR replaces multiple magic numbers with the Message#MAX_CONTENT_LENGTH constant.
This makes updating JDA when the content length updates easier.
Just changing the constants value and the docs should be enough.