### PR TITLE
Check for empty token in AuthorizationConfig, instead of JDAImpl

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -74,7 +74,10 @@ import net.dv8tion.jda.internal.requests.restaction.CommandCreateActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.CommandEditActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.CommandListUpdateActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.GuildActionImpl;
-import net.dv8tion.jda.internal.utils.*;
+import net.dv8tion.jda.internal.utils.Checks;
+import net.dv8tion.jda.internal.utils.Helpers;
+import net.dv8tion.jda.internal.utils.JDALogger;
+import net.dv8tion.jda.internal.utils.UnlockHook;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
@@ -287,10 +290,7 @@ public class JDAImpl implements JDA
         this.gatewayUrl = gatewayUrl == null ? getGateway() : gatewayUrl;
         Checks.notNull(this.gatewayUrl, "Gateway URL");
 
-        String token = authConfig.getToken();
         setStatus(Status.LOGGING_IN);
-        if (token == null || token.isEmpty())
-            throw new InvalidTokenException("Provided token was null or empty!");
 
         Map<String, String> previousContext = null;
         ConcurrentMap<String, String> contextMap = metaConfig.getMdcContextMap();

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/AuthorizationConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/AuthorizationConfig.java
@@ -27,7 +27,7 @@ public final class AuthorizationConfig
 
     public AuthorizationConfig(@Nonnull String token)
     {
-        Checks.notNull(token, "Token");
+        Checks.notEmpty(token, "Token");
         setToken(token);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/config/AuthorizationConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/AuthorizationConfig.java
@@ -28,6 +28,7 @@ public final class AuthorizationConfig
     public AuthorizationConfig(@Nonnull String token)
     {
         Checks.notEmpty(token, "Token");
+        Checks.noWhitespace(token, "Token");
         setToken(token);
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

`JDAImpl` was doing unnecessary checks and could had been implemented where the token comes from, so, `AuthorizationConfig`, the PR moves the `notEmpty` check there
