### PR TITLE
Remove unnecessary processing in `ErrorResponse#test(ErrorResponse...`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
@@ -230,7 +230,7 @@ public enum ErrorResponse
         Checks.noneNull(responses, "ErrorResponse");
         EnumSet<ErrorResponse> set = EnumSet.noneOf(ErrorResponse.class);
         Collections.addAll(set, responses);
-        return test(set);
+        return error -> error instanceof ErrorResponseException && set.contains(((ErrorResponseException) error).getErrorResponse());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
@@ -230,7 +230,7 @@ public enum ErrorResponse
         Checks.noneNull(responses, "ErrorResponse");
         EnumSet<ErrorResponse> set = EnumSet.noneOf(ErrorResponse.class);
         Collections.addAll(set, responses);
-        return error -> error instanceof ErrorResponseException && set.contains(((ErrorResponseException) error).getErrorResponse());
+        return test(set);
     }
 
     /**
@@ -247,8 +247,11 @@ public enum ErrorResponse
     {
         Checks.noneNull(responses, "ErrorResponse");
         EnumSet<ErrorResponse> set = EnumSet.copyOf(responses);
-        return (error) -> error instanceof ErrorResponseException && set.contains(((ErrorResponseException) error).getErrorResponse());
+        return test(set);
+    }
 
+    private static Predicate<Throwable> test(@Nonnull EnumSet<ErrorResponse> responses){
+        return error -> error instanceof ErrorResponseException && responses.contains(((ErrorResponseException) error).getErrorResponse());
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/ErrorResponse.java
@@ -250,7 +250,8 @@ public enum ErrorResponse
         return test(set);
     }
 
-    private static Predicate<Throwable> test(@Nonnull EnumSet<ErrorResponse> responses){
+    private static Predicate<Throwable> test(@Nonnull EnumSet<ErrorResponse> responses)
+    {
         return error -> error instanceof ErrorResponseException && responses.contains(((ErrorResponseException) error).getErrorResponse());
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

- Currently, `ErrorResponse#test(ErrorResponse...` produces an `EnumSet` of the responses, which it then passes to `ErroResponse#test(Collection`
- That method however, creates another `EnumSet`, which is unnecessary processing.
- To fix that, this PR will create its own predicate without calling the other method.

