### PR TITLE
Support embed deserialization from JSON data

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -96,7 +96,7 @@ public class EmbedBuilder
      *         The serialized embed object
      *
      * @throws IllegalArgumentException
-     *         If the provided data is {@code null}
+     *         If the provided data is {@code null} or invalid
      * @throws net.dv8tion.jda.api.exceptions.ParsingException
      *         If the provided data is malformed
      *
@@ -108,47 +108,42 @@ public class EmbedBuilder
         Checks.notNull(data, "DataObject");
         EmbedBuilder builder = new EmbedBuilder();
 
-        builder.url = data.getString("url", null);
-        builder.title = data.getString("title", null);
+        builder.setTitle(data.getString("title", null));
+        builder.setUrl(data.getString("url", null));
         builder.setDescription(data.getString("description", ""));
-        builder.timestamp = data.isNull("timestamp") ? null : OffsetDateTime.parse(data.getString("timestamp"));
-        builder.color = data.getInt("color", Role.DEFAULT_COLOR_RAW);
+        builder.setTimestamp(data.isNull("timestamp") ? null : OffsetDateTime.parse(data.getString("timestamp")));
+        builder.setColor(data.getInt("color", Role.DEFAULT_COLOR_RAW));
 
         data.optObject("thumbnail").ifPresent(thumbnail ->
-            builder.thumbnail = new MessageEmbed.Thumbnail(thumbnail.getString("url"), null, 0, 0)
+            builder.setThumbnail(thumbnail.getString("url"))
         );
 
         data.optObject("author").ifPresent(author ->
-            builder.author = new MessageEmbed.AuthorInfo(
+            builder.setAuthor(
                 author.getString("name", ""),
                 author.getString("url", null),
-                author.getString("icon_url", null),
-                null
+                author.getString("icon_url", null)
             )
         );
 
         data.optObject("footer").ifPresent(footer ->
-            builder.footer = new MessageEmbed.Footer(
+            builder.setFooter(
                 footer.getString("text", ""),
-                footer.getString("icon_url", null),
-                null
+                footer.getString("icon_url", null)
             )
         );
 
         data.optObject("image").ifPresent(image ->
-            builder.image = new MessageEmbed.ImageInfo(
-                image.getString("url"),
-                null, 0, 0
-            )
+            builder.setImage(image.getString("url"))
         );
 
         data.optArray("fields").ifPresent(arr ->
             arr.stream(DataArray::getObject).forEach(field ->
-                builder.fields.add(new MessageEmbed.Field(
-                        field.getString("name", ""),
-                        field.getString("value", ""),
-                        field.getBoolean("inline", false)
-                ))
+                builder.addField(
+                    field.getString("name", ZERO_WIDTH_SPACE),
+                    field.getString("value", ZERO_WIDTH_SPACE),
+                    field.getBoolean("inline", false)
+                )
             )
         );
 
@@ -725,7 +720,7 @@ public class EmbedBuilder
         }
         else
         {
-            Checks.check(name.length() <= MessageEmbed.AUTHOR_MAX_LENGTH, "Name cannot be longer than %d characters.", MessageEmbed.AUTHOR_MAX_LENGTH);
+            Checks.notLonger(name, MessageEmbed.AUTHOR_MAX_LENGTH, "Name");
             urlCheck(url);
             urlCheck(iconUrl);
             this.author = new MessageEmbed.AuthorInfo(name, url, iconUrl, null);
@@ -800,7 +795,7 @@ public class EmbedBuilder
         }
         else
         {
-            Checks.check(text.length() <= MessageEmbed.TEXT_MAX_LENGTH, "Text cannot be longer than %d characters.", MessageEmbed.TEXT_MAX_LENGTH);
+            Checks.notLonger(text, MessageEmbed.TEXT_MAX_LENGTH, "Text");
             urlCheck(iconUrl);
             this.footer = new MessageEmbed.Footer(text, iconUrl, null);
         }
@@ -909,7 +904,7 @@ public class EmbedBuilder
     {
         if (url != null)
         {
-            Checks.check(url.length() <= MessageEmbed.URL_MAX_LENGTH, "URL cannot be longer than %d characters.", MessageEmbed.URL_MAX_LENGTH);
+            Checks.notLonger(url, MessageEmbed.URL_MAX_LENGTH, "URL");
             Checks.check(URL_PATTERN.matcher(url).matches(), "URL must be a valid http(s) or attachment url.");
         }
     }

--- a/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/EmbedBuilder.java
@@ -18,6 +18,8 @@ package net.dv8tion.jda.api;
 import net.dv8tion.jda.api.entities.EmbedType;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.utils.data.DataArray;
+import net.dv8tion.jda.api.utils.data.DataObject;
 import net.dv8tion.jda.internal.entities.EntityBuilder;
 import net.dv8tion.jda.internal.utils.Checks;
 import net.dv8tion.jda.internal.utils.Helpers;
@@ -27,6 +29,7 @@ import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAccessor;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -45,7 +48,7 @@ public class EmbedBuilder
     public final static String ZERO_WIDTH_SPACE = "\u200E";
     public final static Pattern URL_PATTERN = Pattern.compile("\\s*(https?|attachment)://\\S+\\s*", Pattern.CASE_INSENSITIVE);
 
-    private final List<MessageEmbed.Field> fields = new LinkedList<>();
+    private final List<MessageEmbed.Field> fields = new ArrayList<>();
     private final StringBuilder description = new StringBuilder();
     private int color = Role.DEFAULT_COLOR_RAW;
     private String url, title;
@@ -82,6 +85,74 @@ public class EmbedBuilder
     public EmbedBuilder(@Nullable MessageEmbed embed)
     {
         copyFrom(embed);
+    }
+
+    /**
+     * Creates an instance of this builder from the provided {@link DataObject}.
+     *
+     * <p>This is the inverse of {@link MessageEmbed#toData()}.
+     *
+     * @param  data
+     *         The serialized embed object
+     *
+     * @throws IllegalArgumentException
+     *         If the provided data is {@code null}
+     * @throws net.dv8tion.jda.api.exceptions.ParsingException
+     *         If the provided data is malformed
+     *
+     * @return The new builder instance
+     */
+    @Nonnull
+    public static EmbedBuilder fromData(@Nonnull DataObject data)
+    {
+        Checks.notNull(data, "DataObject");
+        EmbedBuilder builder = new EmbedBuilder();
+
+        builder.url = data.getString("url", null);
+        builder.title = data.getString("title", null);
+        builder.setDescription(data.getString("description", ""));
+        builder.timestamp = data.isNull("timestamp") ? null : OffsetDateTime.parse(data.getString("timestamp"));
+        builder.color = data.getInt("color", Role.DEFAULT_COLOR_RAW);
+
+        data.optObject("thumbnail").ifPresent(thumbnail ->
+            builder.thumbnail = new MessageEmbed.Thumbnail(thumbnail.getString("url"), null, 0, 0)
+        );
+
+        data.optObject("author").ifPresent(author ->
+            builder.author = new MessageEmbed.AuthorInfo(
+                author.getString("name", ""),
+                author.getString("url", null),
+                author.getString("icon_url", null),
+                null
+            )
+        );
+
+        data.optObject("footer").ifPresent(footer ->
+            builder.footer = new MessageEmbed.Footer(
+                footer.getString("text", ""),
+                footer.getString("icon_url", null),
+                null
+            )
+        );
+
+        data.optObject("image").ifPresent(image ->
+            builder.image = new MessageEmbed.ImageInfo(
+                image.getString("url"),
+                null, 0, 0
+            )
+        );
+
+        data.optArray("fields").ifPresent(arr ->
+            arr.stream(DataArray::getObject).forEach(field ->
+                builder.fields.add(new MessageEmbed.Field(
+                        field.getString("name", ""),
+                        field.getString("value", ""),
+                        field.getBoolean("inline", false)
+                ))
+            )
+        );
+
+        return builder;
     }
 
     /**

--- a/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
+++ b/src/test/java/net/dv8tion/jda/entities/MessageSerializationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.entities;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.EmbedType;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MessageSerializationTest
+{
+    @Test
+    void testEmbedSerialization()
+    {
+        EmbedBuilder builder = new EmbedBuilder();
+        builder.setDescription("Description Text");
+        builder.setTitle("Title Text", "https://example.com/title");
+        builder.setAuthor("Author Text", "https://example.com/author", "https://example.com/author_icon");
+        builder.setFooter("Footer Text", "https://example.com/footer_icon");
+        builder.setImage("https://example.com/image");
+        builder.setThumbnail("https://example.com/thumbnail");
+        builder.addField("Field 1", "Field 1 Text", true);
+        builder.addField("Field 2", "Field 2 Text", false);
+        builder.addField("Field 3", "Field 3 Text", true);
+
+        MessageEmbed embed = builder.build();
+
+        MessageEmbed dataEmbed = EmbedBuilder.fromData(embed.toData()).build();
+
+        Assertions.assertEquals(embed.getType(), dataEmbed.getType());
+        Assertions.assertEquals(EmbedType.RICH, embed.getType());
+
+        Assertions.assertEquals(embed.getDescription(), dataEmbed.getDescription());
+        Assertions.assertEquals(embed.getTitle(), dataEmbed.getTitle());
+        Assertions.assertEquals(embed.getUrl(), dataEmbed.getUrl());
+        Assertions.assertEquals(embed.getAuthor(), dataEmbed.getAuthor());
+        Assertions.assertEquals(embed.getFooter(), dataEmbed.getFooter());
+        Assertions.assertEquals(embed.getImage(), dataEmbed.getImage());
+        Assertions.assertEquals(embed.getThumbnail(), dataEmbed.getThumbnail());
+        Assertions.assertEquals(embed.getFields(), dataEmbed.getFields());
+
+        Assertions.assertEquals(embed, dataEmbed);
+
+        Assertions.assertEquals("Description Text", dataEmbed.getDescription());
+        Assertions.assertEquals("Title Text", dataEmbed.getTitle());
+        Assertions.assertEquals("https://example.com/title", dataEmbed.getUrl());
+        Assertions.assertEquals("Author Text", dataEmbed.getAuthor().getName());
+        Assertions.assertEquals("https://example.com/author", dataEmbed.getAuthor().getUrl());
+        Assertions.assertEquals("https://example.com/author_icon", dataEmbed.getAuthor().getIconUrl());
+        Assertions.assertEquals("Footer Text", dataEmbed.getFooter().getText());
+        Assertions.assertEquals("https://example.com/footer_icon", dataEmbed.getFooter().getIconUrl());
+        Assertions.assertEquals("https://example.com/image", dataEmbed.getImage().getUrl());
+        Assertions.assertEquals("https://example.com/thumbnail", dataEmbed.getThumbnail().getUrl());
+        Assertions.assertEquals(3, dataEmbed.getFields().size());
+        Assertions.assertEquals("Field 1", dataEmbed.getFields().get(0).getName());
+        Assertions.assertEquals("Field 1 Text", dataEmbed.getFields().get(0).getValue());
+        Assertions.assertTrue(dataEmbed.getFields().get(0).isInline());
+        Assertions.assertEquals("Field 2", dataEmbed.getFields().get(1).getName());
+        Assertions.assertEquals("Field 2 Text", dataEmbed.getFields().get(1).getValue());
+        Assertions.assertFalse(dataEmbed.getFields().get(1).isInline());
+        Assertions.assertEquals("Field 3", dataEmbed.getFields().get(2).getName());
+        Assertions.assertEquals("Field 3 Text", dataEmbed.getFields().get(2).getValue());
+        Assertions.assertTrue(dataEmbed.getFields().get(2).isInline());
+    }
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Now, you can use `EmbedBuilder.fromData(json)` to create an instance of `EmbedBuilder` from a JSON object. This is simply the inverse of `MessageEmbed#toData`, which already existed.
