### PR TITLE
Fix IllegalStateException for OptionType.MENTIONABLE

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -196,14 +196,14 @@ public class OptionMapping
     @Nonnull
     public User getAsUser()
     {
-        if (type != OptionType.USER)
+        if (type != OptionType.USER && type != OptionType.MENTIONABLE)
             throw new IllegalStateException("Cannot resolve User for option " + getName() + " of type " + type);
         Object object = resolved.get(getAsLong());
         if (object instanceof Member)
             return ((Member) object).getUser();
         if (object instanceof User)
             return (User) object;
-        throw new IllegalStateException("Could not resolve user!");
+        throw new IllegalStateException("Could not resolve User from option type " + type);
     }
 
     /**
@@ -217,12 +217,12 @@ public class OptionMapping
     @Nonnull
     public Role getAsRole()
     {
-        if (type != OptionType.ROLE)
+        if (type != OptionType.ROLE && type != OptionType.MENTIONABLE)
             throw new IllegalStateException("Cannot resolve Role for option " + getName() + " of type " + type);
         Object role = resolved.get(getAsLong());
         if (role instanceof Role)
             return (Role) role;
-        throw new IllegalStateException("Could not resolve role!");
+        throw new IllegalStateException("Could not resolve Role from option type " + type);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -177,7 +177,7 @@ public class OptionMapping
     @Nullable
     public Member getAsMember()
     {
-        if (type != OptionType.USER)
+        if (type != OptionType.USER && type != OptionType.MENTIONABLE)
             throw new IllegalStateException("Cannot resolve Member for option " + getName() + " of type " + type);
         Object object = resolved.get(getAsLong());
         if (object instanceof Member)

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -170,7 +170,7 @@ public class OptionMapping
      * <br>Note that {@link OptionType#USER OptionType.USER} can also accept users that are not members of a guild, in which case this will be null!
      *
      * @throws IllegalStateException
-     *         If this option is not of type {@link OptionType#USER USER}
+     *         If this option is not of type {@link OptionType#USER USER} or {@link OptionType#MENTIONABLE MENTIONABLE}
      *
      * @return The resolved {@link Member}, or null
      */
@@ -189,7 +189,8 @@ public class OptionMapping
      * The resolved {@link User} for this option value.
      *
      * @throws IllegalStateException
-     *         If this option is not of type {@link OptionType#USER USER}
+     *         If this option is not of type {@link OptionType#USER USER} or
+     *         {@link OptionType#MENTIONABLE MENTIONABLE} without a resolved user
      *
      * @return The resolved {@link User}
      */
@@ -210,7 +211,8 @@ public class OptionMapping
      * The resolved {@link Role} for this option value.
      *
      * @throws IllegalStateException
-     *         If this option is not of type {@link OptionType#ROLE ROLE}
+     *         If this option is not of type {@link OptionType#ROLE ROLE} or
+     *         {@link OptionType#MENTIONABLE MENTIONABLE} without a resolved role
      *
      * @return The resolved {@link Role}
      */


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

If `CommandInteraction#getCommandString` is called when a `MENTIONABLE` option was included, `OptionMapping#getAsUser` and `OptionMapping#getAsRole` will always throw `IllegalStateException` regardless of the type of the resolved object.

![unknown](https://cdn.discordapp.com/attachments/125227483518861312/923032113966628884/unknown.png)
![unknown](https://cdn.discordapp.com/attachments/125227483518861312/923032594818428928/unknown.png)