### PR TITLE
Make annotation dependencies compileOnly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,8 +97,8 @@ dependencies {
     /* ABI dependencies */
 
     //Code safety
-    api("com.google.code.findbugs:jsr305:3.0.2")
-    api("org.jetbrains:annotations:23.0.0")
+    compileOnly("com.google.code.findbugs:jsr305:3.0.2")
+    compileOnly("org.jetbrains:annotations:23.0.0")
 
     //Logger
     api("org.slf4j:slf4j-api:1.7.36")
@@ -130,6 +130,7 @@ dependencies {
     configurations["examplesImplementation"].withDependencies {
         addAll(configurations["api"].allDependencies)
         addAll(configurations["implementation"].allDependencies)
+        addAll(configurations["compileOnly"].allDependencies)
     }
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Dependencies

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Updates the scope to compileOnly for annotation dependencies. Saves about 20kB on the fat jar artifact.

This is breaking for anyone who relied on these being provided by JDA.
