### PR TITLE
Deprecate all region usages for guilds

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -450,9 +450,13 @@ public interface Guild extends ISnowflake
      * <br>This will include deprecated voice regions by default.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type {@link java.util.EnumSet EnumSet}
+     *
+     * @deprecated Guilds no longer have the {@link net.dv8tion.jda.api.Region Region} option. Use {@link VoiceChannel#getRegion()} instead.
      */
     @Nonnull
     @CheckReturnValue
+    @Deprecated
+    @ForRemoval(deadline = "5.0.0")
     default RestAction<EnumSet<Region>> retrieveRegions()
     {
         return retrieveRegions(true);
@@ -465,9 +469,13 @@ public interface Guild extends ISnowflake
      *         Whether to include deprecated regions
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type {@link java.util.EnumSet EnumSet}
+     *
+     * @deprecated Guilds no longer have the {@link net.dv8tion.jda.api.Region Region} option. Use {@link VoiceChannel#getRegion()} instead.
      */
     @Nonnull
     @CheckReturnValue
+    @Deprecated
+    @ForRemoval(deadline = "5.0.0")
     RestAction<EnumSet<Region>> retrieveRegions(boolean includeDeprecated);
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/templates/TemplateGuild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/templates/TemplateGuild.java
@@ -16,6 +16,7 @@
 
 package net.dv8tion.jda.api.entities.templates;
 
+import net.dv8tion.jda.annotations.ForRemoval;
 import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Guild.ExplicitContentLevel;
@@ -23,6 +24,7 @@ import net.dv8tion.jda.api.entities.Guild.NotificationLevel;
 import net.dv8tion.jda.api.entities.Guild.Timeout;
 import net.dv8tion.jda.api.entities.Guild.VerificationLevel;
 import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.VoiceChannel;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -104,8 +106,12 @@ public class TemplateGuild implements ISnowflake
      * can still use the {@link #getRegionRaw()} to retrieve the raw name this region has.
      *
      * @return The the audio Region this Guild is using for audio connections. Can return Region.UNKNOWN.
+     *
+     * @deprecated Guilds no longer have the {@link net.dv8tion.jda.api.Region Region} option. Use {@link VoiceChannel#getRegion()} instead.
      */
     @Nonnull
+    @Deprecated
+    @ForRemoval(deadline = "5.0.0")
     public Region getRegion()
     {
         return Region.fromKey(region);
@@ -116,8 +122,12 @@ public class TemplateGuild implements ISnowflake
      * <br>This is resolved to an enum constant of {@link Region Region} by {@link #getRegion()}!
      *
      * @return Raw region name
+     *
+     * @deprecated Guilds no longer have the {@link net.dv8tion.jda.api.Region Region} option. Use {@link VoiceChannel#getRegion()} instead.
      */
     @Nonnull
+    @Deprecated
+    @ForRemoval(deadline = "5.0.0")
     public String getRegionRaw()
     {
         return region;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

## Description

I found a few places where the region of a guild is missing a deprecation. This was apparently forgotten in #1622 
This is required for the v4-lts. Methods will be removed with #1818
