### PR TITLE
Clean up build constant conditions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,11 +17,7 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import de.undercouch.gradle.tasks.download.Download
-import net.dv8tion.jda.tasks.VerifyBytecodeVersion
-import net.dv8tion.jda.tasks.Version
-import net.dv8tion.jda.tasks.applyAudioExclusions
-import net.dv8tion.jda.tasks.applyOpusExclusions
-import net.dv8tion.jda.tasks.nullableReplacement
+import net.dv8tion.jda.tasks.*
 import nl.littlerobots.vcu.plugin.resolver.VersionSelectors
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.jreleaser.gradle.plugin.tasks.AbstractJReleaserTask
@@ -271,7 +267,6 @@ val javadoc by tasks.getting(Javadoc::class) {
         tags("incubating:a:Incubating:")
         links("https://docs.oracle.com/javase/8/docs/api/", "https://takahikokawasaki.github.io/nv-websocket-client/")
 
-        addBooleanOption("html5", true) // Adds search bar
         addStringOption("-release", "8")
         addBooleanOption("Xdoclint:all,-missing", true)
 


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [X] Other: Build script

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Removes conditions that became constants with the upgrade to Gradle 9, as it requires JDK 17+ to run.

The only way I know to still build using a Java <17 compiler is to use a toolchain, and JDA does not use toolchains, so I assume Gradle will only build using the JDK it runs on.
