### PR TITLE
Fix issues with ChannelManager#setPinned and setTagRequired

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/managers/ManagerBase.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/ManagerBase.java
@@ -146,7 +146,7 @@ public abstract class ManagerBase<M extends Manager<M>> extends AuditableRestAct
 
     protected boolean shouldUpdate(long bit)
     {
-        return (set & bit) == bit;
+        return (set & bit) != 0;
     }
 
     protected <E> void withLock(E object, Consumer<? super E> consumer)


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Fixes an issue where `setPinned` and `setTagRequired` were not functioning as intended. The update check uses `shouldUpdate(PINNED | REQUIRES_TAG)`, which would make it require both with the previous logic.
