### PR TITLE
Add Message#getStartedThread and ThreadChannel#retrieveParentMessage

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2334,6 +2334,15 @@ public interface Message extends ISnowflake, Formattable
     boolean isEphemeral();
 
     /**
+     * Returns a possibly {@code null} {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that this message started.
+     * This can be {@code null} due to no ThreadChannel being started from it or the ThreadChannel later being deleted.
+     * 
+     * @return The {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that this message started
+     */
+    @Nullable
+    ThreadChannel getStartedThread();
+
+    /**
      * This specifies the {@link net.dv8tion.jda.api.entities.MessageType MessageType} of this Message.
      *
      * <p>Messages can represent more than just simple text sent by Users, they can also be special messages that

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2337,7 +2337,7 @@ public interface Message extends ISnowflake, Formattable
      * Returns a possibly {@code null} {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that this message started.
      * This can be {@code null} due to no ThreadChannel being started from it or the ThreadChannel later being deleted.
      * 
-     * @return The {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that this message started
+     * @return The {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that was started from this message.
      */
     @Nullable
     ThreadChannel getStartedThread();

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2334,7 +2334,7 @@ public interface Message extends ISnowflake, Formattable
     boolean isEphemeral();
 
     /**
-     * Returns a possibly {@code null} {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that this message started.
+     * Returns a possibly {@code null} {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that was started from this message.
      * This can be {@code null} due to no ThreadChannel being started from it or the ThreadChannel later being deleted.
      * 
      * @return The {@link net.dv8tion.jda.api.entities.ThreadChannel ThreadChannel} that was started from this message.

--- a/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
@@ -141,6 +141,47 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer
     }
 
     /**
+     * Attempts to get the {@link net.dv8tion.jda.api.entities.Message Message} from Discord's servers that started this thread.
+     *
+     * <p>The {@link Message#getMember() Message.getMember()} method will always return null for the resulting message.
+     * To retrieve the member you can use {@code getGuild().retrieveMember(message.getAuthor())}.
+     *
+     * <p>The following {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} are possible:
+     * <ul>
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
+     *     <br>The request was attempted after the account lost access to the {@link net.dv8tion.jda.api.entities.Guild Guild}
+     *         typically due to being kicked or removed, or after {@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL}
+     *         was revoked in the {@link net.dv8tion.jda.api.entities.GuildMessageChannel GuildMessageChannel}</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost {@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}
+     *         in the {@link net.dv8tion.jda.api.entities.GuildMessageChannel GuildMessageChannel}.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_MESSAGE UNKNOWN_MESSAGE}
+     *     <br>The message has already been deleted.</li>
+     *
+     *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#UNKNOWN_CHANNEL UNKNOWN_CHANNEL}
+     *     <br>The request was attempted after the parent channel was deleted.</li>
+     * </ul>
+     *
+     * @throws net.dv8tion.jda.api.exceptions.AccountTypeException
+     *         If the currently logged in account is not from {@link net.dv8tion.jda.api.AccountType#BOT AccountType.BOT}
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If this is a {@link net.dv8tion.jda.api.entities.GuildMessageChannel GuildMessageChannel} and the logged in account does not have
+     *         <ul>
+     *             <li>{@link net.dv8tion.jda.api.Permission#VIEW_CHANNEL Permission.VIEW_CHANNEL}</li>
+     *             <li>{@link net.dv8tion.jda.api.Permission#MESSAGE_HISTORY Permission.MESSAGE_HISTORY}</li>
+     *         </ul>
+     * @throws UnsupportedOperationException
+     *         If the parent channel is not a {@link net.dv8tion.jda.api.entities.GuildMessageChannel GuildMessageChannel}.
+     *
+     * @return {@link net.dv8tion.jda.api.requests.RestAction RestAction} - Type: Message
+     *         <br>The Message that started this thread
+     */
+    @Nonnull
+    RestAction<Message> retrieveParentMessage();
+
+    /**
      * Gets the self member, as a member of this thread.
      *
      * <br>If the current account is not a member of this thread, this will return null.

--- a/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/AbstractMessage.java
@@ -525,6 +525,14 @@ public abstract class AbstractMessage implements Message
         return false;
     }
 
+    @Nullable
+    @Override
+    public ThreadChannel getStartedThread()
+    {
+        unsupported();
+        return null;
+    }
+
     @Nonnull
     @Override
     public MessageType getType()

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1524,16 +1524,20 @@ public class EntityBuilder
             api, guild, content, mentionsEveryone,
             jsonObject.getArray("mentions"), jsonObject.getArray("mention_roles")
         );
+        
+        ThreadChannel startedThread = null;
+        if (guild != null && !jsonObject.isNull("thread"))
+            startedThread = createThreadChannel(guild, jsonObject.getObject("thread"), guild.getIdLong());
 
         if (!type.isSystem())
         {
             return new ReceivedMessage(id, channel, type, messageReference, fromWebhook, tts, pinned,
-                    content, nonce, user, member, activity, editTime, mentions, reactions, attachments, embeds, stickers, components, flags, messageInteraction);
+                    content, nonce, user, member, activity, editTime, mentions, reactions, attachments, embeds, stickers, components, flags, messageInteraction, startedThread);
         }
         else
         {
             return new SystemMessage(id, channel, type, messageReference, fromWebhook, tts, pinned,
-                    content, nonce, user, member, activity, editTime, mentions, reactions, attachments, embeds, stickers, flags);
+                    content, nonce, user, member, activity, editTime, mentions, reactions, attachments, embeds, stickers, flags, startedThread);
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -68,6 +68,7 @@ public class ReceivedMessage extends AbstractMessage
     protected final List<ActionRow> components;
     protected final int flags;
     protected final Message.Interaction interaction;
+    protected final ThreadChannel startedThread;
 
     protected InteractionHook interactionHook = null; // late-init
 
@@ -81,7 +82,7 @@ public class ReceivedMessage extends AbstractMessage
             long id, MessageChannel channel, MessageType type, MessageReference messageReference,
             boolean fromWebhook, boolean tts, boolean pinned, String content, String nonce, User author,
             Member member, MessageActivity activity, OffsetDateTime editTime, Mentions mentions, List<MessageReaction> reactions,
-            List<Attachment> attachments, List<MessageEmbed> embeds, List<MessageSticker> stickers, List<ActionRow> components, int flags, Message.Interaction interaction)
+            List<Attachment> attachments, List<MessageEmbed> embeds, List<MessageSticker> stickers, List<ActionRow> components, int flags, Message.Interaction interaction, ThreadChannel startedThread)
     {
         super(content, nonce, tts);
         this.id = id;
@@ -103,6 +104,7 @@ public class ReceivedMessage extends AbstractMessage
         this.components = Collections.unmodifiableList(components);
         this.flags = flags;
         this.interaction = interaction;
+        this.startedThread = startedThread;
     }
 
     public ReceivedMessage withHook(InteractionHook hook)
@@ -718,6 +720,13 @@ public class ReceivedMessage extends AbstractMessage
     public boolean isEphemeral()
     {
         return (this.flags & MessageFlag.EPHEMERAL.getValue()) != 0;
+    }
+
+    @Nullable
+    @Override
+    public ThreadChannel getStartedThread()
+    {
+        return this.startedThread;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
@@ -33,10 +33,10 @@ public class SystemMessage extends ReceivedMessage
         long id, MessageChannel channel, MessageType type, MessageReference messageReference,
         boolean fromWebhook, boolean tts, boolean pinned,
         String content, String nonce, User author, Member member, MessageActivity activity, OffsetDateTime editTime, Mentions mentions,
-        List<MessageReaction> reactions, List<Attachment> attachments, List<MessageEmbed> embeds, List<MessageSticker> stickers, int flags)
+        List<MessageReaction> reactions, List<Attachment> attachments, List<MessageEmbed> embeds, List<MessageSticker> stickers, int flags, ThreadChannel startedThread)
     {
         super(id, channel, type, messageReference, fromWebhook, tts, pinned, content, nonce, author, member,
-                activity, editTime, mentions, reactions, attachments, embeds, stickers, Collections.emptyList(), flags, null);
+                activity, editTime, mentions, reactions, attachments, embeds, stickers, Collections.emptyList(), flags, null, startedThread);
     }
 
     @Nonnull

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -119,6 +119,13 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         return (IThreadContainer) guild.getGuildChannelById(parentChannelId);
     }
 
+    @Nonnull
+    @Override
+    public RestAction<Message> retrieveParentMessage()
+    {
+        return this.getParentMessageChannel().retrieveMessageById(this.getIdLong());
+    }
+
     @Override
     public IPermissionContainer getPermissionContainer()
     {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2092

## Description

Adds a `getStartedThread()` method to the Message object to provide a method that returns the Thread that was started from the message (if one exists).

Example:
```Java
Message message = //retrieve the message somehow
ThreadChannel thread = message.getStartedThread();
if (thread != null) {
    System.out.println(thread.getName());
    thread.sendMessage("Hello thread people!").queue();
}
```
