### PR TITLE
Add missing method overrides for `GuildImpl#ban` & `GuildImpl#kick`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3936,7 +3936,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @CheckReturnValue
     default AuditableRestAction<Void> ban(long userId, int delDays)
     {
-        return ban(userId, delDays, null);
+        return ban(Long.toUnsignedString(userId), delDays, null);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3404,6 +3404,44 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     AuditableRestAction<Void> kick(@Nonnull String userId, @Nullable String reason);
 
     /**
+     * Kicks the {@link net.dv8tion.jda.api.entities.Member Member} specified by the userId from the from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *
+     * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User}
+     * until Discord sends the {@link net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent}.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The target Member cannot be kicked due to a permission discrepancy</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER}
+     *     <br>The specified Member was removed from the Guild before finishing the task</li>
+     * </ul>
+     *
+     * @param  userId
+     *         The id of the {@link net.dv8tion.jda.api.entities.User User} to kick
+     *         from the from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     * @param  reason
+     *         The reason for this action or {@code null} if there is no specified reason
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS} permission.
+     * @throws net.dv8tion.jda.api.exceptions.HierarchyException
+     *         If the logged in account cannot kick the other member due to permission hierarchy position.
+     *         <br>See {@link Member#canInteract(Member)}
+     * @throws java.lang.IllegalArgumentException
+     *         If the user for the provided id cannot be kicked from this Guild or the provided {@code userId} is blank/null.
+     * @throws java.lang.IllegalArgumentException
+     *         If the provided reason is longer than 512 characters
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    AuditableRestAction<Void> kick(long userId, @Nullable String reason);
+
+    /**
      * Kicks a {@link net.dv8tion.jda.api.entities.Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
      *
      * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User}
@@ -3472,6 +3510,42 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     @CheckReturnValue
     default AuditableRestAction<Void> kick(@Nonnull String userId)
+    {
+        return kick(userId, null);
+    }
+
+    /**
+     * Kicks the {@link net.dv8tion.jda.api.entities.Member Member} specified by the userId from the from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *
+     * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User}
+     * until Discord sends the {@link net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent}.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The target Member cannot be kicked due to a permission discrepancy</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER}
+     *     <br>The specified Member was removed from the Guild before finishing the task</li>
+     * </ul>
+     *
+     * @param  userId
+     *         The id of the {@link net.dv8tion.jda.api.entities.User User} to kick from the from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#KICK_MEMBERS} permission.
+     * @throws net.dv8tion.jda.api.exceptions.HierarchyException
+     *         If the logged in account cannot kick the other member due to permission hierarchy position.
+     *         <br>See {@link Member#canInteract(Member)}
+     * @throws java.lang.IllegalArgumentException
+     *         If the userId provided does not correspond to a Member in this Guild or the provided {@code userId} is blank/null.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default AuditableRestAction<Void> kick(long userId)
     {
         return kick(userId, null);
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3571,6 +3571,53 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     AuditableRestAction<Void> ban(@Nonnull String userId, int delDays, @Nullable String reason);
 
     /**
+     * Bans the user specified by the userId and deletes messages sent by the user
+     * based on the amount of delDays.
+     * <br>If you wish to ban a user without deleting any messages, provide delDays with a value of 0.
+     *
+     * <p>You can unban a user with {@link net.dv8tion.jda.api.entities.Guild#unban(User) Guild.unban(User)}.
+     *
+     * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User's}
+     * {@link net.dv8tion.jda.api.entities.Member Member} object (if the User was in the Guild)
+     * until Discord sends the {@link net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent}.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The target Member cannot be banned due to a permission discrepancy</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_USER UNKNOWN_USER}
+     *     <br>The specified User does not exit</li>
+     * </ul>
+     *
+     * @param  userId
+     *         The id of the {@link net.dv8tion.jda.api.entities.User User} to ban.
+     * @param  delDays
+     *         The history of messages, in days, that will be deleted.
+     * @param  reason
+     *         The reason for this action or {@code null} if there is no specified reason
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#BAN_MEMBERS} permission.
+     * @throws net.dv8tion.jda.api.exceptions.HierarchyException
+     *         If the logged in account cannot ban the other user due to permission hierarchy position.
+     *         <br>See {@link Member#canInteract(Member)}
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided amount of days (delDays) is less than 0.</li>
+     *             <li>If the provided amount of days (delDays) is bigger than 7.</li>
+     *             <li>If the provided reason is longer than 512 characters.</li>
+     *             <li>If the provided userId is null</li>
+     *         </ul>
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    AuditableRestAction<Void> ban(@Nonnull long userId, int delDays, @Nullable String reason);
+
+    /**
      * Bans the {@link net.dv8tion.jda.api.entities.Member Member} and deletes messages sent by the user
      * based on the amount of delDays.
      * <br>If you wish to ban a member without deleting any messages, provide delDays with a value of 0.
@@ -3761,6 +3808,53 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     @CheckReturnValue
     default AuditableRestAction<Void> ban(@Nonnull String userId, int delDays)
+    {
+        return ban(userId, delDays, null);
+    }
+
+    /**
+     * Bans the user specified by the userId and deletes messages sent by the user
+     * based on the amount of delDays.
+     * <br>If you wish to ban a user without deleting any messages, provide delDays with a value of 0.
+     *
+     * <p>You can unban a user with {@link net.dv8tion.jda.api.entities.Guild#unban(User) Guild.unban(User)}.
+     *
+     * <p><b>Note:</b> {@link net.dv8tion.jda.api.entities.Guild#getMembers()} will still contain the {@link net.dv8tion.jda.api.entities.User User's}
+     * {@link net.dv8tion.jda.api.entities.Member Member} object (if the User was in the Guild)
+     * until Discord sends the {@link net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent GuildMemberRemoveEvent}.
+     *
+     * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
+     * the returned {@link net.dv8tion.jda.api.requests.RestAction RestAction} include the following:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The target Member cannot be banned due to a permission discrepancy</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MEMBER UNKNOWN_MEMBER}
+     *     <br>The specified Member was removed from the Guild before finishing the task</li>
+     * </ul>
+     *
+     * @param  userId
+     *         The id of the {@link net.dv8tion.jda.api.entities.User User} to ban.
+     * @param  delDays
+     *         The history of messages, in days, that will be deleted.
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#BAN_MEMBERS} permission.
+     * @throws net.dv8tion.jda.api.exceptions.HierarchyException
+     *         If the logged in account cannot ban the other user due to permission hierarchy position.
+     *         <br>See {@link Member#canInteract(Member)}
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the provided amount of days (delDays) is less than 0.</li>
+     *             <li>If the provided amount of days (delDays) is bigger than 7.</li>
+     *             <li>If the provided userId is {@code null}</li>
+     *         </ul>
+     *
+     * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
+     */
+    @Nonnull
+    @CheckReturnValue
+    default AuditableRestAction<Void> ban(long userId, int delDays)
     {
         return ban(userId, delDays, null);
     }

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3615,7 +3615,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    AuditableRestAction<Void> ban(@Nonnull long userId, int delDays, @Nullable String reason);
+    AuditableRestAction<Void> ban(long userId, int delDays, @Nullable String reason);
 
     /**
      * Bans the {@link net.dv8tion.jda.api.entities.Member Member} and deletes messages sent by the user

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -3439,7 +3439,10 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    AuditableRestAction<Void> kick(long userId, @Nullable String reason);
+    default AuditableRestAction<Void> kick(long userId, @Nullable String reason)
+    {
+        return kick(Long.toUnsignedString(userId), reason);
+    }
 
     /**
      * Kicks a {@link net.dv8tion.jda.api.entities.Member Member} from the {@link net.dv8tion.jda.api.entities.Guild Guild}.
@@ -3547,7 +3550,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @CheckReturnValue
     default AuditableRestAction<Void> kick(long userId)
     {
-        return kick(userId, null);
+        return kick(Long.toUnsignedString(userId), null);
     }
 
     /**
@@ -3689,7 +3692,10 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      */
     @Nonnull
     @CheckReturnValue
-    AuditableRestAction<Void> ban(long userId, int delDays, @Nullable String reason);
+    default AuditableRestAction<Void> ban(long userId, int delDays, @Nullable String reason)
+    {
+        return ban(Long.toUnsignedString(userId), delDays, reason);
+    }
 
     /**
      * Bans the {@link net.dv8tion.jda.api.entities.Member Member} and deletes messages sent by the user

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1327,6 +1327,13 @@ public class GuildImpl implements Guild
     }
 
     @Nonnull
+    @Override
+    public AuditableRestAction<Void> kick(long userId, @Nullable String reason)
+    {
+        return kick(Long.toUnsignedString(userId), reason);
+    }
+
+    @Nonnull
     private AuditableRestAction<Void> kick0(@Nonnull String userId, @Nullable String reason)
     {
         Route.CompiledRoute route = Route.Guilds.KICK_MEMBER.compile(getId(), userId);

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1366,6 +1366,20 @@ public class GuildImpl implements Guild
     }
 
     @Nonnull
+    @Override
+    public AuditableRestAction<Void> ban(long userId, int delDays, String reason)
+    {
+        Checks.notNull(userId, "User");
+        checkPermission(Permission.BAN_MEMBERS);
+
+        User user = getJDA().getUserById(userId);
+        if (user != null) // If we have the user cached then we should use the additional information available to use during the ban process.
+            return ban(user, delDays, reason);
+
+        return ban0(String.valueOf(userId), delDays, reason);
+    }
+
+    @Nonnull
     private AuditableRestAction<Void> ban0(@Nonnull String userId, int delDays, String reason)
     {
         Checks.notNegative(delDays, "Deletion Days");

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1369,14 +1369,7 @@ public class GuildImpl implements Guild
     @Override
     public AuditableRestAction<Void> ban(long userId, int delDays, String reason)
     {
-        Checks.notNull(userId, "User");
-        checkPermission(Permission.BAN_MEMBERS);
-
-        User user = getJDA().getUserById(userId);
-        if (user != null) // If we have the user cached then we should use the additional information available to use during the ban process.
-            return ban(user, delDays, reason);
-
-        return ban0(String.valueOf(userId), delDays, reason);
+       return ban(Long.toUnsignedString(userId), delDays, reason);
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds a missing override for the `GuildImpl#ban` method, which uses a `long` user id.

Closed in favor of #2065 