### PR TITLE
Change publishing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,13 +437,6 @@ Be sure to replace the **VERSION** key below with the one of the versions shown 
     <version>VERSION</version>
 </dependency>
 ```
-```xml
-<repository>
-    <id>dv8tion</id>
-    <name>m2-dv8tion</name>
-    <url>https://m2.dv8tion.net/releases</url>
-</repository>
-```
 
 **Maven without Audio**
 ```xml
@@ -462,17 +455,13 @@ Be sure to replace the **VERSION** key below with the one of the versions shown 
 
 **Gradle**
 ```gradle
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     //Change 'implementation' to 'compile' in old Gradle versions
     implementation("net.dv8tion:JDA:VERSION")
-}
-
-repositories {
-    mavenCentral() // for transitive dependencies
-    maven {
-      name 'm2-dv8tion'
-      url 'https://m2.dv8tion.net/releases'
-    }
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,9 @@ plugins {
     `java-library`
     `maven-publish`
 
-    id("io.codearte.nexus-staging") version "0.22.0"
+    id("io.codearte.nexus-staging") version "0.30.0"
     id("de.marcphilipp.nexus-publish") version "0.4.0"
-    id("com.github.johnrengelman.shadow") version "6.1.0"
+    id("com.github.johnrengelman.shadow") version "7.1.0"
 }
 
 val versionObj = Version(major = "4", minor = "4", revision = "0")
@@ -236,7 +236,7 @@ compileJava.apply {
 jar.apply {
     archiveBaseName.set(project.name)
     manifest.attributes(mapOf(
-            "Implementation-Version" to version,
+            "Implementation-Version" to project.version,
             "Automatic-Module-Name" to "net.dv8tion.jda"))
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -437,8 +437,30 @@ publishing {
 
             generatePom(pom)
         }
+
+        register("Local", MavenPublication::class) {
+            from(components["java"])
+
+            artifactId = project.name
+            groupId = project.group as String
+            version = project.version as String
+
+            artifact(sourcesJar)
+            artifact(javadocJar)
+
+            generatePom(pom)
+
+            artifacts.forEach {
+                println("Added artifact ${it.file}")
+            }
+        }
     }
 }
+
+// Skip fat jar publication (See https://github.com/johnrengelman/shadow/issues/586)
+components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) { skip() }
+val SoftwareComponentContainer.java
+    get() = components.getByName("java") as AdhocComponentWithVariants
 
 
 
@@ -519,3 +541,9 @@ tasks.withType<AbstractPublishToMaven> {
 tasks.withType<Copy> {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
+
+// Allow local publishing
+val publishToMavenLocal: Task by tasks
+val publishLocalPublicationToMavenLocal: Task by tasks
+publishToMavenLocal.enabled = true
+publishLocalPublicationToMavenLocal.enabled = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -402,6 +402,11 @@ fun generatePom(pom: Pom) {
 
 // Publish
 
+// Skip fat jar publication (See https://github.com/johnrengelman/shadow/issues/586)
+components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) { skip() }
+val SoftwareComponentContainer.java
+    get() = components.getByName("java") as AdhocComponentWithVariants
+
 publishing {
     publications {
         register("Release", MavenPublication::class) {
@@ -449,18 +454,11 @@ publishing {
             artifact(javadocJar)
 
             generatePom(pom)
-
-            artifacts.forEach {
-                println("Added artifact ${it.file}")
-            }
         }
     }
 }
 
-// Skip fat jar publication (See https://github.com/johnrengelman/shadow/issues/586)
-components.java.withVariantsFromConfiguration(configurations.shadowRuntimeElements.get()) { skip() }
-val SoftwareComponentContainer.java
-    get() = components.getByName("java") as AdhocComponentWithVariants
+
 
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,11 +39,15 @@ plugins {
 }
 
 val versionObj = Version(major = "4", minor = "4", revision = "0")
+val isCI = System.getProperty("BUILD_NUMBER") != null // jenkins
+        || System.getenv("BUILD_NUMBER") != null
+        || System.getProperty("GIT_COMMIT") != null // jitpack
+        || System.getenv("GIT_COMMIT") != null
 
 // Check the commit hash and version information
 val commitHash: String by lazy {
     val file = File(".git/refs/heads/master")
-    if (file.canRead())
+    if (isCI && file.canRead())
         file.readText().substring(0, 7)
     else
         "DEV"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,6 +140,11 @@ val check: Task by tasks
 
 shadowJar.archiveClassifier.set("withDependencies")
 
+fun nullable(string: String?): String {
+    return if (string == null) "null"
+           else "\"$string\""
+}
+
 val sourcesForRelease = task<Copy>("sourcesForRelease") {
     from("src/main/java") {
         include("**/JDAInfo.java")
@@ -147,8 +152,8 @@ val sourcesForRelease = task<Copy>("sourcesForRelease") {
                 "versionMajor" to versionObj.major,
                 "versionMinor" to versionObj.minor,
                 "versionRevision" to versionObj.revision,
-                "versionClassifier" to versionObj.classifier.toString(),
-                "commitHash" to commitHash
+                "versionClassifier" to nullable(versionObj.classifier),
+                "commitHash" to nullable(commitHash)
         )
         filter<ReplaceTokens>(mapOf("tokens" to tokens))
     }
@@ -262,6 +267,10 @@ javadoc.apply {
         }
     }
 
+    dependsOn(sourcesJar)
+    source = sourcesJar.source.asFileTree
+    exclude("MANIFEST.MF")
+
     //### excludes ###
 
     //jda internals
@@ -280,8 +289,6 @@ build.apply {
     dependsOn(minimalJar)
 
     jar.mustRunAfter(clean)
-    javadocJar.mustRunAfter(jar)
-    sourcesJar.mustRunAfter(javadocJar)
     shadowJar.mustRunAfter(sourcesJar)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,7 +158,7 @@ val sourcesForRelease = task<Copy>("sourcesForRelease") {
                 "versionMinor" to versionObj.minor,
                 "versionRevision" to versionObj.revision,
                 "versionClassifier" to nullable(versionObj.classifier),
-                "commitHash" to nullable(commitHash)
+                "commitHash" to commitHash
         )
         // Allow for setting null on some strings without breaking the source
         // for this, we have special tokens marked with "!@...@!" which are replaced to @...@

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,6 @@ configure<SourceSetContainer> {
 repositories {
     mavenLocal()
     mavenCentral()
-    maven("https://m2.dv8tion.net/releases")
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/dv8tion/jda/api/JDAInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/JDAInfo.java
@@ -27,8 +27,8 @@ public class JDAInfo
     public static final String VERSION_MAJOR = "@versionMajor@";
     public static final String VERSION_MINOR = "@versionMinor@";
     public static final String VERSION_REVISION = "@versionRevision@";
-    public static final String VERSION_CLASSIFIER = @versionClassifier@;
-    public static final String COMMIT_HASH = @commitHash@;
+    public static final String VERSION_CLASSIFIER = "!@versionClassifier@!";
+    public static final String COMMIT_HASH = "!@commitHash@!";
     public static final String VERSION = String.format("%s.%s.%s%s%s", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION,
             VERSION_CLASSIFIER == null ? "" : "-" + VERSION_CLASSIFIER,
             COMMIT_HASH == null ? "" : "_" + COMMIT_HASH);

--- a/src/main/java/net/dv8tion/jda/api/JDAInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/JDAInfo.java
@@ -27,6 +27,9 @@ public class JDAInfo
     public static final String VERSION_MAJOR = "@versionMajor@";
     public static final String VERSION_MINOR = "@versionMinor@";
     public static final String VERSION_REVISION = "@versionRevision@";
-    public static final String VERSION_BUILD = "@versionBuild@";
-    public static final String VERSION = VERSION_MAJOR.startsWith("@") ? "dev" : String.format("%s.%s.%s_%s", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION, VERSION_BUILD);
+    public static final String VERSION_CLASSIFIER = "@versionClassifier@";
+    public static final String COMMIT_HASH = "@commitHash@";
+    public static final String VERSION = String.format("%s.%s.%s%s%s", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION,
+            VERSION_CLASSIFIER == null ? "" : "-" + VERSION_CLASSIFIER,
+            COMMIT_HASH == null ? "" : "_" + COMMIT_HASH);
 }

--- a/src/main/java/net/dv8tion/jda/api/JDAInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/JDAInfo.java
@@ -28,7 +28,7 @@ public class JDAInfo
     public static final String VERSION_MINOR = "@versionMinor@";
     public static final String VERSION_REVISION = "@versionRevision@";
     public static final String VERSION_CLASSIFIER = "!@versionClassifier@!";
-    public static final String COMMIT_HASH = "!@commitHash@!";
+    public static final String COMMIT_HASH = "@commitHash@";
     public static final String VERSION = String.format("%s.%s.%s%s%s", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION,
             VERSION_CLASSIFIER == null ? "" : "-" + VERSION_CLASSIFIER,
             COMMIT_HASH == null ? "" : "_" + COMMIT_HASH);

--- a/src/main/java/net/dv8tion/jda/api/JDAInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/JDAInfo.java
@@ -27,8 +27,8 @@ public class JDAInfo
     public static final String VERSION_MAJOR = "@versionMajor@";
     public static final String VERSION_MINOR = "@versionMinor@";
     public static final String VERSION_REVISION = "@versionRevision@";
-    public static final String VERSION_CLASSIFIER = "@versionClassifier@";
-    public static final String COMMIT_HASH = "@commitHash@";
+    public static final String VERSION_CLASSIFIER = @versionClassifier@;
+    public static final String COMMIT_HASH = @commitHash@;
     public static final String VERSION = String.format("%s.%s.%s%s%s", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION,
             VERSION_CLASSIFIER == null ? "" : "-" + VERSION_CLASSIFIER,
             COMMIT_HASH == null ? "" : "_" + COMMIT_HASH);


### PR DESCRIPTION
With this new logic, we can publish to maven central and jitpack.

If the version is bumped (e.g. 5.0.0 -> 5.0.1), we release the artifact to maven central and upload the jars to jenkins as usual.

If the version is not bumped and we only have a new commit, we only build the jars and javadoc on jenkins and append the commit hash (abbreviated to 7 chars) to the artifact version.

For people who are interested in using snapshot builds between version bumps, you can either use jitpack to get specific commit versions or download jars from jenkins. We do not intend to publish every single commit to maven central.