### PR TITLE
Remove archived threads from cache

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/handle/ThreadUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/ThreadUpdateHandler.java
@@ -26,6 +26,8 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.channel.concrete.ThreadChannelImpl;
 import net.dv8tion.jda.internal.utils.Helpers;
+import net.dv8tion.jda.internal.utils.cache.SnowflakeCacheViewImpl;
+import net.dv8tion.jda.internal.utils.cache.SortedSnowflakeCacheViewImpl;
 
 import java.util.List;
 import java.util.Objects;
@@ -169,6 +171,14 @@ public class ThreadUpdateHandler extends SocketHandler
                         api, responseNumber,
                         thread, oldTagList, newTagList));
             }
+        }
+
+        if (thread.isArchived())
+        {
+            SortedSnowflakeCacheViewImpl<ThreadChannel> guildView = thread.getGuild().getThreadChannelsView();
+            SnowflakeCacheViewImpl<ThreadChannel> globalView = api.getThreadChannelsView();
+            guildView.remove(threadId);
+            globalView.remove(threadId);
         }
 
         return null;


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This will remove archived threads from the cache. You can use [Guild#retrieveArchivedPublicThreadChannels](https://ci.dv8tion.net/job/JDA5/javadoc/net/dv8tion/jda/api/entities/channel/attribute/IThreadContainer.html#retrieveArchivedPublicThreadChannels()) to get them again.

Since thread cache is necessary to handle update events, those events will no longer function for archived threads. However, that was partially the case anyway, since archived threads were discarded already on invalidation (or startup).
