### PR TITLE
Prevent explicitly required select menus when `minValues` is zero

### DIFF
--- a/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/EntitySelectMenu.java
@@ -620,7 +620,10 @@ public interface EntitySelectMenu extends SelectMenu {
          * Creates a new {@link EntitySelectMenu} instance if all requirements are satisfied.
          *
          * @throws IllegalArgumentException
-         *         Throws if {@link #getMinValues()} is greater than {@link #getMaxValues()}
+         *         <ul>
+         *             <li>If {@link #getMinValues()} is greater than {@link #getMaxValues()}</li>
+         *             <li>If the minimum value range is 0 and a selection is also explicitly required</li>
+         *         </ul>
          *
          * @return The new {@link EntitySelectMenu} instance
          */
@@ -628,6 +631,11 @@ public interface EntitySelectMenu extends SelectMenu {
         @Override
         public EntitySelectMenu build() {
             Checks.check(minValues <= maxValues, "Min values cannot be greater than max values!");
+            if (required != null && required) {
+                Checks.check(
+                        minValues > 0,
+                        "A select menu cannot have min values set to 0 and be required at the same time");
+            }
             EnumSet<ChannelType> channelTypes =
                     componentType == Type.CHANNEL_SELECT ? this.channelTypes : EnumSet.noneOf(ChannelType.class);
             List<DefaultValue> defaultValues = new ArrayList<>(this.defaultValues);

--- a/src/main/java/net/dv8tion/jda/api/components/selections/SelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/SelectMenu.java
@@ -214,6 +214,9 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent, La
          *
          * <p>The minimum must not exceed the amount of available options.
          *
+         * <p><b>Note:</b> In modals, if you set this to zero,
+         * you must set this select menu as {@linkplain #setRequired(Boolean) optional}.
+         *
          * @param  minValues
          *         The min values
          *
@@ -265,6 +268,9 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent, La
          * <br>Default: {@code 1} for both
          *
          * <p>The minimum or maximum must not exceed the amount of available options.
+         *
+         * <p><b>Note:</b> In modals, if you set the minimum to zero,
+         * you must set this select menu as {@linkplain #setRequired(Boolean) optional}.
          *
          * @param  min
          *         The min values
@@ -393,7 +399,10 @@ public interface SelectMenu extends ActionComponent, ActionRowChildComponent, La
          * Creates a new {@link SelectMenu} instance if all requirements are satisfied.
          *
          * @throws IllegalArgumentException
-         *         Throws if {@link #getMinValues()} is greater than {@link #getMaxValues()}
+         *         <ul>
+         *             <li>If {@link #getMinValues()} is greater than {@link #getMaxValues()}</li>
+         *             <li>If the minimum value range is 0 and a selection is also explicitly required</li>
+         *         </ul>
          *
          * @return The new {@link SelectMenu} instance
          */

--- a/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
+++ b/src/main/java/net/dv8tion/jda/api/components/selections/StringSelectMenu.java
@@ -378,6 +378,7 @@ public interface StringSelectMenu extends SelectMenu {
          *             <li>If {@link #getMinValues()} is greater than {@link #getMaxValues()}</li>
          *             <li>If no options are provided</li>
          *             <li>If more than {@value #OPTIONS_MAX_AMOUNT} options are provided</li>
+         *             <li>If the minimum value range is 0 and a selection is also explicitly required</li>
          *         </ul>
          *
          * @return The new {@link StringSelectMenu} instance
@@ -390,6 +391,11 @@ public interface StringSelectMenu extends SelectMenu {
                     options.size() <= OPTIONS_MAX_AMOUNT,
                     "Cannot build a select menu with more than %d options.",
                     OPTIONS_MAX_AMOUNT);
+            if (required != null && required) {
+                Checks.check(
+                        minValues > 0,
+                        "A select menu cannot have min values set to 0 and be required at the same time");
+            }
             int min = Math.min(minValues, options.size());
             int max = Math.min(maxValues, options.size());
             return new StringSelectMenuImpl(customId, uniqueId, placeholder, min, max, disabled, options, required);


### PR DESCRIPTION
## Pull Request Etiquette

- [X] I have checked the PRs for upcoming features/bug fixes.
- [X] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [X] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [X] Internal code
- [ ] Library interface (affecting end-user code) 
- [X] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

The API does not allow such select menus in modals.
