### PR TITLE
Replaced the deprecated function in the example to a new one in JDA.java

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/JDA.java
+++ b/src/main/java/net/dv8tion/jda/api/JDA.java
@@ -789,7 +789,7 @@ public interface JDA extends IGuildChannelContainer<Channel>
      * jda.updateCommands()
      *   .addCommands(Commands.slash("ping", "Gives the current ping"))
      *   .addCommands(Commands.slash("ban", "Ban the target user")
-     *     .setGuildOnly(true)
+     *     .setContexts(InteractionContextType.GUILD)
      *     .setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
      *     .addOption(OptionType.USER, "user", "The user to ban", true))
      *   .queue();


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [x] Documentation
- [ ] Other: \_____ 

Closes Issue: NaN

## Description

Replaced `.setGuildOnly(true)` function in the example to `.setContexts(InteractionContextType.GUILD)` in JDA.java because `.setGuildOnly(true)` is deprecated
