### PR TITLE
Update JDK javadoc links

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -275,7 +275,10 @@ val javadoc by tasks.getting(Javadoc::class) {
 
         author()
         tags("incubating:a:Incubating:")
-        links("https://docs.oracle.com/javase/8/docs/api/", "https://takahikokawasaki.github.io/nv-websocket-client/")
+        // We compile to Java 8 but JDK 8 docs don't seem to supply `element-list` anymore, failing the build
+        // so we'll be using the minimum JDK that can be used to build JDA (JDK 17 due to Gradle 9) instead.
+        // Failing: https://docs.oracle.com/javase/8/docs/api/element-list
+        links("https://docs.oracle.com/en/java/javase/17/docs/api/", "https://takahikokawasaki.github.io/nv-websocket-client/")
 
         if (JavaVersion.VERSION_1_8 < javaVersion) {
             addBooleanOption("html5", true) // Adds search bar
@@ -493,4 +496,3 @@ jreleaser {
 tasks.withType<AbstractJReleaserTask>().configureEach {
     mustRunAfter(tasks.named("publish"))
 }
-


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

This PR replaces the Javadoc links to the JDK to link against JDK 17
- The current JDK 8 link fails when fetching the package list: https://docs.oracle.com/javase/8/docs/api/element-list
- The nearest working package list is from JDK 10, but I believe it makes more sense to use the same version as what the CI and Gradle uses to build, which is also a much more modern version


