### PR TITLE
Make ForumTag extend ForumTagSnowflake

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/forums/ForumTag.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/forums/ForumTag.java
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
  * Represents a Discord Forum Tag.
  * <br>These tags can be applied to forum posts to help categorize them.
  */
-public interface ForumTag extends ISnowflake, Comparable<ForumTag>, BaseForumTag
+public interface ForumTag extends ForumTagSnowflake, Comparable<ForumTag>, BaseForumTag
 {
     /**
      * The maximum length of a forum tag name ({@value #MAX_NAME_LENGTH})


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This was an oversight. Making it extend ForumTagSnowflakes allows for these tags to be applied to posts.
