### PR TITLE
Add GenericMessageEvent#getThreadChannel()

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -235,13 +235,25 @@ public abstract class GenericMessageEvent extends Event
      * @see    #isFromGuild()
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
-     * @see    ChannelType#isThread()
+     * @see    #isFromThread()
      */
     @Nonnull
     public ThreadChannel getThreadChannel()
     {
-        if (!getChannelType().isThread())
+        if (!isFromThread())
             throw new IllegalStateException("This message event did not happen in a thread channel");
         return (ThreadChannel) channel;
+    }
+
+    /**
+     * If the message event was from a {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel}
+     *
+     * @return If the message event was from a ThreadChannel
+     *
+     * @see ChannelType#isThread()
+     */
+    public boolean isFromThread()
+    {
+        return getChannelType().isThread();
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -221,4 +221,26 @@ public abstract class GenericMessageEvent extends Event
             throw new IllegalStateException("This message event did not happen in a private channel");
         return (PrivateChannel) channel;
     }
+
+    /**
+     * The {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} the Message was received in.
+     * <br>If this Message was not received in a {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel},
+     * this will throw an {@link java.lang.IllegalStateException}.
+     *
+     * @throws java.lang.IllegalStateException
+     *         If this was not sent in a {@link net.dv8tion.jda.api.entities.ThreadChannel}.
+     *
+     * @return The ThreadChannel the Message was received in
+     *
+     * @see    #isFromGuild()
+     * @see    #isFromType(ChannelType)
+     * @see    #getChannelType()
+     */
+    @Nonnull
+    public ThreadChannel getThreadChannel()
+    {
+        if (!isFromType(ChannelType.GUILD_NEWS_THREAD) && !isFromType(ChannelType.GUILD_PUBLIC_THREAD) && !isFromType(ChannelType.GUILD_PRIVATE_THREAD))
+            throw new IllegalStateException("This message event did not happen in a thread channel");
+        return (ThreadChannel) channel;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -235,6 +235,7 @@ public abstract class GenericMessageEvent extends Event
      * @see    #isFromGuild()
      * @see    #isFromType(ChannelType)
      * @see    #getChannelType()
+     * @see    ChannelType#isThread()
      */
     @Nonnull
     public ThreadChannel getThreadChannel()

--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -239,7 +239,7 @@ public abstract class GenericMessageEvent extends Event
     @Nonnull
     public ThreadChannel getThreadChannel()
     {
-        if (!isFromType(ChannelType.GUILD_NEWS_THREAD) && !isFromType(ChannelType.GUILD_PUBLIC_THREAD) && !isFromType(ChannelType.GUILD_PRIVATE_THREAD))
+        if (!getChannelType().isThread())
             throw new IllegalStateException("This message event did not happen in a thread channel");
         return (ThreadChannel) channel;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds a missing GenericMessageEvent#getThreadChannel() to v5