### PR TITLE
Put "options" between command path and options, same for choices

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionType.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionType.java
@@ -28,79 +28,81 @@ import javax.annotation.Nonnull;
 public enum OptionType
 {
     /** Placeholder for future option types */
-    UNKNOWN(-1),
+    UNKNOWN(-1, false),
     /**
      * Option which is serialized as subcommand, this is only used for internals and should be ignored by users.
      * @see SlashCommandData#addSubcommands(SubcommandData...)
      */
-    SUB_COMMAND(1),
+    SUB_COMMAND(1, false),
     /**
      * Option which is serialized as subcommand groups, this is only used for internals and should be ignored by users.
      * @see SlashCommandData#addSubcommandGroups(SubcommandGroupData...)
      */
-    SUB_COMMAND_GROUP(2),
+    SUB_COMMAND_GROUP(2, false),
     /**
      * Options which accept text inputs. This also supports role/channel/user mentions.
      * @see OptionMapping#getAsString()
      * @see OptionMapping#getMentions()
      */
-    STRING(3, true),
+    STRING(3, true, true),
     /**
      * Options which accept {@link Long} integer inputs
      * @see OptionMapping#getAsLong()
      */
-    INTEGER(4, true),
+    INTEGER(4, true, true),
     /**
      * Options which accept boolean true or false inputs
      * @see OptionMapping#getAsBoolean()
      */
-    BOOLEAN(5),
+    BOOLEAN(5, true),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.Member Member} or {@link net.dv8tion.jda.api.entities.User User}
      * @see OptionMapping#getAsUser()
      * @see OptionMapping#getAsMember()
      */
-    USER(6),
+    USER(6, true),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.channel.middleman.GuildChannel GuildChannel}
      * @see OptionMapping#getAsChannel()
      */
-    CHANNEL(7),
+    CHANNEL(7, true),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.Role Role}
      * @see OptionMapping#getAsRole()
      */
-    ROLE(8),
+    ROLE(8, true),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.Role Role}, {@link net.dv8tion.jda.api.entities.User User}, or {@link net.dv8tion.jda.api.entities.Member Member}.
      * @see OptionMapping#getAsMentionable()
      */
-    MENTIONABLE(9),
+    MENTIONABLE(9, true),
     /**
      * Options which accept a {@link Double} value (also includes {@link Long})
      * @see OptionMapping#getAsDouble()
      * @see OptionMapping#getAsLong()
      */
-    NUMBER(10, true),
+    NUMBER(10, true, true),
     /**
      * Options which accept a file attachment
      * @see OptionMapping#getAsAttachment()
      */
-    ATTACHMENT(11),
+    ATTACHMENT(11, true),
     ;
 
     private final int raw;
     private final boolean supportsChoices;
+    private final boolean isOption;
 
-    OptionType(int raw)
+    OptionType(int raw, boolean isOption)
     {
-        this(raw, false);
+        this(raw, false, isOption);
     }
 
-    OptionType(int raw, boolean supportsChoices)
+    OptionType(int raw, boolean supportsChoices, boolean isOption)
     {
         this.raw = raw;
         this.supportsChoices = supportsChoices;
+        this.isOption = isOption;
     }
 
     /**
@@ -111,6 +113,16 @@ public enum OptionType
     public int getKey()
     {
         return raw;
+    }
+
+    /**
+     * Whether this option type is an input option.
+     *
+     * @return True, if this is an input option.
+     */
+    public boolean isOption()
+    {
+        return isOption;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionType.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/OptionType.java
@@ -28,81 +28,79 @@ import javax.annotation.Nonnull;
 public enum OptionType
 {
     /** Placeholder for future option types */
-    UNKNOWN(-1, false),
+    UNKNOWN(-1),
     /**
      * Option which is serialized as subcommand, this is only used for internals and should be ignored by users.
      * @see SlashCommandData#addSubcommands(SubcommandData...)
      */
-    SUB_COMMAND(1, false),
+    SUB_COMMAND(1),
     /**
      * Option which is serialized as subcommand groups, this is only used for internals and should be ignored by users.
      * @see SlashCommandData#addSubcommandGroups(SubcommandGroupData...)
      */
-    SUB_COMMAND_GROUP(2, false),
+    SUB_COMMAND_GROUP(2),
     /**
      * Options which accept text inputs. This also supports role/channel/user mentions.
      * @see OptionMapping#getAsString()
      * @see OptionMapping#getMentions()
      */
-    STRING(3, true, true),
+    STRING(3, true),
     /**
      * Options which accept {@link Long} integer inputs
      * @see OptionMapping#getAsLong()
      */
-    INTEGER(4, true, true),
+    INTEGER(4, true),
     /**
      * Options which accept boolean true or false inputs
      * @see OptionMapping#getAsBoolean()
      */
-    BOOLEAN(5, true),
+    BOOLEAN(5),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.Member Member} or {@link net.dv8tion.jda.api.entities.User User}
      * @see OptionMapping#getAsUser()
      * @see OptionMapping#getAsMember()
      */
-    USER(6, true),
+    USER(6),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.channel.middleman.GuildChannel GuildChannel}
      * @see OptionMapping#getAsChannel()
      */
-    CHANNEL(7, true),
+    CHANNEL(7),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.Role Role}
      * @see OptionMapping#getAsRole()
      */
-    ROLE(8, true),
+    ROLE(8),
     /**
      * Options which accept a single {@link net.dv8tion.jda.api.entities.Role Role}, {@link net.dv8tion.jda.api.entities.User User}, or {@link net.dv8tion.jda.api.entities.Member Member}.
      * @see OptionMapping#getAsMentionable()
      */
-    MENTIONABLE(9, true),
+    MENTIONABLE(9),
     /**
      * Options which accept a {@link Double} value (also includes {@link Long})
      * @see OptionMapping#getAsDouble()
      * @see OptionMapping#getAsLong()
      */
-    NUMBER(10, true, true),
+    NUMBER(10, true),
     /**
      * Options which accept a file attachment
      * @see OptionMapping#getAsAttachment()
      */
-    ATTACHMENT(11, true),
+    ATTACHMENT(11),
     ;
 
     private final int raw;
     private final boolean supportsChoices;
-    private final boolean isOption;
 
-    OptionType(int raw, boolean isOption)
+    OptionType(int raw)
     {
-        this(raw, false, isOption);
+        this(raw, false);
     }
 
-    OptionType(int raw, boolean supportsChoices, boolean isOption)
+    OptionType(int raw, boolean supportsChoices)
     {
         this.raw = raw;
         this.supportsChoices = supportsChoices;
-        this.isOption = isOption;
     }
 
     /**
@@ -113,16 +111,6 @@ public enum OptionType
     public int getKey()
     {
         return raw;
-    }
-
-    /**
-     * Whether this option type is an input option.
-     *
-     * @return True, if this is an input option.
-     */
-    public boolean isOption()
-    {
-        return isOption;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/localization/LocalizationFunction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/localization/LocalizationFunction.java
@@ -28,6 +28,7 @@ import java.util.Map;
  * <p>
  * <b>Implementation note:</b>
  * The localization key is composed of the command/option/choice tree being walked, where each command/option/choice's name is separated by a dot
+ * <br>Additionally, there is an "options" key between the command path and the name of the option, as well as a "choices" key between the options and the choices
  * <br>Note: the final key is lowercase and spaces replaced by underscores
  * <br>
  * <br>A few examples of localization keys:
@@ -36,8 +37,8 @@ import java.util.Map;
  *    <li>The name of a message context named "Get content raw": {@code get_content_raw.name}</li>
  *    <li>The description of a command named "ban": {@code ban.description}</li>
  *    <li>The name of a subcommand "perm" in a command named "ban": {@code ban.perm.name}</li>
- *    <li>The description of an option "duration" in a subcommand "perm" in a command named "ban": {@code ban.perm.duration.description}</li>
- *    <li>The name of a choice in an option "duration" in a subcommand "perm" in a command named "ban": {@code ban.perm.duration.choice.name}</li>
+ *    <li>The description of an option "duration" in a subcommand "perm" in a command named "ban": {@code ban.perm.options.duration.description}</li>
+ *    <li>The name of a choice (here, "1 day") in an option "duration" in a subcommand "perm" in a command named "ban": {@code ban.perm.options.duration.choices.1_day.name}</li>
  * </ul>
  *
  * <br>Extremely naive implementation of LocalizationFunction

--- a/src/main/java/net/dv8tion/jda/internal/interactions/command/localization/LocalizationMapper.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/command/localization/LocalizationMapper.java
@@ -119,7 +119,9 @@ public class LocalizationMapper
                 };
 
                 //We need to differentiate subcommands/groups from options before inserting the "options" separator
-                if (OptionType.fromKey(item.getInt("type", -1)).isOption()) { //-1 when the object isn't an option
+                final OptionType type = OptionType.fromKey(item.getInt("type", -1)); //-1 when the object isn't an option
+                final boolean isOption = type != OptionType.SUB_COMMAND && type != OptionType.SUB_COMMAND_GROUP;
+                if (isOption) {
                     //At this point the key should look like "path.to.command",
                     // we can insert "options", and the keyExtractor would give option names
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Puts an "options" key between the command path and the option, as well as "choices" between the option and the choice
This helps reading localization files such as JSON or YAML as option names aren't on the same indent as other command-related strings, as well as making it explicit that the user is modifying an option/choice's localization

Related convo: https://discord.com/channels/125227483518861312/869965829024915466/1023634607360462938
