### PR TITLE
Fix default CV2 flag not being applied on message edits

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/messages/MessageEditBuilder.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/messages/MessageEditBuilder.java
@@ -55,7 +55,7 @@ public class MessageEditBuilder extends AbstractMessageBuilder<MessageEditData, 
     protected static final int FLAGS = 1 << 5;
 
     private boolean replace = false;
-    private int configuredFields = 0;
+    private int configuredFields;
 
     private final List<AttachedFile> attachments = new ArrayList<>(10);
 

--- a/src/test/java/net/dv8tion/jda/test/entities/message/MessageEditBuilderTest.java
+++ b/src/test/java/net/dv8tion/jda/test/entities/message/MessageEditBuilderTest.java
@@ -23,6 +23,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
 import net.dv8tion.jda.api.utils.messages.MessageEditData;
+import net.dv8tion.jda.api.utils.messages.MessageRequest;
 import net.dv8tion.jda.test.AbstractSnapshotTest;
 import net.dv8tion.jda.test.Resources;
 import net.dv8tion.jda.test.components.ComponentTestData;
@@ -76,6 +77,17 @@ public class MessageEditBuilderTest extends AbstractSnapshotTest {
 
         try (MessageEditData data = builder.build()) {
             assertWithSnapshot(data);
+        }
+    }
+
+    @Test
+    void testDefaultCV2FlagIsSet() {
+        var oldFlag = MessageRequest.isDefaultUseComponentsV2();
+        MessageRequest.setDefaultUseComponentsV2(true);
+        try (MessageEditData data = new MessageEditBuilder().build()) {
+            assertThat(data.toData().getInt("flags", 0)).isEqualTo(Message.MessageFlag.IS_COMPONENTS_V2.getValue());
+        } finally {
+            MessageRequest.setDefaultUseComponentsV2(oldFlag);
         }
     }
 


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

An user with `MessageRequest.isDefaultUseComponentsV2()` returning `true` was unable to create CV2 edits by default, see https://discord.com/channels/125227483518861312/1406042603350130708/1448498020604973200.

The flag was set appropriately by `AbstractMessageBuilder` (a superclass of `MessageEditBuilder`), but then was "marked as not set" because of `MessageEditBuilder#configuredFields`'s initializer which set it back to 0.

So, this PR removes the initializer, while still keeping the `0` default, to prevent it from being overwritten.