### PR TITLE
Improve handling of global rate-limit

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/requests/SequentialRestRateLimiter.java
+++ b/src/main/java/net/dv8tion/jda/api/requests/SequentialRestRateLimiter.java
@@ -387,20 +387,16 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
             long now = getNow();
 
             long global = getGlobalRateLimit(now);
-            // Global rate limit is more important to handle
-            if (global > 0)
-                return global;
 
             // Check if the bucket reset time has expired
             if (reset <= now)
             {
                 // Update the remaining uses to the limit (we don't know better)
                 remaining = 1;
-                return 0L;
             }
 
             // If there are remaining requests we don't need to do anything, otherwise return backoff in milliseconds
-            return remaining < 1 ? reset - now : 0L;
+            return Math.max(global, remaining < 1 ? reset - now : 0L);
         }
 
         protected boolean isGlobalRateLimit()
@@ -501,6 +497,22 @@ public final class SequentialRestRateLimiter implements RestRateLimiter
         public String toString()
         {
             return bucketId;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return bucketId.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj == this)
+                return true;
+            if (!(obj instanceof Bucket))
+                return false;
+            return this.bucketId.equals(((Bucket) obj).bucketId);
         }
     }
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Slightly improves how we handle global rate-limit backoff. We were always prioritizing the global rate-limit, even when it's shorter than the bucket limit. With this change, we will always use whichever limit is greater.

I've also added implementations for hashCode and equals, to handle potential regressions with duplicated bucket instances.
