### PR TITLE
Fix CommandAutoCompleteInteraction#getChannel

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandAutoCompleteInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandAutoCompleteInteractionImpl.java
@@ -77,9 +77,10 @@ public class CommandAutoCompleteInteractionImpl extends InteractionImpl implemen
 
     @Nonnull
     @Override
+    @SuppressWarnings("ConstantConditions")
     public MessageChannelUnion getChannel()
     {
-        return (MessageChannelUnion) super.getMessageChannel();
+        return (MessageChannelUnion) super.getChannel();
     }
 
     @Override


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This caused a StackOverflowException, since getMessageChannel just calls getChannel.
