### PR TITLE
Fix NPE when cloning guild role with null icon

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -288,7 +288,7 @@ public class RoleImpl implements Role
                     .setMentionable(mentionable)
                     .setName(name)
                     .setPermissions(rawPermissions)
-                    .setIcon(icon.getEmoji()); // we can only copy the emoji as we don't have access to the Icon instance
+                    .setIcon(icon == null ? null : icon.getEmoji()); // we can only copy the emoji as we don't have access to the Icon instance
     }
 
     @Nonnull


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Fixes: [JDA Discord message](https://canary.discord.com/channels/125227483518861312/125227483518861312/920470164498157618)

I targetted `legacy/v4` as it is a bugfix, hopefully this is the correct branch.

## Description

Calling icon.getEmoji() on a null icon will throw an NPE, this will pass null if the icon is null.
