### PR TITLE
Properly escape quotes with leading spaces

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -554,7 +554,7 @@ public class MarkdownSanitizer
     {
         Checks.notNull(sequence, "Input");
         StringBuilder builder = new StringBuilder();
-        String end = handleQuote(sequence, false);
+        String end = handleQuote(sequence);
         if (end != null) return end;
 
         boolean onlySpacesSinceNewLine = true;
@@ -568,14 +568,13 @@ public class MarkdownSanitizer
 
             if (nextRegion == NORMAL)
             {
-                if ((isNewLine || (isSpace && onlySpacesSinceNewLine)) && i + 1 < sequence.length())
+                builder.append(sequence.charAt(i++));
+                if ((isNewLine || (isSpace && onlySpacesSinceNewLine)) && i < sequence.length())
                 {
-                    String result = handleQuote(sequence.substring(i + 1), isNewLine);
+                    String result = handleQuote(sequence.substring(i));
                     if (result != null)
                         return builder.append(result).toString();
                 }
-
-                builder.append(sequence.charAt(i++));
                 continue;
             }
 
@@ -594,7 +593,7 @@ public class MarkdownSanitizer
         return builder.toString();
     }
 
-    private String handleQuote(@Nonnull String sequence, boolean newline)
+    private String handleQuote(@Nonnull String sequence)
     {
         // Special handling for quote
         if (!isIgnored(QUOTE) && quote.matcher(sequence).matches())
@@ -605,8 +604,6 @@ public class MarkdownSanitizer
             StringBuilder builder = new StringBuilder(compute(sequence.substring(start + 2)));
             if (strategy == SanitizationStrategy.ESCAPE)
                 builder.insert(0, "\\> ");
-            if (newline)
-                builder.insert(0, '\n');
             return builder.toString();
 
         }

--- a/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/MarkdownSanitizer.java
@@ -557,14 +557,20 @@ public class MarkdownSanitizer
         String end = handleQuote(sequence, false);
         if (end != null) return end;
 
+        boolean onlySpacesSinceNewLine = true;
         for (int i = 0; i < sequence.length();)
         {
             int nextRegion = getRegion(i, sequence);
+            char c = sequence.charAt(i);
+            boolean isNewLine = c == '\n';
+            boolean isSpace = c == ' ';
+            onlySpacesSinceNewLine = isNewLine || (onlySpacesSinceNewLine && isSpace);
+
             if (nextRegion == NORMAL)
             {
-                if (sequence.charAt(i) == '\n' && i + 1 < sequence.length())
+                if ((isNewLine || (isSpace && onlySpacesSinceNewLine)) && i + 1 < sequence.length())
                 {
-                    String result = handleQuote(sequence.substring(i + 1), true);
+                    String result = handleQuote(sequence.substring(i + 1), isNewLine);
                     if (result != null)
                         return builder.append(result).toString();
                 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -463,5 +463,6 @@ class EscapeMarkdownAllTest
         Assertions.assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape("\\>\\>\\> Hello World", true));
         Assertions.assertEquals("Hello > World", MarkdownSanitizer.escape("Hello > World"));
         Assertions.assertEquals("Hello\n \\> World", MarkdownSanitizer.escape("Hello\n > World"));
+        Assertions.assertEquals("Hello\n\\> World", MarkdownSanitizer.escape("Hello\n> World"));
     }
 }

--- a/src/test/java/MarkdownTest.java
+++ b/src/test/java/MarkdownTest.java
@@ -150,6 +150,7 @@ class MarkdownTest
         Assertions.assertEquals("Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
         Assertions.assertEquals("Hello\nWorld", markdown.compute(">>>\nHello\nWorld"));
         Assertions.assertEquals("Hello > World", markdown.compute(">>>\nHello > World"));
+        Assertions.assertEquals("Hello\n World", markdown.compute("Hello\n > World"));
     }
 }
 
@@ -261,6 +262,7 @@ class IgnoreMarkdownTest
         Assertions.assertEquals(">>> Hello\nWorld", markdown.compute(">>> Hello\nWorld"));
         Assertions.assertEquals(">>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
         Assertions.assertEquals(">>>\nHello > World", markdown.compute(">>>\nHello > World"));
+        Assertions.assertEquals("Hello\n > World", markdown.compute("Hello\n > World"));
     }
 }
 
@@ -389,6 +391,7 @@ class EscapeMarkdownTest
         Assertions.assertEquals("\\>>>\nHello\nWorld", markdown.compute(">>>\nHello\nWorld"));
         Assertions.assertEquals("\\>>>\nHello > World", markdown.compute(">>>\nHello > World"));
         Assertions.assertEquals("\\> \\_Hello \n\\> World\\_", markdown.compute("> _Hello \n> World_"));
+        Assertions.assertEquals("Hello\n \\> World", markdown.compute("Hello\n > World"));
     }
 }
 
@@ -459,5 +462,6 @@ class EscapeMarkdownAllTest
         Assertions.assertEquals("\\> Hello World", MarkdownSanitizer.escape("\\> Hello World", true));
         Assertions.assertEquals("\\>\\>\\> Hello World", MarkdownSanitizer.escape("\\>\\>\\> Hello World", true));
         Assertions.assertEquals("Hello > World", MarkdownSanitizer.escape("Hello > World"));
+        Assertions.assertEquals("Hello\n \\> World", MarkdownSanitizer.escape("Hello\n > World"));
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2358 

## Description

Fixes an issue that caused quotes with leading spaces to not be escaped.
