### PR TITLE
Downgrade jreleaser to 1.20.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ junit-java8 = [
 
 [plugins]
 download = "de.undercouch.download:5.6.0"
-jreleaser = "org.jreleaser:1.21.0"
+jreleaser = "org.jreleaser:1.20.0"
 openrewrite = "org.openrewrite.rewrite:7.20.0"
 shadow = "com.gradleup.shadow:9.2.2"
 spotless = "com.diffplug.spotless:8.0.0"


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Downgrade gradle plugin

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

There is currently a bug in 1.21.0 that is expected to be fixed in the next release of jreleaser. In the meantime, we donwgrade.
