### PR TITLE
Renamed MessageCreateBuilder#fromEdit() to fromEditData

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/messages/MessageCreateBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/messages/MessageCreateBuilder.java
@@ -103,7 +103,7 @@ public class MessageCreateBuilder extends AbstractMessageBuilder<MessageCreateDa
      * @see    #applyEditData(MessageEditData)
      */
     @Nonnull
-    public static MessageCreateBuilder fromEdit(@Nonnull MessageEditData data)
+    public static MessageCreateBuilder fromEditData(@Nonnull MessageEditData data)
     {
         return new MessageCreateBuilder().applyEditData(data);
     }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: [#2224](https://github.com/DV8FromTheWorld/JDA/issues/2224)

## Description

Renames `MessageCreateBuilder#fromEdit()` to `MessageCreateBuilder#fromEditData()` for consistent naming between `MessageCreateBuilder` and `MessageEditBuilder`.