### PR TITLE
Add support for custom rate limiters

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -32,6 +32,7 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.cache.SnowflakeCacheView;
 import net.dv8tion.jda.internal.requests.CompletedRestAction;
+import net.dv8tion.jda.internal.requests.RateLimiter;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -380,6 +381,14 @@ public interface JDA
      * @see    RestAction#setCheck(BooleanSupplier)
      */
     int cancelRequests();
+
+    /**
+     * The rate limiter used by JDA for handling rate limit responses from discord.
+     *
+     * @return {@link RateLimiter} currently in use for this jda connection.
+     */
+    @Nonnull
+    RateLimiter getRateLimiter();
 
     /**
      * {@link ScheduledExecutorService} used to handle rate-limits for {@link RestAction}

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -3062,7 +3062,7 @@ public interface Message extends ISnowflake, Formattable
         {
             return new Request.Builder()
                 .url(getUrl())
-                .addHeader("user-agent", Requester.USER_AGENT)
+                .addHeader("user-agent", Requester.getUserAgent())
                 .addHeader("accept-encoding", "gzip, deflate")
                 .build();
         }

--- a/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
@@ -50,8 +50,8 @@ import java.util.List;
  */
 public class WidgetUtil 
 {
-    public static final String WIDGET_PNG = Requester.DISCORD_API_PREFIX + "guilds/%s/widget.png?style=%s";
-    public static final String WIDGET_URL = Requester.DISCORD_API_PREFIX + "guilds/%s/widget.json";
+    public static final String WIDGET_PNG = Requester.getDiscordApiPrefix() + "guilds/%s/widget.png?style=%s";
+    public static final String WIDGET_URL = Requester.getDiscordApiPrefix() + "guilds/%s/widget.json";
     public static final String WIDGET_HTML = "<iframe src=\"https://discord.com/widget?id=%s&theme=%s\" width=\"%d\" height=\"%d\" allowtransparency=\"true\" frameborder=\"0\"></iframe>";
     
     /**
@@ -210,7 +210,7 @@ public class WidgetUtil
         Request request = new Request.Builder()
                     .url(String.format(WIDGET_URL, guildId))
                     .method("GET", null)
-                    .header("user-agent", Requester.USER_AGENT)
+                    .header("user-agent", Requester.getUserAgent())
                     .header("accept-encoding", "gzip")
                     .build();
 

--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -147,7 +147,7 @@ public class JDAImpl implements JDA
         this.metaConfig = metaConfig == null ? MetaConfig.getDefault() : metaConfig;
         this.shutdownHook = this.metaConfig.isUseShutdownHook() ? new Thread(this::shutdown, "JDA Shutdown Hook") : null;
         this.presence = new PresenceImpl(this);
-        this.requester = new Requester(this);
+        this.requester = new Requester(this, this.sessionConfig);
         this.requester.setRetryOnTimeout(this.sessionConfig.isRetryOnTimeout());
         this.guildSetupController = new GuildSetupController(this);
         this.audioController = new DirectAudioControllerImpl(this);
@@ -488,6 +488,13 @@ public class JDAImpl implements JDA
     public int cancelRequests()
     {
         return requester.getRateLimiter().cancelRequests();
+    }
+
+    @Nonnull
+    @Override
+    public RateLimiter getRateLimiter()
+    {
+        return requester.getRateLimiter();
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
@@ -137,7 +137,7 @@ public class WebhookImpl extends AbstractWebhookClient<Void> implements Webhook
     @Override
     public String getUrl()
     {
-        return Requester.DISCORD_API_PREFIX + "webhooks/" + getId() + (getToken() == null ? "" : "/" + getToken());
+        return Requester.getDiscordApiPrefix() + "webhooks/" + getId() + (getToken() == null ? "" : "/" + getToken());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/SessionConfig.java
@@ -20,12 +20,15 @@ import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor;
 import net.dv8tion.jda.api.utils.ConcurrentSessionController;
 import net.dv8tion.jda.api.utils.SessionController;
+import net.dv8tion.jda.internal.requests.RateLimiter;
+import net.dv8tion.jda.internal.requests.Requester;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
 import okhttp3.OkHttpClient;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.EnumSet;
+import java.util.function.Function;
 
 public class SessionConfig
 {
@@ -36,11 +39,14 @@ public class SessionConfig
     private final int largeThreshold;
     private EnumSet<ConfigFlag> flags;
     private int maxReconnectDelay;
+    private final Function<Requester, RateLimiter> rateLimiter;
+    private final String endpoint;
 
     public SessionConfig(
         @Nullable SessionController sessionController, @Nullable OkHttpClient httpClient,
         @Nullable WebSocketFactory webSocketFactory, @Nullable VoiceDispatchInterceptor interceptor,
-        EnumSet<ConfigFlag> flags, int maxReconnectDelay, int largeThreshold)
+        EnumSet<ConfigFlag> flags, int maxReconnectDelay, int largeThreshold,
+        @Nullable Function<Requester, RateLimiter> rateLimiter, @Nullable String endpoint)
     {
         this.sessionController = sessionController == null ? new ConcurrentSessionController() : sessionController;
         this.httpClient = httpClient;
@@ -49,6 +55,8 @@ public class SessionConfig
         this.flags = flags;
         this.maxReconnectDelay = maxReconnectDelay;
         this.largeThreshold = largeThreshold;
+        this.rateLimiter = rateLimiter;
+        this.endpoint = endpoint;
     }
 
     private static WebSocketFactory newWebSocketFactory()
@@ -128,9 +136,21 @@ public class SessionConfig
         return flags;
     }
 
+    @Nullable
+    public Function<Requester, RateLimiter> getRateLimiter()
+    {
+        return rateLimiter;
+    }
+
+    @Nullable
+    public String getEndpoint() {
+        return this.endpoint;
+    }
+
     @Nonnull
     public static SessionConfig getDefault()
     {
-        return new SessionConfig(null, new OkHttpClient(), null, null, ConfigFlag.getDefault(), 900, 250);
+        return new SessionConfig(null, new OkHttpClient(), null, null, ConfigFlag.getDefault(), 900, 250, null, null);
     }
+
 }

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingSessionConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/sharding/ShardingSessionConfig.java
@@ -20,6 +20,8 @@ import com.neovisionaries.ws.client.WebSocketFactory;
 import net.dv8tion.jda.api.audio.factory.IAudioSendFactory;
 import net.dv8tion.jda.api.hooks.VoiceDispatchInterceptor;
 import net.dv8tion.jda.api.utils.SessionController;
+import net.dv8tion.jda.internal.requests.RateLimiter;
+import net.dv8tion.jda.internal.requests.Requester;
 import net.dv8tion.jda.internal.utils.IOUtil;
 import net.dv8tion.jda.internal.utils.config.SessionConfig;
 import net.dv8tion.jda.internal.utils.config.flags.ConfigFlag;
@@ -29,6 +31,7 @@ import okhttp3.OkHttpClient;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.EnumSet;
+import java.util.function.Function;
 
 public class ShardingSessionConfig extends SessionConfig
 {
@@ -41,9 +44,10 @@ public class ShardingSessionConfig extends SessionConfig
         @Nullable OkHttpClient httpClient, @Nullable OkHttpClient.Builder httpClientBuilder,
         @Nullable WebSocketFactory webSocketFactory, @Nullable IAudioSendFactory audioSendFactory,
         EnumSet<ConfigFlag> flags, EnumSet<ShardingConfigFlag> shardingFlags,
-        int maxReconnectDelay, int largeThreshold)
+        int maxReconnectDelay, int largeThreshold, @Nullable Function<Requester, RateLimiter> rateLimiter,
+        @Nullable String endpoint)
     {
-        super(sessionController, httpClient, webSocketFactory, interceptor, flags, maxReconnectDelay, largeThreshold);
+        super(sessionController, httpClient, webSocketFactory, interceptor, flags, maxReconnectDelay, largeThreshold, rateLimiter, endpoint);
         if (httpClient == null)
             this.builder = httpClientBuilder == null ? IOUtil.newHttpClientBuilder() : httpClientBuilder;
         else
@@ -54,7 +58,7 @@ public class ShardingSessionConfig extends SessionConfig
 
     public SessionConfig toSessionConfig(OkHttpClient client)
     {
-        return new SessionConfig(getSessionController(), client, getWebSocketFactory(), getVoiceDispatchInterceptor(), getFlags(), getMaxReconnectDelay(), getLargeThreshold());
+        return new SessionConfig(getSessionController(), client, getWebSocketFactory(), getVoiceDispatchInterceptor(), getFlags(), getMaxReconnectDelay(), getLargeThreshold(), getRateLimiter(), getEndpoint());
     }
 
     public EnumSet<ShardingConfigFlag> getShardingFlags()
@@ -77,6 +81,6 @@ public class ShardingSessionConfig extends SessionConfig
     @Nonnull
     public static ShardingSessionConfig getDefault()
     {
-        return new ShardingSessionConfig(null, null, new OkHttpClient(), null, null, null, ConfigFlag.getDefault(), ShardingConfigFlag.getDefault(), 900, 250);
+        return new ShardingSessionConfig(null, null, new OkHttpClient(), null, null, null, ConfigFlag.getDefault(), ShardingConfigFlag.getDefault(), 900, 250, null, null);
     }
 }


### PR DESCRIPTION
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This pull request adds support for implementing a custom rate limiter in JDA, as well as the ability to change the URL to which JDA sends requests to. Both of these features are meant to allow advanced users who may want to use a proxy that already handles rate limits with JDA.

As of right now, JDA is one of the few libraries that still isn't compatible with [Twilight](https://github.com/twilight-rs/http-proxy), this pull request fixes that by allowing the user to change the API endpoint to a custom one and to create a no-op rate limiter implementation.

This is doable in both the JDABuilder and ShardManagerBuilder, with the new `setRateLimiter` and `setEndpoint` methods. As requested by DV8, if a custom rate limiter is defined, the User-Agent used by the library is modified to include that as twilight does not modify headers.