### PR TITLE
Fix unique id not being copied in SelectMenus

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
@@ -150,7 +150,9 @@ public interface EntitySelectMenu extends SelectMenu {
         builder.setPlaceholder(getPlaceholder());
         builder.setDisabled(isDisabled());
         builder.setDefaultValues(getDefaultValues());
-        builder.setUniqueId(getUniqueId());
+        if (getUniqueId() > 0) {
+            builder.setUniqueId(getUniqueId());
+        }
         return builder;
     }
 

--- a/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
@@ -113,7 +113,9 @@ public interface StringSelectMenu extends SelectMenu {
         builder.addOptions(getOptions());
         builder.setDisabled(isDisabled());
         builder.setRequired(isRequired());
-        builder.setUniqueId(getUniqueId());
+        if (getUniqueId() > 0) {
+            builder.setUniqueId(getUniqueId());
+        }
         return builder;
     }
 


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->


## Description

Fixes that `#createCopy` of `EntitySelectMenu` and `StringSelectMenu` didn't copy the unique id
