### PR TITLE
Fix rate limiter not shutting down if there is an empty bucket at shutdown

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/ratelimit/BotRateLimiter.java
@@ -150,6 +150,9 @@ public class BotRateLimiter extends RateLimiter
                 // If the requests of the bucket are drained and the reset is expired the bucket has no valuable information
                 else if (bucket.requests.isEmpty() && bucket.reset <= getNow())
                     entries.remove();
+                // Remove empty buckets when the rate limiter is stopped
+                else if (bucket.requests.isEmpty() && isStopped)
+                    entries.remove();
             }
             // Log how many buckets were removed
             size -= buckets.size();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: [2079](https://github.com/DV8FromTheWorld/JDA/issues/2079)

## Description

Clears out empty buckets (with 0 requests) when the BotRateLimiter is stopped
