### PR TITLE
Fix Activity.listening(String) documentation

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Activity.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Activity.java
@@ -162,7 +162,7 @@ public interface Activity
 
     /**
      * Creates a new Activity instance with the specified name.
-     * <br>This will display as {@code Listening name} in the official client
+     * <br>This will display as {@code Listening to name} in the official client
      *
      * @param  name
      *         The not-null name of the newly created game


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Corrects the documentation of `Activity.listening(String)` such that it specifies "Listening _to_" (instead of just "Listening") as the way it's displayed in the client.
