### PR TITLE
Improve check for GuildVoiceState#declineSpeaker

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildVoiceState.java
@@ -186,7 +186,8 @@ public interface GuildVoiceState extends ISnowflake
     RestAction<Void> approveSpeaker();
 
     /**
-     * Reject this members {@link #getRequestToSpeakTimestamp() request to speak}.
+     * Reject this members {@link #getRequestToSpeakTimestamp() request to speak}
+     * or moves a {@link StageInstance#getSpeakers() speaker} back to the {@link StageInstance#getAudience() audience}.
      * <p>This requires a non-null {@link #getRequestToSpeakTimestamp()}.
      * The member will have to request to speak again.
      *

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildVoiceStateImpl.java
@@ -106,8 +106,9 @@ public class GuildVoiceStateImpl implements GuildVoiceState
 
     private RestAction<Void> update(boolean suppress)
     {
-        if (requestToSpeak == 0L || !(connectedChannel instanceof StageChannel))
+        if (!(connectedChannel instanceof StageChannel) || suppress == isSuppressed())
             return new CompletedRestAction<>(api, null);
+
         Member selfMember = getGuild().getSelfMember();
         boolean isSelf = selfMember.equals(member);
         if (!isSelf && !selfMember.hasPermission(connectedChannel, Permission.VOICE_MUTE_OTHERS))


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The `declineSpeaker` method is also used to move speakers back to the stage audience.
