### PR TITLE
Use Locale.ROOT in AudioEncryption for consistent string handling

### DIFF
--- a/src/main/java/net/dv8tion/jda/internal/audio/AudioEncryption.java
+++ b/src/main/java/net/dv8tion/jda/internal/audio/AudioEncryption.java
@@ -31,7 +31,7 @@ public enum AudioEncryption {
     private final String key;
 
     AudioEncryption() {
-        this.key = name().toLowerCase();
+        this.key = name().toLowerCase(Locale.ROOT);
     }
 
     public String getKey() {
@@ -42,7 +42,7 @@ public enum AudioEncryption {
         AudioEncryption encryption = null;
         for (Object o : array) {
             try {
-                String name = String.valueOf(o).toUpperCase();
+                String name = String.valueOf(o).toUpperCase(Locale.ROOT);
                 AudioEncryption e = valueOf(name);
                 if (encryption == null || e.ordinal() < encryption.ordinal()) {
                     encryption = e;


### PR DESCRIPTION
## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines](https://github.com/discord-jda/JDA/blob/master/.github/CONTRIBUTING.md).
- [x] I applied the code formatter to my changes with `./gradlew format`

### Changes

- [x] Internal code
- [ ] Library interface (affecting end-user code) 
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

For context: https://github.com/discord-jda/JDA/pull/3011#issuecomment-3892046678

In summary, when run from an environment with a Turkish locale, the key/enum value `AEAD_AES256_GCM_RTPSIZE` becomes malformed. 

`[DEBUG] [AudioWebSocket]: Using encryption mode aead_aes256_gcm_rtpsÄ±ze`

Making sure that AudioEncryption uses Locale.ROOT where appropriate should fix this.

#3011 has this change, but has much broader scope. This PR is targeted specifically at this issue.