### PR TITLE
docs: specify that `IWebhookContainer#retrieveWebhooks` might throw an exception

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IWebhookContainer.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/channel/attribute/IWebhookContainer.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public interface IWebhookContainer extends GuildChannel
 {
-     /**
+    /**
      * Retrieves the {@link net.dv8tion.jda.api.entities.Webhook Webhooks} attached to this channel.
      *
      * <p>Possible ErrorResponses include:
@@ -44,6 +44,10 @@ public interface IWebhookContainer extends GuildChannel
      *     <li>{@link net.dv8tion.jda.api.requests.ErrorResponse#MISSING_ACCESS MISSING_ACCESS}
      *     <br>if we were removed from the guild</li>
      * </ul>
+     *
+     * @throws net.dv8tion.jda.api.exceptions.InsufficientPermissionException
+     *         If the currently logged in account does not have
+     *         {@link net.dv8tion.jda.api.Permission#MANAGE_WEBHOOKS Permission.MANAGE_WEBHOOKS} in this channel.
      *
      * @return {@link net.dv8tion.jda.api.requests.RestAction} - Type: List{@literal <}{@link net.dv8tion.jda.api.entities.Webhook Webhook}{@literal >}
      *         <br>Retrieved an immutable list of Webhooks attached to this channel


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

Adds a `throws` clause to the javadoc of `IWebhookContainer#retrieveWebhooks` detailing that the method will throw an `InsufficientPermissionException` if the account does not have the `MANAGE_WEBHOOKS` permission.