### PR TITLE
Add support for setting voice region on channel creation/copy

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
@@ -17,6 +17,7 @@
 package net.dv8tion.jda.api.requests.restaction;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.utils.MiscUtil;
 import net.dv8tion.jda.internal.utils.Checks;
@@ -592,4 +593,19 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
     @Nonnull
     @CheckReturnValue
     ChannelAction<T> setUserlimit(@Nullable Integer userlimit);
+
+    /**
+     * Sets the voice region for the new AudioChannel
+     *
+     * @param   region
+     *          The region for the new AudioChannel, or {@code null} to set to {@link Region#AUTOMATIC}
+     *
+     * @throws UnsupportedOperationException
+     *         If this ChannelAction is not for an AudioChannel
+     *
+     * @return The current ChannelAction, for chaining convenience
+     */
+    @Nonnull
+    @CheckReturnValue
+    ChannelAction<T> setRegion(@Nullable Region region);
 }

--- a/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/restaction/ChannelAction.java
@@ -597,8 +597,8 @@ public interface ChannelAction<T extends GuildChannel> extends AuditableRestActi
     /**
      * Sets the voice region for the new AudioChannel
      *
-     * @param   region
-     *          The region for the new AudioChannel, or {@code null} to set to {@link Region#AUTOMATIC}
+     * @param  region
+     *         The region for the new AudioChannel, or {@code null} to set to {@link Region#AUTOMATIC}
      *
      * @throws UnsupportedOperationException
      *         If this ChannelAction is not for an AudioChannel

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.entities;
 
 import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.channel.concrete.StageChannelManager;

--- a/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/StageChannelImpl.java
@@ -111,8 +111,14 @@ public class StageChannelImpl extends AbstractStandardGuildChannelImpl<StageChan
     public ChannelAction<StageChannel> createCopy(@Nonnull Guild guild)
     {
         Checks.notNull(guild, "Guild");
-        //TODO-v5: .setRegion here?
+
         ChannelAction<StageChannel> action = guild.createStageChannel(name).setBitrate(bitrate);
+
+        if (region != null)
+        {
+            action.setRegion(Region.fromKey(region));
+        }
+
         if (guild.equals(getGuild()))
         {
             Category parent = getParentCategory();

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -116,7 +116,8 @@ public class VoiceChannelImpl extends AbstractStandardGuildChannelImpl<VoiceChan
                 .setBitrate(bitrate)
                 .setUserlimit(userLimit);
 
-        if(region != null) {
+        if (region != null)
+        {
             action.setRegion(Region.fromKey(region));
         }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/VoiceChannelImpl.java
@@ -18,6 +18,7 @@ package net.dv8tion.jda.internal.entities;
 
 import gnu.trove.map.TLongObjectMap;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.managers.channel.concrete.VoiceChannelManager;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
@@ -110,8 +111,15 @@ public class VoiceChannelImpl extends AbstractStandardGuildChannelImpl<VoiceChan
     public ChannelAction<VoiceChannel> createCopy(@Nonnull Guild guild)
     {
         Checks.notNull(guild, "Guild");
-        //TODO-v5: .setRegion here?
-        ChannelAction<VoiceChannel> action = guild.createVoiceChannel(name).setBitrate(bitrate).setUserlimit(userLimit);
+
+        ChannelAction<VoiceChannel> action = guild.createVoiceChannel(name)
+                .setBitrate(bitrate)
+                .setUserlimit(userLimit);
+
+        if(region != null) {
+            action.setRegion(Region.fromKey(region));
+        }
+
         if (guild.equals(getGuild()))
         {
             Category parent = getParentCategory();

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.requests.restaction;
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.Region;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.requests.Request;
@@ -34,6 +35,7 @@ import okhttp3.RequestBody;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -62,6 +64,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
 
     // --voice and stage--
     protected Integer bitrate = null;
+    protected Region region = null;
 
     public ChannelActionImpl(Class<T> clazz, String name, Guild guild, ChannelType type)
     {
@@ -328,6 +331,17 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         return this;
     }
 
+    @Nonnull
+    @Override
+    @CheckReturnValue
+    public ChannelActionImpl<T> setRegion(@Nullable Region region)
+    {
+        if (!type.isAudio())
+            throw new UnsupportedOperationException("Can only set the region for AudioChannels!");
+        this.region = region;
+        return this;
+    }
+
     @Override
     protected RequestBody finalizeData()
     {
@@ -359,6 +373,8 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
         //Voice and Stage
         if (bitrate != null)
             object.put("bitrate", bitrate);
+        if (region != null)
+            object.put("rtc_region", region.getKey());
 
         return getRequestBody(object);
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2208 

## Description

This PR adds support for users to set the voice region of audio channels on creation/copy. Closes #2208 

## Example Code

```java
// also works with `createStageChannel`
guild.createVoiceChannel("brazil").setRegion(Region.BRAZIL)  // creates a voice channel, with Brazil region
    .flatmap(channel -> channel.createCopy().setName("brazil 2"))  // creates a second voice channel, also Brazil region
    .queue();
```
