### PR TITLE
Add required & autoComplete in Command.Option to equals() & hashCode()

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
@@ -648,8 +648,8 @@ public interface Command extends ISnowflake
                 && Objects.equals(other.channelTypes, channelTypes)
                 && Objects.equals(other.minValue, minValue)
                 && Objects.equals(other.maxValue, maxValue)
-                && Objects.equals(other.required, required)
-                && Objects.equals(other.autoComplete, autoComplete)
+                && other.required == required
+                && other.autoComplete == autoComplete
                 && other.type == type;
         }
 

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/Command.java
@@ -633,7 +633,7 @@ public interface Command extends ISnowflake
         @Override
         public int hashCode()
         {
-            return Objects.hash(name, description, type, choices, channelTypes, minValue, maxValue);
+            return Objects.hash(name, description, type, choices, channelTypes, minValue, maxValue, required, autoComplete);
         }
 
         @Override
@@ -648,6 +648,8 @@ public interface Command extends ISnowflake
                 && Objects.equals(other.channelTypes, channelTypes)
                 && Objects.equals(other.minValue, minValue)
                 && Objects.equals(other.maxValue, maxValue)
+                && Objects.equals(other.required, required)
+                && Objects.equals(other.autoComplete, autoComplete)
                 && other.type == type;
         }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This pull request adds the `required` & `autoComplete` field of Command.Option to the corresponding equals() and hashCode() functions.
