### PR TITLE
Add application_id support for received messages

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Message.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Message.java
@@ -484,6 +484,28 @@ public interface Message extends ISnowflake, Formattable
     boolean isWebhookMessage();
 
     /**
+     * If this message is from an application-owned {@link net.dv8tion.jda.api.entities.Webhook Webhook} or
+     * is a response to an {@link net.dv8tion.jda.api.interactions.Interaction Interaction}, this will return
+     * the application's id.
+     * 
+     * @return The application's id or {@code null} if this message was not sent by an application
+     */
+    @Nullable
+    default String getApplicationId()
+    {
+        return getApplicationIdLong() == 0 ? null : Long.toUnsignedString(getApplicationIdLong());
+    }
+
+    /**
+     * If this message is from an application-owned {@link net.dv8tion.jda.api.entities.Webhook Webhook} or
+     * is a response to an {@link net.dv8tion.jda.api.interactions.Interaction Interaction}, this will return
+     * the application's id.
+     * 
+     * @return The application's id or 0 if this message was not sent by an application
+     */
+    long getApplicationIdLong();
+
+    /**
      * Returns the {@link net.dv8tion.jda.api.entities.channel.middleman.MessageChannel MessageChannel} that this message was sent in.
      *
      * @return The MessageChannel of this Message

--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1634,6 +1634,7 @@ public class EntityBuilder
 
         final String content = jsonObject.getString("content", "");
         final boolean fromWebhook = jsonObject.hasKey("webhook_id");
+        final long applicationId = jsonObject.getUnsignedLong("application_id", 0);
         final boolean pinned = jsonObject.getBoolean("pinned");
         final boolean tts = jsonObject.getBoolean("tts");
         final boolean mentionsEveryone = jsonObject.getBoolean("mention_everyone");
@@ -1753,12 +1754,12 @@ public class EntityBuilder
 
         if (!type.isSystem())
         {
-            return new ReceivedMessage(id, channel, type, messageReference, fromWebhook, tts, pinned,
+            return new ReceivedMessage(id, channel, type, messageReference, fromWebhook, applicationId, tts, pinned,
                     content, nonce, user, member, activity, editTime, mentions, reactions, attachments, embeds, stickers, components, flags, messageInteraction, startedThread);
         }
         else
         {
-            return new SystemMessage(id, channel, type, messageReference, fromWebhook, tts, pinned,
+            return new SystemMessage(id, channel, type, messageReference, fromWebhook, applicationId, tts, pinned,
                     content, nonce, user, member, activity, editTime, mentions, reactions, attachments, embeds, stickers, flags, startedThread);
         }
     }

--- a/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/ReceivedMessage.java
@@ -73,6 +73,7 @@ public class ReceivedMessage extends AbstractMessage
     protected final MessageChannel channel;
     protected final MessageReference messageReference;
     protected final boolean fromWebhook;
+    protected final long applicationId;
     protected final boolean pinned;
     protected final User author;
     protected final Member member;
@@ -96,7 +97,7 @@ public class ReceivedMessage extends AbstractMessage
 
     public ReceivedMessage(
             long id, MessageChannel channel, MessageType type, MessageReference messageReference,
-            boolean fromWebhook, boolean  tts, boolean pinned,
+            boolean fromWebhook, long applicationId, boolean  tts, boolean pinned,
             String content, String nonce, User author, Member member, MessageActivity activity, OffsetDateTime editTime,
             Mentions mentions, List<MessageReaction> reactions, List<Attachment> attachments, List<MessageEmbed> embeds,
             List<StickerItem> stickers, List<ActionRow> components,
@@ -109,6 +110,7 @@ public class ReceivedMessage extends AbstractMessage
         this.type = type;
         this.api = (JDAImpl) channel.getJDA();
         this.fromWebhook = fromWebhook;
+        this.applicationId = applicationId;
         this.pinned = pinned;
         this.author = author;
         this.member = member;
@@ -507,6 +509,12 @@ public class ReceivedMessage extends AbstractMessage
     public boolean isWebhookMessage()
     {
         return fromWebhook;
+    }
+
+    @Override
+    public long getApplicationIdLong()
+    {
+        return applicationId;
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/SystemMessage.java
@@ -37,12 +37,12 @@ public class SystemMessage extends ReceivedMessage
 {
     public SystemMessage(
             long id, MessageChannel channel, MessageType type, MessageReference messageReference,
-            boolean fromWebhook, boolean  tts, boolean pinned,
+            boolean fromWebhook, long applicationId, boolean  tts, boolean pinned,
             String content, String nonce, User author, Member member, MessageActivity activity, OffsetDateTime editTime,
             Mentions mentions, List<MessageReaction> reactions, List<Attachment> attachments, List<MessageEmbed> embeds,
             List<StickerItem> stickers, int flags, ThreadChannel startedThread)
     {
-        super(id, channel, type, messageReference, fromWebhook, tts, pinned, content, nonce, author, member,
+        super(id, channel, type, messageReference, fromWebhook, applicationId, tts, pinned, content, nonce, author, member,
                 activity, editTime, mentions, reactions, attachments, embeds, stickers, Collections.emptyList(), flags, null, startedThread);
     }
 


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2311 

## Description

Adds `Message#getApplicationId` and `Message#getApplicationIdLong` to easily tell which bot sent the message without the need to look up webhooks.