### PR TITLE
Add CommandInteractionPayload#getOption fallback overloads

### DIFF
--- a/src/examples/java/SlashBotExample.java
+++ b/src/examples/java/SlashBotExample.java
@@ -156,7 +156,7 @@ public class SlashBotExample extends ListenerAdapter
         }
 
         // optional command argument, fall back to 0 if not provided
-        long delDays = event.getOption("del_days", 0L, OptionMapping::getAsLong); // this last part is a method reference used to "resolve" the option value
+        int delDays = event.getOption("del_days", 0, OptionMapping::getAsInt); // this last part is a method reference used to "resolve" the option value
 
         // optional ban reason with a lazy evaluated fallback (supplier)
         String reason = event.getOption("reason",
@@ -164,7 +164,7 @@ public class SlashBotExample extends ListenerAdapter
                 OptionMapping::getAsString); // used if getOption("reason") is not null (provided)
 
         // Ban the user and send a success response
-        event.getGuild().ban(user, (int) delDays, reason)
+        event.getGuild().ban(user, delDays, reason)
             .reason(reason) // audit-log reason
             .flatMap(v -> hook.sendMessage("Banned user " + user.getAsTag()))
             .queue();

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
@@ -306,6 +306,8 @@ public interface CommandInteractionPayload extends Interaction
      * @param  resolver
      *         The mapping resolver function to use if there is a mapping available,
      *         the provided mapping will never be null!
+     * @param  <T>
+     *         The type of the resolved option value
      *
      * @throws IllegalArgumentException
      *         If the name or resolver is null
@@ -348,6 +350,8 @@ public interface CommandInteractionPayload extends Interaction
      * @param  resolver
      *         The mapping resolver function to use if there is a mapping available,
      *         the provided mapping will never be null!
+     * @param  <T>
+     *         The type of the resolved option value
      *
      * @throws IllegalArgumentException
      *         If the name or resolver is null
@@ -395,6 +399,8 @@ public interface CommandInteractionPayload extends Interaction
      * @param  resolver
      *         The mapping resolver function to use if there is a mapping available,
      *         the provided mapping will never be null!
+     * @param  <T>
+     *         The type of the resolved option value
      *
      * @throws IllegalArgumentException
      *         If the name or resolver is null

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
@@ -208,6 +208,8 @@ public interface CommandInteractionPayload extends Interaction
      * Auto-complete interactions happen on incomplete command inputs and are not validated.
      *
      * @return The options passed for this command
+     *
+     * @see    #getOption(String)
      */
     @Nonnull
     List<OptionMapping> getOptions();
@@ -227,6 +229,7 @@ public interface CommandInteractionPayload extends Interaction
      * @return The list of options
      *
      * @see   #getOption(String)
+     * @see   #getOptions()
      */
     @Nonnull
     default List<OptionMapping> getOptionsByName(@Nonnull String name)
@@ -250,6 +253,8 @@ public interface CommandInteractionPayload extends Interaction
      *         If the provided type is null
      *
      * @return The list of options
+     *
+     * @see    #getOptions()
      */
     @Nonnull
     default List<OptionMapping> getOptionsByType(@Nonnull OptionType type)
@@ -266,6 +271,9 @@ public interface CommandInteractionPayload extends Interaction
      * <p>For {@link CommandAutoCompleteInteraction}, this might be incomplete and unvalidated.
      * Auto-complete interactions happen on incomplete command inputs and are not validated.
      *
+     * <p>You can use the second and third parameter overloads to handle optional arguments gracefully.
+     * See {@link #getOption(String, Function)} and {@link #getOption(String, Object, Function)}.
+     *
      * @param  name
      *         The option name
      *
@@ -273,6 +281,10 @@ public interface CommandInteractionPayload extends Interaction
      *         If the name is null
      *
      * @return The option with the provided name, or null if that option is not provided
+     *
+     * @see    #getOption(String, Function)
+     * @see    #getOption(String, Object, Function)
+     * @see    #getOption(String, Supplier, Function)
      */
     @Nullable
     default OptionMapping getOption(@Nonnull String name)

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
@@ -281,12 +281,82 @@ public interface CommandInteractionPayload extends Interaction
         return options.isEmpty() ? null : options.get(0);
     }
 
+    /**
+     * Finds the first option with the specified name.
+     * <br>A resolver is used to get the value if the option is provided.
+     * If no option is provided for the given name, this will simply return null instead.
+     * You can use {@link #getOption(String, Object, Function)} to provide a fallback for missing options.
+     *
+     * <p>For {@link CommandAutoCompleteInteraction}, this might be incomplete and unvalidated.
+     * Auto-complete interactions happen on incomplete command inputs and are not validated.
+     *
+     * <p><b>Example</b>
+     * <br>You can understand this as a shortcut for these lines of code:
+     * <pre>{@code
+     * OptionMapping opt = event.getOption("reason");
+     * String reason = opt == null ? null : opt.getAsString();
+     * }</pre>
+     * Which can be written with this resolver as:
+     * <pre>{@code
+     * String reason = event.getOption("reason", OptionMapping::getAsString);
+     * }</pre>
+     *
+     * @param  name
+     *         The option name
+     * @param  resolver
+     *         The mapping resolver function to use if there is a mapping available,
+     *         the provided mapping will never be null!
+     *
+     * @throws IllegalArgumentException
+     *         If the name or resolver is null
+     *
+     * @return The resolved option with the provided name, or null if that option is not provided
+     *
+     * @see    #getOption(String, Object, Function)
+     * @see    #getOption(String, Supplier, Function)
+     */
     @Nullable
     default <T> T getOption(@Nonnull String name, @Nonnull Function<? super OptionMapping, ? extends T> resolver)
     {
         return getOption(name, null, resolver);
     }
 
+    /**
+     * Finds the first option with the specified name.
+     * <br>A resolver is used to get the value if the option is provided.
+     * If no option is provided for the given name, this will simply return your provided fallback instead.
+     * You can use {@link #getOption(String, Function)} to fall back to {@code null}.
+     *
+     * <p>For {@link CommandAutoCompleteInteraction}, this might be incomplete and unvalidated.
+     * Auto-complete interactions happen on incomplete command inputs and are not validated.
+     *
+     * <p><b>Example</b>
+     * <br>You can understand this as a shortcut for these lines of code:
+     * <pre>{@code
+     * OptionMapping opt = event.getOption("reason");
+     * String reason = opt == null ? "ban by mod" : opt.getAsString();
+     * }</pre>
+     * Which can be written with this resolver as:
+     * <pre>{@code
+     * String reason = event.getOption("reason", "ban by mod", OptionMapping::getAsString);
+     * }</pre>
+     *
+     * @param  name
+     *         The option name
+     * @param  fallback
+     *         The fallback to use if the option is not provided, meaning {@link #getOption(String)} returns null
+     * @param  resolver
+     *         The mapping resolver function to use if there is a mapping available,
+     *         the provided mapping will never be null!
+     *
+     * @throws IllegalArgumentException
+     *         If the name or resolver is null
+     *
+     * @return The resolved option with the provided name, or {@code fallback} if that option is not provided
+     *
+     * @see    #getOption(String, Function)
+     * @see    #getOption(String, Supplier, Function)
+     */
     default <T> T getOption(@Nonnull String name,
                             @Nullable T fallback,
                             @Nonnull Function<? super OptionMapping, ? extends T> resolver)
@@ -298,6 +368,42 @@ public interface CommandInteractionPayload extends Interaction
         return fallback;
     }
 
+    /**
+     * Finds the first option with the specified name.
+     * <br>A resolver is used to get the value if the option is provided.
+     * If no option is provided for the given name, this will simply return your provided fallback instead.
+     * You can use {@link #getOption(String, Function)} to fall back to {@code null}.
+     *
+     * <p>For {@link CommandAutoCompleteInteraction}, this might be incomplete and unvalidated.
+     * Auto-complete interactions happen on incomplete command inputs and are not validated.
+     *
+     * <p><b>Example</b>
+     * <br>You can understand this as a shortcut for these lines of code:
+     * <pre>{@code
+     * OptionMapping opt = event.getOption("reason");
+     * String reason = opt == null ? context.getFallbackReason() : opt.getAsString();
+     * }</pre>
+     * Which can be written with this resolver as:
+     * <pre>{@code
+     * String reason = event.getOption("reason", context::getFallbackReason , OptionMapping::getAsString);
+     * }</pre>
+     *
+     * @param  name
+     *         The option name
+     * @param  fallback
+     *         The fallback supplier to use if the option is not provided, meaning {@link #getOption(String)} returns null
+     * @param  resolver
+     *         The mapping resolver function to use if there is a mapping available,
+     *         the provided mapping will never be null!
+     *
+     * @throws IllegalArgumentException
+     *         If the name or resolver is null
+     *
+     * @return The resolved option with the provided name, or {@code fallback} if that option is not provided
+     *
+     * @see    #getOption(String, Function)
+     * @see    #getOption(String, Object, Function)
+     */
     default <T> T getOption(@Nonnull String name,
                             @Nullable Supplier<? extends T> fallback,
                             @Nonnull Function<? super OptionMapping, ? extends T> resolver)

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/CommandInteractionPayload.java
@@ -26,6 +26,8 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -277,5 +279,33 @@ public interface CommandInteractionPayload extends Interaction
     {
         List<OptionMapping> options = getOptionsByName(name);
         return options.isEmpty() ? null : options.get(0);
+    }
+
+    @Nullable
+    default <T> T getOption(@Nonnull String name, @Nonnull Function<? super OptionMapping, ? extends T> resolver)
+    {
+        return getOption(name, null, resolver);
+    }
+
+    default <T> T getOption(@Nonnull String name,
+                            @Nullable T fallback,
+                            @Nonnull Function<? super OptionMapping, ? extends T> resolver)
+    {
+        Checks.notNull(resolver, "Resolver");
+        OptionMapping mapping = getOption(name);
+        if (mapping != null)
+            return resolver.apply(mapping);
+        return fallback;
+    }
+
+    default <T> T getOption(@Nonnull String name,
+                            @Nullable Supplier<? extends T> fallback,
+                            @Nonnull Function<? super OptionMapping, ? extends T> resolver)
+    {
+        Checks.notNull(resolver, "Resolver");
+        OptionMapping mapping = getOption(name);
+        if (mapping != null)
+            return resolver.apply(mapping);
+        return fallback == null ? null : fallback.get();
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.interactions.commands;
 
 import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.utils.data.DataObject;
 
 import javax.annotation.Nonnull;
@@ -273,6 +274,26 @@ public class OptionMapping
             case INTEGER:
                 return data.getLong("value");
         }
+    }
+
+    /**
+     * The int value for this option.
+     * <br>This will be the ID of any resolved entity such as {@link Role} or {@link Member}.
+     *
+     * <p><b>It is highly recommended to assert int values by using {@link OptionData#setRequiredRange(long, long)}</b>
+     *
+     * @throws IllegalStateException
+     *         If this option {@link #getType() type} cannot be converted to a long
+     * @throws NumberFormatException
+     *         If this option is of type {@link OptionType#STRING STRING} and could not be parsed to a valid long value
+     * @throws ArithmeticException
+     *         If the provided integer value cannot fit into a 32bit signed int
+     *
+     * @return The long value
+     */
+    public int getAsInt()
+    {
+        return Math.toIntExact(getAsLong());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionMapping.java
@@ -289,7 +289,7 @@ public class OptionMapping
      * @throws ArithmeticException
      *         If the provided integer value cannot fit into a 32bit signed int
      *
-     * @return The long value
+     * @return The int value
      */
     public int getAsInt()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds fallback methods which can be used to more easily handle optional command arguments without needing 3 lines of code:

```java
public void onSlashCommandInteraction(SlashCommandInteractionEvent event)
{
    //                              name      fallback          resolver
    
    // null if user is not a member of the guild (fallback not used, since option is mapped to a User instance)
    Member member = event.getOption("target", event::getMember, OptionMapping::getAsMember);
    // null if fallback is used (getAsUser cannot be null)
    User user =     event.getOption("target", null            , OptionMapping::getAsUser);
    // null fallback implied
    User nullable = event.getOption("target",                   OptionMapping::getAsUser); // <- implicit fallback null

    // real use-cases:
    int days = event.getOption("days", 7, OptionMapping::getAsInt); // optional ban days
    String reason = event.getOption("reason", "banned by mod", OptionMapping::getAsString); // optional ban reason
}
```

It may seem strange to put the resolver function as the last argument, but this goes back to kotlin interop:

```kt
// if it is the second argument you have to write this
val user = event.getOption("user", { it.asUser }, event.user)
// with it as last argument it becomes this
val user = event.getOption("user", event.user) { it.asUser }
```

An easy way to interpret the fallback syntax is to think of it as a ternary, like `option == null ? fallback : option.value`