### PR TITLE
Add newly_created field to ThreadChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/ThreadChannel.java
@@ -110,6 +110,15 @@ public interface ThreadChannel extends GuildMessageChannel, IMemberContainer
     boolean isInvitable();
 
     /**
+     * Whether this thread is newly created.
+     * <br>
+     * Indicates whether a thread was newly created in an {@link net.dv8tion.jda.api.events.channel.ChannelCreateEvent event}.
+     *
+     * @return true if this thread was newly created, false if not from an {@link net.dv8tion.jda.api.events.channel.ChannelCreateEvent event} or the self member just joined the thread.
+     */
+    boolean isNewlyCreated();
+
+    /**
      * Gets the {@link IThreadContainer parent channel} of this thread.
      *
      * @see IThreadContainer#getThreadChannels()

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1167,6 +1167,7 @@ public class EntityBuilder
                 .setLocked(threadMetadata.getBoolean("locked"))
                 .setArchived(threadMetadata.getBoolean("archived"))
                 .setInvitable(threadMetadata.getBoolean("invitable"))
+                .setNewlyCreated(threadMetadata.getBoolean("newly_created"))
                 .setArchiveTimestamp(Helpers.toTimestamp(threadMetadata.getString("archive_timestamp")))
                 .setCreationTimestamp(threadMetadata.isNull("create_timestamp") ? 0 : Helpers.toTimestamp(threadMetadata.getString("create_timestamp")))
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.fromKey(threadMetadata.getInt("auto_archive_duration")));

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1164,10 +1164,10 @@ public class EntityBuilder
                 .setMessageCount(json.getInt("message_count"))
                 .setLatestMessageIdLong(json.getLong("last_message_id", 0))
                 .setSlowmode(json.getInt("rate_limit_per_user", 0))
+                .setNewlyCreated(json.getBoolean("newly_created"))
                 .setLocked(threadMetadata.getBoolean("locked"))
                 .setArchived(threadMetadata.getBoolean("archived"))
                 .setInvitable(threadMetadata.getBoolean("invitable"))
-                .setNewlyCreated(threadMetadata.getBoolean("newly_created"))
                 .setArchiveTimestamp(Helpers.toTimestamp(threadMetadata.getString("archive_timestamp")))
                 .setCreationTimestamp(threadMetadata.isNull("create_timestamp") ? 0 : Helpers.toTimestamp(threadMetadata.getString("create_timestamp")))
                 .setAutoArchiveDuration(ThreadChannel.AutoArchiveDuration.fromKey(threadMetadata.getInt("auto_archive_duration")));

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -51,6 +51,7 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
     private boolean locked;
     private boolean archived;
     private boolean invitable;
+    private boolean newlyCreated;
     private long parentChannelId;
     private long archiveTimestamp;
     private long creationTimestamp;
@@ -206,6 +207,12 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
     }
 
     @Override
+    public boolean isNewlyCreated()
+    {
+        return newlyCreated;
+    }
+
+    @Override
     public OffsetDateTime getTimeArchiveInfoLastModified()
     {
         return Helpers.toOffset(archiveTimestamp);
@@ -318,6 +325,12 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
     public ThreadChannelImpl setInvitable(boolean invitable)
     {
         this.invitable = invitable;
+        return this;
+    }
+
+    public ThreadChannelImpl setNewlyCreated(boolean newlyCreated)
+    {
+        this.newlyCreated = newlyCreated;
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: N/A

## Description

Adds a new method `isNewlyCreated` to ThreadChannel so you can differenciate when a ThreadChannel is created or if the self member joined the thread