### PR TITLE
Dont override latest message id on deletion event

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -89,7 +89,7 @@ public interface MessageChannel extends Channel, Formattable
      *
      * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
      * and <u><b>the value might point to an already deleted message since the ID is not cleared when the message is deleted,
-     * so calling {@link #retrieveMessageById(long)} with this id can throw {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}</b></u>
+     * so calling {@link #retrieveMessageById(long)} with this id can result in an {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE} error</b></u>
      *
      * @return The most recent message's id
      */
@@ -105,7 +105,7 @@ public interface MessageChannel extends Channel, Formattable
      *
      * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
      * and <u><b>the value might point to an already deleted message since the value is not cleared when the message is deleted,
-     * so calling {@link #retrieveMessageById(long)} with this id can throw {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}</b></u>
+     * so calling {@link #retrieveMessageById(long)} with this id can result in an {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE} error</b></u>
      *
      * @return The most recent message's id
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -86,19 +86,14 @@ public interface MessageChannel extends Channel, Formattable
     /**
      * The id for the most recent message sent
      * in this current MessageChannel.
-     * <br>This should only be used if {@link #hasLatestMessage()} returns {@code true}!
      *
      * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
      * and <u><b>the value might point to an already deleted message since the ID is not cleared when the message is deleted,
      * so calling {@link #retrieveMessageById(long)} with this id can throw {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}</b></u>
      *
-     * @throws java.lang.IllegalStateException
-     *         If no message id is available
-     *
      * @return The most recent message's id
      */
     @Nonnull
-    //TODO-v5: Revisit this. Surely this should be Nullable instead of throw an exception...
     default String getLatestMessageId()
     {
         return Long.toUnsignedString(getLatestMessageIdLong());
@@ -107,36 +102,14 @@ public interface MessageChannel extends Channel, Formattable
     /**
      * The id for the most recent message sent
      * in this current MessageChannel.
-     * <br>This should only be used if {@link #hasLatestMessage()} returns {@code true}!
      *
      * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
      * and <u><b>the value might point to an already deleted message since the value is not cleared when the message is deleted,
      * so calling {@link #retrieveMessageById(long)} with this id can throw {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}</b></u>
      *
-     * @throws java.lang.IllegalStateException
-     *         If no message id is available
-     *
      * @return The most recent message's id
      */
     long getLatestMessageIdLong();
-
-    /**
-     * Whether this MessageChannel contains a tracked most recent
-     * message or not.
-     *
-     * <p>This does not directly mean that {@link #getHistory()} will be unable to retrieve past messages,
-     * it merely means that the latest message is untracked by our internal cache meaning that
-     * if this returns {@code false} the {@link #getLatestMessageId()}
-     * method will throw an {@link java.util.NoSuchElementException NoSuchElementException}
-     *
-     * @return True, if a latest message id is available for retrieval by {@link #getLatestMessageId()}
-     *
-     * @see    #getLatestMessageId()
-     */
-    default boolean hasLatestMessage()
-    {
-        return getLatestMessageIdLong() != 0;
-    }
 
     /**
      * Whether the currently logged in user can send messages in this channel or not.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -89,7 +89,8 @@ public interface MessageChannel extends Channel, Formattable
      * <br>This should only be used if {@link #hasLatestMessage()} returns {@code true}!
      *
      * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
-     * and <u><b>will be reset to {@code null} if the message associated with this ID gets deleted</b></u>
+     * and <u><b>the value might point to an already deleted message since the ID is not cleared when the message is deleted,
+     * so calling {@link #retrieveMessageById(long)} with this id can throw {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}</b></u>
      *
      * @throws java.lang.IllegalStateException
      *         If no message id is available
@@ -109,7 +110,8 @@ public interface MessageChannel extends Channel, Formattable
      * <br>This should only be used if {@link #hasLatestMessage()} returns {@code true}!
      *
      * <p>This value is updated on each {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
-     * and <u><b>will be reset to {@code null} if the message associated with this ID gets deleted</b></u>
+     * and <u><b>the value might point to an already deleted message since the value is not cleared when the message is deleted,
+     * so calling {@link #retrieveMessageById(long)} with this id can throw {@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}</b></u>
      *
      * @throws java.lang.IllegalStateException
      *         If no message id is available

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageDeleteHandler.java
@@ -58,12 +58,6 @@ public class MessageDeleteHandler extends SocketHandler
             return null;
         }
 
-        // Reset the latest message id as it was deleted.
-        if (channel.hasLatestMessage() & messageId == channel.getLatestMessageIdLong())
-        {
-            ((MessageChannelMixin<?>) channel).setLatestMessageIdLong(0);
-        }
-
         if (channel.getType().isThread())
         {
             ThreadChannelImpl gThread = (ThreadChannelImpl) channel;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].


### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2009

## Description

The internal handle of the Message Deletion event no longer sets the LatestMessageIdLong to 0. 
