### PR TITLE
Fix NewsChannel#getManager always returning null

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/NewsChannelImpl.java
@@ -27,6 +27,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.mixin.channel.middleman.BaseGuildMessageChannelMixin;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
+import net.dv8tion.jda.internal.managers.channel.concrete.NewsChannelManagerImpl;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
@@ -137,7 +138,7 @@ public class NewsChannelImpl extends AbstractGuildChannelImpl<NewsChannelImpl> i
     @Override
     public NewsChannelManager getManager()
     {
-        return null;
+        return new NewsChannelManagerImpl(this);
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [ ] I have checked the PRs for upcoming features/bug fixes.
- [ ] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR fixes a bug with `NewsChannel#getManager` always returning null instead of an actual `NewsChannelManager`