### PR TITLE
Add Tags, Default Install Url, Scopes and Permissions to ApplicationInfo

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -290,9 +290,9 @@ public interface ApplicationInfo extends ISnowflake
     /**
      * A {@link java.util.List} containing the tags of this bot's application.
      *
-     * This List is empty if no tags are set in the Developer Portal.
+     * <p>This List is empty if no tags are set in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a>.
      *
-     * @return List containing the tags of this bot's application
+     * @return Immutable list containing the tags of this bot's application
      */
     @Nonnull
     List<String> getTags();
@@ -300,7 +300,7 @@ public interface ApplicationInfo extends ISnowflake
     /**
      * The custom Authorization URL of this bot's application.
      *
-     * This returns null if no custom URL is set in the Developer Portal or if In-app Authorization is enabled.
+     * <p>This returns null if no custom URL is set in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a> or if In-app Authorization is enabled.
      *
      * @return Custom Authorization URL, or null if it has not been set
      */
@@ -310,17 +310,17 @@ public interface ApplicationInfo extends ISnowflake
     /**
      * A {@link java.util.List} of scopes the default authorization URL is set up with.
      *
-     * This is empty if you set a custom URL in the Developer Portal.
+     * <p>This is empty if you set a custom URL in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a>.
      *
-     * @return List of scopes the default authorization URL is set up with.
+     * @return Immutable list of scopes the default authorization URL is set up with.
      */
     @Nonnull
     List<String> getScopes();
 
     /**
-     * A {@link java.util.EnumSet} of permissions the default authorization URL is set up with.
+     * An {@link java.util.EnumSet} of permissions the default authorization URL is set up with.
      *
-     * This is empty if you set a custom URL in the Developer Portal.
+     * <p>This is empty if you set a custom URL in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a>.
      *
      * @return Set of permissions the default authorization URL is set up with.
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -289,7 +289,9 @@ public interface ApplicationInfo extends ISnowflake
 
     /**
      * A {@link java.util.List} containing the tags of this bot's application.
+     *
      * This List is empty if no tags are set in the Developer Portal.
+     *
      * @return List containing the tags of this bot's application
      */
     @Nonnull
@@ -297,7 +299,9 @@ public interface ApplicationInfo extends ISnowflake
 
     /**
      * The custom Authorization URL of this bot's application.
+     *
      * This returns null if no custom URL is set in the Developer Portal or if In-app Authorization is enabled.
+     *
      * @return Custom Authorization URL, or null if it has not been set
      */
     @Nullable
@@ -305,6 +309,7 @@ public interface ApplicationInfo extends ISnowflake
 
     /**
      * A {@link java.util.List} of scopes the default authorization URL is set up with.
+     *
      * This is empty if you set a custom URL in the Developer Portal.
      *
      * @return List of scopes the default authorization URL is set up with.
@@ -314,6 +319,7 @@ public interface ApplicationInfo extends ISnowflake
 
     /**
      * A {@link java.util.EnumSet} of permissions the default authorization URL is set up with.
+     *
      * This is empty if you set a custom URL in the Developer Portal.
      *
      * @return Set of permissions the default authorization URL is set up with.

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -310,7 +310,7 @@ public interface ApplicationInfo extends ISnowflake
     /**
      * A {@link java.util.List} of scopes the default authorization URL is set up with.
      *
-     * <p>This is empty if you set a custom URL in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a>.
+     * <p>This List is empty if you set a custom URL in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a>.
      *
      * @return Immutable list of scopes the default authorization URL is set up with.
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -326,4 +326,11 @@ public interface ApplicationInfo extends ISnowflake
      */
     @Nonnull
     EnumSet<Permission> getPermissions();
+
+    /**
+     * The {@code long} representation of the literal permissions the default authorization URL is set up with.
+     *
+     * @return Never-negative long containing offset permissions the default authorization URL is set up with.
+     */
+    long getPermissionsRaw();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -22,8 +22,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.*;
 
 /**
  * Represents a Discord Application from its bot's point of view.
@@ -287,4 +286,38 @@ public interface ApplicationInfo extends ISnowflake
      * @return Whether the bot is public
      */
     boolean isBotPublic();
+
+    /**
+     * A {@link java.util.List} containing the tags of this bot's application.
+     * This List is empty if no tags are set in the Developer Portal.
+     * @return List containing the tags of this bot's application
+     */
+    @Nonnull
+    List<String> getTags();
+
+    /**
+     * The custom Authorization URL of this bot's application.
+     * This returns null if no custom URL is set in the Developer Portal or if In-app Authorization is enabled.
+     * @return Custom Authorization URL, or null if it has not been set
+     */
+    @Nullable
+    String getCustomAuthorizationUrl();
+
+    /**
+     * A {@link java.util.List} of scopes the default authorization URL is set up with.
+     * This is empty if you set a custom URL in the Developer Portal.
+     *
+     * @return List of scopes the default authorization URL is set up with.
+     */
+    @Nonnull
+    List<String> getScopes();
+
+    /**
+     * A {@link java.util.EnumSet} of permissions the default authorization URL is set up with.
+     * This is empty if you set a custom URL in the Developer Portal.
+     *
+     * @return Set of permissions the default authorization URL is set up with.
+     */
+    @Nonnull
+    EnumSet<Permission> getPermissions();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ApplicationInfo.java
@@ -300,7 +300,7 @@ public interface ApplicationInfo extends ISnowflake
     /**
      * The custom Authorization URL of this bot's application.
      *
-     * <p>This returns null if no custom URL is set in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a> or if In-app Authorization is enabled.
+     * <p>This returns {@code null} if no custom URL is set in the <a href="https://discord.com/developers/applications" target="_blank">Developer Portal</a> or if In-app Authorization is enabled.
      *
      * @return Custom Authorization URL, or null if it has not been set
      */

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -210,7 +210,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return customAuthUrl;
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public EnumSet<Permission> getPermissions()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -22,10 +22,9 @@ import net.dv8tion.jda.api.entities.ApplicationInfo;
 import net.dv8tion.jda.api.entities.ApplicationTeam;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.internal.utils.Checks;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -197,7 +196,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return this.isBotPublic;
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public List<String> getTags()
     {
@@ -218,7 +217,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return defaultAuthUrlPerms;
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public List<String> getScopes()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -51,7 +51,8 @@ public class ApplicationInfoImpl implements ApplicationInfo
     private String scopes = "bot";
 
     public ApplicationInfoImpl(JDA api, String description, boolean doesBotRequireCodeGrant, String iconId, long id,
-            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team, List<String> tags, String customAuthUrl, long defaultAuthUrlPerms, List<String> defaultAuthUrlScopes)
+            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team,
+            List<String> tags, String customAuthUrl, long defaultAuthUrlPerms, List<String> defaultAuthUrlScopes)
     {
         this.api = api;
         this.description = description;
@@ -68,7 +69,6 @@ public class ApplicationInfoImpl implements ApplicationInfo
         this.customAuthUrl = customAuthUrl;
         this.defaultAuthUrlPerms = defaultAuthUrlPerms;
         this.defaultAuthUrlScopes = Collections.unmodifiableList(defaultAuthUrlScopes);
-
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -45,12 +46,12 @@ public class ApplicationInfoImpl implements ApplicationInfo
     private final ApplicationTeam team;
     private final List<String> tags;
     private final String customAuthUrl;
-    private final EnumSet<Permission> defaultAuthUrlPerms;
+    private final long defaultAuthUrlPerms;
     private final List<String> defaultAuthUrlScopes;
     private String scopes = "bot";
 
     public ApplicationInfoImpl(JDA api, String description, boolean doesBotRequireCodeGrant, String iconId, long id,
-            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team, List<String> tags, String customAuthUrl, EnumSet<Permission> defaultAuthUrlPerms, List<String> defaultAuthUrlScopes)
+            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team, List<String> tags, String customAuthUrl, long defaultAuthUrlPerms, List<String> defaultAuthUrlScopes)
     {
         this.api = api;
         this.description = description;
@@ -66,7 +67,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
         this.tags = Collections.unmodifiableList(tags);
         this.customAuthUrl = customAuthUrl;
         this.defaultAuthUrlPerms = defaultAuthUrlPerms;
-        this.defaultAuthUrlScopes = Collection.unmodifiableList(defaultAuthUrlScopes);
+        this.defaultAuthUrlScopes = Collections.unmodifiableList(defaultAuthUrlScopes);
 
     }
 
@@ -214,7 +215,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
     @Override
     public EnumSet<Permission> getPermissions()
     {
-        return defaultAuthUrlPerms;
+        return Permission.getPermissions(defaultAuthUrlPerms);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -218,6 +218,12 @@ public class ApplicationInfoImpl implements ApplicationInfo
         return Permission.getPermissions(defaultAuthUrlPerms);
     }
 
+    @Override
+    public long getPermissionsRaw()
+    {
+        return defaultAuthUrlPerms;
+    }
+
     @Nonnull
     @Override
     public List<String> getScopes()

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -22,9 +22,13 @@ import net.dv8tion.jda.api.entities.ApplicationInfo;
 import net.dv8tion.jda.api.entities.ApplicationTeam;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
 
 public class ApplicationInfoImpl implements ApplicationInfo
 {
@@ -40,10 +44,14 @@ public class ApplicationInfoImpl implements ApplicationInfo
     private final String name;
     private final User owner;
     private final ApplicationTeam team;
+    private final List<String> tags;
+    private final String customAuthUrl;
+    private final EnumSet<Permission> defaultAuthUrlPerms;
+    private final List<String> defaultAuthUrlScopes;
     private String scopes = "bot";
 
     public ApplicationInfoImpl(JDA api, String description, boolean doesBotRequireCodeGrant, String iconId, long id,
-            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team)
+            boolean isBotPublic, String name, String termsOfServiceUrl, String privacyPolicyUrl, User owner, ApplicationTeam team, List<String> tags, String customAuthUrl, EnumSet<Permission> defaultAuthUrlPerms, List<String> defaultAuthUrlScopes)
     {
         this.api = api;
         this.description = description;
@@ -56,6 +64,11 @@ public class ApplicationInfoImpl implements ApplicationInfo
         this.privacyPolicyUrl = privacyPolicyUrl;
         this.owner = owner;
         this.team = team;
+        this.tags = tags;
+        this.customAuthUrl = customAuthUrl;
+        this.defaultAuthUrlPerms = defaultAuthUrlPerms;
+        this.defaultAuthUrlScopes = defaultAuthUrlScopes;
+
     }
 
     @Override
@@ -182,6 +195,34 @@ public class ApplicationInfoImpl implements ApplicationInfo
     public final boolean isBotPublic()
     {
         return this.isBotPublic;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getTags()
+    {
+        return tags;
+    }
+
+    @Nullable
+    @Override
+    public String getCustomAuthorizationUrl()
+    {
+        return customAuthUrl;
+    }
+
+    @NotNull
+    @Override
+    public EnumSet<Permission> getPermissions()
+    {
+        return defaultAuthUrlPerms;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getScopes()
+    {
+        return defaultAuthUrlScopes;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -63,10 +63,10 @@ public class ApplicationInfoImpl implements ApplicationInfo
         this.privacyPolicyUrl = privacyPolicyUrl;
         this.owner = owner;
         this.team = team;
-        this.tags = tags;
+        this.tags = Collections.unmodifiableList(tags);
         this.customAuthUrl = customAuthUrl;
         this.defaultAuthUrlPerms = defaultAuthUrlPerms;
-        this.defaultAuthUrlScopes = defaultAuthUrlScopes;
+        this.defaultAuthUrlScopes = Collection.unmodifiableList(defaultAuthUrlScopes);
 
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -22,7 +22,6 @@ import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
-import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.audit.ActionType;
 import net.dv8tion.jda.api.audit.AuditLogChange;
 import net.dv8tion.jda.api.audit.AuditLogEntry;

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -22,6 +22,7 @@ import gnu.trove.set.TLongSet;
 import gnu.trove.set.hash.TLongHashSet;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.audit.ActionType;
 import net.dv8tion.jda.api.audit.AuditLogChange;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
@@ -2099,9 +2100,22 @@ public class EntityBuilder
         final boolean isBotPublic = object.getBoolean("bot_public");
         final User owner = createUser(object.getObject("owner"));
         final ApplicationTeam team = !object.isNull("team") ? createApplicationTeam(object.getObject("team")) : null;
+        final String customAuthUrl = object.getString("custom_install_url", null);
+        final List<String> tags = !object.isNull("tags")
+                ? Collections.unmodifiableList(object.getArray("tags").stream(DataArray::getString).collect(Collectors.toList()))
+                : Collections.emptyList();
+
+        final long defaultAuthUrlPerms = !object.isNull("install_params")
+                ? Long.parseLong(object.getObject("install_params").getString("permissions"))
+                : 0L;
+
+        final List<String> defaultAuthUrlScopes = !object.isNull("install_params")
+                ? Collections.unmodifiableList(object.getObject("install_params").getArray("scopes").stream(DataArray::getString).collect(Collectors.toList()))
+                : Collections.emptyList();
+
 
         return new ApplicationInfoImpl(getJDA(), description, doesBotRequireCodeGrant, iconId, id, isBotPublic, name,
-                termsOfServiceUrl, privacyPolicyUrl, owner, team);
+                termsOfServiceUrl, privacyPolicyUrl, owner, team, tags, customAuthUrl, Permission.getPermissions(defaultAuthUrlPerms), defaultAuthUrlScopes);
     }
 
     public ApplicationTeam createApplicationTeam(DataObject object)

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2101,19 +2101,22 @@ public class EntityBuilder
         final User owner = createUser(object.getObject("owner"));
         final ApplicationTeam team = !object.isNull("team") ? createApplicationTeam(object.getObject("team")) : null;
         final String customAuthUrl = object.getString("custom_install_url", null);
-        final List<String> tags = object.optArray("tags").orElseGet(DataArray::empty())
+        final List<String> tags = object.optArray("tags").orElseGet(DataArray::empty)
                     .stream(DataArray::getString)
-                    .collect(Collectors.toList()));
+                    .collect(Collectors.toList());
 
-        final long defaultAuthUrlPerms = object.optObject("install_params").map(o -> o.getLong("permissions")).orElse(0);
+        final long defaultAuthUrlPerms = object.optObject("install_params")
+                    .map(o -> o.getLong("permissions"))
+                    .orElse(0L);
 
-        final List<String> defaultAuthUrlScopes = object.optObject("install_params").map(obj ->
-                    obj.getArray("scopes").stream(DataArray::getString).collect(Collectors.toList()))
-        ).orElse(Collections.emptyList());
-
+        final List<String> defaultAuthUrlScopes = object.optObject("install_params")
+                    .map(obj -> obj.getArray("scopes")
+                            .stream(DataArray::getString)
+                            .collect(Collectors.toList()))
+                    .orElse(Collections.emptyList());
 
         return new ApplicationInfoImpl(getJDA(), description, doesBotRequireCodeGrant, iconId, id, isBotPublic, name,
-                termsOfServiceUrl, privacyPolicyUrl, owner, team, tags, customAuthUrl, Permission.getPermissions(defaultAuthUrlPerms), defaultAuthUrlScopes);
+                termsOfServiceUrl, privacyPolicyUrl, owner, team, tags, customAuthUrl, defaultAuthUrlPerms, defaultAuthUrlScopes);
     }
 
     public ApplicationTeam createApplicationTeam(DataObject object)

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2104,12 +2104,12 @@ public class EntityBuilder
                     .stream(DataArray::getString)
                     .collect(Collectors.toList());
 
-        final long defaultAuthUrlPerms = object.optObject("install_params")
-                    .map(o -> o.getLong("permissions"))
+        final Optional<DataObject> installParams = object.optObject("install_params");
+
+        final long defaultAuthUrlPerms = installParams.map(o -> o.getLong("permissions"))
                     .orElse(0L);
 
-        final List<String> defaultAuthUrlScopes = object.optObject("install_params")
-                    .map(obj -> obj.getArray("scopes")
+        final List<String> defaultAuthUrlScopes = installParams.map(obj -> obj.getArray("scopes")
                             .stream(DataArray::getString)
                             .collect(Collectors.toList()))
                     .orElse(Collections.emptyList());

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2105,9 +2105,7 @@ public class EntityBuilder
                 ? Collections.unmodifiableList(object.getArray("tags").stream(DataArray::getString).collect(Collectors.toList()))
                 : Collections.emptyList();
 
-        final long defaultAuthUrlPerms = !object.isNull("install_params")
-                ? Long.parseLong(object.getObject("install_params").getString("permissions"))
-                : 0L;
+        final long defaultAuthUrlPerms = object.optObject("install_params").map(o -> o.getLong("permissions")).orElse(0);
 
         final List<String> defaultAuthUrlScopes = !object.isNull("install_params")
                 ? Collections.unmodifiableList(object.getObject("install_params").getArray("scopes").stream(DataArray::getString).collect(Collectors.toList()))

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -2101,15 +2101,15 @@ public class EntityBuilder
         final User owner = createUser(object.getObject("owner"));
         final ApplicationTeam team = !object.isNull("team") ? createApplicationTeam(object.getObject("team")) : null;
         final String customAuthUrl = object.getString("custom_install_url", null);
-        final List<String> tags = !object.isNull("tags")
-                ? Collections.unmodifiableList(object.getArray("tags").stream(DataArray::getString).collect(Collectors.toList()))
-                : Collections.emptyList();
+        final List<String> tags = object.optArray("tags").orElseGet(DataArray::empty())
+                    .stream(DataArray::getString)
+                    .collect(Collectors.toList()));
 
         final long defaultAuthUrlPerms = object.optObject("install_params").map(o -> o.getLong("permissions")).orElse(0);
 
-        final List<String> defaultAuthUrlScopes = !object.isNull("install_params")
-                ? Collections.unmodifiableList(object.getObject("install_params").getArray("scopes").stream(DataArray::getString).collect(Collectors.toList()))
-                : Collections.emptyList();
+        final List<String> defaultAuthUrlScopes = object.optObject("install_params").map(obj ->
+                    obj.getArray("scopes").stream(DataArray::getString).collect(Collectors.toList()))
+        ).orElse(Collections.emptyList());
 
 
         return new ApplicationInfoImpl(getJDA(), description, doesBotRequireCodeGrant, iconId, id, isBotPublic, name,


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This pull request adds `getTags()`, `getCustomAuthorizationUrl()`, `getPermissions()` and `getScopes()` to `ApplicationInfo`
