### PR TITLE
Make Messages for Interactions properly reference their channels instead of PrivateChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/MessageContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/MessageContextInteractionImpl.java
@@ -41,6 +41,11 @@ public class MessageContextInteractionImpl extends ContextInteractionImpl<Messag
     {
         DataObject messages = resolved.getObject("messages");
         DataObject message = messages.getObject(messages.keys().iterator().next());
+        //manually include the guild id
+        if (resolved.hasKey("guild_id"))
+        {
+            message.put("guild_id", resolved.getLong("guild_id"));
+        }
         return api.getEntityBuilder().createMessage(message);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/MessageContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/MessageContextInteractionImpl.java
@@ -26,7 +26,15 @@ public class MessageContextInteractionImpl extends ContextInteractionImpl<Messag
 {
     public MessageContextInteractionImpl(JDAImpl jda, DataObject data)
     {
-        super(jda, data, resolved -> parse(jda, resolved));
+        super(jda, data, resolved ->
+        {
+            //temporary fix to set the guild_id for messages that do not contain it
+            if (data.hasKey("guild_id"))
+            {
+                resolved.put("guild_id", data.getLong("guild_id"));
+            }
+            return parse(jda, resolved);
+        });
     }
 
     private static Message parse(JDAImpl api, DataObject resolved)

--- a/src/main/java/net/dv8tion/jda/internal/interactions/component/ComponentInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/component/ComponentInteractionImpl.java
@@ -42,6 +42,11 @@ public abstract class ComponentInteractionImpl extends DeferrableInteractionImpl
         DataObject messageJson = data.getObject("message");
         messageId = messageJson.getUnsignedLong("id");
 
+        if (data.hasKey("guild_id"))
+        {
+            messageJson.put("guild_id", data.getLong("guild_id"));
+        }
+
         message = messageJson.isNull("type") ? null : jda.getEntityBuilder().createMessage(messageJson);
     }
 


### PR DESCRIPTION
Put `guild_id` into MessageContextInteractionImpl's messages as Discord doesn't provide them

[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord message context menu events do not put `guild_id` into the message payload.  This PR will put that into the payload so that the EntityBuilder constructs the correct channel type surrounding it
