### PR TITLE
[Bugfix] DATE_TIME_TYPE_PARSE: Could not parse 859166905289539625. Should be ISO8601.

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/attribute/IThreadContainerMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/attribute/IThreadContainerMixin.java
@@ -77,7 +77,7 @@ public interface IThreadContainerMixin<T extends IThreadContainerMixin<T>> exten
         checkPermission(Permission.MESSAGE_HISTORY);
 
         Route.CompiledRoute route = Route.Channels.LIST_PUBLIC_ARCHIVED_THREADS.compile(getId());
-        return new ThreadChannelPaginationActionImpl(getJDA(), route, this);
+        return new ThreadChannelPaginationActionImpl(getJDA(), route, this, false);
     }
 
     @Nonnull
@@ -89,7 +89,7 @@ public interface IThreadContainerMixin<T extends IThreadContainerMixin<T>> exten
         checkPermission(Permission.MANAGE_THREADS);
 
         Route.CompiledRoute route = Route.Channels.LIST_PRIVATE_ARCHIVED_THREADS.compile(getId());
-        return new ThreadChannelPaginationActionImpl(getJDA(), route, this);
+        return new ThreadChannelPaginationActionImpl(getJDA(), route, this, false);
     }
 
     @Nonnull
@@ -100,6 +100,6 @@ public interface IThreadContainerMixin<T extends IThreadContainerMixin<T>> exten
         checkPermission(Permission.MESSAGE_HISTORY);
 
         Route.CompiledRoute route = Route.Channels.LIST_JOINED_PRIVATE_ARCHIVED_THREADS.compile(getId());
-        return new ThreadChannelPaginationActionImpl(getJDA(), route, this);
+        return new ThreadChannelPaginationActionImpl(getJDA(), route, this, true);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -9,11 +9,11 @@ import net.dv8tion.jda.api.exceptions.ParsingException;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.restaction.pagination.ThreadChannelPaginationAction;
+import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Route;
-import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -22,11 +22,13 @@ import java.util.List;
 public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<ThreadChannel, ThreadChannelPaginationAction> implements ThreadChannelPaginationAction
 {
     protected final IThreadContainer channel;
+    protected final boolean useID;
 
-    public ThreadChannelPaginationActionImpl(JDA api, Route.CompiledRoute route, IThreadContainer channel)
+    public ThreadChannelPaginationActionImpl(JDA api, Route.CompiledRoute route, IThreadContainer channel, boolean useID)
     {
-        super(api, route, 1, 100, 100);
+        super(api, route, 2, 100, 100);
         this.channel = channel;
+        this.useID = useID;
     }
 
     @Nonnull
@@ -46,10 +48,13 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
 
         route = route.withQueryParams("limit", limit);
 
-        if (last != 0)
-            route = route.withQueryParams("before", Helpers.toISO8601(last));
+        if (last == 0)
+            return route;
 
-        return route;
+        if (useID)
+            return route.withQueryParams("before", Long.toUnsignedString(last));
+        // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
+        return route.withQueryParams("before", TimeUtil.getTimeCreated(last).toString());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Route;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -46,7 +47,7 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
         route = route.withQueryParams("limit", limit);
 
         if (last != 0)
-            route = route.withQueryParams("before", Long.toUnsignedString(last));
+            route = route.withQueryParams("before", Helpers.toISO8601(last));
 
         return route;
     }

--- a/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
@@ -16,6 +16,8 @@
 
 package net.dv8tion.jda.internal.utils;
 
+import net.dv8tion.jda.api.utils.TimeUtil;
+
 import javax.annotation.Nullable;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -45,9 +47,9 @@ public final class Helpers
         return OffsetDateTime.ofInstant(Instant.ofEpochMilli(instant), OFFSET);
     }
     
-    public static String toISO8601(long timestamp)
+    public static String toISO8601(long id)
     {
-        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(timestamp));
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(TimeUtil.getTimeCreated(id));
     }
 
     public static long toTimestamp(String iso8601String)

--- a/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
@@ -16,8 +16,6 @@
 
 package net.dv8tion.jda.internal.utils;
 
-import net.dv8tion.jda.api.utils.TimeUtil;
-
 import javax.annotation.Nullable;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -45,11 +43,6 @@ public final class Helpers
     public static OffsetDateTime toOffset(long instant)
     {
         return OffsetDateTime.ofInstant(Instant.ofEpochMilli(instant), OFFSET);
-    }
-    
-    public static String toISO8601(long id)
-    {
-        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(TimeUtil.getTimeCreated(id));
     }
 
     public static long toTimestamp(String iso8601String)

--- a/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
@@ -44,6 +44,11 @@ public final class Helpers
     {
         return OffsetDateTime.ofInstant(Instant.ofEpochMilli(instant), OFFSET);
     }
+    
+    public static String toISO8601(long timestamp)
+    {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(timestamp));
+    }
 
     public static long toTimestamp(String iso8601String)
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description
```
Caused by: net.dv8tion.jda.api.exceptions.ErrorResponseException: 50035: Invalid Form Body
	- DATE_TIME_TYPE_PARSE: Could not parse 859166905289539625. Should be ISO8601.
	at net.dv8tion.jda.internal.requests.RestActionImpl.complete(RestActionImpl.java:227)
	at net.dv8tion.jda.api.requests.RestAction.complete(RestAction.java:633)
	at net.dv8tion.jda.internal.requests.restaction.pagination.PaginationActionImpl.getNextChunk(PaginationActionImpl.java:339)
	at net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction$PaginationIterator.hasNext(PaginationAction.java:663)
	at java.base/java.lang.Iterable.forEach(Iterable.java:74)
Caused by: net.dv8tion.jda.api.exceptions.ContextException
	at net.dv8tion.jda.api.exceptions.ContextException.here(ContextException.java:54)
	at net.dv8tion.jda.api.requests.Request.<init>(Request.java:71)
	at net.dv8tion.jda.api.requests.RestFuture.<init>(RestFuture.java:36)
	at net.dv8tion.jda.internal.requests.RestActionImpl.submit(RestActionImpl.java:209)
	at net.dv8tion.jda.internal.requests.RestActionImpl.complete(RestActionImpl.java:219)
```
(reflection stuff cut out)
https://hastebin.de/yamaqoxuge.txt
