### PR TITLE
feat(api): add `receiveAcknowledged` to SubscribeEvent

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/hooks/AnnotatedEventManager.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/AnnotatedEventManager.java
@@ -16,6 +16,7 @@
 package net.dv8tion.jda.api.hooks;
 
 import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.utils.ClassWalker;
 
@@ -91,6 +92,12 @@ public class AnnotatedEventManager implements IEventManager
                 {
                     try
                     {
+                        if (event instanceof GenericInteractionCreateEvent)
+                        {
+                            if (!method.receiveAcknowledged && ((GenericInteractionCreateEvent) event).isAcknowledged()) {
+                                return;
+                            }
+                        }
                         method.method.setAccessible(true);
                         method.method.invoke(key, event);
                     }

--- a/src/main/java/net/dv8tion/jda/api/hooks/SubscribeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/SubscribeEvent.java
@@ -30,5 +30,12 @@ import java.lang.annotation.*;
 @Inherited
 public @interface SubscribeEvent
 {
-    boolean receiveAcknowledged() default false;
+    /**
+     *
+     * If the event is an instance of {@link net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent} and
+     * has been acknowledged then if this is set to false the annotated event listener will not be called.
+     *
+     * @return If the event listener should receive events that have already been acknowledged
+     */
+    boolean receiveAcknowledged() default true;
 }

--- a/src/main/java/net/dv8tion/jda/api/hooks/SubscribeEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/hooks/SubscribeEvent.java
@@ -30,4 +30,5 @@ import java.lang.annotation.*;
 @Inherited
 public @interface SubscribeEvent
 {
+    boolean receiveAcknowledged() default false;
 }


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds a value to the `@SubscribeEvent` annotation so that you can disable the method being triggered if the event is an GenericInteractionCreateEvent and has already been acknowledged (reduced the boiler plate of checking if the event has been interacted with in every single method)