### PR TITLE
Make SelectionMenu#getOptions return an unmodifiable list

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
@@ -81,9 +81,10 @@ public interface SelectionMenu extends Component
     int getMaxValues();
 
     /**
-     * Up to 25 available options to choose from.
+     * An <b>unmodifiable</b> list of up to 25 available options to choose from.
      *
      * @return The {@link SelectOption SelectOptions} this menu provides
+     * @see Builder#getOptions()
      */
     @Nonnull
     List<SelectOption> getOptions();

--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/SelectionMenu.java
@@ -84,7 +84,8 @@ public interface SelectionMenu extends Component
      * An <b>unmodifiable</b> list of up to 25 available options to choose from.
      *
      * @return The {@link SelectOption SelectOptions} this menu provides
-     * @see Builder#getOptions()
+     *
+     * @see    Builder#getOptions()
      */
     @Nonnull
     List<SelectOption> getOptions();

--- a/src/main/java/net/dv8tion/jda/internal/interactions/SelectionMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/SelectionMenuImpl.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SelectionMenuImpl implements SelectionMenu
@@ -52,7 +53,7 @@ public class SelectionMenuImpl implements SelectionMenu
         this.minValues = minValues;
         this.maxValues = maxValues;
         this.disabled = disabled;
-        this.options = options;
+        this.options = Collections.unmodifiableList(options);
     }
 
     private static List<SelectOption> parseOptions(DataArray array)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This makes `SelectionMenu#getOptions` return an unmodifiable list. This prevents user errors such as inserting `SelectOption`s in it, which would cause bugs as some internal variables wouldn't be updated
