### PR TITLE
Improve usage of cache in Guild#retrieveMemberById

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/CacheRestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/CacheRestAction.java
@@ -16,10 +16,13 @@
 
 package net.dv8tion.jda.api.requests.restaction;
 
-import net.dv8tion.jda.api.requests.FluentRestAction;
+import net.dv8tion.jda.api.requests.RestAction;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 /**
  * Requests which can use cached values instead of making a request to Discord.
@@ -27,8 +30,33 @@ import javax.annotation.Nonnull;
  * @param <T>
  *        The entity type
  */
-public interface CacheRestAction<T> extends FluentRestAction<T, CacheRestAction<T>>
+public interface CacheRestAction<T> extends RestAction<T>
 {
+    @Nonnull
+    @Override
+    CacheRestAction<T> setCheck(@Nullable BooleanSupplier checks);
+
+    @Nonnull
+    @Override
+    default CacheRestAction<T> addCheck(@Nonnull BooleanSupplier checks)
+    {
+        return (CacheRestAction<T>) RestAction.super.addCheck(checks);
+    }
+
+    @Nonnull
+    @Override
+    default CacheRestAction<T> timeout(long timeout, @Nonnull TimeUnit unit)
+    {
+        return (CacheRestAction<T>) RestAction.super.timeout(timeout, unit);
+    }
+
+    @Nonnull
+    @Override
+    default CacheRestAction<T> deadline(long timestamp)
+    {
+        return (CacheRestAction<T>) RestAction.super.deadline(timestamp);
+    }
+
     /**
      * Sets whether this request should rely on cached entities, or always retrieve a new one.
      *

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/CacheRestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/CacheRestAction.java
@@ -16,13 +16,10 @@
 
 package net.dv8tion.jda.api.requests.restaction;
 
-import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.requests.FluentRestAction;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
 
 /**
  * Requests which can use cached values instead of making a request to Discord.
@@ -30,33 +27,8 @@ import java.util.function.BooleanSupplier;
  * @param <T>
  *        The entity type
  */
-public interface CacheRestAction<T> extends RestAction<T>
+public interface CacheRestAction<T> extends FluentRestAction<T, CacheRestAction<T>>
 {
-    @Nonnull
-    @Override
-    CacheRestAction<T> setCheck(@Nullable BooleanSupplier checks);
-
-    @Nonnull
-    @Override
-    default CacheRestAction<T> addCheck(@Nonnull BooleanSupplier checks)
-    {
-        return (CacheRestAction<T>) RestAction.super.addCheck(checks);
-    }
-
-    @Nonnull
-    @Override
-    default CacheRestAction<T> timeout(long timeout, @Nonnull TimeUnit unit)
-    {
-        return (CacheRestAction<T>) RestAction.super.timeout(timeout, unit);
-    }
-
-    @Nonnull
-    @Override
-    default CacheRestAction<T> deadline(long timestamp)
-    {
-        return (CacheRestAction<T>) RestAction.super.deadline(timestamp);
-    }
-
     /**
      * Sets whether this request should rely on cached entities, or always retrieve a new one.
      *

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -16,6 +16,9 @@
 
 package net.dv8tion.jda.internal.entities;
 
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
+import gnu.trove.set.TLongSet;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.audio.hooks.ConnectionStatus;
@@ -73,7 +76,12 @@ import net.dv8tion.jda.internal.utils.cache.MemberCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.concurrent.task.GatewayTask;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
 
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.*;
@@ -82,16 +90,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import gnu.trove.map.TLongObjectMap;
-import gnu.trove.map.hash.TLongObjectHashMap;
-import gnu.trove.set.TLongSet;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
 
 public class GuildImpl implements Guild
 {
@@ -1098,28 +1096,14 @@ public class GuildImpl implements Guild
         return new GatewayTask<>(handler, () -> handler.cancel(false));
     }
 
-    // Helper function for deferred cache access
-    private Member getMember(long id, JDAImpl jda)
-    {
-        if (jda.isIntent(GatewayIntent.GUILD_MEMBERS))
-        {
-            // return member from cache if member tracking is enabled through intents
-            Member member = getMemberById(id);
-            // if the join time is inaccurate we also have to load it through REST to update this information
-            if (member != null && member.hasTimeJoined())
-                return member;
-        }
-        return null;
-    }
-
     @Nonnull
     @Override
     public CacheRestAction<Member> retrieveMemberById(long id)
     {
         JDAImpl jda = getJDA();
         return new DeferredRestAction<>(jda, Member.class,
-                () -> getMember(id, jda),
-                () -> { // otherwise we need to update the member with a REST request first to get the nickname/roles
+                () -> getMemberById(id),
+                () -> {
                     if (id == jda.getSelfUser().getIdLong())
                         return new CompletedRestAction<>(jda, getSelfMember());
                     Route.CompiledRoute route = Route.Guilds.GET_MEMBER.compile(getId(), Long.toUnsignedString(id));

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -1112,7 +1112,7 @@ public class GuildImpl implements Guild
                         jda.getEntityBuilder().updateMemberCache(member);
                         return member;
                     });
-                });
+                }).useCache(jda.isIntent(GatewayIntent.GUILD_MEMBERS));
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This makes `retrieveMemberById(id).useCache(true)` always rely on cache, even when its outdated.
