### PR TITLE
Add generic slowmode channel manager to slowmode channel interface

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/ISlowmodeChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/ISlowmodeChannel.java
@@ -45,4 +45,7 @@ public interface ISlowmodeChannel extends GuildChannel
      * @return The slowmode for this channel, between 1 and {@value #MAX_SLOWMODE}, or {@code 0} if no slowmode is set.
      */
     int getSlowmode();
+    
+    // TODO: does this need docs?
+    ISlowmodeChannelManager<?, ?> getManager();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/ISlowmodeChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/ISlowmodeChannel.java
@@ -16,7 +16,12 @@
 
 package net.dv8tion.jda.api.entities.channel.attribute;
 
+import net.dv8tion.jda.api.entities.channel.ChannelField;
+import net.dv8tion.jda.api.managers.channel.ChannelManager;
+import net.dv8tion.jda.api.managers.channel.attribute.ISlowmodeChannelManager;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+
+import javax.annotation.Nonnull;
 
 /**
  * Channels which support slowmode.
@@ -45,7 +50,22 @@ public interface ISlowmodeChannel extends GuildChannel
      * @return The slowmode for this channel, between 1 and {@value #MAX_SLOWMODE}, or {@code 0} if no slowmode is set.
      */
     int getSlowmode();
-    
-    // TODO: does this need docs?
+
+    /**
+     * Returns the {@link ISlowmodeChannelManager} for this {@link ISlowmodeChannel slow mode channel}.
+     * <br>With the provided ChannelManager, you can additionally modify the {@link ChannelField#SLOWMODE}
+     * compared to a guild channel {@link ChannelManager}.
+     * You modify multiple fields in one request by chaining setters before calling {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction.queue()}.
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_CHANNEL Permission.MANAGE_CHANNEL}
+     *
+     * @return The {@link ISlowmodeChannelManager} of this {@link ISlowmodeChannel}
+     *
+     * @see ChannelManager ChannelManager, for modifying fields each guild channel has
+     * @see ChannelField   ChannelField, for all possible channel fields
+     */
+    @Nonnull
+    @Override
     ISlowmodeChannelManager<?, ?> getManager();
 }

--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/ISlowmodeChannel.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/ISlowmodeChannel.java
@@ -54,7 +54,7 @@ public interface ISlowmodeChannel extends GuildChannel
     /**
      * Returns the {@link ISlowmodeChannelManager} for this {@link ISlowmodeChannel slow mode channel}.
      * <br>With the provided ChannelManager, you can additionally modify the {@link ChannelField#SLOWMODE}
-     * compared to a guild channel {@link ChannelManager}.
+     * compared to a guild channel's {@link ChannelManager}.
      * You modify multiple fields in one request by chaining setters before calling {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction.queue()}.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
@@ -62,7 +62,7 @@ public interface ISlowmodeChannel extends GuildChannel
      *
      * @return The {@link ISlowmodeChannelManager} of this {@link ISlowmodeChannel}
      *
-     * @see ChannelManager ChannelManager, for modifying fields each guild channel has
+     * @see ChannelManager ChannelManager, for modifying fields each guild channel provides
      * @see ChannelField   ChannelField, for all possible channel fields
      */
     @Nonnull


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [x] Documentation (maybe)
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Seems only logical to me to be able to use the generic manager, so you don't have to cast to 3 specific slow mode channels (Text, Thread or Forum).

### Example use case from attempting to port JDA-Butler to JDA-v5

```java
public static void announce(StandardGuildMessageChannel channel, Role role, MessageCreateData message, boolean slowmode)
{
    if (slowmode && channel instanceof ISlowmodeChannel)
    {
        ISlowmodeChannel slow = (ISlowmodeChannel) channel;
        ISlowmodeChannelManager<?, ?> slowMan = (ISlowmodeChannelManager<?, ?>) slow.getManager(); // currently resolves to ChannelManager and requires an unchecked cast
        slowMan.setSlowmode(30).queue(v -> slowMan.setSlowmode(0).queueAfter(2, TimeUnit.MINUTES));
    }

    role.getManager().setMentionable(true)                  // make role mentionable
        .flatMap(v -> channel.sendMessage(message))         // send announcement
        .flatMap(m -> {
            if (channel instanceof NewsChannel && channel.getGuild().getSelfMember().hasPermission(channel, Permission.MESSAGE_MANAGE))
                m.crosspost().queue();                      // publish if it's a news channel
            return role.getManager().setMentionable(false); // make role unmentionable
        })
        .queue();
    }
```
after overloading the manager return type the first if statement's body becomes
```java
    if (slowmode && channel instanceof ISlowmodeChannel)
    {
        ISlowmodeChannel slow = (ISlowmodeChannel) channel;
        ISlowmodeChannelManager<?, ?> slowMan = slow.getManager();
        slowMan.setSlowmode(30).queue(v -> slowMan.setSlowmode(0).queueAfter(2, TimeUnit.MINUTES));
    }
```