### PR TITLE
Fixed permission checks when managing/deleting a thread

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -54,9 +54,7 @@ public interface GuildChannel extends Channel, Comparable<GuildChannel>
      * @return The {@link Permission}
      */
     @Nonnull
-    default Permission getManagePermission() {
-    	return Permission.MANAGE_CHANNEL;
-    }
+    Permission getManagePermission();
 
     /**
      * TODO-v5: this override might not be needed anymore if we remove AuditableRestAction and instead place auditable hooks onto RestAction itself.

--- a/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/GuildChannel.java
@@ -1,6 +1,7 @@
 package net.dv8tion.jda.api.entities;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.managers.channel.ChannelManager;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.internal.utils.Helpers;
@@ -39,12 +40,23 @@ public interface GuildChannel extends Channel, Comparable<GuildChannel>
      * This getter is not thread-safe and would require guards by the user.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_CHANNEL Permission.MANAGE_CHANNEL}
+     *         If the currently logged in account does not have the required {@link #getManagePermission() permission}
      *
      * @return The ChannelManager of this GuildChannel
      */
     @Nonnull
     ChannelManager<?, ?> getManager();
+    
+    /**
+     * Returns the {@link Permission} needed in order to manage or delete this channel.
+     * This returns {@link Permission#MANAGE_CHANNEL} or {@link Permission#MANAGE_THREADS} for {@link ThreadChannel ThreadChannels}
+     * 
+     * @return The {@link Permission}
+     */
+    @Nonnull
+    default Permission getManagePermission() {
+    	return Permission.MANAGE_CHANNEL;
+    }
 
     /**
      * TODO-v5: this override might not be needed anymore if we remove AuditableRestAction and instead place auditable hooks onto RestAction itself.

--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -280,6 +280,12 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         return new ThreadChannelManagerImpl(this);
     }
 
+    @Nonnull
+    @Override
+    public Permission getManagePermission() {
+    	return Permission.MANAGE_THREADS;
+    }
+
     public CacheView.SimpleCacheView<ThreadMember> getThreadMemberView()
     {
         return threadMembers;

--- a/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/GuildChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/GuildChannelMixin.java
@@ -39,7 +39,7 @@ public interface GuildChannelMixin<T extends GuildChannelMixin<T>> extends
     @CheckReturnValue
     default AuditableRestAction<Void> delete()
     {
-        checkPermission(Permission.MANAGE_CHANNEL);
+        checkPermission(this.getManagePermission());
 
         Route.CompiledRoute route = Route.Channels.DELETE_CHANNEL.compile(getId());
         return new AuditableRestActionImpl<>(getJDA(), route);

--- a/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/GuildChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/GuildChannelMixin.java
@@ -45,6 +45,11 @@ public interface GuildChannelMixin<T extends GuildChannelMixin<T>> extends
         return new AuditableRestActionImpl<>(getJDA(), route);
     }
 
+    @Override
+    default Permission getManagePermission() {
+    	return Permission.MANAGE_CHANNEL;
+    }
+
     // ---- Helpers ---
     default boolean hasPermission(Permission permission)
     {

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
@@ -571,8 +571,8 @@ public class ChannelManagerImpl<T extends GuildChannel, M extends ChannelManager
         final Member selfMember = getGuild().getSelfMember();
 
         Checks.checkAccess(selfMember, channel);
-        if (!selfMember.hasPermission(channel, Permission.MANAGE_CHANNEL))
-            throw new InsufficientPermissionException(channel, Permission.MANAGE_CHANNEL);
+        if (!selfMember.hasPermission(channel, channel.getManagePermission()))
+            throw new InsufficientPermissionException(channel, channel.getManagePermission());
 
         return super.checkPermissions();
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2188 

## Description

When calling `ThreadChannel#getManager` or `ThreadChannel#delete` it is currently checked if the user has the `MANAGE_CHANNEL` permission, but the permission actually required to manage or delete a thread is `MANAGE_THREADS`.