### PR TITLE
Properly handle MANAGE_THREAD permission for managing threads

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ThreadChannelImpl.java
@@ -280,6 +280,15 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         return new ThreadChannelManagerImpl(this);
     }
 
+    @Override
+    public void checkCanManage()
+    {
+        if (isOwner())
+            return;
+
+        checkPermission(Permission.MANAGE_THREADS);
+    }
+
     public CacheView.SimpleCacheView<ThreadMember> getThreadMemberView()
     {
         return threadMembers;

--- a/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/GuildChannelMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/mixin/channel/middleman/GuildChannelMixin.java
@@ -39,7 +39,7 @@ public interface GuildChannelMixin<T extends GuildChannelMixin<T>> extends
     @CheckReturnValue
     default AuditableRestAction<Void> delete()
     {
-        checkPermission(Permission.MANAGE_CHANNEL);
+        checkCanManage();
 
         Route.CompiledRoute route = Route.Channels.DELETE_CHANNEL.compile(getId());
         return new AuditableRestActionImpl<>(getJDA(), route);
@@ -62,5 +62,11 @@ public interface GuildChannelMixin<T extends GuildChannelMixin<T>> extends
             else
                 throw new InsufficientPermissionException(this, permission);
         }
+    }
+
+    // Overridden by ThreadChannelImpl
+    default void checkCanManage()
+    {
+        checkPermission(Permission.MANAGE_CHANNEL);
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/ChannelManagerImpl.java
@@ -26,6 +26,7 @@ import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.channel.ChannelManager;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.mixin.channel.attribute.IPermissionContainerMixin;
+import net.dv8tion.jda.internal.entities.mixin.channel.middleman.GuildChannelMixin;
 import net.dv8tion.jda.internal.managers.ManagerBase;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.PermOverrideData;
@@ -571,8 +572,7 @@ public class ChannelManagerImpl<T extends GuildChannel, M extends ChannelManager
         final Member selfMember = getGuild().getSelfMember();
 
         Checks.checkAccess(selfMember, channel);
-        if (!selfMember.hasPermission(channel, Permission.MANAGE_CHANNEL))
-            throw new InsufficientPermissionException(channel, Permission.MANAGE_CHANNEL);
+        ((GuildChannelMixin<?>) channel).checkCanManage();
 
         return super.checkPermissions();
     }

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/concrete/ThreadChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/concrete/ThreadChannelManagerImpl.java
@@ -16,14 +16,30 @@
 
 package net.dv8tion.jda.internal.managers.channel.concrete;
 
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.ThreadChannel;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
 import net.dv8tion.jda.internal.managers.channel.ChannelManagerImpl;
+import net.dv8tion.jda.internal.utils.Checks;
 
 public class ThreadChannelManagerImpl extends ChannelManagerImpl<ThreadChannel, ThreadChannelManager> implements ThreadChannelManager
 {
     public ThreadChannelManagerImpl(ThreadChannel channel)
     {
         super(channel);
+    }
+
+    @Override
+    protected boolean checkPermissions()
+    {
+        final Member selfMember = getGuild().getSelfMember();
+
+        Checks.checkAccess(selfMember, channel);
+        if (!channel.isOwner() && !selfMember.hasPermission(channel, Permission.MANAGE_THREADS))
+            throw new InsufficientPermissionException(channel, Permission.MANAGE_THREADS);
+
+        return super.checkPermissions();
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/managers/channel/concrete/ThreadChannelManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/channel/concrete/ThreadChannelManagerImpl.java
@@ -16,30 +16,14 @@
 
 package net.dv8tion.jda.internal.managers.channel.concrete;
 
-import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.ThreadChannel;
-import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.channel.concrete.ThreadChannelManager;
 import net.dv8tion.jda.internal.managers.channel.ChannelManagerImpl;
-import net.dv8tion.jda.internal.utils.Checks;
 
 public class ThreadChannelManagerImpl extends ChannelManagerImpl<ThreadChannel, ThreadChannelManager> implements ThreadChannelManager
 {
     public ThreadChannelManagerImpl(ThreadChannel channel)
     {
         super(channel);
-    }
-
-    @Override
-    protected boolean checkPermissions()
-    {
-        final Member selfMember = getGuild().getSelfMember();
-
-        Checks.checkAccess(selfMember, channel);
-        if (!channel.isOwner() && !selfMember.hasPermission(channel, Permission.MANAGE_THREADS))
-            throw new InsufficientPermissionException(channel, Permission.MANAGE_THREADS);
-
-        return super.checkPermissions();
     }
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: https://github.com/DV8FromTheWorld/JDA/issues/2188
Replaces PR: https://github.com/DV8FromTheWorld/JDA/pull/2190

## Description
When calling `ThreadChannel#getManager` or `ThreadChannel#delete` it is currently checked if the user has the `MANAGE_CHANNEL `permission, but the permission actually required to manage or delete a thread is `MANAGE_THREADS`.

Additionally, when the bot owns the thread, it doesn't matter whether they have `MANAGE_THREADS` or not.
