### PR TITLE
Fix `ModalMapping::getAsAttachmentList` if no attachments were submitted

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/modals/ModalMapping.java
@@ -29,6 +29,7 @@ import net.dv8tion.jda.internal.utils.EntityString;
 import net.dv8tion.jda.internal.utils.Helpers;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -202,6 +203,9 @@ public class ModalMapping
     {
         if (type != Component.Type.FILE_UPLOAD)
             typeError("List<Message.Attachment>");
+
+        if (resolved.isNull("attachments"))
+            return Collections.emptyList();
 
         final DataObject attachments = resolved.getObject("attachments");
         final EntityBuilder entityBuilder = interaction.getJDA().getEntityBuilder();


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The previous implementation of `ModalMapping::getAsAttachmentList` throws a `DataObjectParsingException` if the user doesn't submit any attachments. This is possible when explicitly making the file upload component optional.

Fix the method by manually checking whether the resolved object has an `attachments` property, returning an empty list if no such object exists.

This patch [was suggested](https://discord.com/channels/125227483518861312/125227483518861312/1430968888866246676) by @freya022.
