### PR TITLE
Restructure message creation to handle a lack of guild_id

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReference.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReference.java
@@ -154,7 +154,8 @@ public class MessageReference
 
         Route.CompiledRoute route = Route.Messages.GET_MESSAGE.compile(getChannelId(), getMessageId());
         return new RestActionImpl<>(jda, route, (response, request) -> {
-            Message created = jda.getEntityBuilder().createMessage(response.getObject(), getChannel(), false);
+            // channel can be null for MessageReferences, but we've already checked for that above, so it is nonnull here
+            Message created = jda.getEntityBuilder().createMessage(response.getObject(), channel, false);
             this.referencedMessage = created;
             return created;
         });

--- a/src/main/java/net/dv8tion/jda/api/entities/NewsChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/NewsChannel.java
@@ -177,7 +177,7 @@ public interface NewsChannel extends BaseGuildMessageChannel
             throw new MissingAccessException(this, Permission.VIEW_CHANNEL);
         Route.CompiledRoute route = Route.Messages.CROSSPOST_MESSAGE.compile(getId(), messageId);
         return new RestActionImpl<>(getJDA(), route,
-                (response, request) -> request.getJDA().getEntityBuilder().createMessage(response.getObject()));
+                (response, request) -> request.getJDA().getEntityBuilder().createMessage(response.getObject(), this, false));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1377,12 +1377,7 @@ public class EntityBuilder
     {
         final long channelId = jsonObject.getLong("channel_id");
 
-        //TODO-v5-unified-channel-cache
-        GuildMessageChannel chan = getJDA().getTextChannelById(channelId);
-        if (chan == null)
-            chan = getJDA().getNewsChannelById(channelId);
-        if (chan == null)
-            chan = getJDA().getThreadChannelById(channelId);
+        GuildMessageChannel chan = getJDA().getChannelById(GuildMessageChannel.class, channelId);
         if (chan == null)
             throw new IllegalArgumentException(MISSING_CHANNEL);
 
@@ -1457,13 +1452,17 @@ public class EntityBuilder
         else {
             //Assume private channel
             if (authorId == getJDA().getSelfUser().getIdLong())
+            {
                 user = getJDA().getSelfUser();
+            }
             else
+            {
                 //Note, while PrivateChannel.getUser() can produce null, this invocation of it WILL NOT produce null
                 // because when the bot receives a message in a private channel that was _not authored by the bot_ then
                 // the message had to have come from the user, so that means that we had all the information to build
                 // the channel properly (or fill-in the missing user info of an existing partial channel)
                 user = ((PrivateChannel) channel).getUser();
+            }
         }
 
         if (modifyCache && !fromWebhook) // update the user information on message receive

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -763,6 +763,15 @@ public class ReceivedMessage extends AbstractMessage
         return (TextChannel) channel;
     }
 
+    @Nonnull
+    @Override
+    public NewsChannel getNewsChannel()
+    {
+        if (!isFromType(ChannelType.NEWS))
+            throw new IllegalStateException("This message was not sent in a news channel");
+        return (NewsChannel) channel;
+    }
+
     @Override
     public Category getCategory()
     {

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageCreateHandler.java
@@ -45,7 +45,8 @@ public class MessageCreateHandler extends SocketHandler
         }
 
         JDAImpl jda = getJDA();
-        if (!content.isNull("guild_id"))
+        boolean isGuild = !content.isNull("guild_id");
+        if (isGuild)
         {
             long guildId = content.getLong("guild_id");
             if (jda.getGuildSetupController().isLocked(guildId))
@@ -55,7 +56,9 @@ public class MessageCreateHandler extends SocketHandler
         Message message;
         try
         {
-            message = jda.getEntityBuilder().createMessage(content, true);
+            message = isGuild
+                ? jda.getEntityBuilder().createMessageGuildChannel(content, true)
+                : jda.getEntityBuilder().createMessagePrivateChannel(content, true);
         }
         catch (IllegalArgumentException e)
         {

--- a/src/main/java/net/dv8tion/jda/internal/interactions/component/ComponentInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/component/ComponentInteractionImpl.java
@@ -42,12 +42,11 @@ public abstract class ComponentInteractionImpl extends DeferrableInteractionImpl
         DataObject messageJson = data.getObject("message");
         messageId = messageJson.getUnsignedLong("id");
 
-        if (data.hasKey("guild_id"))
-        {
-            messageJson.put("guild_id", data.getLong("guild_id"));
-        }
-
-        message = messageJson.isNull("type") ? null : jda.getEntityBuilder().createMessage(messageJson);
+        message = messageJson.isNull("type")
+                ? null
+                : data.hasKey("guild_id")
+                    ? jda.getEntityBuilder().createMessageGuildChannel(messageJson, false)
+                    : jda.getEntityBuilder().createMessagePrivateChannel(messageJson, false);
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Discord does not provide `guild_id` on message objects. We only ever get this property on messages when they come over the Websocket Gateway. However, historically, JDA has been written to expect it and we've gotten lucky that nothing broke.

Recently we made a change to enforce nullability of `getUser` on `PrivateChannel` and restructured some code to enable this along with filling in the data whenever we receive it, which happens to happen on `MESSAGE_CREATE`. This has revealed our erroneous reliance on `guild_id` in non-gateway situations.

This PR restructured the EntityBuilder to enforce upon developers of JDA's internal code that they must either have a channel instance or define if the channel is guild or private when building a message. This makes explicit the methodologies used to determine `isGuild` instead of relying on a typically-missing `guild_id` json property.