### PR TITLE
Fix some escaping of Javadoc snippets

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/interactions/commands/localization/LocalizationFunction.java
+++ b/src/main/java/net/dv8tion/jda/api/interactions/commands/localization/LocalizationFunction.java
@@ -45,9 +45,9 @@ import javax.annotation.Nonnull;
  * <br>Extremely naive implementation of LocalizationFunction
  * {@snippet lang="java":
  * public class MyFunction implements LocalizationFunction {
- *   &#64;Override
- *   public Map&lt;DiscordLocale, String&gt; apply(String localizationKey) {
- *     Map&lt;DiscordLocale, String&gt; map = new HashMap&lt;&gt;();
+ *   @Override
+ *   public Map<DiscordLocale, String> apply(String localizationKey) {
+ *     Map<DiscordLocale, String> map = new HashMap<>();
  *     switch (localizationKey) {
  *       case "ban.name":
  *         map.put(DiscordLocale.SPANISH, "prohibición");
@@ -67,8 +67,8 @@ import javax.annotation.Nonnull;
  *
  * Also, since this is a functional interface, the following is also possible
  * {@snippet lang="java":
- * LocalizationFunction myfunc = s -&gt; {
- *   Map&lt;DiscordLocale, String&gt; map = new HashMap&lt;&gt;();
+ * LocalizationFunction myfunc = s -> {
+ *   Map<DiscordLocale, String> map = new HashMap<>();
  *    switch (localizationKey) {
  *      case "ban.name":
  *        map.put(DiscordLocale.SPANISH, "prohibición");


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

There still is a few issues in `Emojis` but the fix for the website would break IntelliJ.
