### PR TITLE
Added RestAction#onSuccess

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -793,6 +793,7 @@ public interface RestAction<T>
     @CheckReturnValue
     default RestAction<T> onSuccess(@Nonnull Consumer<? super T> consumer)
     {
+        Checks.notNull(consumer, "Consumer");
         return map(result -> {
             consumer.accept(result);
             return result;

--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -769,39 +769,6 @@ public interface RestAction<T>
      *
      * <p>This does not modify this instance but returns a new RestAction, which will consume
      * the actions result using the given consumer on successful execution.
-     *
-     * <p><b>Example</b><br>
-     * <pre>{@code
-     * public RestAction<Void> printMemberNickname(Guild guild, String userId) {
-     *     return guild.retrieveMemberById(userId)
-     *                 .map(Member::getNickname)
-     *                 .accept(System.out::println);
-     * }
-     * }</pre>
-     *
-     * Prefer using {@link #queue(Consumer)} instead, if continuation of the action
-     * chain is not desired.
-     *
-     * @param  consumer
-     *         The consuming function to apply to the action result
-     *
-     * @return RestAction that consumes the action result
-     */
-    @Nonnull
-    @CheckReturnValue
-    default RestAction<Void> accept(@Nonnull Consumer<? super T> consumer)
-    {
-        return map(result -> {
-            consumer.accept(result);
-            return null;
-        });
-    }
-
-    /**
-     * An intermediate operator that returns a modified RestAction.
-     *
-     * <p>This does not modify this instance but returns a new RestAction, which will consume
-     * the actions result using the given consumer on successful execution.
      * The resulting action continues with the previous result.
      *
      * <p><b>Example</b><br>
@@ -809,7 +776,7 @@ public interface RestAction<T>
      * public RestAction<String> retrieveMemberNickname(Guild guild, String userId) {
      *     return guild.retrieveMemberById(userId)
      *                 .map(Member::getNickname)
-     *                 .also(this::logMemberRetrieval);
+     *                 .onSuccess(System.out::println);
      * }
      * }</pre>
      *
@@ -817,13 +784,14 @@ public interface RestAction<T>
      * chain is not desired.
      *
      * @param  consumer
-     *         The consuming function to apply to the action result
+     *         The consuming function to apply to the action result, failures are propagated
+     *         into the resulting action
      *
      * @return RestAction that consumes the action result
      */
     @Nonnull
     @CheckReturnValue
-    default RestAction<T> also(@Nonnull Consumer<? super T> consumer)
+    default RestAction<T> onSuccess(@Nonnull Consumer<? super T> consumer)
     {
         return map(result -> {
             consumer.accept(result);

--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -765,6 +765,73 @@ public interface RestAction<T>
     }
 
     /**
+     * An intermediate operator that returns a modified RestAction.
+     *
+     * <p>This does not modify this instance but returns a new RestAction, which will consume
+     * the actions result using the given consumer on successful execution.
+     *
+     * <p><b>Example</b><br>
+     * <pre>{@code
+     * public RestAction<Void> printMemberNickname(Guild guild, String userId) {
+     *     return guild.retrieveMemberById(userId)
+     *                 .map(Member::getNickname)
+     *                 .accept(System.out::println);
+     * }
+     * }</pre>
+     *
+     * Prefer using {@link #queue(Consumer)} instead, if continuation of the action
+     * chain is not desired.
+     *
+     * @param  consumer
+     *         The consuming function to apply to the action result
+     *
+     * @return RestAction that consumes the action result
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<Void> accept(@Nonnull Consumer<? super T> consumer)
+    {
+        return map(result -> {
+            consumer.accept(result);
+            return null;
+        });
+    }
+
+    /**
+     * An intermediate operator that returns a modified RestAction.
+     *
+     * <p>This does not modify this instance but returns a new RestAction, which will consume
+     * the actions result using the given consumer on successful execution.
+     * The resulting action continues with the previous result.
+     *
+     * <p><b>Example</b><br>
+     * <pre>{@code
+     * public RestAction<String> retrieveMemberNickname(Guild guild, String userId) {
+     *     return guild.retrieveMemberById(userId)
+     *                 .map(Member::getNickname)
+     *                 .also(this::logMemberRetrieval);
+     * }
+     * }</pre>
+     *
+     * Prefer using {@link #queue(Consumer)} instead, if continuation of the action
+     * chain is not desired.
+     *
+     * @param  consumer
+     *         The consuming function to apply to the action result
+     *
+     * @return RestAction that consumes the action result
+     */
+    @Nonnull
+    @CheckReturnValue
+    default RestAction<T> also(@Nonnull Consumer<? super T> consumer)
+    {
+        return map(result -> {
+            consumer.accept(result);
+            return result;
+        });
+    }
+
+    /**
      * Supply a fallback value when the RestAction fails for any reason.
      *
      * <p>This does not modify this instance but returns a new RestAction which will apply

--- a/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/RestAction.java
@@ -787,6 +787,10 @@ public interface RestAction<T>
      *         The consuming function to apply to the action result, failures are propagated
      *         into the resulting action
      *
+     *
+     * @throws IllegalArgumentException
+     *         If the consumer is null
+     *
      * @return RestAction that consumes the action result
      */
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Added ~~two~~ one new user-facing convenience method on `RestAction`, ~~`accept` and `also`~~ `onSuccess`. It represents a frequent scenario on action-chaining that otherwise requires cumbersome workarounds for the user.

### onSuccess

The method works like `map`, but results in a `RestAction<T>`, continuing with the previous result. It just consumes the given result, but allows continuation of the action-chain:

```java
guild.retrieveMemberById(userId) // RestAction<Member>
  .onSuccess(System.out::println)   // RestAction<Member>
  .flatMap(any -> channel.sendMessage("Done"))
  .queue()
```
This enables users to chain in `void` methods.

The workaround without this helper would be:
```java
guild.retrieveMemberById(userId)
  .map(member -> {
    System.out.println(member);
    return member;
  })
  .flatMap(any -> channel.sendMessage("Done"))
  .queue()
```
Which works well, but is just annoying boilerplate. In particular since method references can not be used.

The name `onSuccess` is inspired by similar methods in JDA. For example the callback in `queue(onSuccess)` or `Task#onSuccess`. Also, similar to `onErrorMap` and `onErrorFlatMap`.

### ~~accept~~

**(Removed in favor of `onSuccess` which also handles this use case)**

The method works like `map`, but results in a `RestAction<Void>`. It just consumes the given result, but allows continuation of the action-chain:

```java
guild.retrieveMemberById(userId) // RestAction<Member>
  .accept(System.out::println)   // RestAction<Void>
  .flatMap(any -> channel.sendMessage("Done"))
  .queue()
```
This enables users to chain in `void` methods.

The workaround without this helper would be:
```java
guild.retrieveMemberById(userId)
  .<Void>map(member -> {
    System.out.println(member);
    return null;
  })
  .flatMap(any -> channel.sendMessage("Done"))
  .queue()
```
The main issue for the user is that `Void` is obviously incompatible with `void` and hence can not be automatically inferred. Resulting in a lot of boilerplate for the user.

The name `accept` is inspired by Javas future API: [CompletableFuture#thenAccept](https://docs.oracle.com/en/java/javase/18/docs/api/java.base/java/util/concurrent/CompletableFuture.html#thenAccept(java.util.function.Consumer))

### ~~also~~

**(Removed in favor of `onSuccess` which also handles this use case)**

This method is quite similar to `accept`, but instead it forwards the previous result, continuing with `RestAction<T>`:

```java
guild.retrieveMemberById(userId)  // RestAction<Member>
  .also(System.out::println)      // RestAction<Member>
  .flatMap(Member::openPrivateChannel)
  .flatMap(channel -> channel.sendMessage("hello"))
  .queue()
```
This enables users to chain in `void` methods.

The workaround without this helper would be:
```java
guild.retrieveMemberById(userId)
  .map(member -> {
    System.out.println(member);
    return member;
  })
  .flatMap(Member::openPrivateChannel)
  .flatMap(channel -> channel.sendMessage("hello"))
  .queue()
```
A bit less boilerplate for the user, since the type can at least be automatically inferred. However, it is still annoying that method references can not be used and the user is forced to introduce lambdas.

The name `also` is inspired by Kotlins scoped function: [.also](https://kotlinlang.org/docs/scope-functions.html#also)

## Discussion

An argument can be made that all users of `accept` could also just use `also` and just ignore the action result (what they have to do with `Void` anyways).

I.e. the previous example for `accept` could also be written using `also`:

```java
guild.retrieveMemberById(userId) // RestAction<Member>
  .also(System.out::println)   // RestAction<Member>
  .flatMap(any -> channel.sendMessage("Done")) // just ignore the member
  .queue()
```

That would allow us to just remove `accept`, maybe renaming `also` into `accept` then 🤷 The advantage is clear:
* less confusion for the user due to less options to choose from
* less code to maintain

Personally, I am actually in favor of this decision. Let me hear your opinion on it and we can adjust the PR slightly 👌

## Edits

Removed `accept`, kept `also` (because it can cover both use cases fine). But renamed `also` to `onSuccess`.