### PR TITLE
Fix Message.Attachment#getProxy()

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2696,7 +2696,7 @@ public interface Message extends ISnowflake, Formattable
         @Nonnull
         public String getProxyUrl()
         {
-            return proxyUrl;
+            return isImage() ? proxyUrl : url;
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2709,7 +2709,7 @@ public interface Message extends ISnowflake, Formattable
         @Nonnull
         public AttachmentProxy getProxy()
         {
-            return new AttachmentProxy(isImage() ? proxyUrl : url);
+            return new AttachmentProxy(width > 0 && height > 0 ? proxyUrl : url);
         }
 
         /**

--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -2696,7 +2696,7 @@ public interface Message extends ISnowflake, Formattable
         @Nonnull
         public String getProxyUrl()
         {
-            return isImage() ? proxyUrl : url;
+            return proxyUrl;
         }
 
         /**
@@ -2709,7 +2709,7 @@ public interface Message extends ISnowflake, Formattable
         @Nonnull
         public AttachmentProxy getProxy()
         {
-            return new AttachmentProxy(getProxyUrl());
+            return new AttachmentProxy(isImage() ? proxyUrl : url);
         }
 
         /**


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes `Message.Attachment#getProxy()`, the proxy url returns status code 415 (unsupported media type) for non-image attachments.
