### PR TITLE
Add missing cache cleanup for news/stage/thread channels

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildDeleteHandler.java
@@ -66,6 +66,7 @@ public class GuildDeleteHandler extends SocketHandler
         SnowflakeCacheViewImpl<Guild> guildView = getJDA().getGuildsView();
         SnowflakeCacheViewImpl<StoreChannel> storeView = getJDA().getStoreChannelsView();
         SnowflakeCacheViewImpl<TextChannel> textView = getJDA().getTextChannelsView();
+        SnowflakeCacheViewImpl<NewsChannel> newsView = getJDA().getNewsChannelView();
         SnowflakeCacheViewImpl<VoiceChannel> voiceView = getJDA().getVoiceChannelsView();
         SnowflakeCacheViewImpl<Category> categoryView = getJDA().getCategoriesView();
         guildView.remove(id);
@@ -78,6 +79,11 @@ public class GuildDeleteHandler extends SocketHandler
         {
             guild.getTextChannelCache()
                  .forEachUnordered(chan -> textView.getMap().remove(chan.getIdLong()));
+        }
+        try (UnlockHook hook = newsView.writeLock())
+        {
+            guild.getNewsChannelCache()
+                    .forEachUnordered(chan -> newsView.getMap().remove(chan.getIdLong()));
         }
         try (UnlockHook hook = voiceView.writeLock())
         {


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

There is a bug where if you kick a bot from a guild and then re-invite it, news channels would return null if fetched from the jda instance. I don't understand it fully but there might be objects of the newsChannel left when the bot is kicked because the GuildDeleteHandler wasn't cleaning the global cache from the news channels. This change fixes that bug.

Edit: Same thing applied to stage channels and thread channels, so I added those too.
