### PR TITLE
Fix handling of empty select menu interactions

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/component/EntitySelectInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/component/EntitySelectInteractionImpl.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.Mentions;
 import net.dv8tion.jda.api.interactions.components.selections.EntitySelectInteraction;
 import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu;
+import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.JDAImpl;
 import net.dv8tion.jda.internal.entities.GuildImpl;
@@ -39,8 +40,8 @@ public class EntitySelectInteractionImpl extends SelectMenuInteractionImpl<IMent
         this.mentions = new SelectMenuMentions(
                 jda,
                 (GuildImpl) getGuild(),
-                content.getObject("resolved"),
-                content.getArray("values")
+                content.optObject("resolved").orElseGet(DataObject::empty),
+                content.optArray("values").orElseGet(DataArray::empty)
         );
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/interactions/component/StringSelectInteractionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/component/StringSelectInteractionImpl.java
@@ -39,9 +39,10 @@ public class StringSelectInteractionImpl extends SelectMenuInteractionImpl<Strin
 
     protected List<String> parseValues(DataObject data)
     {
-        return data.getArray("values")
-                .stream(DataArray::getString)
-                .collect(Collectors.toList());
+        return data.optArray("values").map(arr ->
+            arr.stream(DataArray::getString)
+               .collect(Collectors.toList())
+        ).orElse(Collections.emptyList());
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

When clearing an entity select menu, the resolved is omitted for the interaction event. This caused parsing exceptions because of `getObject(..)` asserting it to be present.