### PR TITLE
Fix ban pagination

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/BanPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/BanPaginationActionImpl.java
@@ -19,6 +19,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.requests.Request;
 import net.dv8tion.jda.api.requests.Response;
 import net.dv8tion.jda.api.requests.restaction.pagination.BanPaginationAction;
+import net.dv8tion.jda.api.requests.restaction.pagination.PaginationAction;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
@@ -39,10 +40,22 @@ public class BanPaginationActionImpl
     {
         super(guild.getJDA(), Route.Guilds.GET_BANS.compile(guild.getId()), 1, 1000, 1000);
         this.guild = guild;
+        this.lastKey = Long.MAX_VALUE;
     }
 
-    @Override
     @Nonnull
+    @Override
+    public BanPaginationAction order(@Nonnull PaginationAction.PaginationOrder order)
+    {
+        if (order == PaginationOrder.BACKWARD && lastKey == 0)
+            lastKey = Long.MAX_VALUE;
+        else if (order == PaginationOrder.FORWARD && lastKey == Long.MAX_VALUE)
+            lastKey = 0;
+        return super.order(order);
+    }
+
+    @Nonnull
+    @Override
     public Guild getGuild()
     {
         return guild;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes #2199 

## Description

This fixes pagination for `Guild#retrieveBanList`. The problem was that backwards iteration has to explicitly tell it to start before the newest ID (since it is descending rather than ascending in that case).
