### PR TITLE
add MODERATE_MEMBERS permission

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -45,6 +45,7 @@ public enum Permission
     BAN_MEMBERS(          2, true, false, "Ban Members"),
     NICKNAME_CHANGE(     26, true, false, "Change Nickname"),
     NICKNAME_MANAGE(     27, true, false, "Manage Nicknames"),
+    MODERATE_MEMBERS(    40, true, false, "Moderate Members"),
 
     // Text Permissions
     MESSAGE_ADD_REACTION(     6, true, true, "Add Reactions"),


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR adds the MODERATE_MEMBERS permission which is used for timing out members (already on canary, not an experiment). in case someone makes a PR for implementing timeouts, I'll close this PR in favor of adding the permission with that PR.