### PR TITLE
Replace faulty link with value in replyChoices docs

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/callbacks/IAutoCompleteCallback.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/callbacks/IAutoCompleteCallback.java
@@ -43,7 +43,7 @@ public interface IAutoCompleteCallback extends Interaction
      * <br>The user may continue writing inputs instead of using one of your choices.
      *
      * @param  choices
-     *         The choice suggestions to present to the user, 0-{@link OptionData#MAX_CHOICES} choices
+     *         The choice suggestions to present to the user, 0-{@value OptionData#MAX_CHOICES} choices
      *
      * @throws IllegalArgumentException
      *         If any of the following is true:
@@ -67,7 +67,7 @@ public interface IAutoCompleteCallback extends Interaction
      * <br>The user may continue writing inputs instead of using one of your choices.
      *
      * @param  choices
-     *         The choice suggestions to present to the user, 0-{@link OptionData#MAX_CHOICES} choices
+     *         The choice suggestions to present to the user, 0-{@value OptionData#MAX_CHOICES} choices
      *
      * @throws IllegalArgumentException
      *         If any of the following is true:


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the contributing guidelines.

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____

Closes Issue: NaN

## Description

This PR replaces two faulty link tags with value tags in the `replyChoices` methods in the `IAutoCompleteCallback` interface.

Before:
![before](https://user-images.githubusercontent.com/63104422/160769138-552475d1-027f-4c24-b959-dc9b27b32dae.png)
After:
![after](https://user-images.githubusercontent.com/63104422/160768899-ece47f76-5778-4eca-8243-ae9a11ec4cf4.png)

