### PR TITLE
Clear up some events' documentation wording

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/guild/GuildBanEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/GuildBanEvent.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.User User} was banned from a {@link net.dv8tion.jda.api.entities.Guild Guild}.
  *
- * <p>Can be used to retrieve the user who was banned (if available) and triggering guild.
+ * <p>Can be used to retrieve the user who was banned (if available) and the triggering guild.
  * <br><b>Note</b>: This does not directly indicate that a Member is removed from the Guild!
  *
  * @see net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateAvatarEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateAvatarEvent.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} avatar.
  *
- * <p>Can be used to retrieve members who change their per guild avatar, triggering guild, the old avatar id and the new avatar id.
+ * <p>Can be used to retrieve members who change their per guild avatar, the triggering guild, the old avatar id and the new avatar id.
  *
  * <p>Identifier: {@code avatar}
  *

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateBoostTimeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateBoostTimeEvent.java
@@ -27,7 +27,7 @@ import java.time.OffsetDateTime;
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} boost time.
  * <br>This happens when a member started or stopped boosting a guild.
  *
- * <p>Can be used to retrieve members who boosted, triggering guild.
+ * <p>Can be used to retrieve members who boosted and the triggering guild.
  *
  * <p>Identifier: {@code boost_time}
  *

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateNicknameEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdateNicknameEvent.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 /**
  * Indicates that a {@link net.dv8tion.jda.api.entities.Member Member} updated their {@link net.dv8tion.jda.api.entities.Guild Guild} nickname.
  *
- * <p>Can be used to retrieve members who change their nickname, triggering guild, the old nick and the new nick.
+ * <p>Can be used to retrieve members who change their nickname, the triggering guild, the old nick and the new nick.
  *
  * <p>Identifier: {@code nick}
  *

--- a/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdatePendingEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/member/update/GuildMemberUpdatePendingEvent.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 /**
  * Indicates that a {@link Member Member} has agreed to Membership Screening requirements.
  *
- * <p>Can be used to retrieve members who have agreed to Membership Screening requirements.
+ * <p>Can be used to retrieve members who have agreed to Membership Screening requirements and the triggering guild.
  *
  * <p>Identifier: {@code pending}
  *


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR clears up some guild events' documentation wording by prepending `(and) the` to `triggering guild`, making it sound less like an action.