### PR TITLE
Add support for reverse audit-log iteration

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
@@ -36,7 +36,6 @@ import net.dv8tion.jda.internal.requests.Route;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -145,8 +144,6 @@ public class AuditLogPaginationActionImpl
 
         if (!list.isEmpty())
         {
-            if (order == PaginationOrder.FORWARD)
-                Collections.reverse(list);
             if (this.useCache)
                 this.cached.addAll(list);
             this.last = list.get(list.size() - 1);

--- a/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/restaction/pagination/AuditLogPaginationActionImpl.java
@@ -36,6 +36,7 @@ import net.dv8tion.jda.internal.requests.Route;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -84,7 +85,7 @@ public class AuditLogPaginationActionImpl
     @Override
     public EnumSet<PaginationOrder> getSupportedOrders()
     {
-        return EnumSet.of(PaginationOrder.BACKWARD);
+        return EnumSet.of(PaginationOrder.BACKWARD, PaginationOrder.FORWARD);
     }
 
     @Override
@@ -135,15 +136,21 @@ public class AuditLogPaginationActionImpl
                 DataObject webhook = webhookMap.get(entry.getLong("target_id", 0));
                 AuditLogEntry result = builder.createAuditLogEntry((GuildImpl) guild, entry, user, webhook);
                 list.add(result);
-                if (this.useCache)
-                    this.cached.add(result);
-                this.last = result;
-                this.lastKey = last.getIdLong();
             }
             catch (ParsingException | NullPointerException e)
             {
                 LOG.warn("Encountered exception in AuditLogPagination", e);
             }
+        }
+
+        if (!list.isEmpty())
+        {
+            if (order == PaginationOrder.FORWARD)
+                Collections.reverse(list);
+            if (this.useCache)
+                this.cached.addAll(list);
+            this.last = list.get(list.size() - 1);
+            this.lastKey = last.getIdLong();
         }
 
         request.onSuccess(list);


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This allows using `guild.retrieveAuditLogs().reverse()`, iterating from the oldest entry to the newest. ~~(Currently broken due to wrong implementation of `?after=0` in the API)~~

Reference: discord/discord-api-docs#5821
