### PR TITLE
Catch errors thrown during login validation

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/JDAImpl.java
@@ -394,14 +394,22 @@ public class JDAImpl implements JDA
             }
         }.priority();
 
-        DataObject userResponse = login.complete();
-        if (userResponse != null)
+        try
         {
-            getEntityBuilder().createSelfUser(userResponse);
-            return;
+            DataObject userResponse = login.complete();
+            if (userResponse != null)
+            {
+                getEntityBuilder().createSelfUser(userResponse);
+                return;
+            }
+
+            throw new InvalidTokenException("The provided token is invalid!");
         }
-        shutdownNow();
-        throw new InvalidTokenException("The provided token is invalid!");
+        catch (Throwable error)
+        {
+            shutdownNow();
+            throw error;
+        }
     }
 
     public AuthorizationConfig getAuthorizationConfig()


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2405 

## Description

This fixes an issue where errors thrown by `complete()` would prevent a graceful cleanup during token validation.
