### PR TITLE
Improve handling of Role#getPosition and canInteract

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -60,6 +60,7 @@ public class RoleImpl implements Role
     private long rawPermissions;
     private int color;
     private int rawPosition;
+    private int realPosition = Integer.MIN_VALUE; // this is used exclusively for delete events
     private RoleIcon icon;
 
     public RoleImpl(long id, Guild guild)
@@ -73,6 +74,8 @@ public class RoleImpl implements Role
     @Override
     public int getPosition()
     {
+        if (realPosition > Integer.MIN_VALUE)
+            return realPosition;
         Guild guild = getGuild();
         if (equals(guild.getPublicRole()))
             return -1;
@@ -456,6 +459,11 @@ public class RoleImpl implements Role
     {
         this.icon = icon;
         return this;
+    }
+
+    public void freezePosition()
+    {
+        this.realPosition = getPosition();
     }
 
     public static class RoleTagsImpl implements RoleTags

--- a/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/RoleImpl.java
@@ -60,7 +60,7 @@ public class RoleImpl implements Role
     private long rawPermissions;
     private int color;
     private int rawPosition;
-    private int realPosition = Integer.MIN_VALUE; // this is used exclusively for delete events
+    private int frozenPosition = Integer.MIN_VALUE; // this is used exclusively for delete events
     private RoleIcon icon;
 
     public RoleImpl(long id, Guild guild)
@@ -74,8 +74,8 @@ public class RoleImpl implements Role
     @Override
     public int getPosition()
     {
-        if (realPosition > Integer.MIN_VALUE)
-            return realPosition;
+        if (frozenPosition > Integer.MIN_VALUE)
+            return frozenPosition;
         Guild guild = getGuild();
         if (equals(guild.getPublicRole()))
             return -1;
@@ -463,7 +463,7 @@ public class RoleImpl implements Role
 
     public void freezePosition()
     {
-        this.realPosition = getPosition();
+        this.frozenPosition = getPosition();
     }
 
     public static class RoleTagsImpl implements RoleTags

--- a/src/main/java/net/dv8tion/jda/internal/utils/PermissionUtil.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/PermissionUtil.java
@@ -108,20 +108,14 @@ public class PermissionUtil
 
         if(!issuer.getGuild().equals(target.getGuild()))
             throw new IllegalArgumentException("The 2 Roles are not from same Guild!");
-        return target.getPosition() < issuer.getPosition();
+        return target.compareTo(issuer) < 0;
     }
 
     /**
      * Check whether the provided {@link net.dv8tion.jda.api.entities.Member Member} can use the specified {@link net.dv8tion.jda.api.entities.Emote Emote}.
      *
      * <p>If the specified Member is not in the emote's guild or the emote provided is from a message this will return false.
-     * Otherwise it will check if the emote is restricted to any roles and if that is the case if the Member has one of these.
-     *
-     * <p>In the case of an {@link net.dv8tion.jda.api.entities.Emote#isAnimated() animated} Emote, this will
-     * check if the issuer is the currently logged in account, and then check if the account has
-     * {@link net.dv8tion.jda.api.entities.SelfUser#isNitro() nitro}, and return false if it doesn't.
-     * <br>For other accounts, this method will not take into account whether the emote is animated, as there is
-     * no real way to check if the Member can interact with them.
+     * Otherwise, it will check if the emote is restricted to any roles and if that is the case if the Member has one of these.
      *
      * <br><b>Note</b>: This is not checking if the issuer owns the Guild or not.
      *


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This improves the user experience for RoleDeleteEvent and allows `Role#getPosition` to still be usable once it's detached from cache. This position value is naturally not accurate for long, but still good enough for informational purposes at the time of deletion. Like any other entity value, this drifts over time after detaching from cache.

Additionally, this optimizes `Role#canInteract(Role)` by not re-calculating positions for both roles each time. We can completely rely on `compareTo` as this is only a relative comparison, rather than absolute positions.
