### PR TITLE
Forward shutdown reason to awaitStatus exception

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -76,10 +76,7 @@ import net.dv8tion.jda.internal.requests.restaction.CommandCreateActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.CommandEditActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.CommandListUpdateActionImpl;
 import net.dv8tion.jda.internal.requests.restaction.GuildActionImpl;
-import net.dv8tion.jda.internal.utils.Checks;
-import net.dv8tion.jda.internal.utils.Helpers;
-import net.dv8tion.jda.internal.utils.JDALogger;
-import net.dv8tion.jda.internal.utils.UnlockHook;
+import net.dv8tion.jda.internal.utils.*;
 import net.dv8tion.jda.internal.utils.cache.AbstractCacheView;
 import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
 import net.dv8tion.jda.internal.utils.config.AuthorizationConfig;
@@ -130,6 +127,7 @@ public class JDAImpl implements JDA
     protected final SessionConfig sessionConfig;
     protected final MetaConfig metaConfig;
 
+    public ShutdownReason shutdownReason = ShutdownReason.USER_SHUTDOWN; // indicates why shutdown happened in awaitStatus / awaitReady
     protected WebSocketClient client;
     protected Requester requester;
     protected IAudioSendFactory audioSendFactory = new DefaultSendFactory();
@@ -493,7 +491,7 @@ public class JDAImpl implements JDA
                 || getStatus().ordinal() < status.ordinal()) // Wait until status is bypassed
         {
             if (getStatus() == Status.SHUTDOWN)
-                throw new IllegalStateException("Was shutdown trying to await status");
+                throw new IllegalStateException("Was shutdown trying to await status.\nReason: " + shutdownReason);
             else if (failStatus.contains(getStatus()))
                 return this;
             Thread.sleep(50);

--- a/src/main/java/net/dv8tion/jda/internal/utils/ShutdownReason.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/ShutdownReason.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.internal.utils;
+
+public class ShutdownReason
+{
+    public static final ShutdownReason USER_SHUTDOWN = new ShutdownReason("User requested shutdown");
+    public static final ShutdownReason INVALID_SHARDS = new ShutdownReason("Invalid shard configuration");
+    public static final ShutdownReason DISALLOWED_INTENTS = new ShutdownReason("You tried turning on an intent you aren't allowed to use. " +
+            "For more information check https://jda.wiki/using-jda/troubleshooting/#im-getting-closecode4014-disallowed-intents");
+
+    protected final String reason;
+
+    public ShutdownReason(String reason)
+    {
+        this.reason = reason;
+    }
+
+    public String getReason()
+    {
+        return reason;
+    }
+
+    @Override
+    public String toString()
+    {
+        return reason;
+    }
+}


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This provides the context of shutdowns to the exceptions throw by `awaitStatus`:

```
Exception in thread "main" java.lang.IllegalStateException: Was shutdown trying to await status.
Reason: You tried turning on an intent you aren't allowed to use. For more information check https://jda.wiki/using-jda/troubleshooting/#im-getting-closecode4014-disallowed-intents
	at net.dv8tion.jda.internal.JDAImpl.awaitStatus(JDAImpl.java:494)
	at net.dv8tion.jda.api.JDA.awaitStatus(JDA.java:324)
	at net.dv8tion.jda.api.JDA.awaitReady(JDA.java:374)
```
