### PR TITLE
Implement parent channel fetching when checking thread permissions

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -919,7 +919,7 @@ public class ReceivedMessage extends AbstractMessage
             if (isFromType(ChannelType.PRIVATE))
                 throw new IllegalStateException("Cannot delete another User's messages in a PrivateChannel.");
 
-            IPermissionContainer permChan = (IPermissionContainer) channel;
+            IPermissionContainer permChan = getPermissionContainer();
             if (!getGuild().getSelfMember().hasAccess(permChan))
                 throw new MissingAccessException(permChan, Permission.VIEW_CHANNEL);
             else if (!getGuild().getSelfMember().hasPermission(permChan, Permission.MESSAGE_MANAGE))
@@ -940,7 +940,7 @@ public class ReceivedMessage extends AbstractMessage
             if (isFromType(ChannelType.PRIVATE))
                 throw new PermissionException("Cannot suppress embeds of others in a PrivateChannel.");
 
-            IPermissionContainer permChan = (IPermissionContainer) channel;
+            IPermissionContainer permChan = getPermissionContainer();
             if (!getGuild().getSelfMember().hasPermission(permChan, Permission.MESSAGE_MANAGE))
                 throw new InsufficientPermissionException(permChan, Permission.MESSAGE_MANAGE);
         }
@@ -1085,6 +1085,24 @@ public class ReceivedMessage extends AbstractMessage
             catch (NumberFormatException ignored) {}
         }
         return collection;
+    }
+
+    private IPermissionContainer getPermissionContainer()
+    {
+        IPermissionContainer permChan;
+
+        // Check if the channel is a thread
+        if (isFromType(ChannelType.GUILD_NEWS_THREAD) || isFromType(ChannelType.GUILD_PUBLIC_THREAD) || isFromType(ChannelType.GUILD_PRIVATE_THREAD))
+        {
+            // Get the parent channel for permissions if we are using a thread
+            permChan = ((ThreadChannel) channel).getParentChannel();
+        }
+        else
+        {
+            permChan = (IPermissionContainer) channel;
+        }
+
+        return permChan;
     }
 
     private static class FormatToken

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -919,10 +919,12 @@ public class ReceivedMessage extends AbstractMessage
             if (isFromType(ChannelType.PRIVATE))
                 throw new IllegalStateException("Cannot delete another User's messages in a PrivateChannel.");
 
-            if (!getGuild().getSelfMember().hasAccess(getGuildChannel()))
-                throw new MissingAccessException(getGuildChannel(), Permission.VIEW_CHANNEL);
-            else if (!getGuild().getSelfMember().hasPermission(getGuildChannel(), Permission.MESSAGE_MANAGE))
-                throw new InsufficientPermissionException(getGuildChannel(), Permission.MESSAGE_MANAGE);
+            GuildMessageChannel gChan = getGuildChannel();
+            Member sMember = getGuild().getSelfMember();
+            if (!sMember.hasAccess(gChan))
+                throw new MissingAccessException(gChan, Permission.VIEW_CHANNEL);
+            else if (!sMember.hasPermission(gChan, Permission.MESSAGE_MANAGE))
+                throw new InsufficientPermissionException(gChan, Permission.MESSAGE_MANAGE);
         }
         return channel.deleteMessageById(getIdLong());
     }
@@ -939,8 +941,9 @@ public class ReceivedMessage extends AbstractMessage
             if (isFromType(ChannelType.PRIVATE))
                 throw new PermissionException("Cannot suppress embeds of others in a PrivateChannel.");
 
-            if (!getGuild().getSelfMember().hasPermission(getGuildChannel(), Permission.MESSAGE_MANAGE))
-                throw new InsufficientPermissionException(getGuildChannel(), Permission.MESSAGE_MANAGE);
+            GuildMessageChannel gChan = getGuildChannel();
+            if (!getGuild().getSelfMember().hasPermission(gChan, Permission.MESSAGE_MANAGE))
+                throw new InsufficientPermissionException(gChan, Permission.MESSAGE_MANAGE);
         }
         JDAImpl jda = (JDAImpl) getJDA();
         Route.CompiledRoute route = Route.Messages.EDIT_MESSAGE.compile(getChannel().getId(), getId());

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -919,11 +919,10 @@ public class ReceivedMessage extends AbstractMessage
             if (isFromType(ChannelType.PRIVATE))
                 throw new IllegalStateException("Cannot delete another User's messages in a PrivateChannel.");
 
-            IPermissionContainer permChan = getPermissionContainer();
-            if (!getGuild().getSelfMember().hasAccess(permChan))
-                throw new MissingAccessException(permChan, Permission.VIEW_CHANNEL);
-            else if (!getGuild().getSelfMember().hasPermission(permChan, Permission.MESSAGE_MANAGE))
-                throw new InsufficientPermissionException(permChan, Permission.MESSAGE_MANAGE);
+            if (!getGuild().getSelfMember().hasAccess(getGuildChannel()))
+                throw new MissingAccessException(getGuildChannel(), Permission.VIEW_CHANNEL);
+            else if (!getGuild().getSelfMember().hasPermission(getGuildChannel(), Permission.MESSAGE_MANAGE))
+                throw new InsufficientPermissionException(getGuildChannel(), Permission.MESSAGE_MANAGE);
         }
         return channel.deleteMessageById(getIdLong());
     }
@@ -940,9 +939,8 @@ public class ReceivedMessage extends AbstractMessage
             if (isFromType(ChannelType.PRIVATE))
                 throw new PermissionException("Cannot suppress embeds of others in a PrivateChannel.");
 
-            IPermissionContainer permChan = getPermissionContainer();
-            if (!getGuild().getSelfMember().hasPermission(permChan, Permission.MESSAGE_MANAGE))
-                throw new InsufficientPermissionException(permChan, Permission.MESSAGE_MANAGE);
+            if (!getGuild().getSelfMember().hasPermission(getGuildChannel(), Permission.MESSAGE_MANAGE))
+                throw new InsufficientPermissionException(getGuildChannel(), Permission.MESSAGE_MANAGE);
         }
         JDAImpl jda = (JDAImpl) getJDA();
         Route.CompiledRoute route = Route.Messages.EDIT_MESSAGE.compile(getChannel().getId(), getId());
@@ -1085,24 +1083,6 @@ public class ReceivedMessage extends AbstractMessage
             catch (NumberFormatException ignored) {}
         }
         return collection;
-    }
-
-    private IPermissionContainer getPermissionContainer()
-    {
-        IPermissionContainer permChan;
-
-        // Check if the channel is a thread
-        if (getChannelType().isThread())
-        {
-            // Get the parent channel for permissions if we are using a thread
-            permChan = ((ThreadChannel) channel).getParentChannel();
-        }
-        else
-        {
-            permChan = (IPermissionContainer) channel;
-        }
-
-        return permChan;
     }
 
     private static class FormatToken

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -1092,7 +1092,7 @@ public class ReceivedMessage extends AbstractMessage
         IPermissionContainer permChan;
 
         // Check if the channel is a thread
-        if (isFromType(ChannelType.GUILD_NEWS_THREAD) || isFromType(ChannelType.GUILD_PUBLIC_THREAD) || isFromType(ChannelType.GUILD_PRIVATE_THREAD))
+        if (getChannelType().isThread())
         {
             // Get the parent channel for permissions if we are using a thread
             permChan = ((ThreadChannel) channel).getParentChannel();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1921

## Description

When trying to get the IPermissionContainer for a thread it now gets it from the parent to stop a ClassCastException.
