### PR TITLE
Fix GuildSticker#retrieveOwner

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/sticker/GuildSticker.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/sticker/GuildSticker.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.managers.GuildStickerManager;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction;
@@ -93,6 +94,15 @@ public interface GuildSticker extends RichSticker
      * Retrieves the sticker owner.
      * <br>If {@link #getOwner()} is present, this will directly return the owner in a completed {@link RestAction} without making a request.
      * The user information might be outdated, you can use {@link CacheRestAction#useCache(boolean) action.useCache(false)} to force an update.
+     *
+     * <p>Possible {@link ErrorResponse ErrorResponses} include:
+     * <ul>
+     *     <li>{@link ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
+     *     <br>The request was attempted after the account lost {@link Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS} in the guild</li>
+     * </ul>
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS} in the guild.
      *
      * @return {@link CacheRestAction} - Type: {@link User}
      */

--- a/src/main/java/net/dv8tion/jda/internal/entities/sticker/GuildStickerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/sticker/GuildStickerImpl.java
@@ -17,14 +17,21 @@
 package net.dv8tion.jda.internal.entities.sticker;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.sticker.GuildSticker;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.managers.GuildStickerManager;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction;
+import net.dv8tion.jda.api.utils.data.DataObject;
+import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.managers.GuildStickerManagerImpl;
 import net.dv8tion.jda.internal.requests.DeferredRestAction;
+import net.dv8tion.jda.internal.requests.RestActionImpl;
 import net.dv8tion.jda.internal.requests.Route;
 import net.dv8tion.jda.internal.requests.restaction.AuditableRestActionImpl;
 import net.dv8tion.jda.internal.utils.EntityString;
@@ -102,11 +109,19 @@ public class GuildStickerImpl extends RichStickerImpl implements GuildSticker
     @Override
     public CacheRestAction<User> retrieveOwner()
     {
+        Guild g = getGuild();
+        if (g != null && !g.getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
+            throw new InsufficientPermissionException(g, Permission.MANAGE_EMOJIS_AND_STICKERS);
         return new DeferredRestAction<>(jda, User.class, this::getOwner,
-                () -> jda.retrieveSticker(this).map(union -> {
-                    this.owner = union.asGuildSticker().getOwner();
-                    return this.owner;
-                }));
+            () -> {
+                Route.CompiledRoute route = Route.Stickers.GET_GUILD_STICKER.compile(getGuildId(), getId());
+                return new RestActionImpl<>(jda, route, (response, request) -> {
+                    DataObject json = response.getObject();
+                    return this.owner = json.optObject("user").map(
+                        user -> ((JDAImpl) jda).getEntityBuilder().createUser(json.getObject("user"))
+                    ).orElseThrow(() -> ErrorResponseException.create(ErrorResponse.MISSING_PERMISSIONS, response));
+                });
+            });
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes #2315

## Description

This was using the wrong endpoint, causing user to always be null.
