### PR TITLE
Add FileUpload class

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/InteractionCallbackAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/InteractionCallbackAction.java
@@ -18,11 +18,25 @@ package net.dv8tion.jda.api.requests.restaction.interactions;
 
 import net.dv8tion.jda.api.requests.RestAction;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+
 /**
  * A callback action is used to <b>acknowledge</b> an {@link net.dv8tion.jda.api.interactions.Interaction Interaction}.
  */
 public interface InteractionCallbackAction<T> extends RestAction<T>
 {
+    /**
+     * Closes all owned resources used for this request.
+     *
+     * <p>This closes all files added, if applicable.
+     *
+     * @return This instance for chaining.
+     */
+    @Nonnull
+    @CheckReturnValue
+    InteractionCallbackAction<T> closeResources();
+
     /**
      * The possible types of interaction responses.
      * <br>This is currently only used internally to reduce interface complexity.

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/MessageEditCallbackAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/MessageEditCallbackAction.java
@@ -32,6 +32,8 @@ import javax.annotation.Nullable;
 import java.io.*;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 /**
@@ -39,6 +41,22 @@ import java.util.stream.Collectors;
  */
 public interface MessageEditCallbackAction extends InteractionCallbackAction<InteractionHook>
 {
+    @Nonnull
+    @Override
+    MessageEditCallbackAction setCheck(@Nullable BooleanSupplier checks);
+
+    @Nonnull
+    @Override
+    MessageEditCallbackAction timeout(long timeout, @Nonnull TimeUnit unit);
+
+    @Nonnull
+    @Override
+    MessageEditCallbackAction deadline(long timestamp);
+
+    @Nonnull
+    @Override
+    MessageEditCallbackAction closeResources();
+
     /**
      * Set the new content for this message.
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/ReplyCallbackAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/interactions/ReplyCallbackAction.java
@@ -52,6 +52,10 @@ public interface ReplyCallbackAction extends InteractionCallbackAction<Interacti
     @Override
     ReplyCallbackAction deadline(long timestamp);
 
+    @Nonnull
+    @Override
+    ReplyCallbackAction closeResources();
+
     /**
      * Add {@link MessageEmbed MessageEmbeds} for the message
      *

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import okhttp3.MultipartBody;
+
+import javax.annotation.Nonnull;
+import java.io.Closeable;
+import java.io.InputStream;
+import java.util.List;
+
+public interface AttachedFile extends Closeable
+{
+    @Nonnull
+    static FileUpload fromData(@Nonnull InputStream data, @Nonnull String name)
+    {
+        return FileUpload.fromData(data, name);
+    }
+
+    @Nonnull
+    static FileUpload fromData(@Nonnull byte[] data, @Nonnull String name)
+    {
+        return FileUpload.fromData(data, name);
+    }
+
+    @Nonnull
+    static AttachmentUpdate fromAttachment(long id)
+    {
+        return AttachmentUpdate.fromAttachment(id);
+    }
+
+    @Nonnull
+    static AttachmentUpdate fromAttachment(@Nonnull String id)
+    {
+        return AttachmentUpdate.fromAttachment(id);
+    }
+
+    @Nonnull
+    static AttachmentUpdate fromAttachment(@Nonnull Message.Attachment attachment)
+    {
+        return AttachmentUpdate.fromAttachment(attachment);
+    }
+
+    default void addPart(MultipartBody.Builder builder, int index) {}
+
+    @Nonnull
+    DataObject toAttachmentData(int index);
+
+    @Nonnull
+    static MultipartBody.Builder createMultipartBody(List<? extends AttachedFile> files, DataObject payloadJson)
+    {
+        MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+        DataArray descriptors = DataArray.empty();
+        for (int i = 0; i < files.size(); i++)
+        {
+            AttachedFile file = files.get(i);
+            file.addPart(builder, i);
+            descriptors.add(file.toAttachmentData(i));
+        }
+// TODO: Add this when appropriate methods for editing attachments are provided in future changes
+//        if (payloadJson == null)
+//            payloadJson = DataObject.empty();
+//        payloadJson.put("attachments", descriptors);
+//        builder.addFormDataPart("payload_json", payloadJson.toString());
+        return builder;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
@@ -182,7 +182,7 @@ public interface AttachedFile extends Closeable
     @Nonnull
     static FileUpload fromData(@Nonnull Path path, @Nonnull OpenOption... options)
     {
-        return FileUpload.fromData(path, path.getFileName().toString(), options);
+        return FileUpload.fromData(path, options);
     }
 
     /**
@@ -241,7 +241,7 @@ public interface AttachedFile extends Closeable
      * @throws IllegalStateException
      *         If this attachment has already been used
      */
-    default void claim() {}
+    void claim();
 
     /**
      * Whether this attached file has already been used.
@@ -251,20 +251,19 @@ public interface AttachedFile extends Closeable
      *
      * @return True if this attachment has already been used
      */
-    default boolean isClaimed()
-    {
-        return false;
-    }
+    boolean isClaimed();
 
     /**
      * Used internally to build the multipart request.
+     *
+     * <p>The index can be used as a unique identifier for the multipart name, which is required to be unique by Discord.
      *
      * @param builder
      *        The {@link MultipartBody.Builder} used for the request body
      * @param index
      *        The index of the attachment, ignored for {@link AttachmentUpdate}
      */
-    default void addPart(MultipartBody.Builder builder, int index) {}
+    void addPart(@Nonnull MultipartBody.Builder builder, int index);
 
     /**
      * Used internally to build attachment descriptions for requests.

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
@@ -22,49 +22,148 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import okhttp3.MultipartBody;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.InputStream;
 import java.util.List;
 
+/**
+ * Represents files that are attached to requests.
+ */
 public interface AttachedFile extends Closeable
 {
+    /**
+     * Create a new {@link FileUpload} for an input stream.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>The {@link InputStream} will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  data
+     *         The {@link InputStream} to upload
+     * @param  name
+     *         The representative name to use for the file
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     *
+     * @return {@link FileUpload}
+     *
+     * @see    java.io.FileInputStream FileInputStream
+     */
     @Nonnull
     static FileUpload fromData(@Nonnull InputStream data, @Nonnull String name)
     {
         return FileUpload.fromData(data, name);
     }
 
+    /**
+     * Create a new {@link FileUpload} for a byte array.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * @param  data
+     *         The {@code byte[]} to upload
+     * @param  name
+     *         The representative name to use for the file
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     *
+     * @return {@link FileUpload}
+     */
     @Nonnull
     static FileUpload fromData(@Nonnull byte[] data, @Nonnull String name)
     {
         return FileUpload.fromData(data, name);
     }
 
+    /**
+     * Creates an {@link AttachmentUpdate} with the given attachment id.
+     * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+     *
+     * @param  id
+     *         The id of the attachment to retain
+     *
+     * @return {@link AttachmentUpdate}
+     */
     @Nonnull
     static AttachmentUpdate fromAttachment(long id)
     {
         return AttachmentUpdate.fromAttachment(id);
     }
 
+    /**
+     * Creates an {@link AttachmentUpdate} with the given attachment id.
+     * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+     *
+     * @param  id
+     *         The id of the attachment to retain
+     *
+     * @throws IllegalArgumentException
+     *         If the id is not a valid snowflake
+     *
+     * @return {@link AttachmentUpdate}
+     */
     @Nonnull
     static AttachmentUpdate fromAttachment(@Nonnull String id)
     {
         return AttachmentUpdate.fromAttachment(id);
     }
 
+
+    /**
+     * Creates an {@link AttachmentUpdate} with the given attachment.
+     * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+     *
+     * @param  attachment
+     *         The attachment to retain
+     *
+     * @return {@link AttachmentUpdate}
+     */
     @Nonnull
     static AttachmentUpdate fromAttachment(@Nonnull Message.Attachment attachment)
     {
         return AttachmentUpdate.fromAttachment(attachment);
     }
 
+    /**
+     * Used internally to build the multipart request.
+     *
+     * @param builder
+     *        The {@link MultipartBody.Builder} used for the request body
+     * @param index
+     *        The index of the attachment, ignored for {@link AttachmentUpdate}
+     */
     default void addPart(MultipartBody.Builder builder, int index) {}
 
+    /**
+     * Used internally to build attachment descriptions for requests.
+     * <br>This contains the id/index of the attachment, and the name of the file.
+     *
+     * @param  index
+     *         The reference index (should be same as {@link #addPart(MultipartBody.Builder, int)})
+     *
+     * @return {@link DataObject} for the attachment
+     */
     @Nonnull
     DataObject toAttachmentData(int index);
 
+    /**
+     * Build a complete request using the provided files and payload data.
+     * <br>If the provided {@code payloadJson} is null, the multipart request will not set {@code attachments}.
+     *
+     * @param  files
+     *         The files to upload/edit
+     * @param  payloadJson
+     *         The payload data to send, excluding {@code attachments} field
+     *
+     * @throws IllegalArgumentException
+     *         If the file list is null
+     *
+     * @return {@link MultipartBody.Builder}
+     */
     @Nonnull
-    static MultipartBody.Builder createMultipartBody(List<? extends AttachedFile> files, DataObject payloadJson)
+    static MultipartBody.Builder createMultipartBody(@Nonnull List<? extends AttachedFile> files, @Nullable DataObject payloadJson)
     {
         MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
         DataArray descriptors = DataArray.empty();
@@ -74,11 +173,11 @@ public interface AttachedFile extends Closeable
             file.addPart(builder, i);
             descriptors.add(file.toAttachmentData(i));
         }
-// TODO: Add this when appropriate methods for editing attachments are provided in future changes
-//        if (payloadJson == null)
-//            payloadJson = DataObject.empty();
-//        payloadJson.put("attachments", descriptors);
-//        builder.addFormDataPart("payload_json", payloadJson.toString());
+
+        if (payloadJson == null)
+            return builder;
+        payloadJson.put("attachments", descriptors);
+        builder.addFormDataPart("payload_json", payloadJson.toString());
         return builder;
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
@@ -235,6 +235,28 @@ public interface AttachedFile extends Closeable
     }
 
     /**
+     * Marks this attachment as used and throws if it has already been used.
+     * <br>This does nothing on {@link AttachmentUpdate}.
+     *
+     * @throws IllegalStateException
+     *         If this attachment has already been used
+     */
+    default void claim() {}
+
+    /**
+     * Whether this attached file has already been used.
+     * <br>When this is true, {@link #claim()} will throw an {@link IllegalStateException}.
+     *
+     * <p>Resources cannot be read multiple times, so repeated use of this instance is not allowed.
+     *
+     * @return True if this attachment has already been used
+     */
+    default boolean isClaimed()
+    {
+        return false;
+    }
+
+    /**
      * Used internally to build the multipart request.
      *
      * @param builder

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
@@ -23,8 +23,10 @@ import okhttp3.MultipartBody;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.Closeable;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -75,6 +77,112 @@ public interface AttachedFile extends Closeable
     static FileUpload fromData(@Nonnull byte[] data, @Nonnull String name)
     {
         return FileUpload.fromData(data, name);
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>This opens a {@link FileInputStream}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  file
+     *         The {@link File} to upload
+     * @param  name
+     *         The representative name to use for the file
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     *
+     * @see    java.io.FileInputStream FileInputStream
+     */
+    @Nonnull
+    static FileUpload fromData(@Nonnull File file, @Nonnull String name)
+    {
+        return FileUpload.fromData(file, name);
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>This opens a {@link FileInputStream}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  file
+     *         The {@link File} to upload
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     *
+     * @see    java.io.FileInputStream FileInputStream
+     * @see    #fromData(File, String)
+     */
+    @Nonnull
+    static FileUpload fromData(@Nonnull File file)
+    {
+        return FileUpload.fromData(file);
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  path
+     *         The {@link Path} of the file to upload
+     * @param  name
+     *         The representative name to use for the file
+     * @param  options
+     *         The {@link OpenOption OpenOptions} specifying how the file is opened
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     */
+    @Nonnull
+    static FileUpload fromData(@Nonnull Path path, @Nonnull String name, @Nonnull OpenOption... options)
+    {
+        return FileUpload.fromData(path, name, options);
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     * Uses {@link Path#getFileName()} to specify the name of the file.
+     *
+     * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  path
+     *         The {@link Path} of the file to upload
+     * @param  options
+     *         The {@link OpenOption OpenOptions} specifying how the file is opened
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     */
+    @Nonnull
+    static FileUpload fromData(@Nonnull Path path, @Nonnull OpenOption... options)
+    {
+        return FileUpload.fromData(path, path.getFileName().toString(), options);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachedFile.java
@@ -162,7 +162,7 @@ public interface AttachedFile extends Closeable
     /**
      * Create a new {@link FileUpload} for a local file.
      * <br>This is used to upload data to discord for various purposes.
-     * Uses {@link Path#getFileName()} to specify the name of the file.
+     * Uses {@link Path#getFileName()} to specify the name of the file, to customize the filename use {@link #fromData(Path, String, OpenOption...)}.
      *
      * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
      * You can use {@link FileUpload#close()} to close the stream manually.

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
@@ -117,4 +117,10 @@ public class AttachmentUpdate implements AttachedFile, ISnowflake
 
     @Override
     public void close() {}
+
+    @Override
+    public String toString()
+    {
+        return "AttachedFile[Attachment]:" + name + '(' + id + ')';
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
@@ -20,6 +20,8 @@ import net.dv8tion.jda.api.entities.ISnowflake;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.utils.Checks;
+import okhttp3.MultipartBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -105,6 +107,18 @@ public class AttachmentUpdate implements AttachedFile, ISnowflake
         return id;
     }
 
+    @Override
+    public void claim() {}
+
+    @Override
+    public boolean isClaimed()
+    {
+        return false;
+    }
+
+    @Override
+    public void addPart(@NotNull MultipartBody.Builder builder, int index) {}
+
     @Nonnull
     @Override
     public DataObject toAttachmentData(int index)
@@ -121,6 +135,6 @@ public class AttachmentUpdate implements AttachedFile, ISnowflake
     @Override
     public String toString()
     {
-        return "AttachedFile[Attachment]:" + name + '(' + id + ')';
+        return "AttachedFile[Attachment]" + (name == null ? "" : ":" + name) + '(' + id + ')';
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
@@ -21,7 +21,6 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.utils.Checks;
 import okhttp3.MultipartBody;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -117,7 +116,7 @@ public class AttachmentUpdate implements AttachedFile, ISnowflake
     }
 
     @Override
-    public void addPart(@NotNull MultipartBody.Builder builder, int index) {}
+    public void addPart(@Nonnull MultipartBody.Builder builder, int index) {}
 
     @Nonnull
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils;
+
+import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.utils.Checks;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class AttachmentUpdate implements AttachedFile, ISnowflake
+{
+    private final long id;
+    private final String name;
+
+    protected AttachmentUpdate(long id, String name)
+    {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Nonnull
+    public static AttachmentUpdate fromAttachment(long id)
+    {
+        return new AttachmentUpdate(id, null);
+    }
+
+    @Nonnull
+    public static AttachmentUpdate fromAttachment(@Nonnull String id)
+    {
+        return fromAttachment(MiscUtil.parseSnowflake(id));
+    }
+
+    @Nonnull
+    public static AttachmentUpdate fromAttachment(@Nonnull Message.Attachment attachment)
+    {
+        Checks.notNull(attachment, "Attachment");
+        return new AttachmentUpdate(attachment.getIdLong(), attachment.getFileName());
+    }
+
+    @Nullable
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public long getIdLong()
+    {
+        return id;
+    }
+
+    @Nonnull
+    @Override
+    public DataObject toAttachmentData(int index)
+    {
+        DataObject object = DataObject.empty().put("id", getId());
+        if (name != null)
+            object.put("filename", name);
+        return object;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/AttachmentUpdate.java
@@ -24,6 +24,10 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * Represents existing message attachment.
+ * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+ */
 public class AttachmentUpdate implements AttachedFile, ISnowflake
 {
     private final long id;
@@ -35,18 +39,48 @@ public class AttachmentUpdate implements AttachedFile, ISnowflake
         this.name = name;
     }
 
+    /**
+     * Creates an {@link AttachmentUpdate} with the given attachment id.
+     * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+     *
+     * @param  id
+     *         The id of the attachment to retain
+     *
+     * @return {@link AttachmentUpdate}
+     */
     @Nonnull
     public static AttachmentUpdate fromAttachment(long id)
     {
         return new AttachmentUpdate(id, null);
     }
 
+    /**
+     * Creates an {@link AttachmentUpdate} with the given attachment id.
+     * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+     *
+     * @param  id
+     *         The id of the attachment to retain
+     *
+     * @throws IllegalArgumentException
+     *         If the id is not a valid snowflake
+     *
+     * @return {@link AttachmentUpdate}
+     */
     @Nonnull
     public static AttachmentUpdate fromAttachment(@Nonnull String id)
     {
         return fromAttachment(MiscUtil.parseSnowflake(id));
     }
 
+    /**
+     * Creates an {@link AttachmentUpdate} with the given attachment.
+     * <br>This is primarily used for message edit requests, to specify which attachments to retain in the message after the update.
+     *
+     * @param  attachment
+     *         The attachment to retain
+     *
+     * @return {@link AttachmentUpdate}
+     */
     @Nonnull
     public static AttachmentUpdate fromAttachment(@Nonnull Message.Attachment attachment)
     {
@@ -54,6 +88,11 @@ public class AttachmentUpdate implements AttachedFile, ISnowflake
         return new AttachmentUpdate(attachment.getIdLong(), attachment.getFileName());
     }
 
+    /**
+     * The existing attachment filename.
+     *
+     * @return The filename, or {@code null} if not provided
+     */
     @Nullable
     public String getName()
     {

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -205,7 +205,7 @@ public class FileUpload implements Closeable, AttachedFile
     /**
      * Create a new {@link FileUpload} for a local file.
      * <br>This is used to upload data to discord for various purposes.
-     * Uses {@link Path#getFileName()} to specify the name of the file, to set the filename {@see fromData(Path, String, OpenOption...)}.
+     * Uses {@link Path#getFileName()} to specify the name of the file, to customize the filename use {@link #fromData(Path, String, OpenOption...)}.
      *
      * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
      * You can use {@link FileUpload#close()} to close the stream manually.

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -269,4 +269,17 @@ public class FileUpload implements Closeable, AttachedFile
         if (resource != null)
             resource.close();
     }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected void finalize()
+    {
+        IOUtil.silentClose(resource);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AttachedFile[Data]:" + name;
+    }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -28,6 +28,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Represents a file that is intended to be uploaded to Discord for arbitrary requests.
+ * <br>This is used to upload data to discord for various purposes.
+ *
+ * <p>The {@link InputStream} will be closed on consumption by the request.
+ * You can use {@link #close()} to close the stream manually.
+ */
 public class FileUpload implements Closeable, AttachedFile
 {
     private final InputStream resource;
@@ -39,6 +46,25 @@ public class FileUpload implements Closeable, AttachedFile
         this.name = name;
     }
 
+    /**
+     * Create a new {@link FileUpload} for an input stream.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>The {@link InputStream} will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  data
+     *         The {@link InputStream} to upload
+     * @param  name
+     *         The representative name to use for the file
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     *
+     * @return {@link FileUpload}
+     *
+     * @see    java.io.FileInputStream FileInputStream
+     */
     @Nonnull
     public static FileUpload fromData(@Nonnull InputStream data, @Nonnull String name)
     {
@@ -47,6 +73,20 @@ public class FileUpload implements Closeable, AttachedFile
         return new FileUpload(data, name);
     }
 
+    /**
+     * Create a new {@link FileUpload} for a byte array.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * @param  data
+     *         The {@code byte[]} to upload
+     * @param  name
+     *         The representative name to use for the file
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     *
+     * @return {@link FileUpload}
+     */
     @Nonnull
     public static FileUpload fromData(@Nonnull byte[] data, @Nonnull String name)
     {
@@ -55,19 +95,22 @@ public class FileUpload implements Closeable, AttachedFile
         return fromData(new ByteArrayInputStream(data), name);
     }
 
-    @Override
-    public void close() throws IOException
-    {
-        if (resource != null)
-            resource.close();
-    }
-
+    /**
+     * The filename for the file.
+     *
+     * @return The filename
+     */
     @Nonnull
     public String getName()
     {
         return name;
     }
 
+    /**
+     * The {@link InputStream} representing the data to upload as a file.
+     *
+     * @return The {@link InputStream}
+     */
     @Nonnull
     public InputStream getData()
     {
@@ -86,5 +129,12 @@ public class FileUpload implements Closeable, AttachedFile
         return DataObject.empty()
                 .put("id", index)
                 .put("filename", name);
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        if (resource != null)
+            resource.close();
     }
 }

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -205,7 +205,7 @@ public class FileUpload implements Closeable, AttachedFile
     /**
      * Create a new {@link FileUpload} for a local file.
      * <br>This is used to upload data to discord for various purposes.
-     * Uses {@link Path#getFileName()} to specify the name of the file.
+     * Uses {@link Path#getFileName()} to specify the name of the file, to set the filename {@see fromData(Path, String, OpenOption...)}.
      *
      * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
      * You can use {@link FileUpload#close()} to close the stream manually.

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -248,6 +248,7 @@ public class FileUpload implements Closeable, AttachedFile
         return resource;
     }
 
+    @Override
     public void addPart(MultipartBody.Builder builder, int index)
     {
         builder.addFormDataPart("files[" + index + "]", name, IOUtil.createRequestBody(Requester.MEDIA_TYPE_OCTET, resource));

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -23,10 +23,10 @@ import net.dv8tion.jda.internal.utils.IOUtil;
 import okhttp3.MultipartBody;
 
 import javax.annotation.Nonnull;
-import java.io.ByteArrayInputStream;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
 
 /**
  * Represents a file that is intended to be uploaded to Discord for arbitrary requests.
@@ -93,6 +93,137 @@ public class FileUpload implements Closeable, AttachedFile
         Checks.notNull(data, "Data");
         Checks.notNull(name, "Name");
         return fromData(new ByteArrayInputStream(data), name);
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>This opens a {@link FileInputStream}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  file
+     *         The {@link File} to upload
+     * @param  name
+     *         The representative name to use for the file
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     *
+     * @see    java.io.FileInputStream FileInputStream
+     */
+    @Nonnull
+    public static FileUpload fromData(@Nonnull File file, @Nonnull String name)
+    {
+        Checks.notNull(file, "File");
+        try
+        {
+            return fromData(new FileInputStream(file), name);
+        }
+        catch (FileNotFoundException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>This opens a {@link FileInputStream}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  file
+     *         The {@link File} to upload
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     *
+     * @see    java.io.FileInputStream FileInputStream
+     * @see    #fromData(File, String)
+     */
+    @Nonnull
+    public static FileUpload fromData(@Nonnull File file)
+    {
+        Checks.notNull(file, "File");
+        try
+        {
+            return fromData(new FileInputStream(file), file.getName());
+        }
+        catch (FileNotFoundException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     *
+     * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  path
+     *         The {@link Path} of the file to upload
+     * @param  name
+     *         The representative name to use for the file
+     * @param  options
+     *         The {@link OpenOption OpenOptions} specifying how the file is opened
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided or the name is empty
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     */
+    @Nonnull
+    public static FileUpload fromData(@Nonnull Path path, @Nonnull String name, @Nonnull OpenOption... options)
+    {
+        Checks.notNull(path, "Path");
+        Checks.noneNull(options, "Options");
+        try
+        {
+            return fromData(Files.newInputStream(path, options), name);
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Create a new {@link FileUpload} for a local file.
+     * <br>This is used to upload data to discord for various purposes.
+     * Uses {@link Path#getFileName()} to specify the name of the file.
+     *
+     * <p>This opens the path using {@link Files#newInputStream(Path, OpenOption...)}, which will be closed on consumption by the request.
+     * You can use {@link FileUpload#close()} to close the stream manually.
+     *
+     * @param  path
+     *         The {@link Path} of the file to upload
+     * @param  options
+     *         The {@link OpenOption OpenOptions} specifying how the file is opened
+     *
+     * @throws IllegalArgumentException
+     *         If null is provided
+     * @throws UncheckedIOException
+     *         If an IOException is thrown while opening the file
+     *
+     * @return {@link FileUpload}
+     */
+    @Nonnull
+    public static FileUpload fromData(@Nonnull Path path, @Nonnull OpenOption... options)
+    {
+        return fromData(path, path.getFileName().toString(), options);
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -39,6 +39,7 @@ public class FileUpload implements Closeable, AttachedFile
 {
     private final InputStream resource;
     private final String name;
+    private boolean claimed = false;
 
     protected FileUpload(InputStream resource, String name)
     {
@@ -246,6 +247,20 @@ public class FileUpload implements Closeable, AttachedFile
     public InputStream getData()
     {
         return resource;
+    }
+
+    @Override
+    public synchronized void claim()
+    {
+        if (claimed)
+            throw new IllegalStateException("Instances of FileUpload can only be used once. Create a new instance with a new data source for each use.");
+        claimed = true;
+    }
+
+    @Override
+    public synchronized boolean isClaimed()
+    {
+        return claimed;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/FileUpload.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.internal.requests.Requester;
+import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.IOUtil;
+import okhttp3.MultipartBody;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+public class FileUpload implements Closeable
+{
+    private final InputStream resource;
+    private final String name;
+    private final long id;
+    private IOConsumer<InputStream> onClose;
+
+    protected FileUpload(InputStream resource, String name, long id, IOConsumer<InputStream> onClose)
+    {
+        this.resource = resource;
+        this.name = name;
+        this.id = id;
+        this.onClose = onClose;
+    }
+
+    @Nonnull
+    public static FileUpload fromData(@Nonnull InputStream data, @Nonnull String name)
+    {
+        Checks.notNull(data, "Data");
+        Checks.notNull(name, "Name");
+        return new FileUpload(data, name, 0, InputStream::close);
+    }
+
+    @Nonnull
+    public static FileUpload fromData(@Nonnull byte[] data, @Nonnull String name)
+    {
+        Checks.notNull(data, "Data");
+        Checks.notNull(name, "Name");
+        return fromData(new ByteArrayInputStream(data), name);
+    }
+
+    @Nonnull
+    public static FileUpload fromAttachment(long id)
+    {
+        return new FileUpload(null, null, id, null);
+    }
+
+    @Nonnull
+    public static FileUpload fromAttachment(@Nonnull String id)
+    {
+        return fromAttachment(MiscUtil.parseSnowflake(id));
+    }
+
+    @Nonnull
+    public static FileUpload fromAttachment(@Nonnull Message.Attachment attachment)
+    {
+        Checks.notNull(attachment, "Attachment");
+        return fromAttachment(attachment.getIdLong());
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        if (onClose != null && resource != null)
+            onClose.accept(resource);
+    }
+
+    public boolean isData()
+    {
+        return resource != null;
+    }
+
+    @Nullable
+    public String getName()
+    {
+        return name;
+    }
+
+    @Nullable
+    public InputStream getData()
+    {
+        return resource;
+    }
+
+    public long getId()
+    {
+        return id;
+    }
+
+    public void addPart(MultipartBody.Builder builder, int index)
+    {
+        builder.addFormDataPart("files[" + index + "]", name, IOUtil.createRequestBody(Requester.MEDIA_TYPE_OCTET, resource));
+    }
+
+    public static MultipartBody.Builder createMultipartBody(List<? extends FileUpload> files)
+    {
+        MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+        for (int i = 0; i < files.size(); i++)
+        {
+            FileUpload file = files.get(i);
+            file.addPart(builder, i);
+        }
+        return builder;
+    }
+}

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/MessageActionImpl.java
@@ -607,6 +607,8 @@ public class MessageActionImpl extends RestActionImpl<Message> implements Messag
     @SuppressWarnings({"deprecation", "ResultOfMethodCallIgnored"}) /* If this was in JDK9 we would be using java.lang.ref.Cleaner instead! */
     protected void finalize()
     {
+        if (files.isEmpty())
+            return;
         LOG.warn("Found unclosed resources in MessageAction instance, closing on finalization step!");
         clearFiles();
     }

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/WebhookMessageActionImpl.java
@@ -25,6 +25,7 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageAction;
+import net.dv8tion.jda.api.utils.AttachedFile;
 import net.dv8tion.jda.api.utils.AttachmentOption;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.data.DataArray;
@@ -48,7 +49,7 @@ public class WebhookMessageActionImpl<T>
 {
     private final StringBuilder content = new StringBuilder();
     private final List<MessageEmbed> embeds = new ArrayList<>();
-    private final List<FileUpload> files = new ArrayList<>();
+    private final List<AttachedFile> files = new ArrayList<>();
     private final AllowedMentionsImpl allowedMentions = new AllowedMentionsImpl();
     private final List<ActionRow> components = new ArrayList<>();
     private final MessageChannel channel;
@@ -198,7 +199,8 @@ public class WebhookMessageActionImpl<T>
         if (files.isEmpty())
             return getRequestBody(data);
 
-        MultipartBody.Builder body = FileUpload.createMultipartBody(files);
+        // TODO: Handle file edits better
+        MultipartBody.Builder body = AttachedFile.createMultipartBody(files, null);
         body.addFormDataPart("payload_json", data.toString());
         files.clear();
         return body.build();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/InteractionCallbackImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/InteractionCallbackImpl.java
@@ -20,7 +20,7 @@ import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
-import net.dv8tion.jda.api.utils.FileUpload;
+import net.dv8tion.jda.api.utils.AttachedFile;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.interactions.InteractionImpl;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
@@ -37,7 +37,7 @@ import java.util.function.Consumer;
 
 public abstract class InteractionCallbackImpl<T> extends RestActionImpl<T> implements InteractionCallbackAction<T>
 {
-    protected final List<FileUpload> files = new ArrayList<>();
+    protected final List<AttachedFile> files = new ArrayList<>();
     protected final InteractionImpl interaction;
 
     public InteractionCallbackImpl(InteractionImpl interaction)
@@ -55,7 +55,8 @@ public abstract class InteractionCallbackImpl<T> extends RestActionImpl<T> imple
         if (files.isEmpty())
             return getRequestBody(json);
 
-        MultipartBody.Builder body = FileUpload.createMultipartBody(files);
+        // TODO: Handle file edits better
+        MultipartBody.Builder body = AttachedFile.createMultipartBody(files, null);
         body.addFormDataPart("payload_json", json.toString());
         files.clear();
         return body.build();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/InteractionCallbackImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/InteractionCallbackImpl.java
@@ -75,6 +75,9 @@ public abstract class InteractionCallbackImpl<T> extends RestActionImpl<T> imple
     @SuppressWarnings({"deprecation", "ResultOfMethodCallIgnored"})
     protected void finalize()
     {
+        if (files.isEmpty())
+            return;
+        LOG.warn("Found open resources in interaction callback. Did you forget to close them?");
         closeResources();
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/MessageEditCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/MessageEditCallbackActionImpl.java
@@ -31,6 +31,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.InputStream;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 public class MessageEditCallbackActionImpl extends DeferrableCallbackActionImpl implements MessageEditCallbackAction
@@ -43,6 +45,34 @@ public class MessageEditCallbackActionImpl extends DeferrableCallbackActionImpl 
     public MessageEditCallbackActionImpl(InteractionHookImpl hook)
     {
         super(hook);
+    }
+
+    @Nonnull
+    @Override
+    public MessageEditCallbackActionImpl setCheck(BooleanSupplier checks)
+    {
+        return (MessageEditCallbackActionImpl) super.setCheck(checks);
+    }
+
+    @Nonnull
+    @Override
+    public MessageEditCallbackActionImpl timeout(long timeout, @Nonnull TimeUnit unit)
+    {
+        return (MessageEditCallbackActionImpl) super.timeout(timeout, unit);
+    }
+
+    @Nonnull
+    @Override
+    public MessageEditCallbackActionImpl deadline(long timestamp)
+    {
+        return (MessageEditCallbackActionImpl) super.deadline(timestamp);
+    }
+
+    @Nonnull
+    @Override
+    public MessageEditCallbackActionImpl closeResources()
+    {
+        return (MessageEditCallbackActionImpl) super.closeResources();
     }
 
     private boolean isEmpty()

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/MessageEditCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/MessageEditCallbackActionImpl.java
@@ -21,6 +21,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction;
 import net.dv8tion.jda.api.utils.AttachmentOption;
+import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.interactions.InteractionHookImpl;
@@ -129,7 +130,7 @@ public class MessageEditCallbackActionImpl extends DeferrableCallbackActionImpl 
         if (options.length > 0)
             name = "SPOILER_" + name;
 
-        files.put(name, data);
+        files.add(FileUpload.fromData(data, name));
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/ReplyCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/ReplyCallbackActionImpl.java
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.dv8tion.jda.api.utils.AttachmentOption;
+import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.interactions.InteractionHookImpl;
@@ -117,7 +118,7 @@ public class ReplyCallbackActionImpl extends DeferrableCallbackActionImpl implem
         if (options.length > 0)
             name = "SPOILER_" + name;
 
-        files.put(name, data);
+        files.add(FileUpload.fromData(data, name));
         return this;
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/ReplyCallbackActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/interactions/ReplyCallbackActionImpl.java
@@ -53,6 +53,13 @@ public class ReplyCallbackActionImpl extends DeferrableCallbackActionImpl implem
         super(hook);
     }
 
+    @Nonnull
+    @Override
+    public ReplyCallbackActionImpl closeResources()
+    {
+        return (ReplyCallbackActionImpl) super.closeResources();
+    }
+
     public ReplyCallbackActionImpl applyMessage(Message message)
     {
         this.content = message.getContentRaw();


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This changes the internal code used for handling file uploads in message requests. We are introducing a new utility class, which is planned to be utilized for both stickers and message sending.

### Example

Creating stickers:

```java
//                  name        file                                      tags
guild.createSticker("catLoser", FileUpload.fromData(new File("cat.png")), "cat", "animal").queue();
```

### Editing Messages

```java
List<AttachedFile> attached = new ArrayList<>();
// Add files to keep attached (blame discord, you have to list all in v10 if you want to add a single new file)
message.getAttachments()
  .stream()
  .map(AttachedFile::fromAttachment)
  .forEach(attached::add);
// Add new file ontop
attached.add(AttachedFile.fromData(new File("cat.png")));
message.editMessage("new content")
  .setAttachments(attached)
  .queue();
```