### PR TITLE
Fix voice state in events when joining channel

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceDeafenEvent.java
@@ -38,9 +38,9 @@ import javax.annotation.Nonnull;
 public class GuildVoiceDeafenEvent extends GenericGuildVoiceEvent {
     protected final boolean deafened;
 
-    public GuildVoiceDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean deafened) {
         super(api, responseNumber, member);
-        this.deafened = member.getVoiceState().isDeafened();
+        this.deafened = deafened;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildDeafenEvent.java
@@ -36,9 +36,10 @@ import javax.annotation.Nonnull;
 public class GuildVoiceGuildDeafenEvent extends GenericGuildVoiceEvent {
     protected final boolean guildDeafened;
 
-    public GuildVoiceGuildDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceGuildDeafenEvent(
+            @Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean guildDeafened) {
         super(api, responseNumber, member);
-        this.guildDeafened = member.getVoiceState().isGuildDeafened();
+        this.guildDeafened = guildDeafened;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceGuildMuteEvent.java
@@ -36,9 +36,9 @@ import javax.annotation.Nonnull;
 public class GuildVoiceGuildMuteEvent extends GenericGuildVoiceEvent {
     protected final boolean guildMuted;
 
-    public GuildVoiceGuildMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceGuildMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean guildMuted) {
         super(api, responseNumber, member);
-        this.guildMuted = member.getVoiceState().isGuildMuted();
+        this.guildMuted = guildMuted;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceMuteEvent.java
@@ -38,9 +38,9 @@ import javax.annotation.Nonnull;
 public class GuildVoiceMuteEvent extends GenericGuildVoiceEvent {
     protected final boolean muted;
 
-    public GuildVoiceMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean muted) {
         super(api, responseNumber, member);
-        this.muted = member.getVoiceState().isMuted();
+        this.muted = muted;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfDeafenEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfDeafenEvent.java
@@ -36,9 +36,10 @@ import javax.annotation.Nonnull;
 public class GuildVoiceSelfDeafenEvent extends GenericGuildVoiceEvent {
     protected final boolean selfDeafened;
 
-    public GuildVoiceSelfDeafenEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceSelfDeafenEvent(
+            @Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean isSelfDeafened) {
         super(api, responseNumber, member);
-        this.selfDeafened = member.getVoiceState().isSelfDeafened();
+        this.selfDeafened = isSelfDeafened;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfMuteEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSelfMuteEvent.java
@@ -36,9 +36,9 @@ import javax.annotation.Nonnull;
 public class GuildVoiceSelfMuteEvent extends GenericGuildVoiceEvent {
     protected final boolean selfMuted;
 
-    public GuildVoiceSelfMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceSelfMuteEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean isSelfMuted) {
         super(api, responseNumber, member);
-        this.selfMuted = member.getVoiceState().isSelfMuted();
+        this.selfMuted = isSelfMuted;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSuppressEvent.java
+++ b/src/main/java/net/dv8tion/jda/api/events/guild/voice/GuildVoiceSuppressEvent.java
@@ -38,9 +38,9 @@ import javax.annotation.Nonnull;
 public class GuildVoiceSuppressEvent extends GenericGuildVoiceEvent {
     protected final boolean suppressed;
 
-    public GuildVoiceSuppressEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member) {
+    public GuildVoiceSuppressEvent(@Nonnull JDA api, long responseNumber, @Nonnull Member member, boolean suppressed) {
         super(api, responseNumber, member);
-        this.suppressed = member.getVoiceState().isSuppressed();
+        this.suppressed = suppressed;
     }
 
     /**

--- a/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
+++ b/src/main/java/net/dv8tion/jda/internal/handle/VoiceStateUpdateHandler.java
@@ -117,27 +117,27 @@ public class VoiceStateUpdateHandler extends SocketHandler {
         if (selfMuted != vState.isSelfMuted()) {
             vState.setSelfMuted(selfMuted);
             getJDA().getEntityBuilder().updateMemberCache(member);
-            getJDA().handleEvent(new GuildVoiceSelfMuteEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceSelfMuteEvent(getJDA(), responseNumber, member, selfMuted));
         }
         if (selfDeafened != vState.isSelfDeafened()) {
             vState.setSelfDeafened(selfDeafened);
             getJDA().getEntityBuilder().updateMemberCache(member);
-            getJDA().handleEvent(new GuildVoiceSelfDeafenEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceSelfDeafenEvent(getJDA(), responseNumber, member, selfDeafened));
         }
         if (guildMuted != vState.isGuildMuted()) {
             vState.setGuildMuted(guildMuted);
             getJDA().getEntityBuilder().updateMemberCache(member);
-            getJDA().handleEvent(new GuildVoiceGuildMuteEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceGuildMuteEvent(getJDA(), responseNumber, member, guildMuted));
         }
         if (guildDeafened != vState.isGuildDeafened()) {
             vState.setGuildDeafened(guildDeafened);
             getJDA().getEntityBuilder().updateMemberCache(member);
-            getJDA().handleEvent(new GuildVoiceGuildDeafenEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceGuildDeafenEvent(getJDA(), responseNumber, member, guildDeafened));
         }
         if (suppressed != vState.isSuppressed()) {
             vState.setSuppressed(suppressed);
             getJDA().getEntityBuilder().updateMemberCache(member);
-            getJDA().handleEvent(new GuildVoiceSuppressEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceSuppressEvent(getJDA(), responseNumber, member, suppressed));
         }
         if (stream != vState.isStream()) {
             vState.setStream(stream);
@@ -150,10 +150,10 @@ public class VoiceStateUpdateHandler extends SocketHandler {
             getJDA().handleEvent(new GuildVoiceVideoEvent(getJDA(), responseNumber, member, video));
         }
         if (wasMute != vState.isMuted()) {
-            getJDA().handleEvent(new GuildVoiceMuteEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceMuteEvent(getJDA(), responseNumber, member, vState.isMuted()));
         }
         if (wasDeaf != vState.isDeafened()) {
-            getJDA().handleEvent(new GuildVoiceDeafenEvent(getJDA(), responseNumber, member));
+            getJDA().handleEvent(new GuildVoiceDeafenEvent(getJDA(), responseNumber, member, vState.isDeafened()));
         }
         if (requestToSpeakTimestamp != vState.getRequestToSpeak()) {
             OffsetDateTime oldRequestToSpeak = vState.getRequestToSpeakTimestamp();
@@ -186,11 +186,9 @@ public class VoiceStateUpdateHandler extends SocketHandler {
 
                     // If we have connected (VOICE_SERVER_UPDATE received and AudioConnection
                     // created (actual connection might still be setting up)),
-                    // then we need to stop sending audioOpen/Move requests through the MainWS if
-                    // the channel
-                    // we have just joined / moved to is the same as the currently queued
-                    // audioRequest
-                    // (handled by updateAudioConnection)
+                    // then we need to stop sending audioOpen/Move requests through the MainWS
+                    // if the channel we have just joined / moved to
+                    // is the same as the currently queued audioRequest (handled by updateAudioConnection)
                     if (mng.isConnected()) {
                         getJDA().getDirectAudioController().update(guild, channel);
                     }


### PR DESCRIPTION
[contributing]: https://jda.wiki/contributing/contributing/

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #2958

## Description

The voice state is not yet fully cached when these events are created. Instead of using the cache to assess the state, we now use the parsed state from the event directly.
