### PR TITLE
fix wrong check in GenericMessageEvent#getGuildChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Message Message} was created/deleted/changed.
  * <br>Every MessageEvent is an instance of this event and can be casted.
- * 
+ *
  * <p>Can be used to detect any MessageEvent.
  *
  * <h2>Requirements</h2>
@@ -72,7 +72,7 @@ public abstract class GenericMessageEvent extends Event
     @Nonnull
     public GuildMessageChannel getGuildChannel()
     {
-        if (isFromGuild())
+        if (!isFromGuild())
             throw new IllegalStateException("This message event did not happen in a guild");
         return (GuildMessageChannel) channel;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1926

## Description

this PR fixes the check in GenericMessageEvent#getGuildChannel that would always throw.