### PR TITLE
default to an empty string in Emoji#fromData

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/emoji/Emoji.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/emoji/Emoji.java
@@ -174,7 +174,7 @@ public interface Emoji extends SerializableData, Formattable
         if (emoji.isNull("id"))
             return (EmojiUnion) fromUnicode(emoji.getString("name"));
         else
-            return (EmojiUnion) fromCustom(emoji.getString("name"), emoji.getUnsignedLong("id"), emoji.getBoolean("animated"));
+            return (EmojiUnion) fromCustom(emoji.getString("name", ""), emoji.getUnsignedLong("id"), emoji.getBoolean("animated"));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmojiHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionClearEmojiHandler.java
@@ -67,8 +67,6 @@ public class MessageReactionClearEmojiHandler extends SocketHandler
 
         long messageId = content.getUnsignedLong("message_id");
         DataObject emoji = content.getObject("emoji");
-        if (emoji.isNull("name"))
-            emoji.put("name", "");
         EmojiUnion reactionEmoji = Emoji.fromData(emoji);
 
         MessageReaction reaction = new MessageReaction(channel, reactionEmoji, messageId, false, 0);

--- a/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/MessageReactionHandler.java
@@ -147,11 +147,7 @@ public class MessageReactionHandler extends SocketHandler
             );
         }
 
-        // reaction remove has null name sometimes
-        if (emoji.isNull("name"))
-            emoji.put("name", "");
         EmojiUnion rEmoji = Emoji.fromData(emoji);
-
         MessageReaction reaction = new MessageReaction(channel, rEmoji, messageId, userId == api.getSelfUser().getIdLong(), -1);
 
         if (channel.getType() == ChannelType.PRIVATE)


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

this PR fixes possible exceptions when `name` in emoji objects is `null`, as mentioned in [this example in the api docs](https://discord.com/developers/docs/resources/emoji#emoji-object-custom-emoji-examples).