### PR TITLE
StringSelectMenu#getOptions not actually unmodifiable (docs)

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/components/selections/StringSelectMenu.java
@@ -83,7 +83,7 @@ public interface StringSelectMenu extends SelectMenu
     }
 
     /**
-     * An <b>unmodifiable</b> list of up to {@value #OPTIONS_MAX_AMOUNT} available options to choose from.
+     * A list of up to {@value #OPTIONS_MAX_AMOUNT} available options to choose from.
      *
      * @return The {@link SelectOption SelectOptions} this menu provides
      *


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Says unmodifiable but it is actually modifiable: https://github.com/DV8FromTheWorld/JDA/blob/9a83045b427465f1be279045409e9f59e8858db0/src/main/java/net/dv8tion/jda/internal/interactions/component/StringSelectMenuImpl.java#L45-L66
