### PR TITLE
Adding s/S TimeFormat

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/utils/TimeFormat.java
+++ b/src/main/java/net/dv8tion/jda/api/utils/TimeFormat.java
@@ -52,6 +52,10 @@ public enum TimeFormat {
     DATE_TIME_SHORT("f"),
     /** Formats date and time as {@code Wednesday, 16 June 2021 18:49} or {@code Wednesday, June 16, 2021 6:49 PM} */
     DATE_TIME_LONG("F"),
+    /** Formats date and time as {@code 16/06/2021, 18:49} or {@code 16/06/2021, 6:49 PM} */
+    DATE_SHORT_TIME_SHORT("s"),
+    /** Formats date and time as {@code 16/06/2021, 18:49:26} or {@code 16/06/2021, 6:49:26 PM} */
+    DATE_SHORT_TIME_LONG("S"),
     /** Formats date and time as relative {@code 18 minutes ago} or {@code 2 days ago} */
     RELATIVE("R"),
     ;
@@ -91,7 +95,7 @@ public enum TimeFormat {
      *
      * @see #parse(String)
      */
-    public static final Pattern MARKDOWN = Pattern.compile("<t:(?<time>-?\\d{1,17})(?::(?<style>[tTdDfFR]))?>");
+    public static final Pattern MARKDOWN = Pattern.compile("<t:(?<time>-?\\d{1,17})(?::(?<style>[tTdDfFsSR]))?>");
 
     private final String style;
 


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [x] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Adds support for TimeFormat formats described in documentation [here](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles), added to the documentation [here](https://github.com/discord/discord-api-docs/commit/8e844425497bc409c41fcadb7f2d7e2e9cbe8d4a).

The documentation also updated the description of the individual formats and used different terminology. As aligning all of them would be a breaking change (or using a different name for the new ones confusing), I asked in lib-dev and used the suggestion from there.

Also, when I switched the time format in the client I saw that the time format actually is "pm", instead of "PM", but I kept it consistent with the rest of the examples, as I dont know where the upper case is coming from. (Should I also update this?)