### PR TITLE
Fix possible ClassCastException when removing reactions in threads

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageReaction.java
@@ -351,7 +351,7 @@ public class MessageReaction
                 throw new PermissionException("Unable to remove Reaction of other user in non-guild channels!");
             }
 
-            IPermissionContainer permChannel = (IPermissionContainer) this.channel;
+            IPermissionContainer permChannel = getGuildChannel().getPermissionContainer();
             if (!permChannel.getGuild().getSelfMember().hasPermission(permChannel, Permission.MESSAGE_MANAGE))
                 throw new InsufficientPermissionException(permChannel, Permission.MESSAGE_MANAGE);
         }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2068

## Description

This is a fix for issue #2068, I had another look and noticed that in other places we get the permission container from the guild channel, so I modified the logic here to do the same. This should be fine as we already check that the channel is from a guild since we cannot remove reactions in non-guild channels. I tested that this resolves the issue I was having.
