### PR TITLE
Add check for valid interface types on ChannelCacheView#ofType

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/utils/cache/ChannelCacheViewImpl.java
+++ b/src/main/java/net/dv8tion/jda/internal/utils/cache/ChannelCacheViewImpl.java
@@ -253,6 +253,8 @@ public class ChannelCacheViewImpl<T extends Channel> extends ReadWriteLockCache<
         protected FilteredCacheView(Class<C> type)
         {
             Checks.notNull(type, "Type");
+            checkChannelInterface(type);
+
             this.type = type;
 
             this.filteredMaps = caches.entrySet()
@@ -260,6 +262,14 @@ public class ChannelCacheViewImpl<T extends Channel> extends ReadWriteLockCache<
                 .filter(entry -> entry.getKey() != null && type.isAssignableFrom(entry.getKey().getInterface()))
                 .map(entry -> (TLongObjectMap<C>) entry.getValue())
                 .collect(Collectors.toList());
+        }
+
+        private void checkChannelInterface(Class<C> type)
+        {
+            boolean isValidInterfaceType = false;
+            for (ChannelType channelType : ChannelType.values())
+                isValidInterfaceType |= type.isAssignableFrom(channelType.getInterface());
+            Checks.check(isValidInterfaceType, "Type %s is not a valid channel interface", type.getSimpleName());
         }
 
         protected void removeIf(Predicate<? super C> filter)

--- a/src/test/java/net/dv8tion/jda/test/cacheview/ChannelCacheViewTest.java
+++ b/src/test/java/net/dv8tion/jda/test/cacheview/ChannelCacheViewTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 Austin Keener, Michael Ritter, Florian Spieß, and the JDA contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.dv8tion.jda.test.cacheview;
+
+import net.dv8tion.jda.api.entities.channel.Channel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.internal.entities.channel.concrete.TextChannelImpl;
+import net.dv8tion.jda.internal.utils.cache.ChannelCacheViewImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static net.dv8tion.jda.test.ChecksHelper.assertChecks;
+import static org.assertj.core.api.Assertions.*;
+
+class ChannelCacheViewTest
+{
+    @ValueSource(classes = {
+        Channel.class,
+        MessageChannel.class,
+        TextChannel.class,
+    })
+    @ParameterizedTest
+    @SuppressWarnings("unchecked")
+    void testValidChannelInterfaceFilters(Class<?> interfaceType)
+    {
+        ChannelCacheViewImpl<Channel> cache = new ChannelCacheViewImpl<>(Channel.class);
+        assertThatNoException()
+            .isThrownBy(() -> cache.ofType((Class<Channel>) interfaceType).getElementById(0L));
+    }
+
+    @ValueSource(classes = {
+        TextChannelImpl.class,
+        String.class
+    })
+    @ParameterizedTest
+    @SuppressWarnings("unchecked")
+    void testInvalidChannelInterfaceFilters(Class<?> interfaceType)
+    {
+        ChannelCacheViewImpl<Channel> cache = new ChannelCacheViewImpl<>(Channel.class);
+
+        assertThatThrownBy(() -> cache.ofType((Class<Channel>) interfaceType).getElementById(0L))
+            .hasMessage(String.format("Type %s is not a valid channel interface", interfaceType.getSimpleName()));
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testNullChannelInterfaceFilters()
+    {
+        ChannelCacheViewImpl<Channel> cache = new ChannelCacheViewImpl<>(Channel.class);
+
+        assertChecks("Type", (value) -> cache.ofType((Class<Channel>) value))
+            .checksNotNull();
+    }
+}


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2924 

## Description

This adds a check to ensure people use the filter with a valid channel interface.
