### PR TITLE
Use github actions to publish artifacts

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
     paths:
-      - 'src/main'
+      - 'src/main/**'
       - 'build.gradle.kts'
       - '.github/workflows/artifacts.yml'
 

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build Artifacts
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: build
       - name: Upload Artifacts

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,33 @@
+name: Upload Artifacts
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/main'
+      - 'build.gradle.kts'
+      - '.github/workflows/artifacts.yml'
+
+jobs:
+  build:
+    name: Build and Upload Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build Artifacts
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Artifacts
+          path: build/libs/*.jar


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: CI/CD

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This adds a new github action workflow to automatically build and upload artifacts on each push to master.

An example run is here: https://github.com/MinnDevelopment/JDA/actions/runs/2966524280

Artifacts are retained for 90 days.
