### PR TITLE
Remove GuildManager#setVanityCode

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -693,8 +693,6 @@ public interface Guild extends ISnowflake
      * The vanity url code for this Guild. The vanity url is the custom invite code of partnered / official / boosted Guilds.
      * <br>The returned String will be the code that can be provided to {@code discord.gg/{code}} to get the invite link.
      *
-     * <p>The Vanity Code can be modified using {@link GuildManager#setVanityCode(String)}.
-     *
      * @return The vanity code or null
      *
      * @since  4.0.0
@@ -707,8 +705,6 @@ public interface Guild extends ISnowflake
     /**
      * The vanity url for this Guild. The vanity url is the custom invite code of partnered / official / boosted Guilds.
      * <br>The returned String will be the vanity invite link to this guild.
-     *
-     * <p>The Vanity Code can be modified using {@link GuildManager#setVanityCode(String)}.
      *
      * @return The vanity url or null
      *

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
@@ -45,33 +45,32 @@ public interface GuildManager extends Manager<GuildManager>
 {
     /** Used to reset the name field */
     long NAME   = 1;
-    //Bitmap gap due to removed REGION field
     /** Used to reset the icon field */
-    long ICON   = 1 << 2;
+    long ICON   = 1 << 1;
     /** Used to reset the splash field */
-    long SPLASH = 1 << 3;
+    long SPLASH = 1 << 2;
     /** Used to reset the afk channel field */
-    long AFK_CHANNEL    = 1 << 4;
+    long AFK_CHANNEL    = 1 << 3;
     /** Used to reset the afk timeout field */
-    long AFK_TIMEOUT    = 1 << 5;
+    long AFK_TIMEOUT    = 1 << 4;
     /** Used to reset the system channel field */
-    long SYSTEM_CHANNEL = 1 << 6;
+    long SYSTEM_CHANNEL = 1 << 5;
     /** Used to reset the mfa level field */
-    long MFA_LEVEL      = 1 << 7;
+    long MFA_LEVEL      = 1 << 6;
     /** Used to reset the default notification level field */
-    long NOTIFICATION_LEVEL     = 1 << 8;
+    long NOTIFICATION_LEVEL     = 1 << 7;
     /** Used to reset the explicit content level field */
-    long EXPLICIT_CONTENT_LEVEL = 1 << 9;
+    long EXPLICIT_CONTENT_LEVEL = 1 << 8;
     /** Used to reset the verification level field */
-    long VERIFICATION_LEVEL     = 1 << 10;
+    long VERIFICATION_LEVEL     = 1 << 9;
     /** Used to reset the banner field */
-    long BANNER                 = 1 << 11;
+    long BANNER                 = 1 << 10;
     /** Used to reset the description field */
-    long DESCRIPTION                = 1 << 12;
+    long DESCRIPTION                = 1 << 11;
     /** Used to reset the rules channel field */
-    long RULES_CHANNEL              = 1 << 13;
+    long RULES_CHANNEL              = 1 << 12;
     /** Used to reset the community updates channel field */
-    long COMMUNITY_UPDATES_CHANNEL  = 1 << 14;
+    long COMMUNITY_UPDATES_CHANNEL  = 1 << 13;
 
     /**
      * Resets the fields specified by the provided bit-flag pattern.

--- a/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/GuildManager.java
@@ -66,14 +66,12 @@ public interface GuildManager extends Manager<GuildManager>
     long VERIFICATION_LEVEL     = 1 << 10;
     /** Used to reset the banner field */
     long BANNER                 = 1 << 11;
-    /** Used to reset the vanity code field */
-    long VANITY_URL                 = 1 << 12;
     /** Used to reset the description field */
-    long DESCRIPTION                = 1 << 13;
+    long DESCRIPTION                = 1 << 12;
     /** Used to reset the rules channel field */
-    long RULES_CHANNEL              = 1 << 14;
+    long RULES_CHANNEL              = 1 << 13;
     /** Used to reset the community updates channel field */
-    long COMMUNITY_UPDATES_CHANNEL  = 1 << 15;
+    long COMMUNITY_UPDATES_CHANNEL  = 1 << 14;
 
     /**
      * Resets the fields specified by the provided bit-flag pattern.
@@ -342,22 +340,6 @@ public interface GuildManager extends Manager<GuildManager>
     @Nonnull
     @CheckReturnValue
     GuildManager setBanner(@Nullable Icon banner);
-
-    /**
-     * Sets the Vanity Code {@link net.dv8tion.jda.api.entities.Icon Icon} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.
-     *
-     * @param  code
-     *         The new vanity code for this {@link net.dv8tion.jda.api.entities.Guild Guild}
-     *         or {@code null} to reset
-     *
-     * @throws java.lang.IllegalStateException
-     *         If the guild's {@link net.dv8tion.jda.api.entities.Guild#getFeatures() features} do not include {@code VANITY_URL}
-     *
-     * @return GuildManager for chaining convenience
-     */
-    @Nonnull
-    @CheckReturnValue
-    GuildManager setVanityCode(@Nullable String code);
 
     /**
      * Sets the Description {@link net.dv8tion.jda.api.entities.Icon Icon} of this {@link net.dv8tion.jda.api.entities.Guild Guild}.

--- a/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/GuildManagerImpl.java
@@ -40,7 +40,7 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
     protected String name;
     protected Icon icon, splash, banner;
     protected String afkChannel, systemChannel, rulesChannel, communityUpdatesChannel;
-    protected String description, vanityCode;
+    protected String description;
     protected int afkTimeout;
     protected int mfaLevel;
     protected int notificationLevel;
@@ -111,7 +111,6 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
         this.name = null;
         this.icon = null;
         this.splash = null;
-        this.vanityCode = null;
         this.description = null;
         this.banner = null;
         this.afkChannel = null;
@@ -267,16 +266,6 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
 
     @Nonnull
     @Override
-    public GuildManager setVanityCode(@Nullable String code)
-    {
-        checkFeature("VANITY_URL");
-        this.vanityCode = code;
-        set |= VANITY_URL;
-        return this;
-    }
-
-    @Nonnull
-    @Override
     public GuildManager setDescription(@Nullable String description)
     {
         checkFeature("VERIFIED");
@@ -315,8 +304,6 @@ public class GuildManagerImpl extends ManagerBase<GuildManager> implements Guild
             body.put("explicit_content_filter", explicitContentLevel);
         if (shouldUpdate(BANNER))
             body.put("banner", banner == null ? null : banner.getEncoding());
-        if (shouldUpdate(VANITY_URL))
-            body.put("vanity_code", vanityCode);
         if (shouldUpdate(DESCRIPTION))
             body.put("description", description);
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1932

## Description

this PR removes `GuildManager#setVanityCode` as the vanity code can't be modified using the `Modify Guild` endpoint.