### PR TITLE
Remove timeout for rate-limit pool

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/config/ThreadingConfig.java
@@ -20,7 +20,10 @@ import net.dv8tion.jda.internal.utils.concurrent.CountingThreadFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.function.Supplier;
 
 public class ThreadingConfig
@@ -97,19 +100,6 @@ public class ThreadingConfig
             eventPool.shutdown();
         if (shutdownAudioPool && audioPool != null)
             audioPool.shutdown();
-        if (shutdownRateLimitPool)
-        {
-            if (rateLimitPool instanceof ScheduledThreadPoolExecutor)
-            {
-                ScheduledThreadPoolExecutor executor = (ScheduledThreadPoolExecutor) rateLimitPool;
-                executor.setKeepAliveTime(5L, TimeUnit.SECONDS);
-                executor.allowCoreThreadTimeOut(true);
-            }
-            else
-            {
-                rateLimitPool.shutdown();
-            }
-        }
     }
 
     public void shutdownRequester()


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2455 

## Description

Setting this timeout does not make sense in our current shutdown logic. And the docs for the executor specifically say this is not a good idea. The requester shutdown will also shutdown the pool explicitly.
