### PR TITLE
Fix MemberCacheViewImpl#getElementsWithRoles and Guild#findMembersWithRoles ignoring the public role

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1234,7 +1234,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     default List<Member> getMembersWithRoles(@Nonnull Role... roles)
     {
-        Checks.noneNull(roles, "Roles");
+        Checks.notNull(roles, "Roles");
         return getMembersWithRoles(Arrays.asList(roles));
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1258,6 +1258,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     default List<Member> getMembersWithRoles(@Nonnull Collection<Role> roles)
     {
+        Checks.noneNull(roles, "Roles");
         for (Role role : roles)
             Checks.check(this.equals(role.getGuild()), "All roles must be from the same guild!");
         return getMemberCache().getElementsWithRoles(roles);

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1234,6 +1234,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     default List<Member> getMembersWithRoles(@Nonnull Role... roles)
     {
+        Checks.noneNull(roles, "Roles");
         return getMembersWithRoles(Arrays.asList(roles));
     }
 

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1234,7 +1234,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     default List<Member> getMembersWithRoles(@Nonnull Role... roles)
     {
-        return getMemberCache().getElementsWithRoles(roles);
+        return getMembersWithRoles(Arrays.asList(roles));
     }
 
     /**
@@ -1258,6 +1258,8 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     @Nonnull
     default List<Member> getMembersWithRoles(@Nonnull Collection<Role> roles)
     {
+        for (Role role : roles)
+            Checks.check(this.equals(role.getGuild()), "All roles must be from the same guild!");
         return getMemberCache().getElementsWithRoles(roles);
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
@@ -24,6 +24,7 @@ import net.dv8tion.jda.internal.utils.Checks;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implements MemberCacheView
 {
@@ -93,10 +94,13 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
         Checks.noneNull(roles, "Roles");
         if (isEmpty())
             return Collections.emptyList();
+        List<Role> rolesWithoutPublicRole = roles.stream().filter(role -> !role.isPublicRole()).collect(Collectors.toList());
+        if (rolesWithoutPublicRole.isEmpty())
+            return asList();
         List<Member> members = new ArrayList<>();
         forEach(member ->
         {
-            if (member.getRoles().containsAll(roles))
+            if (member.getRoles().containsAll(rolesWithoutPublicRole))
                 members.add(member);
         });
         return members;

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
@@ -94,9 +94,11 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
         Checks.noneNull(roles, "Roles");
         if (isEmpty())
             return Collections.emptyList();
+
         List<Role> rolesWithoutPublicRole = roles.stream().filter(role -> !role.isPublicRole()).collect(Collectors.toList());
         if (rolesWithoutPublicRole.isEmpty())
             return asList();
+
         List<Member> members = new ArrayList<>();
         forEach(member ->
         {


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2291

## Description

Fixes an issue that caused `MemberCacheViewImpl#getElementsWithRoles` to return an empty list when given the public role.
