### PR TITLE
Move canTalk() from GuildMessageChannel to MessageChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildMessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildMessageChannel.java
@@ -14,16 +14,7 @@ import java.util.stream.Collectors;
 //TODO-v5: Docs
 public interface GuildMessageChannel extends GuildChannel, MessageChannel
 {
-    /**
-     * Whether we can send messages in this channel.
-     * <br>This is an overload of {@link #canTalk(Member)} with the SelfMember.
-     * <br>Checks for both {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL} and
-     * {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}.
-     *
-     * For {@link ThreadChannel} this method checks for {@link Permission#MESSAGE_SEND_IN_THREADS} instead of {@link Permission#MESSAGE_SEND}.
-     *
-     * @return True, if we are able to read and send messages in this channel
-     */
+    @Override
     default boolean canTalk()
     {
         return canTalk(getGuild().getSelfMember());

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -135,12 +135,13 @@ public interface MessageChannel extends Channel, Formattable
     }
 
     /**
-     * Whether we can send messages in this channel.
+     * Whether we have the required permissions to send messages in this channel or not.
      * <br>For {@link GuildMessageChannel} this method checks for
      * both {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL}
      * and {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}.
      * <br>For {@link ThreadChannel} this method checks for {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND_IN_THREADS} instead of {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND}.
-     * <br>For {@link PrivateChannel} this method checks if the user that this PrivateChannel communicates with is not the self user
+     * <br>For {@link PrivateChannel} this method does <b>not</b> check if the currently logged in user is blocked
+     * by the user that this PrivateChannel communicates with, or if the said user has their DMs disabled.
      *
      * @return True, if we are able to read and send messages in this channel
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -101,7 +101,6 @@ public interface MessageChannel extends Channel, Formattable
         return Long.toUnsignedString(getLatestMessageIdLong());
     }
 
-
     /**
      * The id for the most recent message sent
      * in this current MessageChannel.
@@ -134,6 +133,18 @@ public interface MessageChannel extends Channel, Formattable
     {
         return getLatestMessageIdLong() != 0;
     }
+
+    /**
+     * Whether we can send messages in this channel.
+     * <br>For {@link GuildMessageChannel} this method checks for
+     * both {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL}
+     * and {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}.
+     * <br>For {@link ThreadChannel} this method checks for {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND_IN_THREADS} instead of {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND}.
+     * <br>For {@link PrivateChannel} this method checks if the user that this PrivateChannel communicates with is not the self user
+     *
+     * @return True, if we are able to read and send messages in this channel
+     */
+    boolean canTalk();
 
     /**
      * Convenience method to delete messages in the most efficient way available.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -135,13 +135,13 @@ public interface MessageChannel extends Channel, Formattable
     }
 
     /**
-     * Whether we have the required permissions to send messages in this channel or not.
+     * Whether the currently logged in user can send messages in this channel or not.
      * <br>For {@link GuildMessageChannel} this method checks for
      * both {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL}
      * and {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND Permission.MESSAGE_SEND}.
      * <br>For {@link ThreadChannel} this method checks for {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND_IN_THREADS} instead of {@link net.dv8tion.jda.api.Permission#MESSAGE_SEND}.
-     * <br>For {@link PrivateChannel} this method does <b>not</b> check if the currently logged in user is blocked
-     * by the user that this PrivateChannel communicates with, or if the said user has their DMs disabled.
+     * <br>For {@link PrivateChannel} this method checks if the user that this PrivateChannel communicates with is not a bot,
+     * but it does <b>not</b> check if the said user blocked the currently logged in user or have their DMs disabled.
      *
      * @return True, if we are able to read and send messages in this channel
      */

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -85,7 +85,7 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
     @Override
     public boolean canTalk()
     {
-        return !getUser().isBot() || getJDA().getAccountType() != AccountType.BOT;
+        return true;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -85,7 +85,7 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
     @Override
     public boolean canTalk()
     {
-        return true;
+        return !user.isBot();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -83,6 +83,12 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
     }
 
     @Override
+    public boolean canTalk()
+    {
+        return !getUser().isBot() || getJDA().getAccountType() != AccountType.BOT;
+    }
+
+    @Override
     public void checkCanAccessChannel() {}
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____

Closes Issue: #1920

## Description

Move the canTalk() method from GuildMessageChannel to MessageChannel, which calls for an implementation in PrivateChannel since GuildMessageChannel already has a default one.
For that, I simply use the condition used in the private checkBot() method
This is my first ever pull request for this repository, so please tell me if I am doing anything wrong here, ty