### PR TITLE
[Bugfix] retrieving public archived threads

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -163,18 +163,6 @@ public class EntityBuilder
         }
     }
 
-    public TLongObjectMap<DataObject> convertToUserMap(ToLongFunction<DataObject> getId, DataArray array)
-    {
-        TLongObjectMap<DataObject> map = new TLongObjectHashMap<>();
-        for (int i = 0; i < array.length(); i++)
-        {
-            DataObject obj = array.getObject(i);
-            long userId = getId.applyAsLong(obj);
-            map.put(userId, obj);
-        }
-        return map;
-    }
-
     public GuildImpl createGuild(long guildId, DataObject guildJson, TLongObjectMap<DataObject> members, int memberCount)
     {
         final GuildImpl guildObj = new GuildImpl(getJDA(), guildId);
@@ -262,8 +250,8 @@ public class EntityBuilder
             createGuildChannel(guildObj, channelJson);
         }
 
-        TLongObjectMap<DataObject> voiceStates = convertToUserMap((o) -> o.getUnsignedLong("user_id", 0L), voiceStateArray);
-        TLongObjectMap<DataObject> presences = presencesArray.map(o1 -> convertToUserMap(o2 -> o2.getObject("user").getUnsignedLong("id"), o1)).orElseGet(TLongObjectHashMap::new);
+        TLongObjectMap<DataObject> voiceStates = Helpers.convertToMap((o) -> o.getUnsignedLong("user_id", 0L), voiceStateArray);
+        TLongObjectMap<DataObject> presences = presencesArray.map(o1 -> Helpers.convertToMap(o2 -> o2.getObject("user").getUnsignedLong("id"), o1)).orElseGet(TLongObjectHashMap::new);
         try (UnlockHook h1 = guildObj.getMembersView().writeLock();
              UnlockHook h2 = getJDA().getUsersView().writeLock())
         {

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildMembersChunkHandler.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 public class GuildMembersChunkHandler extends SocketHandler
 {
@@ -48,7 +49,7 @@ public class GuildMembersChunkHandler extends SocketHandler
             // Chunk handling
             EntityBuilder builder = getJDA().getEntityBuilder();
             TLongObjectMap<DataObject> presences = content.optArray("presences").map(it ->
-                builder.convertToUserMap(o -> o.getObject("user").getUnsignedLong("id"), it)
+                Helpers.convertToMap(o -> o.getObject("user").getUnsignedLong("id"), it)
             ).orElseGet(TLongObjectHashMap::new);
             for (int i = 0; i < members.length(); i++)
             {

--- a/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/MemberChunkManager.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -193,7 +194,7 @@ public class MemberChunkManager
             EntityBuilder builder = guild.getJDA().getEntityBuilder();
             DataArray memberArray = chunk.getArray("members");
             TLongObjectMap<DataObject> presences = chunk.optArray("presences").map(it ->
-                builder.convertToUserMap(o -> o.getObject("user").getUnsignedLong("id"), it)
+                Helpers.convertToMap(o -> o.getObject("user").getUnsignedLong("id"), it)
             ).orElseGet(TLongObjectHashMap::new);
             List<Member> collect = new ArrayList<>(memberArray.length());
             for (int i = 0; i < memberArray.length(); i++)

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
@@ -352,7 +352,7 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     // Introduced for paginating archived threads, because two endpoints require a different request parameter value format.
     // May become more useful if discord introduces more pagination endpoints not using ids.
     // Check ThreadChannelPaginationActionImpl
-    // Background of #formatKeyValue:
+    // Background of #getPaginationLastEvaluatedKey:
     //     Archived thread channel pagination (example: TextChannel#retrieveArchivedPublicThreadChannels) would throw an exception,
     //     where Discord complained about receiving a snowflake instead of an ISO8601 date.
     //     The snowflake originated from this class (creating initial & subsequent requests),
@@ -374,12 +374,12 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         Route.CompiledRoute route = super.finalizeRoute();
 
         final String limit = String.valueOf(this.getLimit());
-        final long last = this.lastKey;
+        final long localLastKey = this.lastKey;
 
         route = route.withQueryParams("limit", limit);
 
-        if (last != 0)
-            route = route.withQueryParams(order.getKey(), getPaginationLastEvaluatedKey(last, this.getLast()));
+        if (localLastKey != 0)
+            route = route.withQueryParams(order.getKey(), getPaginationLastEvaluatedKey(localLastKey, this.last));
         else if (order == PaginationOrder.FORWARD)
             route = route.withQueryParams("after", getPaginationLastEvaluatedKey(0, this.last));
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/PaginationActionImpl.java
@@ -363,9 +363,9 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
     //     The fix here is to let the implementor supply the "last" string value, which could be anything,
     //     while the default implementation still would provide snowflakes
     @Nonnull
-    protected String formatKeyValue(long last)
+    protected String getPaginationLastEvaluatedKey(long lastId, T last)
     {
-        return Long.toUnsignedString(last);
+        return Long.toUnsignedString(lastId);
     }
 
     @Override
@@ -379,9 +379,9 @@ public abstract class PaginationActionImpl<T, M extends PaginationAction<T, M>>
         route = route.withQueryParams("limit", limit);
 
         if (last != 0)
-            route = route.withQueryParams(order.getKey(), formatKeyValue(last));
+            route = route.withQueryParams(order.getKey(), getPaginationLastEvaluatedKey(last, this.getLast()));
         else if (order == PaginationOrder.FORWARD)
-            route = route.withQueryParams("after", formatKeyValue(0));
+            route = route.withQueryParams("after", getPaginationLastEvaluatedKey(0, this.last));
 
         return route;
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -22,7 +22,6 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<ThreadChannel, ThreadChannelPaginationAction> implements ThreadChannelPaginationAction
 {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.Route;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -82,14 +83,7 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
         List<ThreadChannel> list = new ArrayList<>(threads.length());
         EntityBuilder builder = api.getEntityBuilder();
 
-        TLongObjectMap<DataObject> selfThreadMemberMap = new TLongObjectHashMap<>();
-        for (int i = 0; i < selfThreadMembers.length(); i++)
-        {
-            DataObject selfThreadMember = selfThreadMembers.getObject(i);
-
-            //Store the thread member based on the "id" which is the _thread's_ id, not the member's id (which would be our id)
-            selfThreadMemberMap.put(selfThreadMember.getLong("id"), selfThreadMember);
-        }
+        TLongObjectMap<DataObject> selfThreadMemberMap = Helpers.convertToMap((o) -> o.getUnsignedLong("id"), selfThreadMembers);
 
         for (int i = 0; i < threads.length(); i++)
         {

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -60,9 +60,9 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
             return route;
 
         if (useID)
-            return route.withQueryParams("before", Long.toUnsignedString(last));
+            return route = route.withQueryParams("before", Long.toUnsignedString(last));
         // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
-        return route.withQueryParams("before", TimeUtil.getTimeCreated(last).toString());
+        return route = route.withQueryParams("before", TimeUtil.getTimeCreated(last).toString());
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -16,6 +16,9 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -67,7 +70,7 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
         // this should be redundant, due to calling this with PaginationAction#getLast() as last param,
         // but let's have this here.
         if (last == null)
-            throw new NoSuchElementException("No entities have been retrieved yet.");
+            return OffsetDateTime.now(ZoneOffset.UTC).toString();
 
         // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
         return last.getTimeArchiveInfoLastModified().toString();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.utils.TimeUtil;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
+import net.dv8tion.jda.internal.entities.ThreadChannelImpl;
 import net.dv8tion.jda.internal.requests.Route;
 
 import javax.annotation.Nonnull;
@@ -57,7 +58,7 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
         if (useID)
             return Long.toUnsignedString(last);
         // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
-        return TimeUtil.getTimeCreated(last).toString();
+        return this.last.getTimeArchiveInfoLastModified().toString();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -46,23 +46,15 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
         return EnumSet.of(PaginationOrder.BACKWARD);
     }
 
+    //Thread pagination supplies ISO8601 timestamps for some cases, see constructor
+    @Nonnull
     @Override
-    protected Route.CompiledRoute finalizeRoute()
+    protected String getLastKeyValue(long last)
     {
-        Route.CompiledRoute route = super.finalizeRoute();
-
-        final String limit = String.valueOf(this.limit.get());
-        final long last = this.lastKey;
-
-        route = route.withQueryParams("limit", limit);
-
-        if (last == 0)
-            return route;
-
         if (useID)
-            return route = route.withQueryParams("before", Long.toUnsignedString(last));
+            return Long.toUnsignedString(last);
         // OffsetDateTime#toString() is defined to be ISO8601, needs no helper method.
-        return route = route.withQueryParams("before", TimeUtil.getTimeCreated(last).toString());
+        return TimeUtil.getTimeCreated(last).toString();
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/ThreadChannelPaginationActionImpl.java
@@ -23,6 +23,9 @@ import java.util.List;
 public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<ThreadChannel, ThreadChannelPaginationAction> implements ThreadChannelPaginationAction
 {
     protected final IThreadContainer channel;
+
+    // Whether IDs or ISO8601 timestamps shall be provided for all pagination requests.
+    // Some thread pagination endpoints require this odd and singular behavior throughout the discord api.
     protected final boolean useID;
 
     public ThreadChannelPaginationActionImpl(JDA api, Route.CompiledRoute route, IThreadContainer channel, boolean useID)
@@ -49,7 +52,7 @@ public class ThreadChannelPaginationActionImpl extends PaginationActionImpl<Thre
     //Thread pagination supplies ISO8601 timestamps for some cases, see constructor
     @Nonnull
     @Override
-    protected String getLastKeyValue(long last)
+    protected String formatKeyValue(long last)
     {
         if (useID)
             return Long.toUnsignedString(last);

--- a/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/Helpers.java
@@ -16,12 +16,18 @@
 
 package net.dv8tion.jda.internal.utils;
 
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
+import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
+
 import javax.annotation.Nullable;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.ToLongFunction;
 
 /**
  * This class has major inspiration from <a href="https://commons.apache.org/proper/commons-lang/" target="_blank">Lang 3</a>
@@ -223,6 +229,18 @@ public final class Helpers
     public static <E extends Enum<E>> EnumSet<E> copyEnumSet(Class<E> clazz, Collection<E> col)
     {
         return col == null || col.isEmpty() ? EnumSet.noneOf(clazz) : EnumSet.copyOf(col);
+    }
+
+    public static TLongObjectMap<DataObject> convertToMap(ToLongFunction<DataObject> getId, DataArray array)
+    {
+        TLongObjectMap<DataObject> map = new TLongObjectHashMap<>();
+        for (int i = 0; i < array.length(); i++)
+        {
+            DataObject obj = array.getObject(i);
+            long userId = getId.applyAsLong(obj);
+            map.put(userId, obj);
+        }
+        return map;
     }
 
     // ## ExceptionUtils ##


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation

Closes Issue: NaN

## Description

Follow-up requests of ThreadChannelPaginationAction had duplicated `before` request parameters,
while discord only read the first (invalid) one provided by PaginationAction route finalization.

```
net.dv8tion.jda.api.exceptions.ErrorResponseException: 50035: Invalid Form Body
    - DATE_TIME_TYPE_PARSE: Could not parse 968844240228585543. Should be ISO8601.
```