### PR TITLE
Update Wiki URLs to new wiki site

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Based on the current `master` changes!
 
 1. Adding a new Method or Class
     - If your addition is not internal (e.g. an impl class or private method) you have to write documentation.
-        - For that please follow the [JavaDoc template](https://github.com/DV8FromTheWorld/JDA/wiki/6%29-JDA-Structure-Guide#javadoc)
-    - Keep your code consistent! [example](https://github.com/DV8FromTheWorld/JDA/wiki/5%29-contributing#examples)
-        - Follow the guides provided at [JDA Structure Guide](https://github.com/DV8FromTheWorld/JDA/wiki/6%29-JDA-Structure-Guide)
+        - For that please follow the [JavaDoc template](https://jda.wiki/contributing/structure-guide/#javadoc)
+    - Keep your code consistent! [example](https://jda.wiki/contributing/contributing/#making-changes)
+        - Follow the guides provided at [JDA Structure Guide](https://jda.wiki/contributing/structure-guide/)
         - Compare your code style to the one used all over JDA and ensure you
           do not break the consistency (if you find issues in the JDA style you can include and update it)
     - Do not remove existing functionality, use deprecation instead (for reference [deprecation policy](https://github.com/DV8FromTheWorld/JDA#deprecation-policy))
@@ -27,7 +27,7 @@ Based on the current `master` changes!
       or [Keeping a Fork Updated](https://robots.thoughtbot.com/keeping-a-github-fork-updated))
       
 4. Only open Pull Requests to master
-    - Look at the [Repository Structure](https://github.com/DV8FromTheWorld/JDA/wiki/11%29-Repository-Structure) for further details
+    - Look at the [Repository Structure](https://jda.wiki/contributing/repository-structure/) for further details
       
-For more information please consult the [Contributing](https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing)
+For more information please consult the [Contributing](https://jda.wiki/contributing/contributing/)
 section of our wiki.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,7 +10,7 @@ contact_links:
     url: https://ci.dv8tion.net/job/JDA/
     about: You can find the latest Dev Builds on the Jenkins CI Server.
   - name: Wiki
-    url: https://github.com/DV8FromTheWorld/JDA/wiki
+    url: https://jda.wiki
     about: You can find answers to common questions on our Wiki. Make sure to read the FAQ page!
   - name: Releases
     url: https://github.com/DV8FromTheWorld/JDA/releases

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing
+[contributing]: https://jda.wiki/contributing/contributing/
 
 ## Pull Request Etiquette
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Updates the Wiki URLs in `.github/ISSUE_TEMPLATE/config.yml`, `.github/CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` to the new ones located at https://jda.wiki
