### PR TITLE
Change some voice Regions and remove VOICE_CHANNEL_REGIONS set

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Region.java
+++ b/src/main/java/net/dv8tion/jda/api/Region.java
@@ -17,9 +17,6 @@ package net.dv8tion.jda.api;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.Set;
 
 /**
  * Represents the Regions used for Audio connections.
@@ -28,38 +25,34 @@ import java.util.Set;
  */
 public enum Region
 {
-    AMSTERDAM("amsterdam", "Amsterdam", "\uD83C\uDDF3\uD83C\uDDF1", false),
     BRAZIL("brazil", "Brazil", "\uD83C\uDDE7\uD83C\uDDF7", false),
-    EUROPE("europe", "Europe", "\uD83C\uDDEA\uD83C\uDDFA", false),
-    EU_CENTRAL("eu-central", "EU Central", "\uD83C\uDDEA\uD83C\uDDFA", false),
-    EU_WEST("eu-west", "EU West", "\uD83C\uDDEA\uD83C\uDDFA", false),
-    FRANKFURT("frankfurt", "Frankfurt", "\uD83C\uDDE9\uD83C\uDDEA", false),
     HONG_KONG("hongkong", "Hong Kong", "\uD83C\uDDED\uD83C\uDDF0", false),
-    JAPAN("japan", "Japan", "\uD83C\uDDEF\uD83C\uDDF5", false),
-    SOUTH_KOREA("south-korea", "South Korea", "\uD83C\uDDF0\uD83C\uDDF7", false),
-    LONDON("london", "London", "\uD83C\uDDEC\uD83C\uDDE7", false),
-    RUSSIA("russia", "Russia", "\uD83C\uDDF7\uD83C\uDDFA", false),
     INDIA("india", "India", "\uD83C\uDDEE\uD83C\uDDF3", false),
+    JAPAN("japan", "Japan", "\uD83C\uDDEF\uD83C\uDDF5", false),
+    MILAN("milan", "Milan", "\uD83C\uDDEE\uD83C\uDDF9", false),
+    ROTTERDAM("rotterdam", "Rotterdam", "\uD83C\uDDF3\uD83C\uDDF1", false),
+    RUSSIA("russia", "Russia", "\uD83C\uDDF7\uD83C\uDDFA", false),
     SINGAPORE("singapore", "Singapore", "\uD83C\uDDF8\uD83C\uDDEC", false),
     SOUTH_AFRICA("southafrica", "South Africa", "\uD83C\uDDFF\uD83C\uDDE6", false),
+    SOUTH_KOREA("south-korea", "South Korea", "\uD83C\uDDF0\uD83C\uDDF7", false),
     SYDNEY("sydney", "Sydney", "\uD83C\uDDE6\uD83C\uDDFA", false),
     US_CENTRAL("us-central", "US Central", "\uD83C\uDDFA\uD83C\uDDF8", false),
     US_EAST("us-east", "US East", "\uD83C\uDDFA\uD83C\uDDF8", false),
     US_SOUTH("us-south", "US South", "\uD83C\uDDFA\uD83C\uDDF8", false),
     US_WEST("us-west", "US West", "\uD83C\uDDFA\uD83C\uDDF8", false),
 
-    VIP_AMSTERDAM("vip-amsterdam", "Amsterdam (VIP)", "\uD83C\uDDF3\uD83C\uDDF1", true),
     VIP_BRAZIL("vip-brazil", "Brazil (VIP)", "\uD83C\uDDE7\uD83C\uDDF7", true),
-    VIP_EU_CENTRAL("vip-eu-central", "EU Central (VIP)", "\uD83C\uDDEA\uD83C\uDDFA", true),
-    VIP_EU_WEST("vip-eu-west", "EU West (VIP)", "\uD83C\uDDEA\uD83C\uDDFA", true),
-    VIP_FRANKFURT("vip-frankfurt", "Frankfurt (VIP)", "\uD83C\uDDE9\uD83C\uDDEA", true),
+    VIP_HONG_KONG("vip-hongkong", "Hong Kong (VIP)", "\uD83C\uDDED\uD83C\uDDF0", true),
+    VIP_INDIA("vip-india", "India (VIP)", "\uD83C\uDDEE\uD83C\uDDF3", true),
     VIP_JAPAN("vip-japan", "Japan (VIP)", "\uD83C\uDDEF\uD83C\uDDF5", true),
-    VIP_SOUTH_KOREA("vip-south-korea", "South Korea (VIP)", "\uD83C\uDDF0\uD83C\uDDF7", true),
-    VIP_LONDON("vip-london", "London (VIP)", "\uD83C\uDDEC\uD83C\uDDE7", true),
+    VIP_MILAN("vip-milan", "Milan (VIP)", "\uD83C\uDDEE\uD83C\uDDF9", true),
+    VIP_ROTTERDAM("vip-rotterdam", "Rotterdam (VIP)", "\uD83C\uDDF3\uD83C\uDDF1", true),
+    VIP_RUSSIA("vip-russia", "Russia (VIP)", "\uD83C\uDDF7\uD83C\uDDFA", true),
     VIP_SINGAPORE("vip-singapore", "Singapore (VIP)", "\uD83C\uDDF8\uD83C\uDDEC", true),
     VIP_SOUTH_AFRICA("vip-southafrica", "South Africa (VIP)", "\uD83C\uDDFF\uD83C\uDDE6", true),
+    VIP_SOUTH_KOREA("vip-south-korea", "South Korea (VIP)", "\uD83C\uDDF0\uD83C\uDDF7", true),
     VIP_SYDNEY("vip-sydney", "Sydney (VIP)", "\uD83C\uDDE6\uD83C\uDDFA", true),
-    VIP_US_CENTRAL("vip-us-central", "US Central (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
+    VIP_US_CENTRAL("uvip-s-central", "US Central (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
     VIP_US_EAST("vip-us-east", "US East (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
     VIP_US_SOUTH("vip-us-south", "US South (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
     VIP_US_WEST("vip-us-west", "US West (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
@@ -67,12 +60,6 @@ public enum Region
     UNKNOWN("", "Unknown Region", null, false),
 
     AUTOMATIC("automatic", "Automatic", null, false);
-
-    /**
-     * This {@link java.util.Set Set} represents all regions that can be used for VoiceChannel region overrides.
-     */
-    public static final Set<Region> VOICE_CHANNEL_REGIONS =
-            Collections.unmodifiableSet(EnumSet.of(AUTOMATIC, US_WEST, US_EAST, US_CENTRAL, US_SOUTH, SINGAPORE, SOUTH_AFRICA, SYDNEY, EUROPE, INDIA, SOUTH_KOREA, BRAZIL, JAPAN, RUSSIA));
 
     private final String key;
     private final String name;
@@ -108,10 +95,10 @@ public enum Region
     {
         return key;
     }
-    
+
     /**
      * The unicode flag representative of this Region.
-     * 
+     *
      * @return Possibly-null unicode for the region's flag
      */
     @Nullable

--- a/src/main/java/net/dv8tion/jda/api/Region.java
+++ b/src/main/java/net/dv8tion/jda/api/Region.java
@@ -52,7 +52,7 @@ public enum Region
     VIP_SOUTH_AFRICA("vip-southafrica", "South Africa (VIP)", "\uD83C\uDDFF\uD83C\uDDE6", true),
     VIP_SOUTH_KOREA("vip-south-korea", "South Korea (VIP)", "\uD83C\uDDF0\uD83C\uDDF7", true),
     VIP_SYDNEY("vip-sydney", "Sydney (VIP)", "\uD83C\uDDE6\uD83C\uDDFA", true),
-    VIP_US_CENTRAL("uvip-s-central", "US Central (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
+    VIP_US_CENTRAL("vip-us-central", "US Central (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
     VIP_US_EAST("vip-us-east", "US East (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
     VIP_US_SOUTH("vip-us-south", "US South (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),
     VIP_US_WEST("vip-us-west", "US West (VIP)", "\uD83C\uDDFA\uD83C\uDDF8", true),

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
@@ -373,7 +373,6 @@ public class ChannelManagerImpl<T extends GuildChannel, M extends ChannelManager
         Checks.notNull(region, "Region");
         if (!type.isAudio())
             throw new IllegalStateException("Can only change region on voice channels!");
-        Checks.check(Region.VOICE_CHANNEL_REGIONS.contains(region), "Region is not usable for VoiceChannel region overrides!");
         this.region = region == Region.AUTOMATIC ? null : region.getKey();
         set |= REGION;
         return (M) this;

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
@@ -372,7 +372,7 @@ public class ChannelManagerImpl<T extends GuildChannel, M extends ChannelManager
     {
         Checks.notNull(region, "Region");
         if (!type.isAudio())
-            throw new IllegalStateException("Can only change region on voice channels!");
+            throw new IllegalStateException("Can only change region on audio channels!");
         this.region = region == Region.AUTOMATIC ? null : region.getKey();
         set |= REGION;
         return (M) this;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #1961 

## Description

this PR removes some unused regions and adds a new `MILAN` region, which is not usable at the moment, but it's possible to get it in the client. the `SOUTH_KOREA` region is not listed in the regions endpoint (or in the client for that matter), but it's still applicable. this PR also removes the `VOICE_CHANNEL_REGIONS` collection, which is useless as of v5.