### PR TITLE
Build the User from data in the Interaction if the User was not cached.

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.entities.PrivateChannelImpl;
+import net.dv8tion.jda.internal.entities.UserImpl;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -80,6 +81,7 @@ public class InteractionImpl implements Interaction
             {
                 user = jda.getEntityBuilder().createUser(data.getObject("user"));
                 ((PrivateChannelImpl) channel).setUser(user);
+                ((UserImpl) user).setPrivateChannel(channel);
             }
             this.user = user;
         }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -73,7 +73,13 @@ public class InteractionImpl implements Interaction
                 );
             }
             this.channel = channel;
-            user = channel.getUser();
+
+            User user = channel.getUser();
+            if (user == null)
+            {
+                user = jda.getEntityBuilder().createUser(data.getObject("user"));
+            }
+            this.user = user;
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/InteractionImpl.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
+import net.dv8tion.jda.internal.entities.PrivateChannelImpl;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -78,6 +79,7 @@ public class InteractionImpl implements Interaction
             if (user == null)
             {
                 user = jda.getEntityBuilder().createUser(data.getObject("user"));
+                ((PrivateChannelImpl) channel).setUser(user);
             }
             this.user = user;
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other


Closes Issue: NaN

## Description

Uses user data from the interaction if the user is not already cached.

Currently the @NonNull annotation on the getUser() method may return null, if the user was not cached but the private channel was.