### PR TITLE
Change MessageEmbed#getUrl docs to mention representing the title url

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -71,7 +71,7 @@ public class MessageEmbed implements SerializableData
      * @see net.dv8tion.jda.api.EmbedBuilder#setDescription(CharSequence) EmbedBuilder.setDescription(text)
      */
     public static final int DESCRIPTION_MAX_LENGTH = 4096;
-    
+
     /**
      * The maximum length the footer of an embed can have
      *
@@ -152,8 +152,9 @@ public class MessageEmbed implements SerializableData
 
     /**
      * The that was originally placed into chat that spawned this embed.
+     * <br><b>This will return the {@link #getTitle() title url} if the {@link #getType() type} of this embed is {@link EmbedType#RICH RICH}.</b>
      *
-     * @return Possibly-null String containing the original message url.
+     * @return Possibly-null String containing the link that spawned this embed or the title url
      */
     @Nullable
     public String getUrl()
@@ -251,7 +252,7 @@ public class MessageEmbed implements SerializableData
     {
         return videoInfo;
     }
-    
+
     /**
      * The footer (bottom) of the embedded content.
      * <br>This is typically used for timestamps or site icons.
@@ -264,7 +265,7 @@ public class MessageEmbed implements SerializableData
     {
         return footer;
     }
-    
+
     /**
      * The information about the image in the message embed
      *
@@ -276,7 +277,7 @@ public class MessageEmbed implements SerializableData
     {
         return image;
     }
-    
+
     /**
      * The fields in a message embed.
      * <br>Message embeds can contain multiple fields, each with a name, value, and a boolean
@@ -291,7 +292,7 @@ public class MessageEmbed implements SerializableData
     {
         return fields;
     }
-    
+
     /**
      * The color of the stripe on the side of the embed.
      * <br>If the color is 0 (no color), this will return null.
@@ -314,7 +315,7 @@ public class MessageEmbed implements SerializableData
     {
         return color;
     }
-    
+
     /**
      * The timestamp of the embed.
      *
@@ -687,7 +688,7 @@ public class MessageEmbed implements SerializableData
                 && video.height == height);
         }
     }
-    
+
     /**
      * Represents the information provided to embed an image.
      */
@@ -716,7 +717,7 @@ public class MessageEmbed implements SerializableData
         {
             return url;
         }
-        
+
         /**
          * The url of the image, proxied by Discord
          * <br>This url is used to access the image through Discord instead of directly to prevent ip scraping.
@@ -761,7 +762,7 @@ public class MessageEmbed implements SerializableData
                 && image.height == height);
         }
     }
-    
+
     /**
      * Class that represents the author of content, possibly including an icon
      * that Discord proxies.
@@ -803,7 +804,7 @@ public class MessageEmbed implements SerializableData
         {
             return url;
         }
-        
+
         /**
          * The url of the author's icon.
          *
@@ -814,7 +815,7 @@ public class MessageEmbed implements SerializableData
         {
             return iconUrl;
         }
-        
+
         /**
          * The url of the author's icon, proxied by Discord
          * <br>This url is used to access the image through Discord instead of directly to prevent ip scraping.
@@ -839,7 +840,7 @@ public class MessageEmbed implements SerializableData
                 && Objects.equals(author.proxyIconUrl, proxyIconUrl));
         }
     }
-    
+
     /**
      * Class that represents a footer at the bottom of an embed
      */
@@ -866,7 +867,7 @@ public class MessageEmbed implements SerializableData
         {
             return text;
         }
-        
+
         /**
          * The url of the footer's icon.
          *
@@ -877,7 +878,7 @@ public class MessageEmbed implements SerializableData
         {
             return iconUrl;
         }
-        
+
         /**
          * The url of the footer's icon, proxied by Discord
          * <br>This url is used to access the image through Discord instead of directly to prevent ip scraping.
@@ -901,7 +902,7 @@ public class MessageEmbed implements SerializableData
                 && Objects.equals(footer.proxyIconUrl, proxyIconUrl));
         }
     }
-    
+
     /**
      * Represents a field in an embed. A single embed contains an array of
      * embed fields, each with a name and value, and a boolean determining if
@@ -945,7 +946,7 @@ public class MessageEmbed implements SerializableData
             }
             this.inline = inline;
         }
-        
+
         public Field(String name, String value, boolean inline)
         {
             this(name, value, inline, true);
@@ -972,7 +973,7 @@ public class MessageEmbed implements SerializableData
         {
             return value;
         }
-        
+
         /**
          * If the field is in line.
          *

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageEmbed.java
@@ -151,7 +151,7 @@ public class MessageEmbed implements SerializableData
     }
 
     /**
-     * The that was originally placed into chat that spawned this embed.
+     * The url that was originally placed into chat that spawned this embed.
      * <br><b>This will return the {@link #getTitle() title url} if the {@link #getType() type} of this embed is {@link EmbedType#RICH RICH}.</b>
      *
      * @return Possibly-null String containing the link that spawned this embed or the title url


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR changes the `MessageEmbed#getUrl` docs to mention that it may represent the title url if the type of the embed is `EmbedType#RICH`.