### PR TITLE
Add voice message read support

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/EntityBuilder.java
@@ -1849,7 +1849,9 @@ public class EntityBuilder
         final String contentType = jsonObject.getString("content_type", null);
         final String description = jsonObject.getString("description", null);
         final long id = jsonObject.getLong("id");
-        return new Message.Attachment(id, url, proxyUrl, filename, contentType, description, size, height, width, ephemeral, getJDA());
+        final String waveformString = jsonObject.getString("waveform", null);
+        final byte[] waveform = waveformString == null ? null : Base64.getDecoder().decode(waveformString);
+        return new Message.Attachment(id, url, proxyUrl, filename, contentType, description, size, height, width, ephemeral, waveform, getJDA());
     }
 
     public MessageEmbed createMessageEmbed(DataObject content)


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds read support for voice messages: both the message flag and the waveform data. Bots cannot currently send these, but they can be received from other users. Tested against both voice and non-voice messages.

Waiting on discord/discord-api-docs#6082
