### PR TITLE
Add getPrivacyPolicyUrl() and getTermsOfServiceUrl() to ApplicationInfo

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -55,6 +55,22 @@ public interface ApplicationInfo extends ISnowflake
     String getDescription();
 
     /**
+     * The URL for the application's terms of service.
+     *
+     * @return The URL for the application's terms of service or {@code null} if none is set
+     */
+    @Nullable
+    String getTermsOfServiceUrl();
+
+    /**
+     * The URL for the application's privacy policy.
+     *
+     * @return The URL for the application's privacy policy or {@code null} if none is set
+     */
+    @Nullable
+    String getPrivacyPolicyUrl();
+
+    /**
      * The icon id of the bot's application.
      * <br>The application icon is <b>not</b> necessarily the same as the bot's avatar!
      * 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -35,13 +35,15 @@ public class ApplicationInfoImpl implements ApplicationInfo
     private final long id;
     private final String iconId;
     private final String description;
+    private final String termsOfServiceUrl;
+    private final String privacyPolicyUrl;
     private final String name;
     private final User owner;
     private final ApplicationTeam team;
     private String scopes = "bot";
 
     public ApplicationInfoImpl(JDA api, String description, boolean doesBotRequireCodeGrant, String iconId, long id,
-            boolean isBotPublic, String name, User owner, ApplicationTeam team)
+            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team)
     {
         this.api = api;
         this.description = description;
@@ -50,6 +52,8 @@ public class ApplicationInfoImpl implements ApplicationInfo
         this.id = id;
         this.isBotPublic = isBotPublic;
         this.name = name;
+        this.termsOfServiceUrl = termsOfServiceUrl;
+        this.privacyPolicyUrl = privacyPolicyUrl;
         this.owner = owner;
         this.team = team;
     }
@@ -71,6 +75,18 @@ public class ApplicationInfoImpl implements ApplicationInfo
     public String getDescription()
     {
         return this.description;
+    }
+
+    @Override
+    public String getTermsOfServiceUrl()
+    {
+        return this.termsOfServiceUrl;
+    }
+
+    @Override
+    public String getPrivacyPolicyUrl()
+    {
+        return this.privacyPolicyUrl;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1907,6 +1907,8 @@ public class EntityBuilder
     public ApplicationInfo createApplicationInfo(DataObject object)
     {
         final String description = object.getString("description");
+        final String termsOfServiceUrl = object.getString("terms_of_service_url", null);
+        final String privacyPolicyUrl = object.getString("privacy_policy_url", null);
         final boolean doesBotRequireCodeGrant = object.getBoolean("bot_require_code_grant");
         final String iconId = object.getString("icon", null);
         final long id = object.getLong("id");
@@ -1915,7 +1917,8 @@ public class EntityBuilder
         final User owner = createUser(object.getObject("owner"));
         final ApplicationTeam team = !object.isNull("team") ? createApplicationTeam(object.getObject("team")) : null;
 
-        return new ApplicationInfoImpl(getJDA(), description, doesBotRequireCodeGrant, iconId, id, isBotPublic, name, owner, team);
+        return new ApplicationInfoImpl(getJDA(), description, doesBotRequireCodeGrant, iconId, id, isBotPublic, name,
+                termsOfServiceUrl, privacyPolicyUrl, owner, team);
     }
 
     public ApplicationTeam createApplicationTeam(DataObject object)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This PR adds the ability to get an application's Privacy Policy and Terms of Service URLs from the ApplicationInfo interface.