### PR TITLE
Fix bug when updating a scheduled events location

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
@@ -188,7 +188,7 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
             {
             case STAGE_INSTANCE:
             case VOICE:
-                object.put("entity_metadata", DataObject.empty());
+                object.putNull("entity_metadata");
                 object.put("channel_id", channelId);
                 break;
             case EXTERNAL:

--- a/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ScheduledEventManagerImpl.java
@@ -188,6 +188,7 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
             {
             case STAGE_INSTANCE:
             case VOICE:
+                object.put("entity_metadata", DataObject.empty());
                 object.put("channel_id", channelId);
                 break;
             case EXTERNAL:
@@ -214,11 +215,11 @@ public class ScheduledEventManagerImpl extends ManagerBase<ScheduledEventManager
     {
         if (shouldUpdate(LOCATION))
         {
-            if (entityType == ScheduledEvent.Type.EXTERNAL)
-                Checks.check((endTime).isAfter(startTime), "Cannot schedule event to end before starting!");
             Checks.check(getScheduledEvent().getStatus() == ScheduledEvent.Status.SCHEDULED, "Cannot update location of non-scheduled event.");
             if (entityType == ScheduledEvent.Type.EXTERNAL && endTime == null && getScheduledEvent().getEndTime() == null)
                 throw new IllegalStateException("Missing required parameter: End Time");
+            if (entityType == ScheduledEvent.Type.EXTERNAL)
+                Checks.check((endTime != null ? endTime : getScheduledEvent().getEndTime()).isAfter(startTime), "Cannot schedule event to end before starting!");
         }
 
         if (shouldUpdate(START_TIME))


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ 


Closes Issue: NaN

## Description

There must have been some stealth changes on Discords part when updating a scheduled event, because in the current implementation we get an error for invalid form body when setting the location to a voice or stage channel if we do not provide null for the entity_metadata field. This was redundant before.

This PR also fixes a "bug" when changing the location to an external one without providing a new end time. It did not take into account that the event can already have an end time set **even though** it was a voice or stage channel event. This might've been a stealth change by Discord as well, because I don't remember it being possible to set the end time on voice or stage channel events. Now you can do that via the API, but not (yet?) via the UI.
