### PR TITLE
Remove checks for archive durations

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/managers/channel/concrete/ThreadChannelManager.java
+++ b/src/main/java/net/dv8tion/jda/api/managers/channel/concrete/ThreadChannelManager.java
@@ -73,9 +73,6 @@ public interface ThreadChannelManager extends ChannelManager<ThreadChannel, Thre
      *
      * @return this ThreadChannelManager for chaining convenience.
      *
-     * @throws IllegalArgumentException
-     *         If the provided duration is not supported by this guild due to the guild boost requirements for higher durations.
-     *
      * @see ThreadChannel#getAutoArchiveDuration()
      */
     ThreadChannelManager setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration autoArchiveDuration);

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
@@ -471,15 +471,6 @@ public class ChannelManagerImpl<T extends GuildChannel, M extends ChannelManager
         if (!type.isThread())
             throw new IllegalStateException("Can only set autoArchiveDuration on threads");
 
-        Set<String> features = getGuild().getFeatures();
-        if (autoArchiveDuration == ThreadChannel.AutoArchiveDuration.TIME_3_DAYS && !features.contains("THREE_DAY_THREAD_ARCHIVE"))
-            throw new IllegalArgumentException("Cannot use TIME_3_DAYS archive duration because feature isn't supported on this Guild." +
-                    " Missing THREE_DAY_THREAD_ARCHIVE feature due to boost level being too low.");
-
-        if (autoArchiveDuration == ThreadChannel.AutoArchiveDuration.TIME_1_WEEK && !features.contains("SEVEN_DAY_THREAD_ARCHIVE"))
-            throw new IllegalArgumentException("Cannot use TIME_1_WEEK archive duration because feature isn't supported on this Guild." +
-                    " Missing SEVEN_DAY_THREAD_ARCHIVE feature due to boost level being too low.");
-
         this.autoArchiveDuration = autoArchiveDuration;
         set |= AUTO_ARCHIVE_DURATION;
         return (M) this;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ThreadChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ThreadChannelActionImpl.java
@@ -115,16 +115,6 @@ public class ThreadChannelActionImpl extends AuditableRestActionImpl<ThreadChann
     public ThreadChannelAction setAutoArchiveDuration(@Nonnull ThreadChannel.AutoArchiveDuration autoArchiveDuration)
     {
         Checks.notNull(autoArchiveDuration, "autoArchiveDuration");
-
-        Set<String> features = guild.getFeatures();
-        if (autoArchiveDuration == ThreadChannel.AutoArchiveDuration.TIME_3_DAYS && !features.contains("THREE_DAY_THREAD_ARCHIVE"))
-            throw new IllegalStateException("Cannot use TIME_3_DAYS archive duration because feature isn't supported on this Guild." +
-                    " Missing THREE_DAY_THREAD_ARCHIVE feature due to boost level being too low.");
-
-        if (autoArchiveDuration == ThreadChannel.AutoArchiveDuration.TIME_1_WEEK && !features.contains("SEVEN_DAY_THREAD_ARCHIVE"))
-            throw new IllegalStateException("Cannot use TIME_1_WEEK archive duration because feature isn't supported on this Guild." +
-                    " Missing SEVEN_DAY_THREAD_ARCHIVE feature due to boost level being too low.");
-
         this.autoArchiveDuration = autoArchiveDuration;
         return this;
     }


### PR DESCRIPTION
Discord removed the unlockable duration of three / seven days of auto archiving.
![image](https://user-images.githubusercontent.com/54246610/167424882-bf3a7f76-dfe6-4040-9ad8-b443fc587954.png)
