### PR TITLE
Add DataPath util

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataArray.java
@@ -542,6 +542,44 @@ public class DataArray implements Iterable<Object>, SerializableArray
     }
 
     /**
+     * Resolves the value at the specified index to a double.
+     *
+     * @param  index
+     *         The index to resolve
+     *
+     * @throws net.dv8tion.jda.api.exceptions.ParsingException
+     *         If the value is of the wrong type
+     *
+     * @return The resolved double value
+     */
+    public double getDouble(int index)
+    {
+        Double value = get(Double.class, index, Double::parseDouble, Number::doubleValue);
+        if (value == null)
+            throw valueError(index, "double");
+        return value;
+    }
+
+    /**
+     * Resolves the value at the specified index to a double.
+     *
+     * @param  index
+     *         The index to resolve
+     * @param  defaultValue
+     *         Alternative value to use when the value associated with the index is null
+     *
+     * @throws net.dv8tion.jda.api.exceptions.ParsingException
+     *         If the value is of the wrong type
+     *
+     * @return The resolved double value
+     */
+    public double getDouble(int index, double defaultValue)
+    {
+        Double value = get(Double.class, index, Double::parseDouble, Number::doubleValue);
+        return value == null ? defaultValue : value;
+    }
+
+    /**
      * Appends the provided value to the end of the array.
      *
      * @param  value

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataPath.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataPath.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.api.utils.data;
+
+import net.dv8tion.jda.api.exceptions.ParsingException;
+import net.dv8tion.jda.internal.utils.Checks;
+import org.jetbrains.annotations.Contract;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiFunction;
+import java.util.regex.Pattern;
+
+// TODO: Documentation and Unit Tests
+public class DataPath
+{
+    private static final Pattern INDEX_EXPRESSION = Pattern.compile("^\\[\\d+].*");
+
+    public static <T> T get(@Nonnull DataObject root, @Nonnull String path, @Nonnull BiFunction<DataObject, String, ? extends T> fromObject, @Nonnull BiFunction<DataArray, Integer, ? extends T> fromArray)
+    {
+        Checks.notEmpty(path, "Path");
+        Checks.notNull(root, "DataObject");
+        Checks.notNull(fromObject, "Object Resolver");
+        Checks.notNull(fromArray, "Array Resolver");
+        return getUnchecked(root, path, fromObject, fromArray);
+    }
+
+    private static <T> T getUnchecked(DataObject root, String path, BiFunction<DataObject, String, ? extends T> fromObject, BiFunction<DataArray, Integer, ? extends T> fromArray)
+    {
+        String[] parts = path.split("\\.", 2);
+        String current = parts[0];
+        String child = parts.length > 1 ? parts[1] : null;
+
+        // if key is array according to index in path
+        if (current.indexOf('[') > -1)
+        {
+            int arrayIndex = current.indexOf('[');
+            String key = current.substring(0, arrayIndex);
+            path = current.substring(arrayIndex);
+
+            // isOptional
+            if (key.endsWith("?"))
+            {
+                key = key.substring(0, key.length() - 1);
+                if (root.isNull(key))
+                    return null;
+            }
+
+            return getUnchecked(root.getArray(key), path, fromObject, fromArray);
+        }
+
+        boolean isOptional = current.endsWith("?");
+        if (isOptional)
+            current = current.substring(0, current.length() - 1);
+
+        if (child == null)
+        {
+            if (isOptional && root.isNull(current))
+                return null;
+            return fromObject.apply(root, current);
+        }
+
+        if (isOptional && root.isNull(current))
+            return null;
+
+        return getUnchecked(root.getObject(current), child, fromObject, fromArray);
+    }
+
+    public static <T> T get(@Nonnull DataArray root, @Nonnull String path, @Nonnull BiFunction<DataObject, String, ? extends T> fromObject, @Nonnull BiFunction<DataArray, Integer, ? extends T> fromArray)
+    {
+        Checks.notNull(root, "DataArray");
+        Checks.notEmpty(path, "Path");
+        Checks.matches(path, INDEX_EXPRESSION, "Path");
+        Checks.notNull(fromObject, "Object Resolver");
+        Checks.notNull(fromArray, "Array Resolver");
+        return getUnchecked(root, path, fromObject, fromArray);
+    }
+
+    private static <T> T getUnchecked(DataArray root, String path, BiFunction<DataObject, String, ? extends T> fromObject, BiFunction<DataArray, Integer, ? extends T> fromArray)
+    {
+        byte[] chars = path.getBytes(StandardCharsets.UTF_8);
+        int offset = 0;
+
+        // This is just to prevent infinite loop if some strange thing happens, should be impossible
+        for (int i = 0; i < chars.length; i++)
+        {
+            int end = indexOf(chars, offset + 1, ']');
+            int index = Integer.parseInt(path.substring(offset + 1, end));
+
+            offset = Math.min(chars.length, end + 1);
+            boolean optional = offset != chars.length && chars[offset] == '?';
+
+            if (optional)
+            {
+                offset++;
+                if (root.isNull(index))
+                    return null;
+            }
+
+            if (offset == chars.length)
+                return optional && root.isNull(index) ? null : fromArray.apply(root, index);
+
+            if (chars[offset] == '[')
+                root = root.getArray(index);
+            else
+                return getUnchecked(root.getObject(index), path.substring(offset), fromObject, fromArray);
+        }
+
+        throw new ParsingException("Array path nesting seems to be way too deep, we went " + chars.length + " arrays deep. Path: " + path);
+    }
+
+    private static int indexOf(byte[] chars, int offset, char c)
+    {
+        byte b = (byte) c;
+        for (int i = offset; i < chars.length; i++)
+            if (chars[i] == b)
+                return i;
+        return -1;
+    }
+
+    public static boolean getBoolean(@Nonnull DataObject root, @Nonnull String path)
+    {
+        Boolean bool = get(root, path, DataObject::getBoolean, DataArray::getBoolean);
+        return bool != null && bool;
+    }
+
+    public static boolean getBoolean(@Nonnull DataObject root, @Nonnull String path, boolean fallback)
+    {
+        Boolean bool = get(root, path, (obj, key) -> obj.getBoolean(key, fallback), (arr, index) -> arr.getBoolean(index, fallback));
+        return bool != null ? bool : fallback;
+    }
+
+    public static int getInt(@Nonnull DataObject root, @Nonnull String path)
+    {
+        Integer integer = get(root, path, DataObject::getInt, DataArray::getInt);
+        if (integer == null)
+            pathError(path, "int");
+        return integer;
+    }
+
+    public static int getInt(@Nonnull DataObject root, @Nonnull String path, int fallback)
+    {
+        Integer integer = get(root, path, (obj, key) -> obj.getInt(key, fallback), (arr, index) -> arr.getInt(index, fallback));
+        return integer == null ? fallback : integer;
+    }
+
+    public static int getUnsignedInt(@Nonnull DataObject root, @Nonnull String path)
+    {
+        Integer integer = get(root, path, DataObject::getUnsignedInt, DataArray::getUnsignedInt);
+        if (integer == null)
+            pathError(path, "unsigned int");
+        return integer;
+    }
+
+    public static int getUnsignedInt(@Nonnull DataObject root, @Nonnull String path, int fallback)
+    {
+        Integer integer = get(root, path, (obj, key) -> obj.getUnsignedInt(key, fallback), (arr, index) -> arr.getUnsignedInt(index, fallback));
+        return integer == null ? fallback : integer;
+    }
+
+    public static long getLong(@Nonnull DataObject root, @Nonnull String path)
+    {
+        Long longValue = get(root, path, DataObject::getLong, DataArray::getLong);
+        if (longValue == null)
+            pathError(path, "long");
+        return longValue;
+    }
+
+    public static long getLong(@Nonnull DataObject root, @Nonnull String path, long fallback)
+    {
+        Long longValue = get(root, path, (obj, key) -> obj.getLong(key, fallback), (arr, index) -> arr.getLong(index, fallback));
+        return longValue == null ? fallback : longValue;
+    }
+
+    public static long getUnsignedLong(@Nonnull DataObject root, @Nonnull String path)
+    {
+        Long longValue = get(root, path, DataObject::getUnsignedLong, DataArray::getUnsignedLong);
+        if (longValue == null)
+            throw pathError(path, "unsigned long");
+        return longValue;
+    }
+
+    public static long getUnsignedLong(@Nonnull DataObject root, @Nonnull String path, long fallback)
+    {
+        Long longValue = get(root, path, (obj, key) -> obj.getUnsignedLong(key, fallback), (arr, index) -> arr.getUnsignedLong(index, fallback));
+        return longValue == null ? fallback : longValue;
+    }
+
+    public static double getDouble(@Nonnull DataObject root, @Nonnull String path)
+    {
+        Double doubleValue = get(root, path, DataObject::getDouble, DataArray::getDouble);
+        if (doubleValue == null)
+            pathError(path, "double");
+        return doubleValue;
+    }
+
+    public static double getDouble(@Nonnull DataObject root, @Nonnull String path, double fallback)
+    {
+        Double doubleValue = get(root, path, (obj, key) -> obj.getDouble(key, fallback), (arr, index) -> arr.getDouble(index, fallback));
+        return doubleValue == null ? fallback : doubleValue;
+    }
+
+    @Nonnull
+    public static String getString(@Nonnull DataObject root, @Nonnull String path)
+    {
+        String string = get(root, path, DataObject::getString, DataArray::getString);
+        if (string == null)
+            pathError(path, "String");
+        return string;
+    }
+
+    @Contract("_, _, !null -> !null")
+    public static String getString(@Nonnull DataObject root, @Nonnull String path, @Nullable String fallback)
+    {
+        String string = get(root, path, (obj, key) -> obj.getString(key, fallback), (arr, index) -> arr.getString(index, fallback));
+        return string == null ? fallback : string;
+    }
+
+    @Nonnull
+    public static DataObject getObject(@Nonnull DataObject root, @Nonnull String path)
+    {
+        DataObject obj = optObject(root, path);
+        if (obj == null)
+            pathError(path, "Object");
+        return obj;
+    }
+
+    @Nullable
+    public static DataObject optObject(@Nonnull DataObject root, @Nonnull String path)
+    {
+        if (!path.endsWith("?"))
+            path += "?";
+        return get(root, path, DataObject::getObject, DataArray::getObject);
+    }
+
+    @Nonnull
+    public static DataArray getArray(@Nonnull DataObject root, @Nonnull String path)
+    {
+        DataArray array = optArray(root, path);
+        if (array == null)
+            pathError(path, "Array");
+        return array;
+    }
+
+    @Nullable
+    public static DataArray optArray(@Nonnull DataObject root, @Nonnull String path)
+    {
+        if (!path.endsWith("?"))
+            path += "?";
+        return get(root, path, DataObject::getArray, DataArray::getArray);
+    }
+
+    private static ParsingException pathError(String path, String type)
+    {
+        throw new ParsingException("Could not resolve value of type " + type + " at path \"" + path + "\"");
+    }
+}

--- a/src/main/java/net/dv8tion/jda/api/utils/data/DataPath.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/DataPath.java
@@ -26,7 +26,42 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 
-// TODO: Documentation and Unit Tests
+// TODO: Documentation
+
+/**
+ * This utility class can be used to access nested values within {@link DataObject DataObjects} and {@link DataArray DataArrays}.
+ *
+ * <p><b>Path Expression Grammar</b><br>
+ *
+ * The syntax for paths is given by this grammar:
+ *
+ * <pre>{@code
+ * <name-syntax>  ::= /[^.\[\]]+/;
+ * <index-syntax> ::= "[" <number> "]";
+ * <name>         ::= <name-syntax> | <name-syntax> "?";
+ * <index>        ::= <index-syntax> | <index-syntax> "?";
+ * <element>      ::= <name> ( <index> )*;
+ * <path-start>   ::= <element> | <index> ( <index> )*;
+ * <path>         ::= <path-start> ( "." <element> )*;
+ * }</pre>
+ *
+ * <p><b>Examples</b><br>
+ * Given a JSON object such as:
+ * <pre>{@code
+ * {
+ *     "array": [{
+ *         "foo": "bar",
+ *     }]
+ * }
+ * }</pre>
+ *
+ * The content of {@code "foo"} can be accessed using the code:
+ * <pre>{@code String foo = DataPath.getString(root, "array[0].foo")}</pre>
+ *
+ * <p>With the safe-access operator {@code "?"}, you can also allow missing values within your path:
+ * <pre>{@code String foo = DataPath.getString(root, "array[1]?.foo", "default")}</pre>
+ * This will result in {@code foo == "default"}, since the array element 1 is marked as optional, and missing in the actual object.
+ */
 public class DataPath
 {
     private static final Pattern INDEX_EXPRESSION = Pattern.compile("^\\[\\d+].*");

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -50,7 +50,6 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.emoji.CustomEmojiImpl;
 import net.dv8tion.jda.internal.entities.emoji.RichCustomEmojiImpl;
@@ -298,7 +297,7 @@ public class EntityBuilder
         }
 
         TLongObjectMap<DataObject> voiceStates = Helpers.convertToMap((o) -> o.getUnsignedLong("user_id", 0L), voiceStateArray);
-        TLongObjectMap<DataObject> presences = presencesArray.map(o1 -> Helpers.convertToMap(o2 -> DataPath.getUnsignedLong(o2, "user.id"), o1)).orElseGet(TLongObjectHashMap::new);
+        TLongObjectMap<DataObject> presences = presencesArray.map(o1 -> Helpers.convertToMap(o2 -> o2.getObject("user").getUnsignedLong("id"), o1)).orElseGet(TLongObjectHashMap::new);
         try (UnlockHook h1 = guildObj.getMembersView().writeLock();
              UnlockHook h2 = getJDA().getUsersView().writeLock())
         {

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -50,6 +50,7 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.dv8tion.jda.api.utils.cache.CacheView;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.emoji.CustomEmojiImpl;
 import net.dv8tion.jda.internal.entities.emoji.RichCustomEmojiImpl;
@@ -297,7 +298,7 @@ public class EntityBuilder
         }
 
         TLongObjectMap<DataObject> voiceStates = Helpers.convertToMap((o) -> o.getUnsignedLong("user_id", 0L), voiceStateArray);
-        TLongObjectMap<DataObject> presences = presencesArray.map(o1 -> Helpers.convertToMap(o2 -> o2.getObject("user").getUnsignedLong("id"), o1)).orElseGet(TLongObjectHashMap::new);
+        TLongObjectMap<DataObject> presences = presencesArray.map(o1 -> Helpers.convertToMap(o2 -> DataPath.getUnsignedLong(o2, "user.id"), o1)).orElseGet(TLongObjectHashMap::new);
         try (UnlockHook h1 = guildObj.getMembersView().writeLock();
              UnlockHook h2 = getJDA().getUsersView().writeLock())
         {

--- a/src/main/java/net/dv8tion/jda/internal/handle/InteractionCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InteractionCreateHandler.java
@@ -30,6 +30,7 @@ import net.dv8tion.jda.api.interactions.InteractionType;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.components.Component;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.interactions.InteractionImpl;
 import net.dv8tion.jda.internal.interactions.ModalInteractionImpl;
@@ -52,9 +53,10 @@ public class InteractionCreateHandler extends SocketHandler
     protected Long handleInternally(DataObject content)
     {
         int type = content.getInt("type");
-        if (content.getInt("version", 1) != 1)
+        int version = content.getInt("version", 1);
+        if (version != 1)
         {
-            WebSocketClient.LOG.debug("Received interaction with version {}. This version is currently unsupported by this version of JDA. Consider updating!", content.getInt("version", 1));
+            WebSocketClient.LOG.debug("Received interaction with version {}. This version is currently unsupported by this version of JDA. Consider updating!", version);
             return null;
         }
 
@@ -103,7 +105,7 @@ public class InteractionCreateHandler extends SocketHandler
 
     private void handleCommand(DataObject content)
     {
-        switch (Command.Type.fromId(content.getObject("data").getInt("type")))
+        switch (Command.Type.fromId(DataPath.getInt(content, "data.type")))
         {
         case SLASH:
             api.handleEvent(
@@ -125,7 +127,7 @@ public class InteractionCreateHandler extends SocketHandler
 
     private void handleAction(DataObject content)
     {
-        switch (Component.Type.fromKey(content.getObject("data").getInt("component_type")))
+        switch (Component.Type.fromKey(DataPath.getInt(content, "data.component_type")))
         {
         case BUTTON:
             api.handleEvent(

--- a/src/main/java/net/dv8tion/jda/internal/handle/InteractionCreateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/InteractionCreateHandler.java
@@ -30,7 +30,6 @@ import net.dv8tion.jda.api.interactions.InteractionType;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.components.Component;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.interactions.InteractionImpl;
 import net.dv8tion.jda.internal.interactions.ModalInteractionImpl;
@@ -105,7 +104,7 @@ public class InteractionCreateHandler extends SocketHandler
 
     private void handleCommand(DataObject content)
     {
-        switch (Command.Type.fromId(DataPath.getInt(content, "data.type")))
+        switch (Command.Type.fromId(content.getObject("data").getInt("type")))
         {
         case SLASH:
             api.handleEvent(
@@ -127,7 +126,7 @@ public class InteractionCreateHandler extends SocketHandler
 
     private void handleAction(DataObject content)
     {
-        switch (Component.Type.fromKey(DataPath.getInt(content, "data.component_type")))
+        switch (Component.Type.fromKey(content.getObject("data").getInt("component_type")))
         {
         case BUTTON:
             api.handleEvent(

--- a/src/main/java/net/dv8tion/jda/internal/handle/ReadyHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ReadyHandler.java
@@ -21,7 +21,6 @@ import gnu.trove.map.hash.TLongObjectHashMap;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.requests.WebSocketClient;
@@ -53,7 +52,11 @@ public class ReadyHandler extends SocketHandler
 
         DataObject selfJson = content.getObject("user");
         // Inject the application id which isn't added to the self user by default
-        selfJson.put("application_id", DataPath.getUnsignedLong(content, "application?.id?", selfJson.getUnsignedLong("id")));
+        selfJson.put("application_id", // Used to update SelfUser#getApplicationId
+            content.optObject("application")
+                .map(obj -> obj.getUnsignedLong("id"))
+                .orElse(selfJson.getUnsignedLong("id"))
+        );
         // SelfUser is already created in login(...) but this just updates it to the current state from the api, and injects the application id
         builder.createSelfUser(selfJson);
 

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandImpl.java
@@ -18,8 +18,8 @@ package net.dv8tion.jda.internal.interactions.command;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationMap;
 import net.dv8tion.jda.api.interactions.commands.privileges.IntegrationPrivilege;
@@ -35,7 +35,9 @@ import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -87,10 +89,10 @@ public class CommandImpl implements Command
     public static <T> List<T> parseOptions(DataObject json, Predicate<DataObject> test, Function<DataObject, T> transform)
     {
         return json.optArray("options").map(arr ->
-                arr.stream(DataArray::getObject)
-                        .filter(test)
-                        .map(transform)
-                        .collect(Collectors.toList())
+            arr.stream(DataArray::getObject)
+               .filter(test)
+               .map(transform)
+               .collect(Collectors.toList())
         ).orElse(Collections.emptyList());
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/CommandInteractionImpl.java
@@ -58,7 +58,6 @@ public class CommandInteractionImpl extends DeferrableInteractionImpl implements
     public ModalCallbackAction replyModal(@Nonnull Modal modal)
     {
         Checks.notNull(modal, "Modal");
-
         return new ModalCallbackActionImpl(this, modal);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/ContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/ContextInteractionImpl.java
@@ -22,19 +22,20 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 
 import javax.annotation.Nonnull;
-import java.util.function.Function;
 
 public abstract class ContextInteractionImpl<T> extends CommandInteractionImpl implements ContextInteraction<T>, CommandInteractionPayloadMixin
 {
     private final T target;
     private final CommandInteractionPayloadImpl payload;
 
-    public ContextInteractionImpl(JDAImpl jda, DataObject data, Function<DataObject, T> entityParser)
+    public ContextInteractionImpl(JDAImpl jda, DataObject data)
     {
         super(jda, data);
         this.payload = new CommandInteractionPayloadImpl(jda, data);
-        this.target = entityParser.apply(data.getObject("data").getObject("resolved"));
+        this.target = parse(data, data.getObject("data").getObject("resolved"));
     }
+
+    protected abstract T parse(DataObject interactionData, DataObject resolved);
 
     @Override
     public CommandInteractionPayload getCommandPayload()

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/ContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/ContextInteractionImpl.java
@@ -19,6 +19,7 @@ package net.dv8tion.jda.internal.interactions.command;
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
 import net.dv8tion.jda.api.interactions.commands.context.ContextInteraction;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 
 import javax.annotation.Nonnull;
@@ -33,7 +34,7 @@ public abstract class ContextInteractionImpl<T> extends CommandInteractionImpl i
     {
         super(jda, data);
         this.payload = new CommandInteractionPayloadImpl(jda, data);
-        this.target = entityParser.apply(data.getObject("data").getObject("resolved"));
+        this.target = entityParser.apply(DataPath.getObject(data, "data.resolved"));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/ContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/ContextInteractionImpl.java
@@ -19,7 +19,6 @@ package net.dv8tion.jda.internal.interactions.command;
 import net.dv8tion.jda.api.interactions.commands.CommandInteractionPayload;
 import net.dv8tion.jda.api.interactions.commands.context.ContextInteraction;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 
 import javax.annotation.Nonnull;
@@ -34,7 +33,7 @@ public abstract class ContextInteractionImpl<T> extends CommandInteractionImpl i
     {
         super(jda, data);
         this.payload = new CommandInteractionPayloadImpl(jda, data);
-        this.target = entityParser.apply(DataPath.getObject(data, "data.resolved"));
+        this.target = entityParser.apply(data.getObject("data").getObject("resolved"));
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/UserContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/UserContextInteractionImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.context.UserContextInteraction;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
@@ -31,10 +32,9 @@ public class UserContextInteractionImpl extends ContextInteractionImpl<User> imp
     public UserContextInteractionImpl(JDAImpl jda, DataObject data)
     {
         super(jda, data, (resolved) -> parse(jda, resolved));
-        DataObject resolved = data.getObject("data").getObject("resolved");
-        if (!resolved.isNull("members"))
+        DataObject members = DataPath.optObject(data, "data.resolved.members?");
+        if (members != null && !members.keys().isEmpty())
         {
-            DataObject members = resolved.getObject("members");
             DataObject member = members.getObject(members.keys().iterator().next());
             this.member = jda.getEntityBuilder().createMember((GuildImpl) guild, member);
             jda.getEntityBuilder().updateMemberCache(this.member);

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/UserContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/UserContextInteractionImpl.java
@@ -26,28 +26,25 @@ import net.dv8tion.jda.internal.entities.MemberImpl;
 
 public class UserContextInteractionImpl extends ContextInteractionImpl<User> implements UserContextInteraction
 {
-    private final MemberImpl member;
+    private MemberImpl member;
 
     public UserContextInteractionImpl(JDAImpl jda, DataObject data)
     {
-        super(jda, data, (resolved) -> parse(jda, resolved));
-        DataObject members = data.getObject("data").getObject("resolved").optObject("members").orElse(null);
-        if (members != null && !members.keys().isEmpty())
-        {
-            DataObject member = members.getObject(members.keys().iterator().next());
-            this.member = jda.getEntityBuilder().createMember((GuildImpl) guild, member);
-            jda.getEntityBuilder().updateMemberCache(this.member);
-        }
-        else
-        {
-            this.member = null;
-        }
+        super(jda, data);
     }
 
-    private static User parse(JDAImpl api, DataObject resolved)
+    @Override
+    protected User parse(DataObject interaction, DataObject resolved)
     {
         DataObject users = resolved.getObject("users");
         DataObject user = users.getObject(users.keys().iterator().next());
+
+        resolved.optObject("members").filter(m -> !m.keys().isEmpty()).ifPresent(members -> {
+            DataObject member = members.getObject(members.keys().iterator().next());
+            this.member = api.getEntityBuilder().createMember((GuildImpl) guild, member);
+            api.getEntityBuilder().updateMemberCache(this.member);
+        });
+
         return api.getEntityBuilder().createUser(user);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/UserContextInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/UserContextInteractionImpl.java
@@ -20,7 +20,6 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.context.UserContextInteraction;
 import net.dv8tion.jda.api.utils.data.DataObject;
-import net.dv8tion.jda.api.utils.data.DataPath;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
 import net.dv8tion.jda.internal.entities.MemberImpl;
@@ -32,7 +31,7 @@ public class UserContextInteractionImpl extends ContextInteractionImpl<User> imp
     public UserContextInteractionImpl(JDAImpl jda, DataObject data)
     {
         super(jda, data, (resolved) -> parse(jda, resolved));
-        DataObject members = DataPath.optObject(data, "data.resolved.members?");
+        DataObject members = data.getObject("data").getObject("resolved").optObject("members").orElse(null);
         if (members != null && !members.keys().isEmpty())
         {
             DataObject member = members.getObject(members.keys().iterator().next());

--- a/src/test/java/DataPathTest.java
+++ b/src/test/java/DataPathTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import net.dv8tion.jda.api.exceptions.ParsingException;
+import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.api.utils.data.DataPath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DataPathTest
+{
+    @Test
+    void testSimple()
+    {
+        DataObject object = DataObject.empty()
+                .put("foo", "10"); // string to also test parsing
+
+        Assertions.assertEquals(10, DataPath.getInt(object, "foo"));
+
+        DataArray array = DataArray.empty().add("20");
+        Assertions.assertEquals(20, DataPath.getInt(array, "[0]"));
+    }
+
+    @Test
+    void testSimpleMissing()
+    {
+        DataObject object = DataObject.empty();
+
+        Assertions.assertEquals(0L, DataPath.getLong(object, "foo?", 0));
+        Assertions.assertThrows(ParsingException.class, () -> DataPath.getLong(object, "foo"));
+
+        DataArray array = DataArray.empty();
+
+        Assertions.assertTrue(DataPath.getBoolean(array, "[0]?", true));
+        Assertions.assertThrows(ParsingException.class, () -> DataPath.getObject(array, "[0]"));
+    }
+
+    @Test
+    void testObjectInArray()
+    {
+        DataObject object = DataObject.empty().put("foo", 10.0);
+        DataArray array = DataArray.empty().add(object);
+
+        Assertions.assertEquals(10.0, DataPath.getDouble(array, "[0].foo"));
+        Assertions.assertEquals(20.0, DataPath.getDouble(array, "[1]?.foo", 20.0));
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getDouble(array, "[1].foo"));
+    }
+
+    @Test
+    void testArrayInObject()
+    {
+        DataArray array = DataArray.empty().add("hello");
+        DataObject object = DataObject.empty().put("foo", array);
+
+        Assertions.assertEquals("hello", DataPath.getString(object, "foo[0]"));
+        Assertions.assertEquals("world", DataPath.getString(object, "foo[1]?", "world"));
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getString(object, "foo[1]"));
+    }
+
+    @Test
+    void testArrayInArray()
+    {
+        DataArray array = DataArray.empty().add(DataArray.empty().add("10"));
+
+        Assertions.assertEquals(10, DataPath.getUnsignedInt(array, "[0][0]"));
+        Assertions.assertEquals(20, DataPath.getUnsignedInt(array, "[0][1]?", 20));
+        Assertions.assertEquals(20, DataPath.getUnsignedInt(array, "[1]?[0]", 20));
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getUnsignedInt(array, "[0][1]"));
+        Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DataPath.getUnsignedInt(array, "[1][0]"));
+        Assertions.assertThrows(ParsingException.class, () -> DataPath.getUnsignedInt(array, "[0][1]?"));
+        Assertions.assertThrows(ParsingException.class, () -> DataPath.getUnsignedInt(array, "[1]?[0]"));
+    }
+
+    @Test
+    void testComplex()
+    {
+        DataObject object = DataObject.empty()
+                .put("array", DataArray.empty()
+                    .add(DataObject.empty()
+                        .put("foo", DataObject.empty()
+                            .put("bar", "hello"))));
+
+        Assertions.assertEquals("hello", DataPath.getString(object, "array[0].foo.bar"));
+        Assertions.assertEquals("world", DataPath.getString(object, "array[0].wrong?.bar", "world"));
+        Assertions.assertThrows(ParsingException.class, () -> DataPath.getString(object, "array[0].wrong?.bar"));
+    }
+}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This new util class allows to access deep nested fields with a simple path expression.

### Example

```java
long value = DataPath.getLong(object, "data.options[0].value");
```

This also allows safe-calls similar to kotlin via `?.` delimiters:

```java
long value = DataPath.getLong(object, "data?.options?[0]?.value?", 0L);
```

This would be equivalent to:

```java
long value = 0L;
DataObject data = object.optObject("data").orElse(null);
if (data != null)
{
  DataArray options = data.optArray("options").orElse(null);
  if (options != null)
    value = options.getLong("value", 0L);
}
```

I'm sure you can see the appeal.

### Motivation

This is very useful in various places, and now also relevant in the case of `Event#getRawData` which usually only is used to access a specific part of the json payload. Previously, you would have to exhaustively get each object and array down the path, which is *especially* annoying with optionals.

### TODO

- [x] Array equivalent methods for each type
- [x] Documentation for all the new getters, including examples
- [x] Unit tests