### PR TITLE
Return 0 on `ActionRow#getMaxAllowed` with `TEXT_INPUT`

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/components/actionrow/ActionRow.java
+++ b/src/main/java/net/dv8tion/jda/api/components/actionrow/ActionRow.java
@@ -165,7 +165,6 @@ public interface ActionRow extends MessageTopLevelComponent, ContainerChildCompo
         case ROLE_SELECT:
         case MENTIONABLE_SELECT:
         case CHANNEL_SELECT:
-        case TEXT_INPUT:
             return 1;
         default:
             return 0;

--- a/src/test/resources/net/dv8tion/jda/test/components/ActionRowTest/testGetMaxAllowedIsUpdated.json
+++ b/src/test/resources/net/dv8tion/jda/test/components/ActionRowTest/testGetMaxAllowedIsUpdated.json
@@ -12,7 +12,7 @@
     "SEPARATOR" : 0,
     "STRING_SELECT" : 1,
     "TEXT_DISPLAY" : 0,
-    "TEXT_INPUT" : 1,
+    "TEXT_INPUT" : 0,
     "THUMBNAIL" : 0,
     "UNKNOWN" : 0,
     "USER_SELECT" : 1


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Text inputs cannot be put inside action rows anymore, return 0 on `ActionRow#getMaxAllowed`.
