### PR TITLE
Added getJumpUrl method to GenericMessageEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.api.events.message;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 
@@ -165,7 +166,7 @@ public abstract class GenericMessageEvent extends Event
     @Nonnull
     public String getJumpUrl()
     {
-        return String.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getMessageId());
+        return Helpers.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getMessageId());
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -157,8 +157,8 @@ public abstract class GenericMessageEvent extends Event
     }
 
     /**
-     * Returns the jump-to URL for the received message. Clicking this URL in the Discord client will cause the client to
-     * jump to the specified message.
+     * Returns the jump-to URL for the received message.
+     * <br>Clicking this URL in the Discord client will cause the client to jump to the specified message.
      *
      * @return A String representing the jump-to URL for the message
      */

--- a/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/GenericMessageEvent.java
@@ -157,6 +157,18 @@ public abstract class GenericMessageEvent extends Event
     }
 
     /**
+     * Returns the jump-to URL for the received message. Clicking this URL in the Discord client will cause the client to
+     * jump to the specified message.
+     *
+     * @return A String representing the jump-to URL for the message
+     */
+    @Nonnull
+    public String getJumpUrl()
+    {
+        return String.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getMessageId());
+    }
+
+    /**
      * The {@link net.dv8tion.jda.api.entities.TextChannel TextChannel} the Message was received in.
      * <br>If this Message was not received in a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel},
      * this will throw an {@link java.lang.IllegalStateException}.

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
@@ -93,16 +93,6 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
                 : issuer;
     }
 
-    /**
-     * Returns the jump-to URL for the received message. Clicking this URL in the Discord client will cause the client to
-     * jump to the specified message.
-     *
-     * @return A String representing the jump-to URL for the message
-     */
-    @Nonnull
-    public String getJumpUrl() {
-        return String.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getMessageId());
-    }
 
     /**
      * The {@link net.dv8tion.jda.api.entities.Member Member} instance for the reacting user

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
@@ -94,6 +94,17 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
     }
 
     /**
+     * Returns the jump-to URL for the received message. Clicking this URL in the Discord client will cause the client to
+     * jump to the specified message.
+     *
+     * @return A String representing the jump-to URL for the message
+     */
+    @Nonnull
+    public String getJumpUrl() {
+        return String.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getMessageId());
+    }
+
+    /**
      * The {@link net.dv8tion.jda.api.entities.Member Member} instance for the reacting user
      * or {@code null} if the reaction was from a user not in this guild.
      * <br>This will also be {@code null} if the member is not available in the cache.

--- a/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/message/react/GenericMessageReactionEvent.java
@@ -93,7 +93,6 @@ public class GenericMessageReactionEvent extends GenericMessageEvent
                 : issuer;
     }
 
-
     /**
      * The {@link net.dv8tion.jda.api.entities.Member Member} instance for the reacting user
      * or {@code null} if the reaction was from a user not in this guild.

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -37,6 +37,7 @@ import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl;
 import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -331,7 +332,7 @@ public class ReceivedMessage extends AbstractMessage
     @Override
     public String getJumpUrl()
     {
-        return String.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getId());
+        return Helpers.format(Message.JUMP_URL, isFromGuild() ? getGuild().getId() : "@me", getChannel().getId(), getId());
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR adds a getJumpUrl method to the `GenericMessageReactionEvent`, as you had to create your own method for this before.