### PR TITLE
Feature: Command choices from enum

### DIFF
--- a/src/examples/java/SlashBotExample.java
+++ b/src/examples/java/SlashBotExample.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
+import org.jetbrains.annotations.NotNull;
 
 import javax.security.auth.login.LoginException;
 import java.util.EnumSet;
@@ -221,15 +222,19 @@ public class SlashBotExample extends ListenerAdapter
             .queue();
     }
 
-    public enum MyEnum{
-        @OptionData.OptionChoice(name = "Asia")
+    public enum MyEnum implements OptionData.ChoiceNameTransformer
+    {
         ASIA,
-        @OptionData.OptionChoice(name = "Europe")
         EUROPE,
-        @OptionData.OptionChoice(name = "America")
         AMERICA,
-        @OptionData.OptionChoice(name = "World")
-        WORLD
+        WORLD;
+
+        @NotNull
+        @Override
+        public String getDisplayName()
+        {
+            return this.name().toLowerCase();
+        }
     }
 
 }

--- a/src/examples/java/SlashBotExample.java
+++ b/src/examples/java/SlashBotExample.java
@@ -71,6 +71,15 @@ public class SlashBotExample extends ListenerAdapter
                 .addOption(INTEGER, "amount", "How many messages to prune (Default 100)") // simple optional argument
         );
 
+        // Commands with predefined choices for an option determined by an enum
+        commands.addCommands(
+                Commands.slash("hello", "Say hello to the world")
+                        .addOptions(
+                                new OptionData(STRING, "worldPart", "The part of the world you want to greet")
+                                        .addChoices(MyEnum.class)
+                        )
+        );
+
         // Send the new set of commands to discord, this will override any existing global commands with the new set provided here
         commands.queue();
     }
@@ -98,6 +107,8 @@ public class SlashBotExample extends ListenerAdapter
         case "prune": // 2 stage command with a button prompt
             prune(event);
             break;
+        case "hello":
+            MyEnum myEnum = event.getOption("worldPart").getAsEnum(MyEnum.class);
         default:
             event.reply("I can't handle that command right now :(").setEphemeral(true).queue();
         }
@@ -168,6 +179,24 @@ public class SlashBotExample extends ListenerAdapter
         event.reply(content).queue(); // This requires no permissions!
     }
 
+    public void sayHello(SlashCommandInteractionEvent event, MyEnum myEnum)
+    {
+        switch (myEnum){
+        case ASIA:
+            event.reply("Hello Asia!").queue();
+            break;
+        case AMERICA:
+            event.reply("Hello America!").queue();
+            break;
+        case EUROPE:
+            event.reply("Hello Europe!").queue();
+            break;
+        case WORLD:
+            event.reply("Hello World!").queue();
+            break;
+        }
+    }
+
     public void leave(SlashCommandInteractionEvent event)
     {
         if (!event.getMember().hasPermission(Permission.KICK_MEMBERS))
@@ -191,4 +220,16 @@ public class SlashBotExample extends ListenerAdapter
                 Button.danger(userId + ":prune:" + amount, "Yes!")) // the first parameter is the component id we use in onButtonInteraction above
             .queue();
     }
+
+    public enum MyEnum{
+        @OptionData.OptionChoice(name = "Asia")
+        ASIA,
+        @OptionData.OptionChoice(name = "Europe")
+        EUROPE,
+        @OptionData.OptionChoice(name = "America")
+        AMERICA,
+        @OptionData.OptionChoice(name = "World")
+        WORLD
+    }
+
 }

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -248,10 +248,10 @@ public class OptionMapping
      * @return The enum-constant corresponding with this option value
      */
     @Nonnull
-    public <T> T getAsEnum(Class<T> enumClass)
+    public <T extends Enum<T>> T getAsEnum(Class<T> enumClass)
     {
         Checks.check(enumClass.isEnum(), "enumClass");
-        T t = Enum.valueOf(enumClass, getAsString())
+        T t = Enum.valueOf(enumClass, getAsString());
         Checks.notNull(t, String.format("Enum constant for %s not found", getAsString()));
         return t;
     }

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.api.interactions.commands;
 import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -231,6 +232,31 @@ public class OptionMapping
     public String getAsString()
     {
         return data.getString("value");
+    }
+
+    /**
+     * The enum-constant representation of this option value
+     * @param enumClass The enum from that the enum-constant shall be returned
+     *
+     * @throws IllegalArgumentException
+     *         If any of the following checks fail
+     *         <ul>
+     *             <li>{@code enumClass} is an enum </li>
+     *             <li>{@code} contains a constant corresponding with this option value</li>
+     *         </ul>
+     *
+     * @return The enum-constant corresponding with this option value
+     */
+    @Nonnull
+    public <T> T getAsEnum(Class<T> enumClass)
+    {
+        Checks.check(enumClass.isEnum(), "enumClass");
+        T t = Arrays.stream(enumClass.getEnumConstants())
+                .filter(t1 -> t1.toString().equals(getAsString()))
+                .findAny()
+                .orElse(null);
+        Checks.notNull(t, String.format("Enum konstant for %s not found", getAsString()));
+        return t;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -251,11 +251,8 @@ public class OptionMapping
     public <T> T getAsEnum(Class<T> enumClass)
     {
         Checks.check(enumClass.isEnum(), "enumClass");
-        T t = Arrays.stream(enumClass.getEnumConstants())
-                .filter(t1 -> t1.toString().equals(getAsString()))
-                .findAny()
-                .orElse(null);
-        Checks.notNull(t, String.format("Enum konstant for %s not found", getAsString()));
+        T t = Enum.valueOf(enumClass, getAsString())
+        Checks.notNull(t, String.format("Enum constant for %s not found", getAsString()));
         return t;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -729,21 +729,21 @@ public class OptionData implements SerializableData
      * @see ChoiceNameTransformer
      */
     @Nonnull
-    public OptionData addChoices(@Nonnull Class<?> enumClass)
+    public OptionData addChoices(@Nonnull Class<? extends Enum<?>> enumClass)
     {
         Checks.check(enumClass.isEnum(), "enumClass has to be an enum!");
         Checks.check(type == OptionType.STRING, "Cannot add enum choice for OptionType." + type);
         Object[] enumConstants = enumClass.getEnumConstants();
         Checks.check(enumConstants.length + this.choices.size() <= MAX_CHOICES, "Cannot have more than 25 choices for one option!");
-        for (Object enumConstant : enumClass.getEnumConstants())
+        for (Enum<?> enumConstant : enumClass.getEnumConstants())
         {
             if (enumConstant instanceof ChoiceNameTransformer)
             {
-                addChoice(((ChoiceNameTransformer) enumConstant).getDisplayName(), enumConstant.toString());
+                addChoice(((ChoiceNameTransformer) enumConstant).getDisplayName(), enumConstant.name());
             }
             else
             {
-                addChoice(enumConstant.toString(), enumConstant.toString());
+                addChoice(enumConstant.name(), enumConstant.name());
             }
         }
         return this;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: SlashBotExample

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds `OptionData#addChoices(Class)` to easily add predefined choices a user can choose in a slash-command.
Enum-Class can implement `OptionData.ChoiceNameTransformer` to map the constants name that will be displayed in the Discord client
In the `SlashCommandInteractionEvent` the enum can be easily used by `OptionMapping#getAsEnum`.
