### PR TITLE
Restore behavior of zero being passed to find category rather than null

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/ICategorizableChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ICategorizableChannel.java
@@ -72,7 +72,7 @@ public interface ICategorizableChannel extends GuildChannel, IPermissionContaine
     @Nullable
     default Category getParentCategory()
     {
-        return getGuild().getCategoryById(getParentCategoryId());
+        return getGuild().getCategoryById(getParentCategoryIdLong());
     }
 
     /**


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

```11:59:55.263 JDA [0 / 3] MainWS-ReadThr WebSocketClient      ERROR  Got an unexpected error. Please redirect the following message to the devs:
    JDA 5.0.0-alpha.4_ce738b9
    CHANNEL_UPDATE -> {"nsfw":false,"bitrate":64000,"user_limit":0,"type":2,"guild_hashes":{"metadata":{"hash":"hashere"},"channels":{"hash":"hashere"},"roles":{"hash":"hashere"},"version":1},"rtc_region":null,"permission_overwrites":[{"allow":"1049616","deny":"0","id":"x","type":1},{"allow":"0","deny":"1048576","id":"x","type":0}],"last_message_id":null,"parent_id":null,"name":"🕐 10:59am UTC","guild_id":"x","position":31,"id":"x"}
java.lang.IllegalArgumentException: ID may not be null
    at net.dv8tion.jda.internal.utils.Checks.notNull(Checks.java:77)
    at net.dv8tion.jda.internal.utils.Checks.notEmpty(Checks.java:83)
at net.dv8tion.jda.api.utils.cache.SnowflakeCacheView.getElementById(SnowflakeCacheView.java:59)
    at net.dv8tion.jda.api.entities.Guild.getCategoryById(Guild.java:1693)
    at net.dv8tion.jda.api.entities.ICategorizableChannel.getParentCategory(ICategorizableChannel.java:75)
    at net.dv8tion.jda.internal.utils.PermissionUtil.getEffectivePermission(PermissionUtil.java:363)
    at net.dv8tion.jda.internal.utils.PermissionUtil.checkPermission(PermissionUtil.java:281)
    at net.dv8tion.jda.internal.entities.MemberImpl.hasPermission(MemberImpl.java:265)
    at net.dv8tion.jda.internal.handle.ChannelUpdateHandler.handleInternally(ChannelUpdateHandler.java:388)
    at net.dv8tion.jda.internal.handle.SocketHandler.handle(SocketHandler.java:36)
    at net.dv8tion.jda.internal.requests.WebSocketClient.onDispatch(WebSocketClient.java:953)
    at net.dv8tion.jda.internal.requests.WebSocketClient.onEvent(WebSocketClient.java:840)
    at net.dv8tion.jda.internal.requests.WebSocketClient.handleEvent(WebSocketClient.java:818)
    at net.dv8tion.jda.internal.requests.WebSocketClient.onTextMessage(WebSocketClient.java:979)
    at com.neovisionaries.ws.client.ListenerManager.callOnTextMessage(ListenerManager.java:369)
    at com.neovisionaries.ws.client.ReadingThread.callOnTextMessage(ReadingThread.java:233)
    at com.neovisionaries.ws.client.ReadingThread.handleTextFrame(ReadingThread.java:969)
    at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:752)
    at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108)
    at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64)
    at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45)
```
getParentCategoryId() may return null if there is no parent, where getCategoryById expects a non-null argument.

This PR will return the code to passing `0` to the cache lookup, rather than null, by using the long value directly rather than the possibly-null String value.
