### PR TITLE
Handle emoji_id sometimes being 0 instead of null

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -162,10 +162,17 @@ public class EntityBuilder
     // Unlike Emoji.fromData this does not check for null or empty
     public static EmojiUnion createEmoji(DataObject emoji)
     {
-        if (emoji.isNull("id"))
-            return new UnicodeEmojiImpl(emoji.getString("name"));
+        return createEmoji(emoji, "name", "id");
+    }
+
+    // Unlike Emoji.fromData this does not check for null or empty
+    public static EmojiUnion createEmoji(DataObject emoji, String nameKey, String idKey)
+    {
+        long id = emoji.getUnsignedLong(idKey, 0L);
+        if (id == 0L)
+            return new UnicodeEmojiImpl(emoji.getString(nameKey));
         else // name can be empty in some cases where discord fails to properly load the emoji
-            return new CustomEmojiImpl(emoji.getString("name", ""), emoji.getUnsignedLong("id"), emoji.getBoolean("animated"));
+            return new CustomEmojiImpl(emoji.getString(nameKey, ""), id, emoji.getBoolean("animated"));
     }
 
     private void createGuildEmojiPass(GuildImpl guildObj, DataArray array)

--- a/src/main/java/net/dv8tion/jda/internal/entities/ForumTagImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ForumTagImpl.java
@@ -81,8 +81,9 @@ public class ForumTagImpl extends ForumTagSnowflakeImpl implements ForumTag
 
     public ForumTagImpl setEmoji(DataObject json)
     {
-        if (!json.isNull("emoji_id"))
-            this.emoji = new CustomEmojiImpl("", json.getUnsignedLong("emoji_id"), false);
+        long id = json.getUnsignedLong("emoji_id", 0);
+        if (id != 0)
+            this.emoji = new CustomEmojiImpl(json.getString("emoji_name", ""), id, false);
         else if (!json.isNull("emoji_name"))
             this.emoji = Emoji.fromUnicode(json.getString("emoji_name"));
         else

--- a/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ChannelUpdateHandler.java
@@ -185,11 +185,7 @@ public class ChannelUpdateHandler extends SocketHandler
             {
                 final String topic = content.getString("topic", null);
                 final EmojiUnion defaultReaction = content.optObject("default_reaction_emoji")
-                        .map(json -> {
-                            json.opt("emoji_id").ifPresent(id -> json.put("id", id));
-                            json.opt("emoji_name").ifPresent(n -> json.put("name", n));
-                            return EntityBuilder.createEmoji(json);
-                        })
+                        .map(json -> EntityBuilder.createEmoji(json, "emoji_name", "emoji_id"))
                         .orElse(null);
 
                 ForumChannelImpl forumChannel = (ForumChannelImpl) channel;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Apparently, sometimes this is 0 instead of null.
