### PR TITLE
Override ThreadChannel#getTimeCreated

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
@@ -475,6 +475,8 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer
 
     /**
      * The timestamp when this thread was created.
+     * <br><b>This will only be valid for threads created after 2022-01-09.
+     * Otherwise, this will return the timestamp of creation based on the {@link #getIdLong() thread's id.}</b>
      *
      * @return The timestamp when this thread was created
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
@@ -473,6 +473,14 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer
     @Nonnull
     AutoArchiveDuration getAutoArchiveDuration();
 
+    /**
+     * The timestamp when this thread was created.
+     * <br><b>This will be {@code null} for threads created before 2022-01-10.</b>
+     *
+     * @return The timestamp when this thread was created or {@code null}
+     */
+    @Nullable
+    OffsetDateTime getTimeCreated();
 
     /**
      * The slowmode time of this thread. This determines the time each non-moderator must wait before sending another message.

--- a/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
@@ -475,11 +475,10 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer
 
     /**
      * The timestamp when this thread was created.
-     * <br><b>This will be {@code null} for threads created before 2022-01-10.</b>
      *
-     * @return The timestamp when this thread was created or {@code null}
+     * @return The timestamp when this thread was created
      */
-    @Nullable
+    @Nonnull
     OffsetDateTime getTimeCreated();
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1187,6 +1187,7 @@ public class EntityBuilder
                 .setArchived(threadMetadata.getBoolean("archived"))
                 .setInvitable(threadMetadata.getBoolean("invitable"))
                 .setArchiveTimestamp(Helpers.toTimestamp(threadMetadata.getString("archive_timestamp")))
+                .setCreationTimestamp(threadMetadata.isNull("create_timestamp") ? 0 : Helpers.toTimestamp(threadMetadata.getString("create_timestamp")))
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.fromKey(threadMetadata.getInt("auto_archive_duration")));
 
         //If the bot in the thread already, then create a thread member for the bot.

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -52,6 +52,7 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
     private boolean invitable;
     private long parentChannelId;
     private long archiveTimestamp;
+    private long creationTimestamp;
     private long ownerId;
     private long latestMessageId;
     private int messageCount;
@@ -209,6 +210,13 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         return autoArchiveDuration;
     }
 
+    @Nullable
+    @Override
+    public OffsetDateTime getTimeCreated()
+    {
+        return creationTimestamp == 0 ? null : Helpers.toOffset(creationTimestamp);
+    }
+
     @Override
     public int getSlowmode()
     {
@@ -308,6 +316,12 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
     public ThreadChannelImpl setArchiveTimestamp(long archiveTimestamp)
     {
         this.archiveTimestamp = archiveTimestamp;
+        return this;
+    }
+
+    public ThreadChannelImpl setCreationTimestamp(long creationTimestamp)
+    {
+        this.creationTimestamp = creationTimestamp;
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
@@ -210,11 +211,11 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         return autoArchiveDuration;
     }
 
-    @Nullable
+    @Nonnull
     @Override
     public OffsetDateTime getTimeCreated()
     {
-        return creationTimestamp == 0 ? null : Helpers.toOffset(creationTimestamp);
+        return creationTimestamp == 0 ? TimeUtil.getTimeCreated(getIdLong()) : Helpers.toOffset(creationTimestamp);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR overrides `ISnowflake#getTimeCreated` for `ThreadChannel` with a field that is present in a Thread payload.
