### PR TITLE
Improve entity toString methods

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -181,7 +181,7 @@ public interface JDA
         @Override
         public String toString()
         {
-            return "ShardInfo" + getShardString();
+            return "ShardInfo " + getShardString();
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -181,7 +181,7 @@ public interface JDA
         @Override
         public String toString()
         {
-            return "Shard " + getShardString();
+            return "ShardInfo" + getShardString();
         }
 
         @Override

--- a/src/main/java/net/dv8tion/jda/api/entities/Emoji.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Emoji.java
@@ -254,6 +254,6 @@ public class Emoji implements SerializableData, IMentionable
     @Override
     public String toString()
     {
-        return "E:" + name + "(" + id + ")";
+        return "Emoji:" + name + '(' + id + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -423,7 +423,7 @@ public class MessageReaction
     @Override
     public String toString()
     {
-        return "MR:(M:(" + messageId + ") / " + emote + ")";
+        return "MessageReaction:" + messageId + '(' + emote + ')';
     }
 
     /**
@@ -603,8 +603,8 @@ public class MessageReaction
         public String toString()
         {
             if (isEmoji())
-                return "RE:" + getAsCodepoints();
-            return "RE:" + getName() + "(" + getId() + ")";
+                return "ReactionEmote:" + getAsCodepoints();
+            return "ReactionEmote:" + getName() + '(' + getId() + ')';
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/VanityInvite.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/VanityInvite.java
@@ -88,6 +88,6 @@ public class VanityInvite
     @Override
     public String toString()
     {
-        return "VanityInvite(" + code + ")";
+        return "VanityInvite(" + code + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GenericGuildMemberUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GenericGuildMemberUpdateEvent.java
@@ -87,6 +87,6 @@ public abstract class GenericGuildMemberUpdateEvent<T> extends GenericGuildMembe
     @Override
     public String toString()
     {
-        return "GenericGuildMemberUpdateEvent[" + getPropertyIdentifier() + "](" + getOldValue() + "->" + getNewValue() + ")";
+        return "GenericGuildMemberUpdateEvent[" + getPropertyIdentifier() + "](" + getOldValue() + "->" + getNewValue() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/events/role/update/GenericRoleUpdateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/role/update/GenericRoleUpdateEvent.java
@@ -77,6 +77,6 @@ public abstract class GenericRoleUpdateEvent<T> extends GenericRoleEvent impleme
     @Override
     public String toString()
     {
-        return "RoleUpdate[" + getPropertyIdentifier() + "](" + getOldValue() + "->" + getNewValue() + ")";
+        return "RoleUpdate[" + getPropertyIdentifier() + "](" + getOldValue() + "->" + getNewValue() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
@@ -352,7 +352,7 @@ public class Command implements ISnowflake
     @Override
     public String toString()
     {
-        return "C:" + getName() + "(" + getId() + ")";
+        return "Command:" + getName() + '(' + getId() + ')';
     }
 
     @Override
@@ -516,7 +516,7 @@ public class Command implements ISnowflake
         @Override
         public String toString()
         {
-            return "Choice(" + name + "," + stringValue + ")";
+            return "Choice:" + name + '(' + stringValue + ')';
         }
 
         private void setIntValue(long value)
@@ -699,7 +699,7 @@ public class Command implements ISnowflake
         @Override
         public String toString()
         {
-            return "Option[" + getType() + "](" + name + ")";
+            return "Option[" + getType() + "](" + name + ')';
         }
     }
 
@@ -771,7 +771,7 @@ public class Command implements ISnowflake
         @Override
         public String toString()
         {
-            return "Subcommand(" + name + ")";
+            return "Subcommand(" + name + ')';
         }
     }
 
@@ -843,7 +843,7 @@ public class Command implements ISnowflake
         @Override
         public String toString()
         {
-            return "SubcommandGroup(" + name + ")";
+            return "SubcommandGroup(" + name + ')';
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -278,7 +278,7 @@ public class OptionMapping
     @Override
     public String toString()
     {
-        return "Option[" + getType() + "](" + getName() + "=" + getAsString() + ")";
+        return "Option[" + getType() + "](" + getName() + '=' + getAsString() + ')';
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/Result.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/Result.java
@@ -295,6 +295,6 @@ public class Result<T>
     @Override
     public String toString()
     {
-        return isSuccess() ? "Result(success=" + value + ")" : "Result(error=" + error + ")";
+        return isSuccess() ? "Result(success=" + value + ')' : "Result(error=" + error + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
@@ -533,7 +533,7 @@ public class WidgetUtil
         @Override
         public String toString()
         {
-            return "Widget[" + (isAvailable() ? getName() : "") + "](" + id + ')';
+            return "Widget:" + (isAvailable() ? getName() : "") + '(' + id + ')';
         }
 
         private void checkAvailable()
@@ -772,7 +772,7 @@ public class WidgetUtil
             @Override
             public String toString()
             {
-                return "WidgetMember:" + getName() + '(' + id + ')';
+                return "Widget.Member:" + getName() + '(' + id + ')';
             }
         }
 
@@ -863,7 +863,7 @@ public class WidgetUtil
             @Override
             public String toString()
             {
-                return "WidgetVoiceChannel:" + getName() + '(' + id + ')';
+                return "Widget.VoiceChannel:" + getName() + '(' + id + ')';
             }
         }
         
@@ -1014,7 +1014,7 @@ public class WidgetUtil
             
             @Override
             public String toString() {
-                return "WidgetVoiceState:" + widget.getName() + '(' + member.getEffectiveName() + ')';
+                return "Widget.VoiceState:" + widget.getName() + '(' + member.getEffectiveName() + ')';
             }
         }
     }

--- a/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/WidgetUtil.java
@@ -533,7 +533,7 @@ public class WidgetUtil
         @Override
         public String toString()
         {
-            return "W:" + (isAvailable() ? getName() : "") + '(' + id + ')';
+            return "Widget[" + (isAvailable() ? getName() : "") + "](" + id + ')';
         }
 
         private void checkAvailable()
@@ -772,7 +772,7 @@ public class WidgetUtil
             @Override
             public String toString()
             {
-                return "W.M:" + getName() + '(' + id + ')';
+                return "WidgetMember:" + getName() + '(' + id + ')';
             }
         }
 
@@ -863,7 +863,7 @@ public class WidgetUtil
             @Override
             public String toString()
             {
-                return "W.VC:" + getName() + '(' + id + ')';
+                return "WidgetVoiceChannel:" + getName() + '(' + id + ')';
             }
         }
         
@@ -1014,7 +1014,7 @@ public class WidgetUtil
             
             @Override
             public String toString() {
-                return "VS:" + widget.getName() + ':' + member.getEffectiveName();
+                return "WidgetVoiceState:" + widget.getName() + '(' + member.getEffectiveName() + ')';
             }
         }
     }

--- a/src/main/java/net/dv8tion/jda/internal/audio/ConnectionRequest.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/ConnectionRequest.java
@@ -84,6 +84,6 @@ public class ConnectionRequest
     @Override
     public String toString()
     {
-        return "ConnectionRequest[" + stage + "](" + guildId + '#' + channelId + ')';
+        return "ConnectionRequest[" + stage + "](" + Long.toUnsignedString(guildId) + '#' + Long.toUnsignedString(channelId) + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/audio/ConnectionRequest.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/ConnectionRequest.java
@@ -84,6 +84,6 @@ public class ConnectionRequest
     @Override
     public String toString()
     {
-        return stage + "(" + Long.toUnsignedString(guildId) + "#" + Long.toUnsignedString(channelId) + ")";
+        return "ConnectionRequest[" + stage + "](" + guildId + '#' + channelId + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -62,10 +62,4 @@ public abstract class AbstractChannelImpl<T extends AbstractChannelImpl<T>> impl
         this.name = name;
         return (T) this;
     }
-
-    @Override
-    public String toString()
-    {
-        return getType().name() + ':' + getName() + '(' + getId() + ')';
-    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractChannelImpl.java
@@ -62,4 +62,10 @@ public abstract class AbstractChannelImpl<T extends AbstractChannelImpl<T>> impl
         this.name = name;
         return (T) this;
     }
+
+    @Override
+    public String toString()
+    {
+        return getType().name() + ':' + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ActivityImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ActivityImpl.java
@@ -123,9 +123,6 @@ public class ActivityImpl implements Activity
     @Override
     public String toString()
     {
-        if (url != null)
-            return String.format("Activity(%s | %s)", name, url);
-        else
-            return String.format("Activity(%s)", name);
+        return "Activity[" + name + (url != null ? "](" + url + ')' : ']');
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ActivityImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ActivityImpl.java
@@ -123,6 +123,9 @@ public class ActivityImpl implements Activity
     @Override
     public String toString()
     {
-        return "Activity[" + name + (url != null ? "](" + url + ')' : ']');
+        if (url != null)
+            return String.format("Activity[%s](%s)", name, url);
+        else
+            return String.format("Activity(%s)", name);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ApplicationInfoImpl.java
@@ -187,7 +187,7 @@ public class ApplicationInfoImpl implements ApplicationInfo
     @Override
     public String toString()
     {
-        return "ApplicationInfo(" + this.id + ")";
+        return "ApplicationInfo(" + this.id + ')';
     }
 
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
@@ -141,12 +141,6 @@ public class CategoryImpl extends AbstractGuildChannelImpl<CategoryImpl> impleme
         return this;
     }
 
-    @Override
-    public String toString()
-    {
-        return "GC:" + getName() + '(' + id + ')';
-    }
-
     private <T extends GuildChannel> ChannelAction<T> trySync(ChannelAction<T> action)
     {
         Member selfMember = getGuild().getSelfMember();

--- a/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/CategoryImpl.java
@@ -156,4 +156,10 @@ public class CategoryImpl extends AbstractGuildChannelImpl<CategoryImpl> impleme
         }
         return action.syncPermissionOverrides();
     }
+
+    @Override
+    public String toString()
+    {
+        return "Category:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EmoteImpl.java
@@ -237,7 +237,7 @@ public class EmoteImpl implements ListedEmote
     @Override
     public String toString()
     {
-        return "E:" + getName() + '(' + getIdLong() + ')';
+        return "Emote:" + getName() + '(' + getIdLong() + ')';
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -2027,7 +2027,7 @@ public class GuildImpl implements Guild
     @Override
     public String toString()
     {
-        return "G:" + getName() + '(' + id + ')';
+        return "Guild:" + getName() + '(' + id + ')';
     }
 
     private void checkCanCreateChannel(Category parent)

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -237,7 +237,7 @@ public class GuildVoiceStateImpl implements GuildVoiceState
     @Override
     public String toString()
     {
-        return "VS:" + getGuild().getName() + '(' + getId() + ')';
+        return "VoiceState:" + getGuild().getName() + '(' + getId() + ')';
     }
 
     // -- Setters --

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -413,7 +413,7 @@ public class MemberImpl implements Member
     @Override
     public String toString()
     {
-        return "Member:" + getEffectiveName() + '[' + getUser() + "](" + getGuild() +')';
+        return "Member:" + getEffectiveName() + '[' + getUser() + "](" + getGuild() + ')';
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -413,7 +413,7 @@ public class MemberImpl implements Member
     @Override
     public String toString()
     {
-        return "MB:" + getEffectiveName() + '(' + getUser().toString() + " / " + getGuild().toString() +')';
+        return "Member:" + getEffectiveName() + '[' + getUser() + "](" + getGuild() +')';
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
@@ -181,4 +181,10 @@ public class NewsChannelImpl extends AbstractGuildChannelImpl<NewsChannelImpl> i
         this.latestMessageId = latestMessageId;
         return this;
     }
+
+    @Override
+    public String toString()
+    {
+        return "NewsChannel:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
@@ -181,11 +181,4 @@ public class NewsChannelImpl extends AbstractGuildChannelImpl<NewsChannelImpl> i
         this.latestMessageId = latestMessageId;
         return this;
     }
-
-    // -- Object Overrides --
-    @Override
-    public String toString()
-    {
-        return "NC:" + getName() + '(' + getId() + ')';
-    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
@@ -186,6 +186,6 @@ public class NewsChannelImpl extends AbstractGuildChannelImpl<NewsChannelImpl> i
     @Override
     public String toString()
     {
-        return "NC:" + getName() + '(' + id + ')';
+        return "NC:" + getName() + '(' + getId() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PermissionOverrideImpl.java
@@ -204,7 +204,7 @@ public class PermissionOverrideImpl implements PermissionOverride
     @Override
     public String toString()
     {
-        return "PermOver:(" + (isMemberOverride() ? "M" : "R") + ")(" + channel.getId() + " | " + getId() + ")";
+        return "PermissionOverride:" + (isMemberOverride() ? "MEMBER" : "ROLE") + ':' + channel.getId() + '(' + getId() + ')';
     }
 
     private void checkPermissions()

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -140,12 +140,6 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
         return impl.id == this.id;
     }
 
-    @Override
-    public String toString()
-    {
-        return "PC:" + getUser().getName() + '(' + getId() + ')';
-    }
-
     private void updateUser()
     {
         // Load user from cache if one exists, otherwise we might have an outdated user instance

--- a/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/PrivateChannelImpl.java
@@ -153,4 +153,10 @@ public class PrivateChannelImpl extends AbstractChannelImpl<PrivateChannelImpl> 
         if (getUser().isBot() && getJDA().getAccountType() == AccountType.BOT)
             throw new UnsupportedOperationException("Cannot send a private message between bots.");
     }
+
+    @Override
+    public String toString()
+    {
+        return "PrivateChannel:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -1031,8 +1031,8 @@ public class ReceivedMessage extends AbstractMessage
     public String toString()
     {
         return author != null
-            ? String.format("M:%#s:%.20s(%s)", author, this, getId())
-            : String.format("M:%.20s", this); // this message was made using MessageBuilder
+                ? String.format("Message:%s:%#s(%.20s)", getId(), author, this)
+                : String.format("Message(%.20s)", this); // this message was made using MessageBuilder
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -1031,8 +1031,8 @@ public class ReceivedMessage extends AbstractMessage
     public String toString()
     {
         return author != null
-                ? String.format("Message:%s:%#s(%.20s)", getId(), author, this)
-                : String.format("Message(%.20s)", this); // this message was made using MessageBuilder
+            ? String.format("Message:%s:%#s(%.20s)", getId(), author, this)
+            : String.format("Message(%.20s)", this); // this message was made using MessageBuilder
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/RichPresenceImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RichPresenceImpl.java
@@ -143,7 +143,7 @@ public class RichPresenceImpl extends ActivityImpl implements RichPresence
     @Override
     public String toString()
     {
-        return String.format("RichPresence(%s / %s)", name, getApplicationId());
+        return "RichPresence[" + name + "](" + applicationId + ')';
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -371,7 +371,7 @@ public class RoleImpl implements Role
     @Override
     public String toString()
     {
-        return "R:" + getName() + '(' + id + ')';
+        return "Role:" + getName() + '(' + id + ')';
     }
 
     @Override
@@ -531,7 +531,7 @@ public class RoleImpl implements Role
         @Override
         public String toString()
         {
-            return "RoleTags(bot=" + getBotId() + ",integration=" + getIntegrationId() + ",boost=" + isBoost() + ")";
+            return "RoleTags(bot=" + getBotId() + ",integration=" + getIntegrationId() + ",boost=" + isBoost() + ')';
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -197,4 +197,11 @@ public class StageChannelImpl extends AbstractGuildChannelImpl<StageChannelImpl>
         this.instance = instance;
         return this;
     }
+
+    // -- Object Overrides --
+    @Override
+    public String toString()
+    {
+        return "StaC:" + getName() + '(' + id + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -197,12 +197,4 @@ public class StageChannelImpl extends AbstractGuildChannelImpl<StageChannelImpl>
         this.instance = instance;
         return this;
     }
-
-    // -- Object Overrides --
-
-    @Override
-    public String toString()
-    {
-        return "StaC:" + getName() + '(' + getId() + ')';
-    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -203,6 +203,6 @@ public class StageChannelImpl extends AbstractGuildChannelImpl<StageChannelImpl>
     @Override
     public String toString()
     {
-        return "StaC:" + getName() + '(' + id + ')';
+        return "StaC:" + getName() + '(' + getId() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -199,6 +199,7 @@ public class StageChannelImpl extends AbstractGuildChannelImpl<StageChannelImpl>
     }
 
     // -- Object Overrides --
+
     @Override
     public String toString()
     {

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -197,4 +197,10 @@ public class StageChannelImpl extends AbstractGuildChannelImpl<StageChannelImpl>
         this.instance = instance;
         return this;
     }
+
+    @Override
+    public String toString()
+    {
+        return "StageChannel:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/StoreChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StoreChannelImpl.java
@@ -98,4 +98,10 @@ public class StoreChannelImpl extends AbstractGuildChannelImpl<StoreChannelImpl>
     {
         return this;
     }
+
+    @Override
+    public String toString()
+    {
+        return "StoreChannel:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/StoreChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StoreChannelImpl.java
@@ -98,10 +98,4 @@ public class StoreChannelImpl extends AbstractGuildChannelImpl<StoreChannelImpl>
     {
         return this;
     }
-
-    @Override
-    public String toString()
-    {
-        return "SC:" + getName() + '(' + getId() + ')';
-    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
@@ -93,6 +93,6 @@ public class SystemMessage extends ReceivedMessage
     @Override
     public String toString()
     {
-        return "M:[" + type + ']' + author + '(' + id + ')';
+        return "SystemMessage[" + type + ']' + author + '(' + id + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/TeamMemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TeamMemberImpl.java
@@ -75,6 +75,6 @@ public class TeamMemberImpl implements TeamMember
     @Override
     public String toString()
     {
-        return "TeamMember(" + getTeamId() + ", " + user + ")";
+        return "TeamMember:" + getTeamId() + '(' + user + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -177,4 +177,10 @@ public class TextChannelImpl extends AbstractGuildChannelImpl<TextChannelImpl> i
         this.slowmode = slowmode;
         return this;
     }
+
+    @Override
+    public String toString()
+    {
+        return "TextChannel:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -177,12 +177,4 @@ public class TextChannelImpl extends AbstractGuildChannelImpl<TextChannelImpl> i
         this.slowmode = slowmode;
         return this;
     }
-
-    // -- Object overrides --
-
-    @Override
-    public String toString()
-    {
-        return "TC:" + getName() + '(' + getId() + ')';
-    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/TextChannelImpl.java
@@ -183,6 +183,6 @@ public class TextChannelImpl extends AbstractGuildChannelImpl<TextChannelImpl> i
     @Override
     public String toString()
     {
-        return "TC:" + getName() + '(' + id + ')';
+        return "TC:" + getName() + '(' + getId() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -329,7 +329,7 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
     @Override
     public String toString()
     {
-        return "ThC:" + getName() + '(' + id + ')';
+        return "ThC:" + getName() + '(' + getId() + ')';
     }
 
     private void checkUnarchived()

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -323,15 +323,6 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         return archiveTimestamp;
     }
 
-
-    // -- Object overrides --
-
-    @Override
-    public String toString()
-    {
-        return "ThC:" + getName() + '(' + getId() + ')';
-    }
-
     private void checkUnarchived()
     {
         if (archived) {

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -329,4 +329,10 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
             throw new IllegalStateException("Cannot modify a ThreadChannel while it is archived!");
         }
     }
+
+    @Override
+    public String toString()
+    {
+        return "ThreadChannel:" + getName() + '(' + getId() + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserById.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserById.java
@@ -69,7 +69,7 @@ public class UserById implements User
     @Override
     public String toString()
     {
-        return "U:(" + getId() + ')';
+        return "User(" + getId() + ')';
     }
 
     @Contract("->fail")

--- a/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/UserImpl.java
@@ -182,7 +182,7 @@ public class UserImpl extends UserById implements User
     @Override
     public String toString()
     {
-        return "U:" + getName() + '(' + getId() + ')';
+        return "User:" + getName() + '(' + getId() + ')';
     }
 
     // -- Setters --

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -176,4 +176,12 @@ public class VoiceChannelImpl extends AbstractGuildChannelImpl<VoiceChannelImpl>
         this.userLimit = userLimit;
         return this;
     }
+
+    // -- Object overrides --
+
+    @Override
+    public String toString()
+    {
+        return "VC:" + getName() + '(' + id + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -176,12 +176,4 @@ public class VoiceChannelImpl extends AbstractGuildChannelImpl<VoiceChannelImpl>
         this.userLimit = userLimit;
         return this;
     }
-
-    // -- Object overrides --
-
-    @Override
-    public String toString()
-    {
-        return "VC:" + getName() + '(' + getId() + ')';
-    }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -182,6 +182,6 @@ public class VoiceChannelImpl extends AbstractGuildChannelImpl<VoiceChannelImpl>
     @Override
     public String toString()
     {
-        return "VC:" + getName() + '(' + id + ')';
+        return "VC:" + getName() + '(' + getId() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -61,7 +61,7 @@ public class VoiceChannelImpl extends AbstractGuildChannelImpl<VoiceChannelImpl>
     {
         return ChannelType.VOICE;
     }
-    
+
     @Override
     public int getBitrate()
     {
@@ -175,5 +175,11 @@ public class VoiceChannelImpl extends AbstractGuildChannelImpl<VoiceChannelImpl>
     {
         this.userLimit = userLimit;
         return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "VoiceChannel:" + getName() + '(' + getId() + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/WebhookImpl.java
@@ -245,7 +245,7 @@ public class WebhookImpl extends AbstractWebhookClient<Void> implements Webhook
     @Override
     public String toString()
     {
-        return "WH:" + getName() + "(" + id + ")";
+        return "Webhook:" + getName() + '(' + id + ')';
     }
 
     // TODO: Implement WebhookMessage

--- a/src/main/java/net/dv8tion/jda/internal/interactions/ButtonImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/ButtonImpl.java
@@ -149,6 +149,6 @@ public class ButtonImpl implements Button
     @Override
     public String toString()
     {
-        return "B:" + label + "(" + id + ")";
+        return "Button:" + label + '(' + id + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/Route.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/Route.java
@@ -489,7 +489,7 @@ public class Route
         @Override
         public String toString()
         {
-            return "CompiledRoute(" + method + ": " + compiledRoute + ")";
+            return "CompiledRoute[" + method + "](" + compiledRoute + ')';
         }
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Every channel previously overrode `Object#toString` individually to differentiate between the channel types. This PR moves this override to the `AbstractChannelImpl` interface and updates the format to `ChannelType:Name(Id)`. This also has the side effect of adding this handling to `StageChannel` and `VoiceChannel` which used the default method.