### PR TITLE
Add EmbedBuilder#setUrl

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -261,6 +261,7 @@ public class EmbedBuilder
     /**
      * Sets the Title of the embed.
      * <br>You can provide {@code null} as url if no url should be used.
+     * <br>If you want to set a URL without a title, use {@link #setUrl(String)} instead.
      *
      * <p><b><a href="https://raw.githubusercontent.com/DV8FromTheWorld/JDA/assets/assets/docs/embeds/04-setTitle.png">Example</a></b>
      *
@@ -300,6 +301,32 @@ public class EmbedBuilder
             this.title = title;
             this.url = url;
         }
+        return this;
+    }
+
+    /**
+     * Sets the URL of the embed.
+     * <br>The Discord client mostly only uses this property in combination with the {@link #setTitle(String) title} for a clickable Hyperlink.
+     *
+     * @throws java.lang.IllegalArgumentException
+     *         <ul>
+     *             <li>If the character limit for {@code url}, defined by {@link net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH} as {@value net.dv8tion.jda.api.entities.MessageEmbed#URL_MAX_LENGTH},
+     *             is exceeded.</li>
+     *             <li>If the provided {@code url} is not a properly formatted http or https url.</li>
+     *         </ul>
+     *
+     * @return the builder after the URL has been set
+     *
+     * @see    #setTitle(String, String)
+     */
+    @Nonnull
+    public EmbedBuilder setUrl(@Nullable String url)
+    {
+        if (Helpers.isBlank(url))
+            url = null;
+        urlCheck(url);
+        this.url = url;
+
         return this;
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

This PR adds `EmbedBuilder#setUrl`. 

Setting a url by itself without a title is not useful for most users, as the only documented behaviour is a hyperlinked title,
however it is also how you create multi-image embeds, and JDA currently doesn't allow setting the URL without also settting the title.