### PR TITLE
Improve implementation of command data

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/CommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/CommandData.java
@@ -40,14 +40,19 @@ import java.util.Map;
 public interface CommandData extends SerializableData
 {
     /**
-     * The maximum length the name of a command can be.
+     * The maximum length the name of a command can be. ({@value})
      */
     int MAX_NAME_LENGTH = 32;
 
     /**
-     * The maximum length the description of a command can be.
+     * The maximum length the description of a command can be. ({@value})
      */
     int MAX_DESCRIPTION_LENGTH = 100;
+
+    /**
+     * The maximum amount of options/subcommands/groups that can be added to a command or subcommand. ({@value})
+     */
+    int MAX_OPTIONS = 25;
 
     /**
      * Sets the {@link LocalizationFunction} for this command
@@ -68,10 +73,10 @@ public interface CommandData extends SerializableData
      * Configure the command name.
      *
      * @param  name
-     *         The name, 1-32 characters (lowercase and alphanumeric for {@link Command.Type#SLASH})
+     *         The name, 1-{@value #MAX_NAME_LENGTH} characters (lowercase and alphanumeric for {@link Command.Type#SLASH})
      *
      * @throws IllegalArgumentException
-     *         If the name is not between 1-32 characters long, or not lowercase and alphanumeric for slash commands
+     *         If the name is not between 1-{@value #MAX_NAME_LENGTH} characters long, or not lowercase and alphanumeric for slash commands
      *
      * @return The builder instance, for chaining
      */

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
@@ -273,7 +273,7 @@ public interface SlashCommandData extends CommandData
      *
      * @throws IllegalArgumentException
      *         <ul>
-     *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If there already is a subcommand or subcommand group on this command (See {@link #addSubcommands(SubcommandData...)} for details).</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
      *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
@@ -296,7 +296,7 @@ public interface SlashCommandData extends CommandData
      *
      * @throws IllegalArgumentException
      *         <ul>
-     *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If there already is a subcommand or subcommand group on this command (See {@link #addSubcommands(SubcommandData...)} for details).</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
      *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
@@ -332,7 +332,7 @@ public interface SlashCommandData extends CommandData
      *
      * @throws IllegalArgumentException
      *         <ul>
-     *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If there already is a subcommand or subcommand group on this command (See {@link #addSubcommands(SubcommandData...)} for details).</li>
      *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If the provided option type does not support auto-complete</li>
@@ -368,7 +368,7 @@ public interface SlashCommandData extends CommandData
      *
      * @throws IllegalArgumentException
      *         <ul>
-     *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If there already is a subcommand or subcommand group on this command (See {@link #addSubcommands(SubcommandData...)} for details).</li>
      *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
@@ -400,7 +400,7 @@ public interface SlashCommandData extends CommandData
      *
      * @throws IllegalArgumentException
      *         <ul>
-     *             <li>If you try to mix subcommands/options/groups in one command.</li>
+     *             <li>If there already is a subcommand or subcommand group on this command (See {@link #addSubcommands(SubcommandData...)} for details).</li>
      *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
@@ -419,13 +419,34 @@ public interface SlashCommandData extends CommandData
 
     /**
      * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandData Subcommands} to this command.
+     * <br>When a subcommand or subcommand group is added, the base command itself cannot be used.
+     * Thus using {@link #addOptions(OptionData...)} and {@link #addSubcommands(SubcommandData...)} / {@link #addSubcommandGroups(SubcommandGroupData...)}
+     * for the same command, is not supported.
+     *
+     * <p>Valid command layouts are as follows:
+     * <pre>{@code
+     * command
+     * |-- subcommand
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |-- option
+     * |__ option
+     * }</pre>
+     *
+     * Having an option and subcommand simultaneously is not allowed.
      *
      * @param  subcommands
      *         The subcommands to add
      *
      * @throws IllegalArgumentException
      *         If null, more than {@value CommandData#MAX_OPTIONS} subcommands, or duplicate subcommand names are provided.
-     *         Also throws if you try to mix subcommands/options/groups in one command.
+     *         Also throws if you try adding subcommands when options are already present.
      *
      * @return The builder instance, for chaining
      */
@@ -434,13 +455,34 @@ public interface SlashCommandData extends CommandData
 
     /**
      * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandData Subcommands} to this command.
+     * <br>When a subcommand or subcommand group is added, the base command itself cannot be used.
+     * Thus using {@link #addOptions(OptionData...)} and {@link #addSubcommands(SubcommandData...)} / {@link #addSubcommandGroups(SubcommandGroupData...)}
+     * for the same command, is not supported.
+     *
+     * <p>Valid command layouts are as follows:
+     * <pre>{@code
+     * command
+     * |-- subcommand
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |-- option
+     * |__ option
+     * }</pre>
+     *
+     * Having an option and subcommand simultaneously is not allowed.
      *
      * @param  subcommands
      *         The subcommands to add
      *
      * @throws IllegalArgumentException
      *         If null, more than {@value CommandData#MAX_OPTIONS} subcommands, or duplicate subcommand names are provided.
-     *         Also throws if you try to mix subcommands/options/groups in one command.
+     *         Also throws if you try adding subcommands when options are already present.
      *
      * @return The builder instance, for chaining
      */
@@ -453,13 +495,34 @@ public interface SlashCommandData extends CommandData
 
     /**
      * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandGroupData Subcommand-Groups} to this command.
+     * <br>When a subcommand or subcommand group is added, the base command itself cannot be used.
+     * Thus using {@link #addOptions(OptionData...)} and {@link #addSubcommands(SubcommandData...)} / {@link #addSubcommandGroups(SubcommandGroupData...)}
+     * for the same command, is not supported.
+     *
+     * <p>Valid command layouts are as follows:
+     * <pre>{@code
+     * command
+     * |-- subcommand
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |-- option
+     * |__ option
+     * }</pre>
+     *
+     * Having an option and subcommand simultaneously is not allowed.
      *
      * @param  groups
      *         The subcommand groups to add
      *
      * @throws IllegalArgumentException
      *         If null, more than {@value CommandData#MAX_OPTIONS} subcommand groups, or duplicate group names are provided.
-     *         Also throws if you try to mix subcommands/options/groups in one command.
+     *         Also throws if you try adding subcommand groups when options are already present.
      *
      * @return The builder instance, for chaining
      */
@@ -468,13 +531,34 @@ public interface SlashCommandData extends CommandData
 
     /**
      * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandGroupData Subcommand-Groups} to this command.
+     * <br>When a subcommand or subcommand group is added, the base command itself cannot be used.
+     * Thus using {@link #addOptions(OptionData...)} and {@link #addSubcommands(SubcommandData...)} / {@link #addSubcommandGroups(SubcommandGroupData...)}
+     * for the same command, is not supported.
+     *
+     * <p>Valid command layouts are as follows:
+     * <pre>{@code
+     * command
+     * |-- subcommand
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |__ subcommand group
+     *     |__ subcommand
+     *
+     * command
+     * |-- option
+     * |__ option
+     * }</pre>
+     *
+     * Having an option and subcommand simultaneously is not allowed.
      *
      * @param  groups
      *         The subcommand groups to add
      *
      * @throws IllegalArgumentException
      *         If null, more than {@value CommandData#MAX_OPTIONS} subcommand groups, or duplicate group names are provided.
-     *         Also throws if you try to mix subcommands/options/groups in one command.
+     *         Also throws if you try adding subcommand groups when options are already present.
      *
      * @return The builder instance, for chaining
      */

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * Extension of {@link CommandData} which allows setting slash-command specific settings such as options and subcommands.
@@ -132,6 +133,111 @@ public interface SlashCommandData extends CommandData
      */
     @Nonnull
     LocalizationMap getDescriptionLocalizations();
+
+    /**
+     * Removes all options that evaluate to {@code true} under the provided {@code condition}.
+     * <br>This will not affect options within subcommands.
+     * Use {@link SubcommandData#removeOptions(Predicate)} instead.
+     *
+     * <p><b>Example: Remove all options</b>
+     * <pre>{@code
+     * command.removeOptions(option -> true);
+     * }</pre>
+     * <p><b>Example: Remove all options that are required</b>
+     * <pre>{@code
+     * command.removeOptions(option -> option.isRequired());
+     * }</pre>
+     *
+     * @param  condition
+     *         The removal condition (must not throw)
+     *
+     * @throws IllegalArgumentException
+     *         If the condition is null
+     *
+     * @return True, if any options were removed
+     */
+    boolean removeOptions(@Nonnull Predicate<? super OptionData> condition);
+
+    /**
+     * Removes options by the provided name.
+     * <br>This will not affect options within subcommands.
+     * Use {@link SubcommandData#removeOptionByName(String)} instead.
+     *
+     * @param  name
+     *         The <b>case-sensitive</b> option name
+     *
+     * @return True, if any options were removed
+     */
+    default boolean removeOptionByName(@Nonnull String name)
+    {
+        return removeOptions(option -> option.getName().equals(name));
+    }
+
+    /**
+     * Removes all subcommands that evaluate to {@code true} under the provided {@code condition}.
+     * <br>This will not apply to subcommands within subcommand groups.
+     * Use {@link SubcommandGroupData#removeSubcommand(Predicate)} instead.
+     *
+     * <p><b>Example: Remove all subcommands</b>
+     * <pre>{@code
+     * command.removeSubcommands(subcommand -> true);
+     * }</pre>
+     *
+     * @param  condition
+     *         The removal condition (must not throw)
+     *
+     * @throws IllegalArgumentException
+     *         If the condition is null
+     *
+     * @return True, if any subcommands were removed
+     */
+    boolean removeSubcommands(@Nonnull Predicate<? super SubcommandData> condition);
+
+    /**
+     * Removes subcommands by the provided name.
+     * <br>This will not apply to subcommands within subcommand groups.
+     * Use {@link SubcommandGroupData#removeSubcommandByName(String)} instead.
+     *
+     * @param  name
+     *         The <b>case-sensitive</b> subcommand name
+     *
+     * @return True, if any subcommands were removed
+     */
+    default boolean removeSubcommandByName(@Nonnull String name)
+    {
+        return removeSubcommands(subcommand -> subcommand.getName().equals(name));
+    }
+
+    /**
+     * Removes all subcommand groups that evaluate to {@code true} under the provided {@code condition}.
+     *
+     * <p><b>Example: Remove all subcommand groups</b>
+     * <pre>{@code
+     * command.removeSubcommandGroups(group -> true);
+     * }</pre>
+     *
+     * @param  condition
+     *         The removal condition (must not throw)
+     *
+     * @throws IllegalArgumentException
+     *         If the condition is null
+     *
+     * @return True, if any subcommand groups were removed
+     */
+    boolean removeSubcommandGroups(@Nonnull Predicate<? super SubcommandGroupData> condition);
+
+    /**
+     * Removes subcommand groups by the provided name.
+     *
+     * @param  name
+     *         The <b>case-sensitive</b> subcommand group name
+     *
+     * @return True, if any subcommand groups were removed
+     */
+    default boolean removeSubcommandGroupByName(@Nonnull String name)
+    {
+        return removeSubcommandGroups(group -> group.getName().equals(name));
+    }
 
     /**
      * The {@link SubcommandData Subcommands} in this command.

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SlashCommandData.java
@@ -67,10 +67,10 @@ public interface SlashCommandData extends CommandData
      * Configure the description
      *
      * @param  description
-     *         The description, 1-100 characters
+     *         The description, 1-{@value #MAX_DESCRIPTION_LENGTH} characters
      *
      * @throws IllegalArgumentException
-     *         If the name is null or not between 1-100 characters
+     *         If the name is null or not between 1-{@value #MAX_DESCRIPTION_LENGTH} characters
      *
      * @return The builder, for chaining
      */
@@ -135,8 +135,6 @@ public interface SlashCommandData extends CommandData
 
     /**
      * The {@link SubcommandData Subcommands} in this command.
-     * <br>These subcommand instances are <b>reconstructed</b>,
-     * which means that any modifications will not be reflected in the backing state.
      *
      * @return Immutable list of {@link SubcommandData}
      */
@@ -145,8 +143,6 @@ public interface SlashCommandData extends CommandData
 
     /**
      * The {@link SubcommandGroupData Subcommand Groups} in this command.
-     * <br>These subcommand group instances are <b>reconstructed</b>,
-     * which means that any modifications will not be reflected in the backing state.
      *
      * @return Immutable list of {@link SubcommandGroupData}
      */
@@ -155,8 +151,6 @@ public interface SlashCommandData extends CommandData
 
     /**
      * The options for this command.
-     * <br>These option instances are <b>reconstructed</b>,
-     * which means that any modifications will not be reflected in the backing state.
      *
      * @return Immutable list of {@link OptionData}
      */
@@ -164,7 +158,7 @@ public interface SlashCommandData extends CommandData
     List<OptionData> getOptions();
 
     /**
-     * Adds up to 25 options to this command.
+     * Adds up to {@value CommandData#MAX_OPTIONS} options to this command.
      *
      * <p>Required options must be added before non-required options!
      *
@@ -176,7 +170,7 @@ public interface SlashCommandData extends CommandData
      *             <li>If you try to mix subcommands/options/groups in one command.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -187,7 +181,7 @@ public interface SlashCommandData extends CommandData
     SlashCommandData addOptions(@Nonnull OptionData... options);
 
     /**
-     * Adds up to 25 options to this command.
+     * Adds up to {@value CommandData#MAX_OPTIONS} options to this command.
      *
      * <p>Required options must be added before non-required options!
      *
@@ -199,7 +193,7 @@ public interface SlashCommandData extends CommandData
      *             <li>If you try to mix subcommands/options/groups in one command.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -221,9 +215,9 @@ public interface SlashCommandData extends CommandData
      * @param  type
      *         The {@link OptionType}
      * @param  name
-     *         The lowercase option name, 1-32 characters
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
      * @param  description
-     *         The option description, 1-100 characters
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
      * @param  required
      *         Whether this option is required (See {@link OptionData#setRequired(boolean)})
      * @param  autoComplete
@@ -237,7 +231,7 @@ public interface SlashCommandData extends CommandData
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If the provided option type does not support auto-complete</li>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -260,9 +254,9 @@ public interface SlashCommandData extends CommandData
      * @param  type
      *         The {@link OptionType}
      * @param  name
-     *         The lowercase option name, 1-32 characters
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
      * @param  description
-     *         The option description, 1-100 characters
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
      * @param  required
      *         Whether this option is required (See {@link OptionData#setRequired(boolean)})
      *
@@ -272,7 +266,7 @@ public interface SlashCommandData extends CommandData
      *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -294,9 +288,9 @@ public interface SlashCommandData extends CommandData
      * @param  type
      *         The {@link OptionType}
      * @param  name
-     *         The lowercase option name, 1-32 characters
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
      * @param  description
-     *         The option description, 1-100 characters
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
      *
      * @throws IllegalArgumentException
      *         <ul>
@@ -304,7 +298,7 @@ public interface SlashCommandData extends CommandData
      *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
      *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -318,13 +312,13 @@ public interface SlashCommandData extends CommandData
     }
 
     /**
-     * Add up to 25 {@link SubcommandData Subcommands} to this command.
+     * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandData Subcommands} to this command.
      *
      * @param  subcommands
      *         The subcommands to add
      *
      * @throws IllegalArgumentException
-     *         If null, more than 25 subcommands, or duplicate subcommand names are provided.
+     *         If null, more than {@value CommandData#MAX_OPTIONS} subcommands, or duplicate subcommand names are provided.
      *         Also throws if you try to mix subcommands/options/groups in one command.
      *
      * @return The builder instance, for chaining
@@ -333,13 +327,13 @@ public interface SlashCommandData extends CommandData
     SlashCommandData addSubcommands(@Nonnull SubcommandData... subcommands);
 
     /**
-     * Add up to 25 {@link SubcommandData Subcommands} to this command.
+     * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandData Subcommands} to this command.
      *
      * @param  subcommands
      *         The subcommands to add
      *
      * @throws IllegalArgumentException
-     *         If null, more than 25 subcommands, or duplicate subcommand names are provided.
+     *         If null, more than {@value CommandData#MAX_OPTIONS} subcommands, or duplicate subcommand names are provided.
      *         Also throws if you try to mix subcommands/options/groups in one command.
      *
      * @return The builder instance, for chaining
@@ -352,13 +346,13 @@ public interface SlashCommandData extends CommandData
     }
 
     /**
-     * Add up to 25 {@link SubcommandGroupData Subcommand-Groups} to this command.
+     * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandGroupData Subcommand-Groups} to this command.
      *
      * @param  groups
      *         The subcommand groups to add
      *
      * @throws IllegalArgumentException
-     *         If null, more than 25 subcommand groups, or duplicate group names are provided.
+     *         If null, more than {@value CommandData#MAX_OPTIONS} subcommand groups, or duplicate group names are provided.
      *         Also throws if you try to mix subcommands/options/groups in one command.
      *
      * @return The builder instance, for chaining
@@ -367,13 +361,13 @@ public interface SlashCommandData extends CommandData
     SlashCommandData addSubcommandGroups(@Nonnull SubcommandGroupData... groups);
 
     /**
-     * Add up to 25 {@link SubcommandGroupData Subcommand-Groups} to this command.
+     * Add up to {@value CommandData#MAX_OPTIONS} {@link SubcommandGroupData Subcommand-Groups} to this command.
      *
      * @param  groups
      *         The subcommand groups to add
      *
      * @throws IllegalArgumentException
-     *         If null, more than 25 subcommand groups, or duplicate group names are provided.
+     *         If null, more than {@value CommandData#MAX_OPTIONS} subcommand groups, or duplicate group names are provided.
      *         Also throws if you try to mix subcommands/options/groups in one command.
      *
      * @return The builder instance, for chaining

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandData.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -212,6 +213,45 @@ public class SubcommandData implements SerializableData
         //Checks are done in LocalizationMap
         descriptionLocalizations.setTranslations(map);
         return this;
+    }
+
+    /**
+     * Removes all options that evaluate to {@code true} under the provided {@code condition}.
+     *
+     * <p><b>Example: Remove all options</b>
+     * <pre>{@code
+     * command.removeOptions(option -> true);
+     * }</pre>
+     * <p><b>Example: Remove all options that are required</b>
+     * <pre>{@code
+     * command.removeOptions(option -> option.isRequired());
+     * }</pre>
+     *
+     * @param  condition
+     *         The removal condition (must not throw)
+     *
+     * @throws IllegalArgumentException
+     *         If the condition is null
+     *
+     * @return True, if any options were removed
+     */
+    public boolean removeOptions(@Nonnull Predicate<? super OptionData> condition)
+    {
+        Checks.notNull(condition, "Condition");
+        return options.removeIf(condition);
+    }
+
+    /**
+     * Removes options by the provided name.
+     *
+     * @param  name
+     *         The <b>case-sensitive</b> option name
+     *
+     * @return True, if any options were removed
+     */
+    public boolean removeOptionByName(@Nonnull String name)
+    {
+        return removeOptions(option -> option.getName().equals(name));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandData.java
@@ -25,14 +25,10 @@ import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.api.utils.data.SerializableData;
 import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.Helpers;
 import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
@@ -40,7 +36,7 @@ import java.util.stream.Stream;
  */
 public class SubcommandData implements SerializableData
 {
-    protected final DataArray options = DataArray.empty();
+    protected final List<OptionData> options = new ArrayList<>(CommandData.MAX_OPTIONS);
     protected String name, description;
     private final LocalizationMap nameLocalizations = new LocalizationMap(this::checkName);
     private final LocalizationMap descriptionLocalizations = new LocalizationMap(this::checkDescription);
@@ -219,7 +215,7 @@ public class SubcommandData implements SerializableData
     }
 
     /**
-     * Adds up to 25 options to this subcommand.
+     * Adds up to {@value CommandData#MAX_OPTIONS} options to this subcommand.
      *
      * <p>Required options must be added before non-required options!
      *
@@ -229,7 +225,7 @@ public class SubcommandData implements SerializableData
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -240,7 +236,7 @@ public class SubcommandData implements SerializableData
     public SubcommandData addOptions(@Nonnull OptionData... options)
     {
         Checks.noneNull(options, "Option");
-        Checks.check(options.length + this.options.length() <= 25, "Cannot have more than 25 options for a subcommand!");
+        Checks.check(options.length + this.options.size() <= CommandData.MAX_OPTIONS, "Cannot have more than %d options for a subcommand!", CommandData.MAX_OPTIONS);
         boolean allowRequired = this.allowRequired;
         for (OptionData option : options)
         {
@@ -255,14 +251,13 @@ public class SubcommandData implements SerializableData
             (count, value) -> new Object[]{ value, count });
 
         this.allowRequired = allowRequired;
-        for (OptionData option : options)
-            this.options.add(option);
+        this.options.addAll(Arrays.asList(options));
 
         return this;
     }
 
     /**
-     * Adds up to 25 options to this subcommand.
+     * Adds up to {@value CommandData#MAX_OPTIONS} options to this subcommand.
      *
      * <p>Required options must be added before non-required options!
      *
@@ -272,7 +267,7 @@ public class SubcommandData implements SerializableData
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -294,9 +289,9 @@ public class SubcommandData implements SerializableData
      * @param  type
      *         The {@link OptionType}
      * @param  name
-     *         The lowercase option name, 1-32 characters
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
      * @param  description
-     *         The option description, 1-100 characters
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
      * @param  required
      *         Whether this option is required (See {@link OptionData#setRequired(boolean)})
      * @param  autoComplete
@@ -307,7 +302,7 @@ public class SubcommandData implements SerializableData
      *         <ul>
      *             <li>If this option is required and you already added a non-required option.</li>
      *             <li>If the provided option type does not support auto-complete</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -330,16 +325,16 @@ public class SubcommandData implements SerializableData
      * @param  type
      *         The {@link OptionType}
      * @param  name
-     *         The lowercase option name, 1-32 characters
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
      * @param  description
-     *         The option description, 1-100 characters
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
      * @param  required
      *         Whether this option is required (See {@link OptionData#setRequired(boolean)})
      *
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -361,14 +356,14 @@ public class SubcommandData implements SerializableData
      * @param  type
      *         The {@link OptionType}
      * @param  name
-     *         The lowercase option name, 1-32 characters
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
      * @param  description
-     *         The option description, 1-100 characters
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
      *
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If this option is required and you already added a non-required option.</li>
-     *             <li>If more than 25 options are provided.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
      *             <li>If the option name is not unique</li>
      *             <li>If null is provided</li>
      *         </ul>
@@ -389,10 +384,7 @@ public class SubcommandData implements SerializableData
     @Nonnull
     public List<OptionData> getOptions()
     {
-        return options.stream(DataArray::getObject)
-                .map(OptionData::fromData)
-                .filter(it -> it.getType().getKey() > OptionType.SUB_COMMAND_GROUP.getKey())
-                .collect(Helpers.toUnmodifiableList());
+        return Collections.unmodifiableList(options);
     }
 
     /**
@@ -449,7 +441,7 @@ public class SubcommandData implements SerializableData
                 .put("name_localizations", nameLocalizations)
                 .put("description", description)
                 .put("description_localizations", descriptionLocalizations)
-                .put("options", options);
+                .put("options", DataArray.fromCollection(options));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandGroupData.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/build/SubcommandGroupData.java
@@ -28,6 +28,7 @@ import net.dv8tion.jda.internal.utils.localization.LocalizationUtils;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -261,6 +262,41 @@ public class SubcommandGroupData implements SerializableData
     public LocalizationMap getDescriptionLocalizations()
     {
         return descriptionLocalizations;
+    }
+
+    /**
+     * Removes all subcommands that evaluate to {@code true} under the provided {@code condition}.
+     *
+     * <p><b>Example: Remove all subcommands</b>
+     * <pre>{@code
+     * command.removeSubcommands(subcommand -> true);
+     * }</pre>
+     *
+     * @param  condition
+     *         The removal condition (must not throw)
+     *
+     * @throws IllegalArgumentException
+     *         If the condition is null
+     *
+     * @return True, if any subcommands were removed
+     */
+    public boolean removeSubcommand(@Nonnull Predicate<? super SubcommandData> condition)
+    {
+        Checks.notNull(condition, "Condition");
+        return subcommands.removeIf(condition);
+    }
+
+    /**
+     * Removes subcommands by the provided name.
+     *
+     * @param  name
+     *         The <b>case-sensitive</b> subcommand name
+     *
+     * @return True, if any subcommands were removed
+     */
+    public boolean removeSubcommandByName(@Nonnull String name)
+    {
+        return removeSubcommand(subcommand -> subcommand.getName().equals(name));
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandCreateActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/CommandCreateActionImpl.java
@@ -34,17 +34,19 @@ import net.dv8tion.jda.internal.interactions.command.CommandImpl;
 import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import okhttp3.RequestBody;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
 
 public class CommandCreateActionImpl extends RestActionImpl<Command> implements CommandCreateAction
 {
     private final Guild guild;
-    private CommandDataImpl data;
+    private final CommandDataImpl data;
 
     public CommandCreateActionImpl(JDAImpl api, CommandDataImpl command)
     {
@@ -206,6 +208,24 @@ public class CommandCreateActionImpl extends RestActionImpl<Command> implements 
     public LocalizationMap getDescriptionLocalizations()
     {
         return data.getDescriptionLocalizations();
+    }
+
+    @Override
+    public boolean removeOptions(@NotNull Predicate<? super OptionData> condition)
+    {
+        return data.removeOptions(condition);
+    }
+
+    @Override
+    public boolean removeSubcommands(@NotNull Predicate<? super SubcommandData> condition)
+    {
+        return data.removeSubcommands(condition);
+    }
+
+    @Override
+    public boolean removeSubcommandGroups(@NotNull Predicate<? super SubcommandGroupData> condition)
+    {
+        return data.removeSubcommandGroups(condition);
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This moves the serialization of options into `toData()`, which removes the need to reconstruct them for getters. Additionally, I've added some more constants to replace the magic numbers in checks.
