### PR TITLE
prevent creating OptionData with OptionType#UNKNOWN

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -160,7 +160,7 @@ public class OptionData implements SerializableData
     public OptionData(@Nonnull OptionType type, @Nonnull String name, @Nonnull String description, boolean isRequired, boolean isAutoComplete)
     {
         Checks.notNull(type, "Type");
-        Checks.check(type != OptionType.UNKNOWN, "Cannot make option of unknown type");
+        Checks.check(type != OptionType.UNKNOWN, "Cannot make option of unknown type!");
         this.type = type;
 
         setName(name);

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/OptionData.java
@@ -95,6 +95,7 @@ public class OptionData implements SerializableData
      *         If any of the following checks fail
      *         <ul>
      *             <li>{@code type} is not null</li>
+     *             <li>{@code type} is not {@link OptionType#UNKNOWN UNKNOWN}</li>
      *             <li>{@code name} is alphanumeric (with dash), lowercase and between 1 and {@value #MAX_NAME_LENGTH} characters long</li>
      *             <li>{@code description} is between 1 and {@value #MAX_DESCRIPTION_LENGTH} characters long</li>
      *         </ul>
@@ -121,6 +122,7 @@ public class OptionData implements SerializableData
      *         If any of the following checks fail
      *         <ul>
      *             <li>{@code type} is not null</li>
+     *             <li>{@code type} is not {@link OptionType#UNKNOWN UNKNOWN}</li>
      *             <li>{@code name} is alphanumeric (with dash), lowercase and between 1 and {@value #MAX_NAME_LENGTH} characters long</li>
      *             <li>{@code description} is between 1 and {@value #MAX_DESCRIPTION_LENGTH} characters long</li>
      *         </ul>
@@ -149,6 +151,7 @@ public class OptionData implements SerializableData
      *         If any of the following checks fail
      *         <ul>
      *             <li>{@code type} is not null</li>
+     *             <li>{@code type} is not {@link OptionType#UNKNOWN UNKNOWN}</li>
      *             <li>{@code name} is alphanumeric (with dash), lowercase and between 1 and {@value #MAX_NAME_LENGTH} characters long</li>
      *             <li>{@code description} is between 1 and {@value #MAX_DESCRIPTION_LENGTH} characters long</li>
      *             <li>{@link OptionType#canSupportChoices()} is false then {@code isAutoComplete} is also false</li>
@@ -157,6 +160,7 @@ public class OptionData implements SerializableData
     public OptionData(@Nonnull OptionType type, @Nonnull String name, @Nonnull String description, boolean isRequired, boolean isAutoComplete)
     {
         Checks.notNull(type, "Type");
+        Checks.check(type != OptionType.UNKNOWN, "Cannot make option of unknown type");
         this.type = type;
 
         setName(name);

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
@@ -161,6 +161,7 @@ public interface SlashCommandData extends CommandData
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If the provided option type does not support auto-complete</li>
      *             <li>If this option is required and you already added a non-required option.</li>
@@ -196,6 +197,7 @@ public interface SlashCommandData extends CommandData
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
      *             <li>If more than 25 options are provided.</li>
@@ -227,6 +229,7 @@ public interface SlashCommandData extends CommandData
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
      *             <li>If more than 25 options are provided.</li>


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR adds a check to `OptionData` constructor which prevents successfully creating an instance with `OptionType#UNKNOWN` (prevents things like #2100 from happening).