### PR TITLE
Disable dependabot gradle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,15 +16,3 @@ updates:
           github-actions:
               patterns:
                   - "*"
-    - package-ecosystem: "gradle"
-      directory: "/"
-      rebase-strategy: "disabled"
-      cooldown:
-          default-days: 7
-      schedule:
-          interval: "weekly"
-      groups:
-          dependencies:
-              applies-to: version-updates
-              patterns:
-                  - "*"


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [ ] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [x] Other: Dependabot

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

Disables gradle updates for dependabot, since it ignores our version catalog pinning.
