### PR TITLE
Remove reflection usage from AbstractCacheView

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/cache/CacheView.java
@@ -95,7 +95,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return {@link ClosableIterator} holding a read-lock on the data structure.
      *
-     * @since  4.0.0
+     * @since 4.0.0
      */
     @Nonnull
     ClosableIterator<T> lockedIterator();
@@ -110,7 +110,7 @@ public interface CacheView<T> extends Iterable<T>
      * @throws NullPointerException
      *         If provided with null
      *
-     * @since  4.0.0
+     * @since 4.0.0
      */
     default void forEachUnordered(@Nonnull final Consumer<? super T> action)
     {
@@ -140,7 +140,7 @@ public interface CacheView<T> extends Iterable<T>
      *
      * @return The resulting value after the action was performed
      *
-     * @since  4.0.0
+     * @since 4.0.0
      *
      * @see    #acceptStream(Consumer)
      */
@@ -174,7 +174,7 @@ public interface CacheView<T> extends Iterable<T>
      * @throws IllegalArgumentException
      *         If the action is null
      *
-     * @since  4.0.0
+     * @since 4.0.0
      *
      * @see    #applyStream(Function)
      */
@@ -449,9 +449,9 @@ public interface CacheView<T> extends Iterable<T>
      */
     class SimpleCacheView<T> extends AbstractCacheView<T>
     {
-        public SimpleCacheView(@Nonnull Class<T> type, @Nullable Function<T, String> nameMapper)
+        public SimpleCacheView(@Nonnull Class<T> type, @Nonnull T[] emptyArray, @Nullable Function<T, String> nameMapper)
         {
-            super(type, nameMapper);
+            super(type, emptyArray, nameMapper);
         }
     }
 }

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/ForumChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/ForumChannelImpl.java
@@ -43,12 +43,12 @@ import java.util.EnumSet;
 import java.util.List;
 
 public class ForumChannelImpl extends AbstractGuildChannelImpl<ForumChannelImpl>
-    implements ForumChannel,
+        implements ForumChannel,
         GuildChannelUnion,
         ForumChannelMixin<ForumChannelImpl>
 {
     private final TLongObjectMap<PermissionOverride> overrides = MiscUtil.newLongMap();
-    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, ForumTag::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, new ForumTag[0], ForumTag::getName, Comparator.naturalOrder());
 
     private Emoji defaultReaction;
     private String topic;

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/MediaChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/MediaChannelImpl.java
@@ -43,12 +43,12 @@ import java.util.EnumSet;
 import java.util.List;
 
 public class MediaChannelImpl extends AbstractGuildChannelImpl<MediaChannelImpl>
-    implements MediaChannel,
+        implements MediaChannel,
         GuildChannelUnion,
         MediaChannelMixin<MediaChannelImpl>
 {
     private final TLongObjectMap<PermissionOverride> overrides = MiscUtil.newLongMap();
-    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, ForumTag::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, new ForumTag[0], ForumTag::getName, Comparator.naturalOrder());
 
     private Emoji defaultReaction;
     private String topic;

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/ThreadChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/ThreadChannelImpl.java
@@ -61,7 +61,7 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         ThreadChannelMixin<ThreadChannelImpl>
 {
     private final ChannelType type;
-    private final CacheView.SimpleCacheView<ThreadMember> threadMembers = new CacheView.SimpleCacheView<>(ThreadMember.class, null);
+    private final CacheView.SimpleCacheView<ThreadMember> threadMembers = new CacheView.SimpleCacheView<>(ThreadMember.class, new ThreadMember[0], null);
 
     private TLongSet appliedTags = new TLongHashSet(ForumChannel.MAX_POST_TAGS);
     private AutoArchiveDuration autoArchiveDuration;
@@ -224,10 +224,11 @@ public class ThreadChannelImpl extends AbstractGuildChannelImpl<ThreadChannelImp
         JDAImpl jda = (JDAImpl) getJDA();
         return new DeferredRestAction<>(jda, ThreadMember.class,
                 () -> getThreadMemberById(id),
-                () -> {
+                () ->
+                {
                     Route.CompiledRoute route = Route.Channels.GET_THREAD_MEMBER.compile(getId(), Long.toUnsignedString(id)).withQueryParams("with_member", "true");
                     return new RestActionImpl<>(jda, route, (resp, req) ->
-                        jda.getEntityBuilder().createThreadMember(getGuild(), this, resp.getObject()));
+                            jda.getEntityBuilder().createThreadMember(getGuild(), this, resp.getObject()));
                 });
     }
 

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedForumChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedForumChannelImpl.java
@@ -41,14 +41,14 @@ import java.util.EnumSet;
 import java.util.List;
 
 public class DetachedForumChannelImpl extends AbstractGuildChannelImpl<DetachedForumChannelImpl>
-    implements
+        implements
         ForumChannel,
         GuildChannelUnion,
         ForumChannelMixin<DetachedForumChannelImpl>,
         IInteractionPermissionMixin<DetachedForumChannelImpl>
 {
     private ChannelInteractionPermissions interactionPermissions;
-    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, ForumTag::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, new ForumTag[0], ForumTag::getName, Comparator.naturalOrder());
 
     private Emoji defaultReaction;
     private String topic;

--- a/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedMediaChannelImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/entities/channel/concrete/detached/DetachedMediaChannelImpl.java
@@ -48,7 +48,7 @@ public class DetachedMediaChannelImpl extends AbstractGuildChannelImpl<DetachedM
         IInteractionPermissionMixin<DetachedMediaChannelImpl>
 {
     private ChannelInteractionPermissions interactionPermissions;
-    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, ForumTag::getName, Comparator.naturalOrder());
+    private final SortedSnowflakeCacheViewImpl<ForumTag> tagCache = new SortedSnowflakeCacheViewImpl<>(ForumTag.class, new ForumTag[0], ForumTag::getName, Comparator.naturalOrder());
 
     private Emoji defaultReaction;
     private String topic;

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/AbstractCacheView.java
@@ -28,7 +28,6 @@ import net.dv8tion.jda.internal.utils.UnlockHook;
 import org.apache.commons.collections4.iterators.ObjectArrayIterator;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Array;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
@@ -44,11 +43,11 @@ public abstract class AbstractCacheView<T> extends ReadWriteLockCache<T> impleme
     protected final Class<T> type;
 
     @SuppressWarnings("unchecked")
-    protected AbstractCacheView(Class<T> type, Function<T, String> nameMapper)
+    protected AbstractCacheView(Class<T> type, T[] emptyArray, Function<T, String> nameMapper)
     {
         this.nameMapper = nameMapper;
         this.type = type;
-        this.emptyArray = (T[]) Array.newInstance(type, 0);
+        this.emptyArray = emptyArray;
     }
 
     public void clear()

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/MemberCacheViewImpl.java
@@ -30,7 +30,7 @@ public class MemberCacheViewImpl extends SnowflakeCacheViewImpl<Member> implemen
 {
     public MemberCacheViewImpl()
     {
-        super(Member.class, Member::getEffectiveName);
+        super(Member.class, new Member[0], Member::getEffectiveName);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SnowflakeCacheViewImpl.java
@@ -23,9 +23,9 @@ import java.util.function.Function;
 
 public class SnowflakeCacheViewImpl<T extends ISnowflake> extends AbstractCacheView<T> implements SnowflakeCacheView<T>
 {
-    public SnowflakeCacheViewImpl(Class<T> type, Function<T, String> nameMapper)
+    public SnowflakeCacheViewImpl(Class<T> type, T[] emptyArray, Function<T, String> nameMapper)
     {
-        super(type, nameMapper);
+        super(type, emptyArray, nameMapper);
     }
 
     @Override

--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/SortedSnowflakeCacheViewImpl.java
@@ -34,14 +34,14 @@ public class SortedSnowflakeCacheViewImpl<T extends ISnowflake & Comparable<? su
 
     protected final Comparator<T> comparator;
 
-    public SortedSnowflakeCacheViewImpl(Class<T> type, Comparator<T> comparator)
+    public SortedSnowflakeCacheViewImpl(Class<T> type, T[] emptyArray, Comparator<T> comparator)
     {
-        this(type, null, comparator);
+        this(type, emptyArray, null, comparator);
     }
 
-    public SortedSnowflakeCacheViewImpl(Class<T> type, Function<T, String> nameMapper, Comparator<T> comparator)
+    public SortedSnowflakeCacheViewImpl(Class<T> type, T[] emptyArray, Function<T, String> nameMapper, Comparator<T> comparator)
     {
-        super(type, nameMapper);
+        super(type, emptyArray, nameMapper);
         this.comparator = comparator;
     }
 

--- a/src/test/java/net/dv8tion/jda/test/restaction/pagination/PinnedMessagePaginationActionTest.java
+++ b/src/test/java/net/dv8tion/jda/test/restaction/pagination/PinnedMessagePaginationActionTest.java
@@ -48,7 +48,7 @@ public class PinnedMessagePaginationActionTest extends IntegrationTest
     void setupMocks()
     {
         when(guild.getJDA()).thenReturn(jda);
-        when(jda.getUsersView()).thenReturn(new SnowflakeCacheViewImpl<>(User.class, User::getName));
+        when(jda.getUsersView()).thenReturn(new SnowflakeCacheViewImpl<>(User.class, new User[0], User::getName));
         channel = new TextChannelImpl(Constants.CHANNEL_ID, guild);
     }
 
@@ -58,17 +58,17 @@ public class PinnedMessagePaginationActionTest extends IntegrationTest
         PinnedMessagePaginationActionImpl action = new PinnedMessagePaginationActionImpl(channel);
 
         assertThatRequestFrom(action)
-            .hasMethod(Method.GET)
-            .hasCompiledRoute("channels/" + Constants.CHANNEL_ID + "/messages/pins?limit=50")
-            .whenQueueCalled();
+                .hasMethod(Method.GET)
+                .hasCompiledRoute("channels/" + Constants.CHANNEL_ID + "/messages/pins?limit=50")
+                .whenQueueCalled();
 
         assertThat(captureListCallback(PinnedMessage.class, action, DataObject.empty().put("items", DataArray.empty())))
-            .isEmpty();
+                .isEmpty();
 
         assertThatRequestFrom(action)
-            .hasMethod(Method.GET)
-            .hasCompiledRoute("channels/" + Constants.CHANNEL_ID + "/messages/pins?limit=50")
-            .whenQueueCalled();
+                .hasMethod(Method.GET)
+                .hasCompiledRoute("channels/" + Constants.CHANNEL_ID + "/messages/pins?limit=50")
+                .whenQueueCalled();
     }
 
     @Test
@@ -83,38 +83,38 @@ public class PinnedMessagePaginationActionTest extends IntegrationTest
         {
             timeStamp = timeStamp.plusSeconds(1);
             items.add(DataObject.empty()
-                .put("pinned_at", timeStamp)
-                .put("message", getTestMessage()));
+                    .put("pinned_at", timeStamp)
+                    .put("message", getTestMessage()));
         }
 
         OffsetDateTime lastTimestamp = timeStamp;
 
         assertThat(captureListCallback(PinnedMessage.class, action, DataObject.empty().put("items", items)))
-            .hasSize(50)
-            .last().matches(pinned -> pinned.getTimePinned().equals(lastTimestamp));
+                .hasSize(50)
+                .last().matches(pinned -> pinned.getTimePinned().equals(lastTimestamp));
 
         assertThatRequestFrom(action)
-            .hasMethod(Method.GET)
-            .hasQueryParams("limit", 50, "before", lastTimestamp)
-            .whenQueueCalled();
+                .hasMethod(Method.GET)
+                .hasQueryParams("limit", 50, "before", lastTimestamp)
+                .whenQueueCalled();
     }
 
     private DataObject getTestMessage()
     {
         return DataObject.empty()
-            .put("type", 0)
-            .put("id", randomSnowflake())
-            .put("channel_id", Constants.CHANNEL_ID)
-            .put("content", "test content")
-            .put("embeds", DataArray.empty())
-            .put("attachments", DataArray.empty())
-            .put("components", DataArray.empty())
-            .put("mentions", DataArray.empty())
-            .put("mention_roles", DataArray.empty())
-            .put("author", DataObject.empty()
-                .put("id", Constants.MINN_USER_ID)
-                .put("username", "minn")
-                .put("discriminator", "0")
-                .put("avatar", null));
+                .put("type", 0)
+                .put("id", randomSnowflake())
+                .put("channel_id", Constants.CHANNEL_ID)
+                .put("content", "test content")
+                .put("embeds", DataArray.empty())
+                .put("attachments", DataArray.empty())
+                .put("components", DataArray.empty())
+                .put("mentions", DataArray.empty())
+                .put("mention_roles", DataArray.empty())
+                .put("author", DataObject.empty()
+                        .put("id", Constants.MINN_USER_ID)
+                        .put("username", "minn")
+                        .put("discriminator", "0")
+                        .put("avatar", null));
     }
 }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [ x] I have checked the PRs for upcoming features/bug fixes.
- [ x] I have read the [contributing guidelines][contributing].

### Changes

- [ x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->



## Description

Removes the usage of Reflection in the constructor of AbstractCacheView `(T[]) Array.newInstance(type, 0)`, This usage of reflection blocks the availability of compiling JDA into native code using Graalvm
