### PR TITLE
Fix check for ChannelAction#setCategory

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
@@ -157,7 +157,7 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
     public ChannelActionImpl<T> setParent(Category category)
     {
         Checks.check(category == null || category.getGuild().equals(guild), "Category is not from same guild!");
-        if (type == ChannelType.CATEGORY)
+        if (type == ChannelType.CATEGORY && category != null)
             throw new UnsupportedOperationException("Cannot set a parent Category on a Category");
 
         this.parent = category;

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/ChannelActionImpl.java
@@ -156,9 +156,12 @@ public class ChannelActionImpl<T extends GuildChannel> extends AuditableRestActi
     @CheckReturnValue
     public ChannelActionImpl<T> setParent(Category category)
     {
-        Checks.check(category == null || category.getGuild().equals(guild), "Category is not from same guild!");
-        if (type == ChannelType.CATEGORY && category != null)
-            throw new UnsupportedOperationException("Cannot set a parent Category on a Category");
+        if (category != null)
+        {
+            Checks.check(category.getGuild().equals(guild), "Category is not from same guild!");
+            if (type == ChannelType.CATEGORY)
+                throw new UnsupportedOperationException("Cannot set a parent Category on a Category");
+        }
 
         this.parent = category;
         return this;


### PR DESCRIPTION


[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes a regression which broke Guild#createCategory due to setting category. Instead of changing the logic for that, I made sure to only throw if the parent is not null.
