### PR TITLE
Update permissions

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -84,9 +84,9 @@ public enum Permission
     VOICE_DEAF_OTHERS(        23, true, true, "Deafen Members"),
     VOICE_MOVE_OTHERS(        24, true, true, "Move Members"),
     VOICE_USE_VAD(            25, true, true, "Use Voice Activity"),
-    VOICE_START_ACTIVITIES(   39, true, true, "Launch Activities in Voice Channels"),
-    VOICE_USE_SOUNDBOARD(     42, true, true, "Use Soundboard in Voice and Stage Channels"),
-    VOICE_USE_EXTERNAL_SOUNDS(45, true, true, "Use Soundboards from other Servers"),
+    VOICE_START_ACTIVITIES(   39, true, true, "Use Activities"),
+    VOICE_USE_SOUNDBOARD(     42, true, true, "Use Soundboard"),
+    VOICE_USE_EXTERNAL_SOUNDS(45, true, true, "Use External Sounds"),
 
     // Stage Channel Permissions
     REQUEST_TO_SPEAK(      32, true, true, "Request to Speak"),

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -56,18 +56,18 @@ public enum Permission
     MODERATE_MEMBERS(    40, true, false, "Timeout Members"),
 
     // Text Permissions
-    MESSAGE_ADD_REACTION(     6, true, true, "Add Reactions"),
-    MESSAGE_SEND(            11, true, true, "Send Messages"),
-    MESSAGE_TTS(             12, true, true, "Send TTS Messages"),
-    MESSAGE_MANAGE(          13, true, true, "Manage Messages"),
-    MESSAGE_EMBED_LINKS(     14, true, true, "Embed Links"),
-    MESSAGE_ATTACH_FILES(    15, true, true, "Attach Files"),
-    MESSAGE_HISTORY(         16, true, true, "Read History"),
-    MESSAGE_MENTION_EVERYONE(17, true, true, "Mention Everyone"),
-    MESSAGE_EXT_EMOJI(       18, true, true, "Use External Emojis"),
-    USE_APPLICATION_COMMANDS(31, true, true, "Use Application Commands"),
-    MESSAGE_EXT_STICKER(     37, true, true, "Use External Stickers"),
-    VOICE_MESSAGE_SEND(      46, true, true, "Send Voice Messages"),
+    MESSAGE_ADD_REACTION(         6, true, true, "Add Reactions"),
+    MESSAGE_SEND(                11, true, true, "Send Messages"),
+    MESSAGE_TTS(                 12, true, true, "Send TTS Messages"),
+    MESSAGE_MANAGE(              13, true, true, "Manage Messages"),
+    MESSAGE_EMBED_LINKS(         14, true, true, "Embed Links"),
+    MESSAGE_ATTACH_FILES(        15, true, true, "Attach Files"),
+    MESSAGE_HISTORY(             16, true, true, "Read History"),
+    MESSAGE_MENTION_EVERYONE(    17, true, true, "Mention Everyone"),
+    MESSAGE_EXT_EMOJI(           18, true, true, "Use External Emojis"),
+    USE_APPLICATION_COMMANDS(    31, true, true, "Use Application Commands"),
+    MESSAGE_EXT_STICKER(         37, true, true, "Use External Stickers"),
+    MESSAGE_ATTACH_VOICE_MESSAGE(46, true, true, "Send Voice Messages"),
 
     // Thread Permissions
     MANAGE_THREADS(          34, true, true, "Manage Threads"),
@@ -127,7 +127,7 @@ public enum Permission
             = Permission.getRaw(MESSAGE_ADD_REACTION, MESSAGE_SEND, MESSAGE_TTS, MESSAGE_MANAGE,
                                 MESSAGE_EMBED_LINKS, MESSAGE_ATTACH_FILES, MESSAGE_EXT_EMOJI, MESSAGE_EXT_STICKER,
                                 MESSAGE_HISTORY, MESSAGE_MENTION_EVERYONE, USE_APPLICATION_COMMANDS,
-                                MANAGE_THREADS, CREATE_PUBLIC_THREADS, CREATE_PRIVATE_THREADS, MESSAGE_SEND_IN_THREADS, VOICE_MESSAGE_SEND);
+                                MANAGE_THREADS, CREATE_PUBLIC_THREADS, CREATE_PRIVATE_THREADS, MESSAGE_SEND_IN_THREADS, MESSAGE_ATTACH_VOICE_MESSAGE);
 
     /**
      * All voice channel specific permissions which are only available in voice channel permission overrides

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -15,6 +15,8 @@
  */
 package net.dv8tion.jda.api;
 
+import net.dv8tion.jda.annotations.ForRemoval;
+import net.dv8tion.jda.annotations.ReplaceWith;
 import net.dv8tion.jda.internal.utils.Checks;
 
 import javax.annotation.Nonnull;
@@ -29,16 +31,21 @@ import java.util.stream.Collectors;
 public enum Permission
 {
     // General Server / Channel Permissions
-    MANAGE_CHANNEL(             4, true,  true,  "Manage Channels"),
-    MANAGE_SERVER(              5, true,  false, "Manage Server"),
-    VIEW_AUDIT_LOGS(            7, true,  false, "View Audit Logs"),
-    VIEW_CHANNEL(              10, true,  true,  "View Channel(s)"),
-    VIEW_GUILD_INSIGHTS(       19, true,  false, "View Server Insights"),
-    MANAGE_ROLES(              28, true,  false, "Manage Roles"),
-    MANAGE_PERMISSIONS(        28, false, true,  "Manage Permissions"),
-    MANAGE_WEBHOOKS(           29, true,  true,  "Manage Webhooks"),
-    MANAGE_EMOJIS_AND_STICKERS(30, true,  false, "Manage Emojis and Stickers"),
-    MANAGE_EVENTS(             33, true,  true,  "Manage Events"),
+    MANAGE_CHANNEL(                      4, true,  true,  "Manage Channels"),
+    MANAGE_SERVER(                       5, true,  false, "Manage Server"),
+    VIEW_AUDIT_LOGS(                     7, true,  false, "View Audit Logs"),
+    VIEW_CHANNEL(                       10, true,  true,  "View Channel(s)"),
+    VIEW_GUILD_INSIGHTS(                19, true,  false, "View Server Insights"),
+    MANAGE_ROLES(                       28, true,  false, "Manage Roles"),
+    MANAGE_PERMISSIONS(                 28, false, true,  "Manage Permissions"),
+    MANAGE_WEBHOOKS(                    29, true,  true,  "Manage Webhooks"),
+    @Deprecated
+    @ForRemoval(deadline = "5.0.0")
+    @ReplaceWith("MANAGE_GUILD_EXPRESSIONS")
+    MANAGE_EMOJIS_AND_STICKERS(         30, true,  false, "Manage Emojis and Stickers"),
+    MANAGE_GUILD_EXPRESSIONS(           30, true,  false, "Manage Emojis, Stickers, and Soundboards"),
+    MANAGE_EVENTS(                      33, true,  true,  "Manage Events"),
+    VIEW_CREATOR_MONETIZATION_ANALYTICS(41, true,  false, "View Creator Analytics"),
 
     // Membership Permissions
     CREATE_INSTANT_INVITE(0, true, true,  "Create Instant Invite"),
@@ -77,6 +84,7 @@ public enum Permission
     VOICE_MOVE_OTHERS(     24, true, true, "Move Members"),
     VOICE_USE_VAD(         25, true, true, "Use Voice Activity"),
     VOICE_START_ACTIVITIES(39, true, true, "Launch Activities in Voice Channels"),
+    VOICE_USE_SOUNDBOARD(  42, true, true, "Use Soundboard in Voice and Stage Channels"),
 
     // Stage Channel Permissions
     REQUEST_TO_SPEAK(      32, true, true, "Request to Speak"),

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -67,6 +67,7 @@ public enum Permission
     MESSAGE_EXT_EMOJI(       18, true, true, "Use External Emojis"),
     USE_APPLICATION_COMMANDS(31, true, true, "Use Application Commands"),
     MESSAGE_EXT_STICKER(     37, true, true, "Use External Stickers"),
+    VOICE_MESSAGE_SEND(      46, true, true, "Send Voice Messages"),
 
     // Thread Permissions
     MANAGE_THREADS(          34, true, true, "Manage Threads"),
@@ -126,7 +127,7 @@ public enum Permission
             = Permission.getRaw(MESSAGE_ADD_REACTION, MESSAGE_SEND, MESSAGE_TTS, MESSAGE_MANAGE,
                                 MESSAGE_EMBED_LINKS, MESSAGE_ATTACH_FILES, MESSAGE_EXT_EMOJI, MESSAGE_EXT_STICKER,
                                 MESSAGE_HISTORY, MESSAGE_MENTION_EVERYONE, USE_APPLICATION_COMMANDS,
-                                MANAGE_THREADS, CREATE_PUBLIC_THREADS, CREATE_PRIVATE_THREADS, MESSAGE_SEND_IN_THREADS);
+                                MANAGE_THREADS, CREATE_PUBLIC_THREADS, CREATE_PRIVATE_THREADS, MESSAGE_SEND_IN_THREADS, VOICE_MESSAGE_SEND);
 
     /**
      * All voice channel specific permissions which are only available in voice channel permission overrides
@@ -134,7 +135,8 @@ public enum Permission
     public static final long ALL_VOICE_PERMISSIONS
             = Permission.getRaw(VOICE_STREAM, VOICE_CONNECT, VOICE_SPEAK, VOICE_MUTE_OTHERS,
                                 VOICE_DEAF_OTHERS, VOICE_MOVE_OTHERS, VOICE_USE_VAD,
-                                PRIORITY_SPEAKER, REQUEST_TO_SPEAK, VOICE_START_ACTIVITIES);
+                                PRIORITY_SPEAKER, REQUEST_TO_SPEAK, VOICE_START_ACTIVITIES,
+                                VOICE_USE_SOUNDBOARD, VOICE_USE_EXTERNAL_SOUNDS);
 
     private final int offset;
     private final long raw;

--- a/src/main/java/net/dv8tion/jda/api/Permission.java
+++ b/src/main/java/net/dv8tion/jda/api/Permission.java
@@ -75,16 +75,17 @@ public enum Permission
     MESSAGE_SEND_IN_THREADS( 38, true, true, "Send Messages in Threads"),
 
     // Voice Permissions
-    PRIORITY_SPEAKER(       8, true, true, "Priority Speaker"),
-    VOICE_STREAM(           9, true, true, "Video"),
-    VOICE_CONNECT(         20, true, true, "Connect"),
-    VOICE_SPEAK(           21, true, true, "Speak"),
-    VOICE_MUTE_OTHERS(     22, true, true, "Mute Members"),
-    VOICE_DEAF_OTHERS(     23, true, true, "Deafen Members"),
-    VOICE_MOVE_OTHERS(     24, true, true, "Move Members"),
-    VOICE_USE_VAD(         25, true, true, "Use Voice Activity"),
-    VOICE_START_ACTIVITIES(39, true, true, "Launch Activities in Voice Channels"),
-    VOICE_USE_SOUNDBOARD(  42, true, true, "Use Soundboard in Voice and Stage Channels"),
+    PRIORITY_SPEAKER(          8, true, true, "Priority Speaker"),
+    VOICE_STREAM(              9, true, true, "Video"),
+    VOICE_CONNECT(            20, true, true, "Connect"),
+    VOICE_SPEAK(              21, true, true, "Speak"),
+    VOICE_MUTE_OTHERS(        22, true, true, "Mute Members"),
+    VOICE_DEAF_OTHERS(        23, true, true, "Deafen Members"),
+    VOICE_MOVE_OTHERS(        24, true, true, "Move Members"),
+    VOICE_USE_VAD(            25, true, true, "Use Voice Activity"),
+    VOICE_START_ACTIVITIES(   39, true, true, "Launch Activities in Voice Channels"),
+    VOICE_USE_SOUNDBOARD(     42, true, true, "Use Soundboard in Voice and Stage Channels"),
+    VOICE_USE_EXTERNAL_SOUNDS(45, true, true, "Use Soundboards from other Servers"),
 
     // Stage Channel Permissions
     REQUEST_TO_SPEAK(      32, true, true, "Request to Speak"),

--- a/src/main/java/net/dv8tion/jda/api/entities/Guild.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Guild.java
@@ -1870,7 +1870,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      * Retrieves an immutable list of Custom Emojis together with their respective creators.
      *
      * <p>Note that {@link RichCustomEmoji#getOwner()} is only available if the currently
-     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}.
+     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}.
      *
      * @return {@link RestAction RestAction} - Type: List of {@link RichCustomEmoji}
      */
@@ -1883,7 +1883,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      * <br><b>This does not include unicode emoji.</b>
      *
      * <p>Note that {@link RichCustomEmoji#getOwner()} is only available if the currently
-     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}.
+     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
      * the returned {@link RestAction RestAction} include the following:
@@ -1908,7 +1908,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      * Retrieves a Custom Emoji together with its respective creator.
      *
      * <p>Note that {@link RichCustomEmoji#getOwner()} is only available if the currently
-     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}.
+     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
      * the returned {@link RestAction RestAction} include the following:
@@ -1933,7 +1933,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      * Retrieves a custom emoji together with its respective creator.
      *
      * <p>Note that {@link RichCustomEmoji#getOwner()} is only available if the currently
-     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}.
+     * logged in account has {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}.
      *
      * <p>Possible {@link net.dv8tion.jda.api.requests.ErrorResponse ErrorResponses} caused by
      * the returned {@link RestAction RestAction} include the following:
@@ -1961,7 +1961,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
             if (emoji instanceof RichCustomEmoji)
             {
                 RichCustomEmoji richEmoji = (RichCustomEmoji) emoji;
-                if (richEmoji.getOwner() != null || !getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
+                if (richEmoji.getOwner() != null || !getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
                     return richEmoji;
             }
             return null;
@@ -2014,7 +2014,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      * @throws IllegalArgumentException
      *         If null is provided
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} in the guild.
+     *         If the currently logged in account does not have {@link Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} in the guild.
      *
      * @return {@link GuildStickerManager}
      */
@@ -4533,7 +4533,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
     /**
      * Creates a new {@link RichCustomEmoji} in this Guild.
      * <br>If one or more Roles are specified the new emoji will only be available to Members with any of the specified Roles (see {@link Member#canInteract(RichCustomEmoji)})
-     * <br>For this to be successful, the logged in account has to have the {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} Permission.
+     * <br>For this to be successful, the logged in account has to have the {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} Permission.
      *
      * <p><b><u>Unicode emojis are not included as {@link RichCustomEmoji}!</u></b>
      *
@@ -4558,7 +4558,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      *         <br>If no roles are provided the emoji will be available to all Members of this Guild
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} Permission
+     *         If the logged in account does not have the {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} Permission
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction} - Type: {@link RichCustomEmoji}
      */
@@ -4587,7 +4587,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      *         The tags to use for auto-suggestions (Up to 200 characters in total)
      *
      * @throws InsufficientPermissionException
-     *         If the currently logged in account does not have the {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} permission
+     *         If the currently logged in account does not have the {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} permission
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If the name is not between 2 and 30 characters long</li>
@@ -4625,7 +4625,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      *         Additional tags to use for suggestions
      *
      * @throws InsufficientPermissionException
-     *         If the currently logged in account does not have the {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} permission
+     *         If the currently logged in account does not have the {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} permission
      * @throws IllegalArgumentException
      *         <ul>
      *             <li>If the name is not between 2 and 30 characters long</li>
@@ -4658,7 +4658,7 @@ public interface Guild extends IGuildChannelContainer, ISnowflake
      * @throws IllegalStateException
      *         If null is provided
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} in the guild.
+     *         If the currently logged in account does not have {@link Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} in the guild.
      *
      * @return {@link AuditableRestAction}
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/emoji/RichCustomEmoji.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/emoji/RichCustomEmoji.java
@@ -106,7 +106,7 @@ public interface RichCustomEmoji extends CustomEmoji
      *
      * <p>This is only available for manually retrieved emojis from {@link Guild#retrieveEmojis()}
      * and {@link Guild#retrieveEmojiById(long)}.
-     * <br>Requires {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}.
+     * <br>Requires {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}.
      *
      * @throws IllegalStateException
      *         If this emoji does not have user information
@@ -124,7 +124,7 @@ public interface RichCustomEmoji extends CustomEmoji
      * The user information might be outdated, you can use {@link CacheRestAction#useCache(boolean) action.useCache(false)} to force an update.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}
      *         in this guild
      *
      * @return {@link RestAction} - Type: {@link User}
@@ -153,7 +153,7 @@ public interface RichCustomEmoji extends CustomEmoji
      * @throws java.lang.UnsupportedOperationException
      *         If this emoji is managed by discord ({@link #isManaged()})
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         if the Permission {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} is not given
+     *         if the Permission {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} is not given
      *
      * @return {@link net.dv8tion.jda.api.requests.restaction.AuditableRestAction AuditableRestAction}
      *         The RestAction to delete this emoji.
@@ -168,7 +168,7 @@ public interface RichCustomEmoji extends CustomEmoji
      * <br>You modify multiple fields in one request by chaining setters before calling {@link net.dv8tion.jda.api.requests.RestAction#queue() RestAction.queue()}.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS}
+     *         If the currently logged in account does not have {@link net.dv8tion.jda.api.Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS}
      *
      * @return The CustomEmojiManager for this emoji
      */

--- a/src/main/java/net/dv8tion/jda/api/entities/sticker/GuildSticker.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/sticker/GuildSticker.java
@@ -98,11 +98,11 @@ public interface GuildSticker extends RichSticker
      * <p>Possible {@link ErrorResponse ErrorResponses} include:
      * <ul>
      *     <li>{@link ErrorResponse#MISSING_PERMISSIONS MISSING_PERMISSIONS}
-     *     <br>The request was attempted after the account lost {@link Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS} in the guild</li>
+     *     <br>The request was attempted after the account lost {@link Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS} in the guild</li>
      * </ul>
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link Permission#MANAGE_EMOJIS_AND_STICKERS Permission.MANAGE_EMOJIS_AND_STICKERS} in the guild.
+     *         If the currently logged in account does not have {@link Permission#MANAGE_GUILD_EXPRESSIONS Permission.MANAGE_GUILD_EXPRESSIONS} in the guild.
      *
      * @return {@link CacheRestAction} - Type: {@link User}
      */
@@ -114,7 +114,7 @@ public interface GuildSticker extends RichSticker
      * Deletes this sticker from the guild.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} in the guild.
+     *         If the currently logged in account does not have {@link Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} in the guild.
      *
      * @return {@link AuditableRestAction}
      */
@@ -127,7 +127,7 @@ public interface GuildSticker extends RichSticker
      * <br>You can update multiple fields at once, by calling the respective setters before executing the request.
      *
      * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
-     *         If the currently logged in account does not have {@link Permission#MANAGE_EMOJIS_AND_STICKERS MANAGE_EMOJIS_AND_STICKERS} in the guild.
+     *         If the currently logged in account does not have {@link Permission#MANAGE_GUILD_EXPRESSIONS MANAGE_GUILD_EXPRESSIONS} in the guild.
      *
      * @return {@link GuildStickerManager}
      */

--- a/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/GuildImpl.java
@@ -812,7 +812,7 @@ public class GuildImpl implements Guild
             RichCustomEmoji emoji = getEmojiById(id);
             if (emoji != null)
             {
-                if (emoji.getOwner() != null || !getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
+                if (emoji.getOwner() != null || !getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
                     return emoji;
             }
             return null;
@@ -1746,7 +1746,7 @@ public class GuildImpl implements Guild
     @Override
     public AuditableRestAction<RichCustomEmoji> createEmoji(@Nonnull String name, @Nonnull Icon icon, @Nonnull Role... roles)
     {
-        checkPermission(Permission.MANAGE_EMOJIS_AND_STICKERS);
+        checkPermission(Permission.MANAGE_GUILD_EXPRESSIONS);
         Checks.inRange(name, 2, 32, "Emoji name");
         Checks.notNull(icon, "Emoji icon");
         Checks.notNull(roles, "Roles");
@@ -1770,7 +1770,7 @@ public class GuildImpl implements Guild
     @Override
     public AuditableRestAction<GuildSticker> createSticker(@Nonnull String name, @Nonnull String description, @Nonnull FileUpload file, @Nonnull Collection<String> tags)
     {
-        checkPermission(Permission.MANAGE_EMOJIS_AND_STICKERS);
+        checkPermission(Permission.MANAGE_GUILD_EXPRESSIONS);
         Checks.inRange(name, 2, 30, "Name");
         Checks.notNull(file, "File");
         Checks.notNull(description, "Description");

--- a/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/emoji/RichCustomEmojiImpl.java
@@ -151,8 +151,8 @@ public class RichCustomEmojiImpl implements RichCustomEmoji, EmojiUnion
     public CacheRestAction<User> retrieveOwner()
     {
         GuildImpl guild = getGuild();
-        if (!guild.getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
-            throw new InsufficientPermissionException(guild, Permission.MANAGE_EMOJIS_AND_STICKERS);
+        if (!guild.getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
+            throw new InsufficientPermissionException(guild, Permission.MANAGE_GUILD_EXPRESSIONS);
         return new DeferredRestAction<>(api, User.class, this::getOwner, () -> {
             Route.CompiledRoute route = Route.Emojis.GET_EMOJI.compile(guild.getId(), getId());
             return new RestActionImpl<>(api, route, (response, request) -> {
@@ -184,8 +184,8 @@ public class RichCustomEmojiImpl implements RichCustomEmoji, EmojiUnion
     {
         if (managed)
             throw new UnsupportedOperationException("You cannot delete a managed emoji!");
-        if (!getGuild().getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
-            throw new InsufficientPermissionException(getGuild(), Permission.MANAGE_EMOJIS_AND_STICKERS);
+        if (!getGuild().getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
+            throw new InsufficientPermissionException(getGuild(), Permission.MANAGE_GUILD_EXPRESSIONS);
 
         Route.CompiledRoute route = Route.Emojis.DELETE_EMOJI.compile(getGuild().getId(), getId());
         return new AuditableRestActionImpl<>(getJDA(), route);

--- a/src/main/java/net/dv8tion/jda/internal/entities/sticker/GuildStickerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/sticker/GuildStickerImpl.java
@@ -110,8 +110,8 @@ public class GuildStickerImpl extends RichStickerImpl implements GuildSticker
     public CacheRestAction<User> retrieveOwner()
     {
         Guild g = getGuild();
-        if (g != null && !g.getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
-            throw new InsufficientPermissionException(g, Permission.MANAGE_EMOJIS_AND_STICKERS);
+        if (g != null && !g.getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
+            throw new InsufficientPermissionException(g, Permission.MANAGE_GUILD_EXPRESSIONS);
         return new DeferredRestAction<>(jda, User.class, this::getOwner,
             () -> {
                 Route.CompiledRoute route = Route.Stickers.GET_GUILD_STICKER.compile(getGuildId(), getId());

--- a/src/main/java/net/dv8tion/jda/internal/managers/CustomEmojiManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/CustomEmojiManagerImpl.java
@@ -147,8 +147,8 @@ public class CustomEmojiManagerImpl extends ManagerBase<CustomEmojiManager> impl
     @Override
     protected boolean checkPermissions()
     {
-        if (!getGuild().getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
-            throw new InsufficientPermissionException(getGuild(), Permission.MANAGE_EMOJIS_AND_STICKERS);
+        if (!getGuild().getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
+            throw new InsufficientPermissionException(getGuild(), Permission.MANAGE_GUILD_EXPRESSIONS);
         return super.checkPermissions();
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/managers/GuildStickerManagerImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/managers/GuildStickerManagerImpl.java
@@ -128,8 +128,8 @@ public class GuildStickerManagerImpl extends ManagerBase<GuildStickerManager> im
     @Override
     protected boolean checkPermissions()
     {
-        if (guild != null && !guild.getSelfMember().hasPermission(Permission.MANAGE_EMOJIS_AND_STICKERS))
-            throw new InsufficientPermissionException(guild, Permission.MANAGE_EMOJIS_AND_STICKERS);
+        if (guild != null && !guild.getSelfMember().hasPermission(Permission.MANAGE_GUILD_EXPRESSIONS))
+            throw new InsufficientPermissionException(guild, Permission.MANAGE_GUILD_EXPRESSIONS);
         return super.checkPermissions();
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This updates the permission enum and replaces (through deprecation) the old `Permission.MANAGE_EMOJIS_AND_STICKERS` permission with the new `Permission.MANAGE_GUILD_EXPRESSIONS` permission.

### References
- https://github.com/discord/discord-api-docs/pull/6017
- https://github.com/discord/discord-api-docs/pull/6039
- https://github.com/discord/discord-api-docs/pull/6082
