### PR TITLE
Fixes setInvitable in ThreadChannelManager

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
@@ -531,7 +531,7 @@ public class ChannelManagerImpl<T extends GuildChannel, M extends ChannelManager
         }
 
         this.invitable = invitable;
-        set |= LOCKED;
+        set |= INVITEABLE;
         return (M) this;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes the modified set for the ThreadChannelManager to correctly mark that the invitable field has been set.  This previously set the bit for LOCKED being updated.
