### PR TITLE
Implement gateway resume url handling

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -90,6 +90,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
     protected volatile String sessionId = null;
     protected final Object readLock = new Object();
     protected Decompressor decompressor;
+    protected String resumeUrl = null;
 
     protected final ReentrantLock queueLock = new ReentrantLock();
     protected final ScheduledExecutorService executor;
@@ -345,7 +346,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
             throw new RejectedExecutionException("JDA is shutdown!");
         initiating = true;
 
-        String url = api.getGatewayUrl()
+        String url = resumeUrl != null ? resumeUrl : api.getGatewayUrl()
                 + "?encoding=" + encoding.name().toLowerCase()
                 + "&v=" + JDAInfo.DISCORD_GATEWAY_VERSION;
         if (compression != Compression.NONE)
@@ -738,6 +739,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
     protected void invalidate()
     {
+        resumeUrl = null;
         sessionId = null;
         sentAuthInfo = false;
 
@@ -926,6 +928,7 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
                     // otherwise the audio connection requests that are currently pending might be removed in the process
                     handlers.get("READY").handle(responseTotal, raw);
                     sessionId = content.getString("session_id");
+                    resumeUrl = content.getString("resume_gateway_url", null);
                     break;
                 case "RESUMED":
                     reconnectTimeoutS = 2;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Implements the new gateway resume URL added to the READY dispatch.

Reference: discord/discord-api-docs#5282
