### PR TITLE
Use String#intern for guild features and atoms

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/data/etf/ExTermDecoder.java
@@ -247,7 +247,7 @@ public class ExTermDecoder
         case "true": return true;
         case "false": return false;
         case "nil": return null;
-        default: return value;
+        default: return value.intern();
         }
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -270,10 +270,10 @@ public class EntityBuilder
             guildView.getMap().put(guildId, guildObj);
         }
 
-        guildObj.setFeatures(featuresArray.map(it ->
-            StreamSupport.stream(it.spliterator(), false)
-                         .map(String::valueOf)
-                         .collect(Collectors.toSet())
+        guildObj.setFeatures(featuresArray.map(array ->
+            array.stream(DataArray::getString)
+                 .map(String::intern) // Prevent allocating the same feature string over and over
+                 .collect(Collectors.toSet())
         ).orElse(Collections.emptySet()));
 
         SnowflakeCacheViewImpl<Role> roleView = guildObj.getRolesView();

--- a/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/GuildUpdateHandler.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class GuildUpdateHandler extends SocketHandler
 {
@@ -94,7 +93,7 @@ public class GuildUpdateHandler extends SocketHandler
         if (!content.isNull("features"))
         {
             DataArray featureArr = content.getArray("features");
-            features = StreamSupport.stream(featureArr.spliterator(), false).map(String::valueOf).collect(Collectors.toSet());
+            features = featureArr.stream(DataArray::getString).map(String::intern).collect(Collectors.toSet());
         }
         else
         {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This slightly reduces latent memory usage and improves performance of map lookups for ETF data. Guild features are a small limited list of possible feature strings that we can intern to reduce duplication.
