### PR TITLE
Add note about default CV2 flag affecting utilities

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/messages/MessageRequest.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/messages/MessageRequest.java
@@ -106,6 +106,11 @@ public interface MessageRequest<R extends MessageRequest<R>> extends MessageData
      *
      * <p>This can be overwritten with {@link #useComponentsV2(boolean)} on each builder instance.
      *
+     * <p><b>NOTE:</b> When enabled, be aware that messages which were built for "V1" content
+     * will cause errors if they don't explicitly disable their V2 flag.
+     * You should check if the helpers you use do set their flag appropriately,
+     * this includes your own utilities/replies as well as 3rd party libraries you may use.
+     *
      * @param  use
      *         {@code true} to enable V2 components by default, {@code false} to disabled them by default.
      */


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds a note when settings the default CV2 flag about checking if the CV2 flag is set appropriately in utilities/3rd party code.
