### PR TITLE
Redact token from trace logs of gateway requests

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
+++ b/src/main/java/net/dv8tion/jda/internal/requests/WebSocketClient.java
@@ -250,7 +250,10 @@ public class WebSocketClient extends WebSocketAdapter implements WebSocketListen
 
         // Allows 115 messages to be sent before limiting.
         if (this.messagesSent.get() <= 115 || (skipQueue && this.messagesSent.get() <= 119)) {
-            LOG.trace("<- {}", message);
+            if (LOG.isTraceEnabled()) {
+                String redactedMessage = message.toString().replace(getToken(), "<REDACTED>");
+                LOG.trace("<- {}", redactedMessage);
+            }
             if (encoding == GatewayEncoding.ETF) {
                 socket.sendBinary(message.toETF());
             } else {


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

For when someone asks for logs, as it would otherwise show the token in `IDENTIFY`/`RESUME` requests