### PR TITLE
Purge messages fix

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/MessageChannel.java
@@ -136,7 +136,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageIds
      *         The message ids to delete
      *
-     * @return List of futures representing all deletion tasks
+     * @return A futures representing all deletion tasks
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
@@ -162,7 +162,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageIds
      *         The message ids to delete
      *
-     * @return List of futures representing all deletion tasks
+     * @return A futures representing all deletion tasks
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
@@ -220,7 +220,7 @@ public interface MessageChannel extends Channel, Formattable
      * @throws IllegalArgumentException
      *         If one of the provided messages is from another user and cannot be deleted because this is not in a guild
      *
-     * @return List of futures representing all deletion tasks
+     * @return A futures representing all deletion tasks
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */
@@ -260,7 +260,7 @@ public interface MessageChannel extends Channel, Formattable
      * @param  messageIds
      *         The message ids to delete
      *
-     * @return List of futures representing all deletion tasks
+     * @return A future representing all deletion tasks
      *
      * @see    CompletableFuture#allOf(java.util.concurrent.CompletableFuture[])
      */

--- a/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/MessageChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/MessageChannelMixin.java
@@ -45,10 +45,10 @@ public interface MessageChannelMixin<T extends MessageChannelMixin<T>> extends
 {
     // ---- Default implementations of interface ----
     @Nonnull
-    default List<CompletableFuture<Void>> purgeMessages(@Nonnull List<? extends Message> messages)
+    default CompletableFuture<Void> purgeMessages(@Nonnull List<? extends Message> messages)
     {
         if (messages == null || messages.isEmpty())
-            return Collections.emptyList();
+            return new CompletableFuture<>();
 
         if (!canDeleteOtherUsersMessages())
         {
@@ -68,10 +68,10 @@ public interface MessageChannelMixin<T extends MessageChannelMixin<T>> extends
     }
 
     @Nonnull
-    default List<CompletableFuture<Void>> purgeMessagesById(@Nonnull long... messageIds)
+    default CompletableFuture<Void> purgeMessagesById(@Nonnull long... messageIds)
     {
         if (messageIds == null || messageIds.length == 0)
-            return Collections.emptyList();
+            return new CompletableFuture<>();
 
         //If we can't use the bulk delete system, then use the standard purge defined in MessageChannel
         if (!canDeleteOtherUsersMessages())
@@ -115,7 +115,7 @@ public interface MessageChannelMixin<T extends MessageChannelMixin<T>> extends
             for (long message : norm)
                 list.add(deleteMessageById(message).submit());
         }
-        return list;
+        return CompletableFuture.allOf(list.toArray(new CompletableFuture[0]));
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: https://github.com/DV8FromTheWorld/JDA/projects/5#card-68160609

## Description

This Pull Request changes the return type of `MessageChannel#purgeMEssages` from `List<CompletableFuture<Void>>` to `CompletableFuture<Void>` .
It internally uses the `CompletableFuture#allOf` method to convert it to a single CompletableFuture