### PR TITLE
Make StringSelectMenuImpl#getOptions return unmodifiable list

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/interactions/component/StringSelectMenuImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/interactions/component/StringSelectMenuImpl.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.utils.data.DataObject;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -62,7 +63,7 @@ public class StringSelectMenuImpl extends SelectMenuImpl implements StringSelect
     @Override
     public List<SelectOption> getOptions()
     {
-        return options;
+        return Collections.unmodifiableList(options);
     }
 
     @Nonnull


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This makes `StringSelectMenuImpl#getOptions` return an unmodifiable list
