### PR TITLE
First steps towards a wiki synchronization

### DIFF
--- a/.github/workflows/wiki_push.yml
+++ b/.github/workflows/wiki_push.yml
@@ -1,13 +1,10 @@
-#
 # Workflow to push changes from the "wiki" folder in the repository towards the actual wiki itself.
-#
+
 name: 'Push to wiki'
 
 on:
   push:
-    #
     # Only push when changed files are in the wiki/ folder and on the master branch.
-    #
     paths:
     - 'wiki/**'
     branches:

--- a/.github/workflows/wiki_push.yml
+++ b/.github/workflows/wiki_push.yml
@@ -1,0 +1,34 @@
+#
+# Workflow to push changes from the "wiki" folder in the repository towards the actual wiki itself.
+#
+name: 'Push to wiki'
+
+on:
+  push:
+    #
+    # Only push when changed files are in the wiki/ folder and on the master branch.
+    #
+    paths:
+    - 'wiki/**'
+    branches:
+    - 'master'
+    #
+    # Ignore any release to avoid accidental trigger of this action.
+    #
+    tags-ignore:
+    - '**'
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout Code'
+      uses: 'actions/checkout@v2'
+    - name: 'Push changes to the wiki'
+      uses: 'Andre-Chen-Wang/github-wiki-action@v2'
+      env:
+        WIKI_DIR: 'wiki/'
+        GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        GH_MAIL: 'actions@github.com'
+        GH_NAME: 'github-actions[bot]'
+        #EXCLUDED_FILES: 'README.md' # Maybe have a README to explain the purpose of this folder?


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: New GitHub Actions <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This has been discussed on the Discord already, but it would be a good idea to have a two-way wiki synchronization that would allow outsiders to suggest changes to the wiki, without the risk of giving everyone write access to it.

This is still a draft since I need to find a somewhat elegant way to also have a `wiki -> wiki-folder` synchronization... Probably with a scheduled workflow and some git actions, but some assistance here is welcome.

I also need to copy over the wiki's content to a wiki folder (Unless you want the scheduled workflow do this on its own) too...
