### PR TITLE
remove unnecessary Authorization header on webhook endpoints

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Requester.java
@@ -170,7 +170,7 @@ public class Requester
 
         //adding token to all requests to the discord api or cdn pages
         //we can check for startsWith(DISCORD_API_PREFIX) because the cdn endpoints don't need any kind of authorization
-        if (url.startsWith(DISCORD_API_PREFIX))
+        if (url.startsWith(DISCORD_API_PREFIX) && apiRequest.getRoute().getBaseRoute().needsAuth())
             builder.header("authorization", api.getToken());
 
         // Apply custom headers like X-Audit-Log-Reason

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -34,7 +34,7 @@ public class Route
     {
         public static final Route TRACK =             new Route(POST, "track");
         public static final Route GET_VOICE_REGIONS = new Route(GET,  "voice/regions");
-        public static final Route GATEWAY =           new Route(GET,  "gateway");
+        public static final Route GATEWAY =           new Route(GET,  "gateway", false);
         public static final Route GATEWAY_BOT =       new Route(GET,  "gateway/bot");
     }
 
@@ -82,10 +82,10 @@ public class Route
         public static final Route EDIT_COMMAND_PERMISSIONS =     new Route(PUT, "applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions");
 
         public static final Route CALLBACK =        new Route(POST,   "interactions/{interaction_id}/{interaction_token}/callback", false);
-        public static final Route CREATE_FOLLOWUP = new Route(POST,   "webhooks/{application_id}/{interaction_token}");
-        public static final Route EDIT_FOLLOWUP =   new Route(PATCH,  "webhooks/{application_id}/{interaction_token}/messages/{message_id}");
-        public static final Route DELETE_FOLLOWUP = new Route(DELETE, "webhooks/{application_id}/{interaction_token}/messages/{message_id}");
-        public static final Route GET_ORIGINAL =    new Route(GET,    "webhooks/{application_id}/{interaction_token}/messages/@original");
+        public static final Route CREATE_FOLLOWUP = new Route(POST,   "webhooks/{application_id}/{interaction_token}", false);
+        public static final Route EDIT_FOLLOWUP =   new Route(PATCH,  "webhooks/{application_id}/{interaction_token}/messages/{message_id}", false);
+        public static final Route DELETE_FOLLOWUP = new Route(DELETE, "webhooks/{application_id}/{interaction_token}/messages/{message_id}", false);
+        public static final Route GET_ORIGINAL =    new Route(GET,    "webhooks/{application_id}/{interaction_token}/messages/@original", false);
     }
 
     public static class Self
@@ -180,19 +180,19 @@ public class Route
 
     public static class Webhooks
     {
-        public static final Route GET_WEBHOOK          = new Route(GET,    "webhooks/{webhook_id}");
-        public static final Route GET_TOKEN_WEBHOOK    = new Route(GET,    "webhooks/{webhook_id}/{token}");
-        public static final Route DELETE_WEBHOOK       = new Route(DELETE, "webhooks/{webhook_id}");
-        public static final Route DELETE_TOKEN_WEBHOOK = new Route(DELETE, "webhooks/{webhook_id}/{token}");
-        public static final Route MODIFY_WEBHOOK       = new Route(PATCH,  "webhooks/{webhook_id}");
-        public static final Route MODIFY_TOKEN_WEBHOOK = new Route(PATCH,  "webhooks/{webhook_id}/{token}");
+        public static final Route GET_WEBHOOK          = new Route(GET,    "webhooks/{webhook_id}", false);
+        public static final Route GET_TOKEN_WEBHOOK    = new Route(GET,    "webhooks/{webhook_id}/{token}", false);
+        public static final Route DELETE_WEBHOOK       = new Route(DELETE, "webhooks/{webhook_id}", false);
+        public static final Route DELETE_TOKEN_WEBHOOK = new Route(DELETE, "webhooks/{webhook_id}/{token}", false);
+        public static final Route MODIFY_WEBHOOK       = new Route(PATCH,  "webhooks/{webhook_id}", false);
+        public static final Route MODIFY_TOKEN_WEBHOOK = new Route(PATCH,  "webhooks/{webhook_id}/{token}", false);
 
         // Separate
-        public static final Route EXECUTE_WEBHOOK        = new Route(POST,   "webhooks/{webhook_id}/{token}");
-        public static final Route EXECUTE_WEBHOOK_EDIT   = new Route(PATCH,  "webhooks/{webhook_id}/{token}/messages/{message_id}");
-        public static final Route EXECUTE_WEBHOOK_DELETE = new Route(DELETE, "webhooks/{webhook_id}/{token}/messages/{message_id}");
-        public static final Route EXECUTE_WEBHOOK_SLACK  = new Route(POST,   "webhooks/{webhook_id}/{token}/slack");
-        public static final Route EXECUTE_WEBHOOK_GITHUB = new Route(POST,   "webhooks/{webhook_id}/{token}/github");
+        public static final Route EXECUTE_WEBHOOK        = new Route(POST,   "webhooks/{webhook_id}/{token}", false);
+        public static final Route EXECUTE_WEBHOOK_EDIT   = new Route(PATCH,  "webhooks/{webhook_id}/{token}/messages/{message_id}", false);
+        public static final Route EXECUTE_WEBHOOK_DELETE = new Route(DELETE, "webhooks/{webhook_id}/{token}/messages/{message_id}", false);
+        public static final Route EXECUTE_WEBHOOK_SLACK  = new Route(POST,   "webhooks/{webhook_id}/{token}/slack", false);
+        public static final Route EXECUTE_WEBHOOK_GITHUB = new Route(POST,   "webhooks/{webhook_id}/{token}/github", false);
     }
 
     public static class Roles

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -81,7 +81,7 @@ public class Route
         public static final Route GET_COMMAND_PERMISSIONS =      new Route(GET, "applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions");
         public static final Route EDIT_COMMAND_PERMISSIONS =     new Route(PUT, "applications/{application_id}/guilds/{guild_id}/commands/{command_id}/permissions");
 
-        public static final Route CALLBACK =        new Route(POST,   "interactions/{interaction_id}/{interaction_token}/callback");
+        public static final Route CALLBACK =        new Route(POST,   "interactions/{interaction_id}/{interaction_token}/callback", false);
         public static final Route CREATE_FOLLOWUP = new Route(POST,   "webhooks/{application_id}/{interaction_token}");
         public static final Route EDIT_FOLLOWUP =   new Route(PATCH,  "webhooks/{application_id}/{interaction_token}/messages/{message_id}");
         public static final Route DELETE_FOLLOWUP = new Route(DELETE, "webhooks/{application_id}/{interaction_token}/messages/{message_id}");
@@ -336,12 +336,19 @@ public class Route
     private static final String majorParameters = "guild_id:channel_id:webhook_id:interaction_token";
     private final String route;
     private final Method method;
+    private final boolean needsAuth;
     private final int paramCount;
 
     private Route(Method method, String route)
     {
+        this(method, route, true);
+    }
+
+    private Route(Method method, String route, boolean needsAuth)
+    {
         this.method = method;
         this.route = route;
+        this.needsAuth = needsAuth;
         this.paramCount = Helpers.countMatches(route, '{'); //All parameters start with {
 
         if (paramCount != Helpers.countMatches(route, '}'))
@@ -356,6 +363,11 @@ public class Route
     public String getRoute()
     {
         return route;
+    }
+
+    public boolean needsAuth()
+    {
+        return needsAuth;
     }
 
     public int getParamCount()

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -180,11 +180,11 @@ public class Route
 
     public static class Webhooks
     {
-        public static final Route GET_WEBHOOK          = new Route(GET,    "webhooks/{webhook_id}", false);
+        public static final Route GET_WEBHOOK          = new Route(GET,    "webhooks/{webhook_id}");
         public static final Route GET_TOKEN_WEBHOOK    = new Route(GET,    "webhooks/{webhook_id}/{token}", false);
-        public static final Route DELETE_WEBHOOK       = new Route(DELETE, "webhooks/{webhook_id}", false);
+        public static final Route DELETE_WEBHOOK       = new Route(DELETE, "webhooks/{webhook_id}");
         public static final Route DELETE_TOKEN_WEBHOOK = new Route(DELETE, "webhooks/{webhook_id}/{token}", false);
-        public static final Route MODIFY_WEBHOOK       = new Route(PATCH,  "webhooks/{webhook_id}", false);
+        public static final Route MODIFY_WEBHOOK       = new Route(PATCH,  "webhooks/{webhook_id}");
         public static final Route MODIFY_TOKEN_WEBHOOK = new Route(PATCH,  "webhooks/{webhook_id}/{token}", false);
 
         // Separate


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes #1898 

## Description

this PR removes the Authorization header from callback endpoints requests. I'm not sure which endpoints don't require this, so assistance is welcome