### PR TITLE
Replace magic embed count number to constant

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/MessageBuilder.java
@@ -124,7 +124,7 @@ public class MessageBuilder implements Appendable
     }
 
     /**
-     * Adds up to 10 {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} to the Message. Embeds can be built using
+     * Adds up to {@value Message#MAX_EMBED_COUNT} {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} to the Message. Embeds can be built using
      * the {@link net.dv8tion.jda.api.EmbedBuilder} and offer specialized formatting.
      *
      * @param  embeds
@@ -144,7 +144,7 @@ public class MessageBuilder implements Appendable
     }
 
     /**
-     * Adds up to 10 {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} to the Message. Embeds can be built using
+     * Adds up to {@value Message#MAX_EMBED_COUNT} {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} to the Message. Embeds can be built using
      * the {@link net.dv8tion.jda.api.EmbedBuilder} and offer specialized formatting.
      *
      * @param  embeds
@@ -166,7 +166,7 @@ public class MessageBuilder implements Appendable
                 "Provided Message contains an empty embed or an embed with a length greater than %d characters, which is the max for bot accounts!",
                 MessageEmbed.EMBED_MAX_LENGTH_BOT)
         );
-        Checks.check(embeds.size() <= 10, "Cannot have more than 10 embeds in a message!");
+        Checks.check(embeds.size() <= Message.MAX_EMBED_COUNT, "Cannot have more than %d embeds in a message!", Message.MAX_EMBED_COUNT);
         Checks.check(embeds.stream().mapToInt(MessageEmbed::getLength).sum() <= MessageEmbed.EMBED_MAX_LENGTH_BOT, "The sum of all MessageEmbeds may not exceed %d!", MessageEmbed.EMBED_MAX_LENGTH_BOT);
         this.embeds.clear();
         this.embeds.addAll(embeds);

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -155,6 +155,14 @@ public interface Message extends ISnowflake, Formattable
     int MAX_REACTIONS = 20;
 
     /**
+     * The maximum amount of Embeds that can be added to one message ({@value})
+     *
+     * @see    MessageChannel#sendMessageEmbeds(Collection)
+     * @see    MessageAction#setEmbeds(Collection)
+     */
+    int MAX_EMBED_COUNT = 10;
+
+    /**
      * Pattern used to find instant invites in strings.
      *
      * <p>The only named group is at index 1 with the name {@code "code"}.
@@ -1345,7 +1353,7 @@ public interface Message extends ISnowflake, Formattable
      *         Additional embeds to reply with
      *
      * @throws IllegalArgumentException
-     *         If null is provided, any of the embeds are not {@link MessageEmbed#isSendable() sendable}, more than 10 embeds are provided,
+     *         If null is provided, any of the embeds are not {@link MessageEmbed#isSendable() sendable}, more than {@value Message#MAX_EMBED_COUNT} embeds are provided,
      *         or the sum of {@link MessageEmbed#getLength()} is greater than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}
      *
      * @return {@link MessageAction} Providing the {@link Message} created from this upload.
@@ -1375,7 +1383,7 @@ public interface Message extends ISnowflake, Formattable
      *         The embeds to reply with
      *
      * @throws IllegalArgumentException
-     *         If null is provided, any of the embeds are not {@link MessageEmbed#isSendable() sendable}, more than 10 embeds are provided,
+     *         If null is provided, any of the embeds are not {@link MessageEmbed#isSendable() sendable}, more than {@value Message#MAX_EMBED_COUNT} embeds are provided,
      *         or the sum of {@link MessageEmbed#getLength()} is greater than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}
      *
      * @return {@link MessageAction} Providing the {@link Message} created from this upload.

--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -363,7 +363,7 @@ public interface MessageChannel extends Channel, Formattable
     }
 
     /**
-     * Sends up to 10 specified {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} as a {@link net.dv8tion.jda.api.entities.Message Message}
+     * Sends up to {@value Message#MAX_EMBED_COUNT} specified {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} as a {@link net.dv8tion.jda.api.entities.Message Message}
      * to this channel.
      * <br>This will fail if this channel is an instance of {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and
      * the currently logged in account does not have permissions to send a message to this channel.
@@ -387,7 +387,7 @@ public interface MessageChannel extends Channel, Formattable
      *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_EMBED_LINKS Permission.MESSAGE_EMBED_LINKS}</li>
      *         </ul>
      * @throws java.lang.IllegalArgumentException
-     *         If null is provided, any of the embeds are not {@link MessageEmbed#isSendable() sendable}, more than 10 embeds are provided,
+     *         If null is provided, any of the embeds are not {@link MessageEmbed#isSendable() sendable}, more than {@value Message#MAX_EMBED_COUNT} embeds are provided,
      *         or the sum of {@link MessageEmbed#getLength()} is greater than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}
      * @throws java.lang.UnsupportedOperationException
      *         If this is a {@link net.dv8tion.jda.api.entities.PrivateChannel PrivateChannel}
@@ -412,7 +412,7 @@ public interface MessageChannel extends Channel, Formattable
     }
 
     /**
-     * Sends up to 10 specified {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} as a {@link net.dv8tion.jda.api.entities.Message Message}
+     * Sends up to {@value Message#MAX_EMBED_COUNT} specified {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} as a {@link net.dv8tion.jda.api.entities.Message Message}
      * to this channel.
      * <br>This will fail if this channel is an instance of {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} and
      * the currently logged in account does not have permissions to send a message to this channel.
@@ -2969,7 +2969,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageId
      *         The id referencing the Message that should be edited
      * @param  newEmbeds
-     *         Up to 10 new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
+     *         Up to {@value Message#MAX_EMBED_COUNT} new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
      *
      * @throws IllegalArgumentException
      *         <ul>
@@ -3018,7 +3018,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageId
      *         The id referencing the Message that should be edited
      * @param  newEmbeds
-     *         Up to 10 new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
+     *         Up to {@value Message#MAX_EMBED_COUNT} new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
      *
      * @throws IllegalArgumentException
      *         <ul>
@@ -3066,7 +3066,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageId
      *         The id referencing the Message that should be edited
      * @param  newEmbeds
-     *         Up to 10 new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
+     *         Up to {@value Message#MAX_EMBED_COUNT} new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
      *
      * @throws IllegalArgumentException
      *         <ul>
@@ -3115,7 +3115,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageId
      *         The id referencing the Message that should be edited
      * @param  newEmbeds
-     *         Up to 10 new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
+     *         Up to {@value Message#MAX_EMBED_COUNT} new {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds} for the edited message
      *
      * @throws IllegalArgumentException
      *         <ul>

--- a/src/main/java/net/dv8tion/jda/api/entities/WebhookClient.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/WebhookClient.java
@@ -126,10 +126,10 @@ public interface WebhookClient<T>
      * </ul>
      *
      * @param  embeds
-     *         {@link MessageEmbed MessageEmbeds} to use (up to 10 in total)
+     *         {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT} in total)
      *
      * @throws IllegalArgumentException
-     *         If any of the embeds are null, more than 10, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
+     *         If any of the embeds are null, more than {@value Message#MAX_EMBED_COUNT}, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
      *
      * @return {@link WebhookMessageAction}
      */
@@ -151,10 +151,10 @@ public interface WebhookClient<T>
      * @param  embed
      *         {@link MessageEmbed} to use
      * @param  embeds
-     *         Additional {@link MessageEmbed MessageEmbeds} to use (up to 10 in total)
+     *         Additional {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT} in total)
      *
      * @throws IllegalArgumentException
-     *         If any of the embeds are null, more than 10, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
+     *         If any of the embeds are null, more than {@value Message#MAX_EMBED_COUNT}, or longer than {@link MessageEmbed#EMBED_MAX_LENGTH_BOT}.
      *
      * @return {@link WebhookMessageAction}
      */
@@ -572,10 +572,10 @@ public interface WebhookClient<T>
      * @param  messageId
      *         The message id. For interactions this supports {@code "@original"} to edit the source message of the interaction.
      * @param  embeds
-     *         {@link MessageEmbed MessageEmbeds} to use (up to 10 in total)
+     *         {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT} in total)
      *
      * @throws IllegalArgumentException
-     *         If the provided embeds are null, or more than 10
+     *         If the provided embeds are null, or more than {@value Message#MAX_EMBED_COUNT}
      *
      * @return {@link WebhookMessageUpdateAction}
      */
@@ -599,10 +599,10 @@ public interface WebhookClient<T>
      * @param  messageId
      *         The message id. For interactions this supports {@code "@original"} to edit the source message of the interaction.
      * @param  embeds
-     *         {@link MessageEmbed MessageEmbeds} to use (up to 10 in total)
+     *         {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT} in total)
      *
      * @throws IllegalArgumentException
-     *         If the provided embeds are null, or more than 10
+     *         If the provided embeds are null, or more than {@value Message#MAX_EMBED_COUNT}
      *
      * @return {@link WebhookMessageUpdateAction}
      */

--- a/src/main/java/net/dv8tion/jda/api/interactions/InteractionHook.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/InteractionHook.java
@@ -242,10 +242,10 @@ public interface InteractionHook extends WebhookClient<Message>
      * </ul>
      *
      * @param  embeds
-     *         {@link MessageEmbed MessageEmbeds} to use (up to 10 in total)
+     *         {@link MessageEmbed MessageEmbeds} to use (up to {@value Message#MAX_EMBED_COUNT} in total)
      *
      * @throws IllegalArgumentException
-     *         If the provided embeds are null, or more than 10
+     *         If the provided embeds are null, or more than {@value Message#MAX_EMBED_COUNT}
      *
      * @return {@link WebhookMessageUpdateAction}
      */

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/MessageAction.java
@@ -422,7 +422,7 @@ public interface MessageAction extends RestAction<Message>, Appendable, AllowedM
     MessageAction content(@Nullable final String content);
 
     /**
-     * Sets up to 10 {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds}
+     * Sets up to {@value Message#MAX_EMBED_COUNT} {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds}
      * that should be used for this Message.
      * Refer to {@link net.dv8tion.jda.api.EmbedBuilder EmbedBuilder} for more information.
      *
@@ -442,7 +442,7 @@ public interface MessageAction extends RestAction<Message>, Appendable, AllowedM
     MessageAction setEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds);
 
     /**
-     * Sets up to 10 {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds}
+     * Sets up to {@value Message#MAX_EMBED_COUNT} {@link net.dv8tion.jda.api.entities.MessageEmbed MessageEmbeds}
      * that should be used for this Message.
      * Refer to {@link net.dv8tion.jda.api.EmbedBuilder EmbedBuilder} for more information.
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/MessageEditCallbackAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/MessageEditCallbackAction.java
@@ -60,7 +60,7 @@ public interface MessageEditCallbackAction extends InteractionCallbackAction<Int
      *         The message embeds
      *
      * @throws IllegalArgumentException
-     *         If null is provided, or one of the embeds is too big
+     *         If null is provided, or one of the embeds is too big, or more than {@value Message#MAX_EMBED_COUNT} embeds are provided
      *
      * @return The same update action, for chaining convenience
      */
@@ -79,7 +79,7 @@ public interface MessageEditCallbackAction extends InteractionCallbackAction<Int
      *         The message embeds
      *
      * @throws IllegalArgumentException
-     *         If null is provided, one of the embeds is too big, or more than 10 embeds are provided
+     *         If null is provided, one of the embeds is too big, or more than {@value Message#MAX_EMBED_COUNT} embeds are provided
      *
      * @return The same update action, for chaining convenience
      */

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -247,7 +247,7 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
                 "Provided Message contains an empty embed or an embed with a length greater than %d characters, which is the max for bot accounts!",
                 MessageEmbed.EMBED_MAX_LENGTH_BOT)
         );
-        Checks.check(embeds.size() <= 10, "Cannot have more than 10 embeds in a message!");
+        Checks.check(embeds.size() <= Message.MAX_EMBED_COUNT, "Cannot have more than %d embeds in a message!", Message.MAX_EMBED_COUNT);
         Checks.check(embeds.stream().mapToInt(MessageEmbed::getLength).sum() <= MessageEmbed.EMBED_MAX_LENGTH_BOT, "The sum of all MessageEmbeds may not exceed %d!", MessageEmbed.EMBED_MAX_LENGTH_BOT);
         if (this.embeds == null)
             this.embeds = new ArrayList<>();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageActionImpl.java
@@ -135,7 +135,7 @@ public class WebhookMessageActionImpl<T>
                 "Provided Message contains an empty embed or an embed with a length greater than %d characters, which is the max for bot accounts!",
                 MessageEmbed.EMBED_MAX_LENGTH_BOT)
         );
-        Checks.check(this.embeds.size() + embeds.size() <= 10, "Cannot have more than 10 embeds in a message!");
+        Checks.check(this.embeds.size() + embeds.size() <= Message.MAX_EMBED_COUNT, "Cannot have more than %d embeds in a message!", Message.MAX_EMBED_COUNT);
         Checks.check(Stream.concat(embeds.stream(), this.embeds.stream()).mapToInt(MessageEmbed::getLength).sum() <= MessageEmbed.EMBED_MAX_LENGTH_BOT, "The sum of all MessageEmbeds may not exceed %d!", MessageEmbed.EMBED_MAX_LENGTH_BOT);
         this.embeds.addAll(embeds);
         return this;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageUpdateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageUpdateActionImpl.java
@@ -85,7 +85,7 @@ public class WebhookMessageUpdateActionImpl<T>
                 "Provided Message contains an empty embed or an embed with a length greater than %d characters, which is the max for bot accounts!",
                 MessageEmbed.EMBED_MAX_LENGTH_BOT)
         );
-        Checks.check(embeds.size() <= 10, "Cannot have more than 10 embeds in a message!");
+        Checks.check(embeds.size() <= Message.MAX_EMBED_COUNT, "Cannot have more than %d embeds in a message!", Message.MAX_EMBED_COUNT);
         Checks.check(embeds.stream().mapToInt(MessageEmbed::getLength).sum() <= MessageEmbed.EMBED_MAX_LENGTH_BOT, "The sum of all MessageEmbeds may not exceed %d!", MessageEmbed.EMBED_MAX_LENGTH_BOT);
         this.embeds.clear();
         this.embeds.addAll(embeds);

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/MessageEditCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/MessageEditCallbackActionImpl.java
@@ -88,7 +88,7 @@ public class MessageEditCallbackActionImpl extends DeferrableCallbackActionImpl 
     public MessageEditCallbackAction setEmbeds(@Nonnull Collection<? extends MessageEmbed> embeds)
     {
         Checks.noneNull(embeds, "MessageEmbed");
-        Checks.check(embeds.size() <= 10, "Cannot have more than 10 embeds per message!");
+        Checks.check(embeds.size() <= Message.MAX_EMBED_COUNT, "Cannot have more than %d embeds per message!", Message.MAX_EMBED_COUNT);
         for (MessageEmbed embed : embeds)
         {
             Checks.check(embed.isSendable(),

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/ReplyCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/ReplyCallbackActionImpl.java
@@ -133,8 +133,8 @@ public class ReplyCallbackActionImpl extends DeferrableCallbackActionImpl implem
                 MessageEmbed.EMBED_MAX_LENGTH_BOT);
         }
 
-        if (embeds.size() + this.embeds.size() > 10)
-            throw new IllegalStateException("Cannot have more than 10 embeds per message!");
+        if (embeds.size() + this.embeds.size() > Message.MAX_EMBED_COUNT)
+            throw new IllegalStateException(String.format("Cannot have more than %d embeds per message!", Message.MAX_EMBED_COUNT));
         this.embeds.addAll(embeds);
         return this;
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This PR replaces magic number with a constant for the max-embed count on messages.
Need this constant personally for a bot, thus creating this PR.
