### PR TITLE
Add `Member#hasRole`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/entities/Member.java
+++ b/src/main/java/net/dv8tion/jda/api/entities/Member.java
@@ -387,6 +387,18 @@ public interface Member extends IMentionable, IPermissionHolder, IDetachableEnti
     Set<Role> getUnsortedRoles();
 
     /**
+     * Checks if this Member has a certain role.
+     *
+     * @param role The role that the Member needs to have.
+     *
+     * @return True, if this Member has the role.
+     *
+     * @see    #getRoles()
+     * @see    #getUnsortedRoles()
+     */
+    boolean hasRole(@Nonnull Role role);
+
+    /**
      * The {@link java.awt.Color Color} of this Member's name in a Guild.
      *
      * <p>This is determined by the color of the highest role assigned to them that does not have the default color.

--- a/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/MemberImpl.java
@@ -36,10 +36,9 @@ import net.dv8tion.jda.internal.utils.PermissionUtil;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Color;
 import java.time.OffsetDateTime;
 import java.util.*;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -221,6 +220,12 @@ public class MemberImpl implements Member, MemberMixin<MemberImpl>
     {
         final int raw = getColorRaw();
         return raw != Role.DEFAULT_COLOR_RAW ? new Color(raw) : null;
+    }
+
+    @Override
+    public boolean hasRole(@Nonnull Role role)
+    {
+        return roles.contains(role);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedMemberImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/detached/DetachedMemberImpl.java
@@ -36,10 +36,9 @@ import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.awt.*;
+import java.awt.Color;
 import java.time.OffsetDateTime;
 import java.util.*;
-import java.util.List;
 
 public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImpl>
 {
@@ -194,6 +193,12 @@ public class DetachedMemberImpl implements Member, MemberMixin<DetachedMemberImp
     @Nonnull
     @Override
     public Set<Role> getUnsortedRoles()
+    {
+        throw detachedException();
+    }
+
+    @Override
+    public boolean hasRole(@Nonnull Role role)
     {
         throw detachedException();
     }


### PR DESCRIPTION
Add `hasRole(Role)` method to avoid creating an unmodified set before checking if a member has a role.

[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [X] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

I believe the frequency of roles checking isn't low. Recently the `getUnsortedRoles()` method was introduced, and since you are working on roles, please reconsider adding `hasRole()` method to simplify role checking.
Usecase:
```java
if (member.hasRole(guild.getRoleById(ADMIN_ROLE_ID)))
    asAdmin();
else
    asMember();
```