### PR TITLE
Remove outdated feature check for private threads

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/attribute/IThreadContainerMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/attribute/IThreadContainerMixin.java
@@ -48,8 +48,6 @@ public interface IThreadContainerMixin<T extends IThreadContainerMixin<T>> exten
         Checks.checkAccess(getGuild().getSelfMember(), this);
         if (isPrivate)
         {
-            if (!getGuild().getFeatures().contains("PRIVATE_THREADS"))
-                throw new IllegalStateException("Can only use private threads in Guilds with the PRIVATE_THREADS feature");
             checkPermission(Permission.CREATE_PRIVATE_THREADS);
         }
         else

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/attribute/IThreadContainerMixin.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/mixin/attribute/IThreadContainerMixin.java
@@ -47,13 +47,9 @@ public interface IThreadContainerMixin<T extends IThreadContainerMixin<T>> exten
 
         Checks.checkAccess(getGuild().getSelfMember(), this);
         if (isPrivate)
-        {
             checkPermission(Permission.CREATE_PRIVATE_THREADS);
-        }
         else
-        {
             checkPermission(Permission.CREATE_PUBLIC_THREADS);
-        }
 
         ChannelType threadType = isPrivate
             ? ChannelType.GUILD_PRIVATE_THREAD


### PR DESCRIPTION
[contributing]: https://github.com/DV8FromTheWorld/JDA/wiki/5%29-Contributing

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____

Closes Issue: NaN

## Description

Discord recently removed the boost gate on private thread creation, but JDA still had a check causing an erroneous short circuit.
