### PR TITLE
Fix NPE when cloning guild role with null icon (v5)

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -289,7 +289,7 @@ public class RoleImpl implements Role
                     .setMentionable(mentionable)
                     .setName(name)
                     .setPermissions(rawPermissions)
-                    .setIcon(icon.getEmoji()); // we can only copy the emoji as we don't have access to the Icon instance
+                    .setIcon(icon == null ? null : icon.getEmoji()); // we can only copy the emoji as we don't have access to the Icon instance
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN (see #1951)

## Description

Cherrypicks the fix for NPE when running Role#createCopy without icon into v5
