### PR TITLE
Properly escape quotes with leading spaces

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -562,9 +562,11 @@ public class MarkdownSanitizer
             int nextRegion = getRegion(i, sequence);
             if (nextRegion == NORMAL)
             {
-                if (sequence.charAt(i) == '\n' && i + 1 < sequence.length())
+                char c = sequence.charAt(i);
+                boolean isNewLine = c == '\n';
+                if ((isNewLine || c == ' ') && i + 1 < sequence.length())
                 {
-                    String result = handleQuote(sequence.substring(i + 1), true);
+                    String result = handleQuote(sequence.substring(i + 1), isNewLine);
                     if (result != null)
                         return builder.append(result).toString();
                 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2358 

## Description

Fixes an issue that caused quotes with leading spaces to not be escaped.
