### PR TITLE
Add Interaction#getUserLocale and Interaction#getGuildLocale

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/interaction/GenericInteractionCreateEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/interaction/GenericInteractionCreateEvent.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.interactions.Interaction;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Locale;
 
 /**
  * Indicates that an {@link Interaction} was created.
@@ -84,6 +85,20 @@ public class GenericInteractionCreateEvent extends Event implements Interaction
     public Channel getChannel()
     {
         return interaction.getChannel();
+    }
+
+    @Nonnull
+    @Override
+    public Locale getUserLocale()
+    {
+        return interaction.getUserLocale();
+    }
+
+    @Nonnull
+    @Override
+    public Locale getGuildLocale()
+    {
+        return interaction.getGuildLocale();
     }
 
     @Nullable

--- a/src/main/java/net/dv8tion/jda/api/interactions/Interaction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/Interaction.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.interactions.commands.Command;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Locale;
 
 /**
  * Abstract representation for any kind of Discord interaction.
@@ -254,6 +255,29 @@ public interface Interaction extends ISnowflake
         if (channel instanceof PrivateChannel)
             return (PrivateChannel) channel;
         throw new IllegalStateException("Cannot convert channel of type " + getChannelType() + " to PrivateChannel");
+    }
+
+    /**
+     * Returns the selected language of the invoking user.
+     *
+     * @return The language of the invoking user
+     */
+    @Nonnull
+    Locale getUserLocale();
+
+    /**
+     * Returns the preferred language of the Guild.
+     * <br>If {@link #isFromGuild()} returns {@code false}, this throws {@link IllegalStateException}!
+     * <br>This is identical to {@code getGuild().getLocale()}.
+     *
+     * @return The preferred language of the Guild
+     */
+    @Nonnull
+    default Locale getGuildLocale()
+    {
+        if (!isFromGuild())
+            throw new IllegalStateException("This interaction did not happen in a guild");
+        return getGuild().getLocale();
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.internal.entities.MemberImpl;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Locale;
 
 public class InteractionImpl implements Interaction
 {
@@ -36,6 +37,7 @@ public class InteractionImpl implements Interaction
     protected final Member member;
     protected final User user;
     protected final Channel channel;
+    protected final Locale userLocale;
     protected final JDAImpl api;
 
     //This is used to give a proper error when an interaction is ack'd twice
@@ -49,6 +51,7 @@ public class InteractionImpl implements Interaction
         this.token = data.getString("token");
         this.type = data.getInt("type");
         this.guild = jda.getGuildById(data.getUnsignedLong("guild_id", 0L));
+        this.userLocale = Locale.forLanguageTag(data.getString("locale"));
         if (guild != null)
         {
             member = jda.getEntityBuilder().createMember((GuildImpl) guild, data.getObject("member"));
@@ -118,6 +121,12 @@ public class InteractionImpl implements Interaction
     public Channel getChannel()
     {
         return channel;
+    }
+
+    @Nonnull
+    public Locale getUserLocale()
+    {
+        return userLocale;
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR adds `Interaction#getUserLocale` and `Interaction#getGuildLocale`. see https://github.com/discord/discord-api-docs/pull/4265. I'm not too sure about the behavior of `getGuildLocale` because there's a separate field for the preferred guild locale (however that is still only changeable with the `COMMUNITY` feature, effectively being `Guild#getLocale`), so feel free to comment on that. this is a fix for my previous PR that I fucked up by rebasing.